### PR TITLE
Docs: REST API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,905 @@
+# REST API reference
+
+Complete HTTP surface of forty-two-watts. Every endpoint listed here has a
+matching `s.handle(…)` line in `go/internal/api/api.go` — that file is the
+source of truth; this doc is a readable projection of it.
+
+## Conventions
+
+- **Base URL:** `http://<host>:8080` (default port from `api.port` in config;
+  see `go/internal/config/config.go:270`)
+- **Authentication:** none. The server assumes a trusted local network.
+  Do not expose it to the public internet without a reverse proxy that adds
+  auth and TLS
+- **Content type:** `application/json` for both requests and responses
+- **CORS:** every response sets `Access-Control-Allow-Origin: *`
+  (`writeJSON` in `go/internal/api/api.go:144`)
+- **WebSocket / SSE:** none. Clients poll `/api/status` and `/api/history`.
+  The top comment in `go/internal/api/api.go:6` notes this explicitly
+- **Static UI:** any path not matched by a registered route is served from
+  `WebDir` (default `web/`) with `Cache-Control: no-cache, must-revalidate`
+  (`go/internal/api/api.go:867`)
+
+## Site sign convention
+
+Every power field in this document uses the site sign convention:
+
+- `grid_w` positive = importing from grid, negative = exporting
+- `pv_w` always negative = generation (leaving PV into the site)
+- `bat_w` positive = charging (energy into battery), negative = discharging
+- `load_w` always positive (clamped)
+
+See `docs/site-convention.md` for the full reasoning.
+
+---
+
+## Health
+
+### GET /api/health
+
+Aggregate driver health counters. Cheap, safe to hit frequently
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "status": "ok",
+  "drivers_ok": 2,
+  "drivers_degraded": 0,
+  "drivers_offline": 0
+}
+```
+
+`status` is `"degraded"` if any driver is offline, else `"ok"`
+
+Handler: `go/internal/api/api.go:163`
+
+---
+
+## Status + control
+
+### GET /api/status
+
+Live snapshot of grid, PV, batteries, dispatch, and per-driver state. This
+is the main polling endpoint for the UI
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "version": "v2.1.1",
+  "mode": "self_consumption",
+  "plan_stale": false,
+  "grid_w": -49.5,
+  "pv_w": -890.0,
+  "pv_w_predicted": 0,
+  "bat_w": -2462,
+  "load_w": 2418,
+  "load_w_predicted": 4247,
+  "bat_soc": 0.749,
+  "grid_target_w": 0,
+  "peak_limit_w": 5000,
+  "ev_charging_w": 0,
+  "drivers": {
+    "ferroamp": {
+      "status": "ok",
+      "consecutive_errors": 0,
+      "tick_count": 603,
+      "meter_w": -49.5,
+      "pv_w": -8.9,
+      "bat_w": -222,
+      "bat_soc": 0.78
+    },
+    "sungrow": {
+      "status": "ok",
+      "consecutive_errors": 0,
+      "tick_count": 601,
+      "bat_w": -2240,
+      "bat_soc": 0.72
+    }
+  },
+  "dispatch": [
+    { "driver": "ferroamp", "target_w": -1363, "clamped": false },
+    { "driver": "sungrow",  "target_w": -861,  "clamped": false }
+  ]
+}
+```
+
+**Side notes:**
+
+- `pv_w` and `bat_w` are summed across every driver whose reading type is
+  `DerPV` / `DerBattery`
+- `bat_soc` is a capacity-weighted average across batteries, so batteries
+  with more kWh pull harder
+- `load_w = grid_w - bat_w - pv_w`, smoothed by `telemetry.UpdateLoad` and
+  clamped to ≥ 0 (see `go/internal/api/api.go:216`)
+- `pv_w_predicted` is negated at emit time so it matches site-sign (negative
+  for generation)
+- `plan_stale` is set by the watchdog when the MPC plan is older than the
+  freshness window; the dispatch loop falls back to autonomous mode when
+  stale (see `docs/safety.md`)
+- Driver `status` values: `ok`, `degraded`, `offline`
+  (`telemetry.DriverStatus`)
+
+Handler: `go/internal/api/api.go:188`
+
+### GET /api/mode
+
+Return the current control mode and the grid target
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "mode": "self_consumption",
+  "grid_target_w": 0
+}
+```
+
+Handler: `go/internal/api/api.go:334`
+
+### POST /api/mode
+
+Set the control mode. Persisted to the state DB under key `mode` so it
+survives restart. If the new mode is a planner mode, the MPC service is
+told about it and an immediate replan is triggered
+
+**Request body:**
+
+```json
+{ "mode": "self_consumption" }
+```
+
+Valid values (from `go/internal/control/dispatch.go:14`):
+
+- `idle`
+- `self_consumption`
+- `peak_shaving`
+- `charge`
+- `priority`
+- `weighted`
+- `planner_self`
+- `planner_cheap`
+- `planner_arbitrage`
+
+**Response (200):**
+
+```json
+{ "status": "ok", "mode": "self_consumption" }
+```
+
+**Errors:**
+
+- `400` `{ "error": "unknown mode: …" }` for values not in the list above
+- `400` `{ "error": "…" }` on malformed JSON
+
+Handler: `go/internal/api/api.go:343`
+
+### POST /api/target
+
+Set the grid target (watts). Persisted to the state DB under key
+`grid_target_w`. The dispatcher applies it on its next tick
+
+**Request body:**
+
+```json
+{ "grid_target_w": 0 }
+```
+
+Site sign: positive = aim to import, negative = aim to export, 0 = aim for
+a flat meter. Usually 0 for self-consumption
+
+**Response (200):**
+
+```json
+{ "status": "ok", "grid_target_w": 0 }
+```
+
+Handler: `go/internal/api/api.go:383`
+
+### POST /api/peak_limit
+
+Set the peak-shaving threshold (watts, positive). In `peak_shaving` mode
+this is the ceiling the dispatcher defends. Not persisted — cleared on
+restart. Set via config if you want it sticky
+
+**Request body:**
+
+```json
+{ "peak_limit_w": 5000 }
+```
+
+**Response (200):**
+
+```json
+{ "status": "ok", "peak_limit_w": 5000 }
+```
+
+Handler: `go/internal/api/api.go:401`
+
+### POST /api/ev_charging
+
+Tell the dispatcher that an external load (EV charger) is about to draw
+power. Used by the planner to pre-condition the battery. Not persisted
+
+**Request body:**
+
+```json
+{ "power_w": 7400, "active": true }
+```
+
+When `active` is `false`, `ev_charging_w` is reset to 0 regardless of
+`power_w`
+
+**Response (200):**
+
+```json
+{ "status": "ok", "ev_charging_w": 7400 }
+```
+
+Handler: `go/internal/api/api.go:417`
+
+---
+
+## Configuration
+
+### GET /api/config
+
+Return the current merged config as JSON. Reads under `CfgMu.RLock()`
+
+**Query params:** none
+
+**Response (200):** full config shape. See `go/internal/config/config.go`
+for the authoritative schema. Top-level keys include `api`, `site`,
+`drivers`, `prices`, `forecast`, `mpc`, `ha`, `pvmodel`, `loadmodel`
+
+Handler: `go/internal/api/api.go:294`
+
+### POST /api/config
+
+Replace the full config. The payload is validated with `config.Validate()`,
+persisted atomically via `SaveConfig`, then the in-memory control state
+(grid target, tolerance, slew rate, min dispatch interval) is updated
+immediately. The file watcher will also pick up the change but this path
+is snappier
+
+**Request body:** full config object (same shape as `GET /api/config`)
+
+**Response (200):**
+
+```json
+{ "status": "ok" }
+```
+
+**Errors:**
+
+- `400` `{ "error": "invalid config: …" }` on unmarshal failure
+- `400` `{ "error": "validation: …" }` if `Validate()` rejects the payload
+- `500` `{ "error": "save failed: …" }` if writing the file fails
+
+Handler: `go/internal/api/api.go:301`
+
+---
+
+## History + time-series
+
+### GET /api/history
+
+Legacy wide-snapshot query used by the live chart. One row per sample
+with `grid_w`, `pv_w`, `bat_w`, `load_w`, `bat_soc` flattened, plus any
+extra fields that were captured as a JSON blob
+
+**Query params:**
+
+- `range` — one of `5m`, `15m`, `1h`, `6h`, `24h`, `3d` (default `5m`)
+- `points` — max number of points to downsample to (default `200`)
+
+**Response (200):**
+
+```json
+{
+  "range": "1h",
+  "items": [
+    {
+      "ts": 1744579200000,
+      "grid_w": -49.5,
+      "pv_w": -890.0,
+      "bat_w": -2462,
+      "load_w": 2418,
+      "bat_soc": 0.749
+    }
+  ]
+}
+```
+
+**Side notes:**
+
+- Timestamps are Unix milliseconds
+- Source is the `history` table in the state SQLite DB; rows are written by
+  the dispatcher
+- Unknown `range` values silently fall back to `5m`
+
+Handler: `go/internal/api/api.go:575`
+
+### GET /api/series
+
+Long-format time-series query — one metric per driver. Used by the metric
+browser UI and for ML training data exports. Backed by the long-format
+SQLite TSDB; see `docs/tsdb.md`
+
+**Query params (required):**
+
+- `driver` — e.g. `ferroamp`, `sungrow`
+- `metric` — e.g. `battery_w`, `meter_w`, `pv_w`, `battery_soc`
+
+**Query params (optional):**
+
+- `range` — `5m|15m|1h|6h|24h|3d` (default `1h`)
+- `points` — downsample cap; `0` / omitted = no cap
+
+**Response (200):**
+
+```json
+{
+  "driver": "ferroamp",
+  "metric": "battery_w",
+  "range": "1h",
+  "points": [
+    { "ts": 1744579200000, "v": -222.0 },
+    { "ts": 1744579260000, "v": -231.5 }
+  ]
+}
+```
+
+**Errors:**
+
+- `400` `{ "error": "driver and metric are required" }`
+- `500` `{ "error": "…" }` on DB read failure
+
+Handler: `go/internal/api/api.go:724`
+
+### GET /api/series/catalog
+
+List every driver name and every metric name that has at least one sample
+in the TSDB. Used by the metric browser dropdowns
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "drivers": ["ferroamp", "sungrow"],
+  "metrics": ["battery_soc", "battery_w", "meter_w", "pv_w"]
+}
+```
+
+Both lists are sorted alphabetically
+
+Handler: `go/internal/api/api.go:756`
+
+---
+
+## Devices + drivers
+
+### GET /api/drivers
+
+Per-driver health map. Lighter than `/api/status` when you only want the
+health surface
+
+**Query params:** none
+
+**Response (200):** map keyed by driver name
+
+```json
+{
+  "ferroamp": {
+    "Name": "ferroamp",
+    "Status": 0,
+    "LastSuccess": "2026-04-14T12:00:00Z",
+    "ConsecutiveErrors": 0,
+    "LastError": "",
+    "TickCount": 603
+  }
+}
+```
+
+**Side notes:** `Status` is an integer enum — `0=ok`, `1=degraded`,
+`2=offline`. The string form is only emitted by `/api/status`
+
+Handler: `go/internal/api/api.go:438`
+
+### GET /api/devices
+
+Every registered device with its hardware-stable identity (SN → MAC →
+endpoint fallback chain). UIs surface this in driver cards ("SN: ABC")
+and in Settings → Devices. See `docs/device-identity.md`
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "devices": [
+    {
+      "device_id": "ferroamp-EHAB-1234567",
+      "driver_name": "ferroamp",
+      "make": "ferroamp",
+      "serial": "EHAB-1234567",
+      "mac": "aa:bb:cc:dd:ee:ff",
+      "endpoint": "mqtt://192.168.1.10:1883",
+      "first_seen_ms": 1744400000000,
+      "last_seen_ms": 1744579200000
+    }
+  ]
+}
+```
+
+`device_id` is derived from `make + serial + mac + endpoint` by
+`state.ResolveDeviceID`. Once bound it never changes — even if the driver
+is renamed in config
+
+Handler: `go/internal/api/api.go:777`
+
+### GET /api/drivers/catalog
+
+Enumerate the `.lua` driver files in `<config-dir>/drivers/`, parsed from
+each file's `DRIVER={…}` metadata table. Used by the Settings UI to offer
+an "Add from catalog" dropdown
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "path": "drivers",
+  "entries": [
+    {
+      "path": "drivers/ferroamp.lua",
+      "filename": "ferroamp.lua",
+      "id": "ferroamp",
+      "name": "Ferroamp EnergyHub",
+      "manufacturer": "Ferroamp",
+      "version": "1.0.0",
+      "protocols": ["mqtt"],
+      "capabilities": ["meter", "pv", "battery"],
+      "description": "EnergyHub XL/S via MQTT",
+      "homepage": "https://ferroamp.com"
+    }
+  ]
+}
+```
+
+**Side notes:**
+
+- If the catalog directory cannot be scanned, the response still returns
+  `200` with `entries: []` and an `error` field
+- Files without a `DRIVER` block are still listed — `id`/`name` just
+  come back empty so the operator can see the file exists
+
+Handler: `go/internal/api/api.go:445`
+
+---
+
+## MPC planner
+
+### GET /api/mpc/plan
+
+Return the most recent MPC plan plus metadata about when and why it was
+generated. See `docs/mpc-planner.md`
+
+**Query params:** none
+
+**Response (200), planner enabled:**
+
+```json
+{
+  "enabled": true,
+  "plan": {
+    "generated_at_ms": 1744579200000,
+    "mode": "self_consumption",
+    "horizon_slots": 96,
+    "capacity_wh": 20000,
+    "initial_soc_pct": 74.9,
+    "total_cost_ore": -120.5,
+    "actions": [
+      {
+        "slot_start_ms": 1744579200000,
+        "slot_len_min": 15,
+        "price_ore": 42.1,
+        "pv_w": -800,
+        "load_w": 2400,
+        "battery_w": -1600,
+        "grid_w": 0,
+        "soc_pct": 73.2,
+        "cost_ore": 0,
+        "confidence": 0.85,
+        "reason": "cover load from battery",
+        "pv_limit_w": 0
+      }
+    ]
+  },
+  "meta": {
+    "last_replan_ms": 1744579100000,
+    "last_replan_reason": "schedule"
+  }
+}
+```
+
+**Response (200), planner disabled:**
+
+```json
+{ "enabled": false }
+```
+
+When enabled but no plan has been computed yet: `plan: null`, `meta` still
+populated
+
+Handler: `go/internal/api/api.go:692`
+
+### POST /api/mpc/replan
+
+Force an immediate replan. Returns the resulting plan
+
+**Request body:** ignored (none required)
+
+**Response (200):**
+
+```json
+{ "enabled": true, "plan": { "...": "same Plan shape as GET /api/mpc/plan" } }
+```
+
+**Errors:**
+
+- `400` `{ "error": "mpc disabled" }` if the MPC service is nil
+
+Handler: `go/internal/api/api.go:710`
+
+---
+
+## ML twins
+
+### GET /api/pvmodel
+
+PV digital-twin self-learner status. See `docs/ml-twins.md`
+
+**Query params:** none
+
+**Response (200), enabled:**
+
+```json
+{
+  "enabled": true,
+  "samples": 4320,
+  "mae_w": 85.2,
+  "rated_w": 8500,
+  "quality": "good",
+  "last_ms": 1744579200000,
+  "forgetting": 0.999,
+  "beta": [0.8, 0.1, -0.05]
+}
+```
+
+**Response (200), disabled:** `{ "enabled": false }`
+
+Handler: `go/internal/api/api.go:801`
+
+### POST /api/pvmodel/reset
+
+Clear the PV twin's learned weights back to baseline. Useful after
+panel changes
+
+**Request body:** ignored
+
+**Response (200):**
+
+```json
+{ "status": "reset" }
+```
+
+**Errors:** `400` `{ "error": "pvmodel disabled" }`
+
+Handler: `go/internal/api/api.go:819`
+
+### GET /api/loadmodel
+
+Load digital-twin self-learner status. Buckets are per-hour-of-week;
+`buckets_warm` is the count where `samples ≥ MinTrustSamples`
+
+**Query params:** none
+
+**Response (200), enabled:**
+
+```json
+{
+  "enabled": true,
+  "samples": 10800,
+  "mae_w": 140.0,
+  "peak_w": 6800,
+  "quality": "good",
+  "last_ms": 1744579200000,
+  "heating_w_per_degc": 45.0,
+  "buckets_warm": 98,
+  "buckets_total": 168
+}
+```
+
+**Response (200), disabled:** `{ "enabled": false }`
+
+Handler: `go/internal/api/api.go:830`
+
+### POST /api/loadmodel/reset
+
+Clear the load twin. Same semantics as `/api/pvmodel/reset`
+
+**Response (200):** `{ "status": "reset" }`
+
+**Errors:** `400` `{ "error": "loadmodel disabled" }`
+
+Handler: `go/internal/api/api.go:856`
+
+---
+
+## Battery models + self-tune
+
+### GET /api/battery_models
+
+Inspect the per-battery first-order response models. Values come directly
+from `battery.Model` — see `docs/battery-models.md` for field semantics
+
+**Query params:** none
+
+**Response (200):** map keyed by battery/driver name
+
+```json
+{
+  "ferroamp": {
+    "tau_s": 3.2,
+    "gain": 0.98,
+    "deadband_w": 40,
+    "n_samples": 1840,
+    "confidence": 0.91,
+    "health_score": 0.97,
+    "health_drift_per_day": 0.0005,
+    "baseline_gain": 1.0,
+    "baseline_tau_s": 3.5,
+    "last_calibrated_ts_ms": 1744380000000,
+    "last_updated_ts_ms": 1744579100000,
+    "max_charge_curve": [[0.0, 5000], [0.8, 3000], [1.0, 500]],
+    "max_discharge_curve": [[0.0, 500], [0.2, 3000], [1.0, 5000]],
+    "a": 0.72,
+    "b": 0.28
+  }
+}
+```
+
+Handler: `go/internal/api/api.go:475`
+
+### POST /api/battery_models/reset
+
+Replace one or all battery models with a fresh `battery.New(name)`.
+Persisted back to the state DB
+
+**Request body (one of):**
+
+```json
+{ "battery": "ferroamp" }
+```
+
+```json
+{ "all": true }
+```
+
+**Response (200):**
+
+```json
+{ "reset": ["ferroamp"] }
+```
+
+**Errors:**
+
+- `400` `{ "error": "provide 'battery' or 'all'" }`
+- `404` `{ "error": "battery not found: …" }`
+
+Handler: `go/internal/api/api.go:501`
+
+### POST /api/self_tune/start
+
+Begin a self-tune sweep across the given batteries. Holds `ModelsMu` for
+the duration of the kickoff. Fails with `409` if a sweep is already
+running
+
+**Request body:**
+
+```json
+{ "batteries": ["ferroamp", "sungrow"] }
+```
+
+**Response (200):**
+
+```json
+{ "status": "started", "batteries": ["ferroamp", "sungrow"] }
+```
+
+**Errors:**
+
+- `400` malformed JSON
+- `409` `{ "error": "already running" }` or similar from the coordinator
+
+Handler: `go/internal/api/api.go:542`
+
+### GET /api/self_tune/status
+
+Return the self-tune coordinator's current state
+
+**Query params:** none
+
+**Response (200):**
+
+```json
+{
+  "active": true,
+  "battery_index": 1,
+  "battery_total": 2,
+  "current_battery": "sungrow",
+  "current_step": "stabilize",
+  "step_elapsed_s": 12.0,
+  "total_elapsed_s": 450.2,
+  "before": {
+    "ferroamp": { "tau_s": 3.5, "gain": 1.0 }
+  },
+  "after": {
+    "ferroamp": { "tau_s": 3.2, "gain": 0.98 }
+  },
+  "last_error": ""
+}
+```
+
+`before` / `after` carry `ModelSnapshot` maps captured at sweep start and
+step completion. Full field list in
+`go/internal/selftune/selftune.go:344`
+
+Handler: `go/internal/api/api.go:561`
+
+### POST /api/self_tune/cancel
+
+Cancel any in-flight sweep. Idempotent — cancelling when idle is a no-op
+
+**Request body:** ignored
+
+**Response (200):**
+
+```json
+{ "status": "cancelled" }
+```
+
+Handler: `go/internal/api/api.go:565`
+
+---
+
+## Home Assistant
+
+### GET /api/ha/status
+
+Live status of the Home Assistant MQTT bridge. Used by the Settings UI
+to show a connection indicator instead of trusting "it's saved"
+
+**Query params:** none
+
+**Response (200), bridge enabled:**
+
+```json
+{
+  "enabled": true,
+  "connected": true,
+  "broker": "192.168.1.20:1883",
+  "last_publish_ms": 1744579200000,
+  "sensors_announced": 24
+}
+```
+
+**Response (200), bridge disabled:**
+
+```json
+{ "enabled": false }
+```
+
+Handler: `go/internal/api/api.go:459`
+
+---
+
+## Forecast + prices
+
+### GET /api/prices
+
+Spot prices for the configured zone. Slot length varies by source (15 min
+for NordPool/elprisetjustnu since late 2025, mostly 60 min for ENTSOE)
+
+**Query params (all optional):**
+
+- `range` — `5m|15m|1h|6h|24h|3d`; when present, starts at `now` and
+  ends `now + range`
+- `since_ms` — explicit start in Unix ms
+- `until_ms` — explicit end in Unix ms
+
+Defaults: `since = now - 1h`, `until = now + 48h`
+
+**Response (200), enabled:**
+
+```json
+{
+  "zone": "SE3",
+  "enabled": true,
+  "items": [
+    {
+      "zone": "SE3",
+      "slot_ts_ms": 1744579200000,
+      "slot_len_min": 15,
+      "spot_ore_kwh": 42.1,
+      "total_ore_kwh": 98.7,
+      "source": "elprisetjustnu",
+      "fetched_at_ms": 1744570000000
+    }
+  ]
+}
+```
+
+**Response (200), disabled:**
+
+```json
+{ "enabled": false, "items": [] }
+```
+
+`total_ore_kwh` = spot plus whatever transmission/retailer markup is in
+the config; `spot_ore_kwh` is the raw day-ahead price
+
+Handler: `go/internal/api/api.go:634`
+
+### GET /api/forecast
+
+Weather-derived PV forecast rows
+
+**Query params:**
+
+- `range` — `5m|15m|1h|6h|24h|3d`; when present, starts at `now`
+
+Default: `since = now - 1h`, `until = now + 48h`
+
+**Response (200), enabled:**
+
+```json
+{
+  "enabled": true,
+  "items": [
+    {
+      "slot_ts_ms": 1744579200000,
+      "slot_len_min": 60,
+      "cloud_cover_pct": 35.0,
+      "temp_c": 8.2,
+      "solar_wm2": 420.0,
+      "pv_w_estimated": 3400.0,
+      "source": "open-meteo",
+      "fetched_at_ms": 1744570000000
+    }
+  ]
+}
+```
+
+`cloud_cover_pct`, `temp_c`, `solar_wm2`, `pv_w_estimated` are nullable —
+they'll be omitted from the row when the source didn't provide them
+
+**Response (200), disabled:**
+
+```json
+{ "enabled": false, "items": [] }
+```
+
+Handler: `go/internal/api/api.go:670`


### PR DESCRIPTION
## Summary
- Adds `docs/api.md` — a complete REST API reference projected from `go/internal/api/api.go`
- Groups all 29 endpoints by domain (status+control, config, history+series, devices+drivers, MPC, ML twins, battery models+self-tune, HA, forecast+prices) with method, purpose, query params, request body, response shape, and side notes for each
- Every endpoint entry cites its handler file:line; base URL / auth / content-type / no-WS covered in the top conventions section; site sign convention called out where power fields appear

## Test plan
- [x] `cd go && go build ./...` clean
- [x] `cd go && go test -timeout 120s -count=1 ./...` green
- [x] Every documented endpoint has a matching `s.handle(…)` in `go/internal/api/api.go`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Generated with Claude Code