### PR TITLE
docs: operations + deployment guide

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,270 @@
+# Architecture overview
+
+This is the canonical system map for forty-two-watts. For the sign
+convention every number in the rest of this document obeys, see
+[site-convention.md](site-convention.md) first.
+
+## System summary
+
+forty-two-watts is an embedded home energy management system that runs
+on a Raspberry Pi and coordinates two batteries (Ferroamp + Sungrow)
+sharing a single 16 A grid connection, so they stop fighting each
+other and the main fuse. A Go control loop unifies dispatch, an MPC
+planner with online ML digital twins sits on top, and per-device Lua
+drivers (one Lua VM per device) translate everything to native MQTT
+or Modbus.
+
+## Site sign convention
+
+All power above the driver boundary follows a single rule:
+
+> Positive W = power flowing **into** the site across the grid-meter
+> boundary. Negative W = power flowing out (export).
+
+Drivers are the only layer that converts from vendor conventions.
+Telemetry store, control loop, MPC, API, UI, HA bridge, SQLite — all
+site convention. Full treatment in [site-convention.md](site-convention.md).
+
+If you're about to write `pv_w` math and it isn't negative, stop.
+
+## Top-level components
+
+### Drivers
+Source: `go/internal/drivers/`, Lua driver scripts in `drivers/*.lua`.
+
+One goroutine per driver runs a poll loop (`go/internal/drivers/registry.go`
+`runLoop` at line 182). Each driver has its own Lua VM and a
+capability-scoped host environment (MQTT/Modbus only if the driver's
+config grants it). Drivers poll their device, call
+`host.emit_telemetry()` to push readings into the telemetry store in
+site convention, and accept battery dispatch commands via
+`Registry.Send` (line 234). On hang or config reload, the registry
+issues a `DefaultMode` call so the device reverts to autonomous.
+
+### Telemetry store
+Source: `go/internal/telemetry/`.
+
+In-memory only. Stores the latest raw + Kalman-smoothed reading per
+(driver, DER-type) and a `DriverHealth` record per driver. Drivers
+also buffer arbitrary metric samples (via `EmitMetric`) into a
+per-cycle queue that the control loop drains with `FlushSamples`.
+The telemetry store owns the watchdog scan — `WatchdogScan` flips
+drivers with stale `LastSuccess` offline.
+
+### State store
+Source: `go/internal/state/`. Backing: SQLite (pure-Go driver).
+
+Single file (default `state.db`). All persistent state lives here:
+
+- `config` — k/v for mode, grid-target overrides, per-service
+  serialized model state
+- `events` — startup/shutdown/etc. log
+- `telemetry` — last-known DER readings (crash recovery)
+- `battery_models` — one JSON blob per battery, keyed by device_id
+- `history_hot` / `history_warm` / `history_cold` — wide history
+  snapshots at full / 15-min / daily resolution
+- `ts_drivers`, `ts_metrics`, `ts_samples` — long-format TSDB
+  (interned driver/metric ids, 14-day retention)
+- `prices` — spot prices per (zone, slot_ts_ms)
+- `forecasts` — weather + PV forecast slots
+- `devices` — canonical hardware identity (make/serial/mac/endpoint)
+
+Retention constants in `go/internal/state/store.go` lines 21-28:
+30 days hot, 365 days warm, 14 days of long-format samples before
+parquet roll-off.
+
+### Control loop
+Source: `go/cmd/forty-two-watts/main.go` (the main ticker at
+line 445) calling `go/internal/control/`.
+
+Runs every `site.control_interval_s` seconds (default 5). Modes:
+
+- `idle` — emit nothing
+- `self_consumption` — PI-chase `grid_target_w` (usually 0)
+- `peak_shaving` — cap grid import at `PeakLimitW`
+- `charge` — force all batteries to max charge
+- `priority` — fill one battery first, then the next
+- `weighted` — split by configured weights
+- `planner_self` / `planner_cheap` / `planner_arbitrage` — pull
+  `grid_target_w` from the MPC plan for the current slot; fall back
+  to `self_consumption` with target 0 when the plan is stale
+
+Outputs one `DispatchTarget` per battery driver (site convention:
++ = charge, − = discharge) after slew-rate and fuse-guard clamping.
+
+### MPC planner
+Source: `go/internal/mpc/`.
+
+Dynamic programming over discretized SoC × actions, 48-hour horizon,
+15-min interval by default. Consumes prices, weather-driven PV
+forecast, load forecast, and current SoC; emits a grid-target
+schedule the control loop reads via `Service.GridTargetAt`
+(`service.go:132`). Three flavors bind to the `planner_*` control
+modes with different action constraints (no grid-charge / no export
+discharge / full freedom).
+
+### ML twins
+Sources: `go/internal/pvmodel/`, `go/internal/loadmodel/`,
+`go/internal/priceforecast/`.
+
+Online learners. Each service subscribes to telemetry + forecast
+inputs, updates a small model every minute, and exposes a `Predict`
+function. `main.go` wires the three `Predict` functions directly
+into the MPC service at startup. Serialized model state round-trips
+through `state.SaveConfig`/`LoadConfig` under keys `pvmodel/state`,
+`loadmodel/state`, `pricefc/state`. See the forthcoming
+`ml-models.md` (or `ml-twins.md`) for model internals.
+
+### API + UI
+Sources: `go/internal/api/`, `web/`.
+
+HTTP REST + static UI served on port 8080 by default
+(`go/internal/config/config.go:270`). The UI reads live telemetry,
+drives mode/target changes, and exposes the planner + model views.
+Config writes go through the API to the same `config.yaml` file.
+
+### HA bridge
+Source: `go/internal/ha/`.
+
+Optional MQTT bridge. Publishes autodiscovery for every driver plus
+site-level sensors, periodically publishes state, and subscribes to
+commands (set mode, set grid target, set peak limit, set EV
+charging). Signs in MQTT payloads match site convention so HA charts
+need no sign fiddling.
+
+### Watchdog
+In-process, owned by `telemetry.Store.WatchdogScan`, invoked once
+per control tick (`main.go:492`). Any driver whose last success is
+older than `site.watchdog_timeout_s` (default 60 s) is flipped
+offline; the control loop then calls `reg.SendDefault` so the
+device reverts to its own autonomous mode. A separate safety check
+at `main.go:505` also skips the whole dispatch cycle if the site
+meter itself is stale — otherwise one battery would charge off the
+other.
+
+## Data flow
+
+```
+          ┌────────────────────────────────────────────────────────┐
+          │                     Devices                             │
+          │  Ferroamp ESO (MQTT)       Sungrow SH (Modbus TCP)      │
+          └──────────┬──────────────────────────┬──────────────────┘
+                     │ native protocol          │ native protocol
+                     ▼                          ▼
+          ┌────────────────────────────────────────────────────────┐
+          │                Drivers (one Lua VM each)                │
+          │  translate ⇆ site convention via host.emit_telemetry    │
+          │  accept battery dispatch via registry.Send              │
+          └──────────┬──────────────────────────┬──────────────────┘
+                     │ DerReading (site conv.)  │ MetricSample queue
+                     ▼                          ▼
+          ┌────────────────────────────────────────────────────────┐
+          │                 telemetry.Store                         │
+          │   • Kalman-smoothed latest reading per (driver,type)    │
+          │   • DriverHealth (watchdog, error counts)               │
+          │   • pending[] metric samples (flushed per cycle)        │
+          └──────────┬──────────────────────────┬──────────────────┘
+                     │ Get / ReadingsByType     │ FlushSamples
+                     ▼                          ▼
+          ┌──────────────────────────┐   ┌──────────────────────┐
+          │ control loop (5 s tick)  │   │ state.Store (SQLite) │
+          │ main.go:445              │   │                      │
+          │ • watchdog scan          │   │ RecordSamples        │
+          │ • compute dispatch       │◀──│ RecordHistory        │
+          │ • slew + fuse clamp      │   │ LoadConfig (mode,    │
+          │ • reg.Send per driver    │   │   grid_target, model │
+          └──────────┬───────┬───────┘   │   blobs)             │
+                     │       │           │ SaveBatteryModel     │
+                     │       │           │ LoadForecasts/Prices │
+                     │       │           └──────────┬───────────┘
+                     │       │                      │
+                     │       │           ┌──────────▼───────────┐
+                     │       │           │ MPC planner          │
+                     │       │           │ (15-min slot plan)   │
+                     │       │           │ GridTargetAt(now)    │
+                     │       └──────────▶│   via ctrl.PlanTarget│
+                     │                   └──────────┬───────────┘
+                     │                              │
+                     │         ┌────────────────────┘
+                     │         ▼
+                     │   ┌───────────────┐       ┌────────────────┐
+                     │   │ ML twins      │       │ HTTP API       │
+                     │   │ pvmodel /     │──────▶│ /api/...       │
+                     │   │ loadmodel /   │       │ static web UI  │
+                     │   │ priceforecast │       │ :8080          │
+                     │   └───────────────┘       └────────────────┘
+                     │
+                     ▼
+          ┌──────────────────────────┐       ┌────────────────────┐
+          │ HA bridge                │──────▶│ MQTT broker        │
+          │ autodiscovery + state    │◀──────│ command topics     │
+          └──────────────────────────┘       └────────────────────┘
+
+  Background (hourly tick, main.go:580):
+    state.Store.RolloffToParquet ──▶ <cold_dir>/YYYY/MM/DD.parquet
+                                     (ts_samples older than 14 days)
+```
+
+Cardinality: one control loop, one telemetry store, one state store,
+N drivers, one MPC service (optional), three ML twin services
+(optional), one API server, one optional HA bridge.
+
+## Persistence map
+
+| Data | Subsystem | Where (state.Store) | Key |
+|---|---|---|---|
+| Battery models (ARX(1) RLS) | control loop | `battery_models` table, `SaveBatteryModel` | `device_id` |
+| PV twin state | `pvmodel` service | `config` table, `LoadConfig`/`SaveConfig` | `pvmodel/state` |
+| Load twin state | `loadmodel` service | `config` table | `loadmodel/state` |
+| Price forecast state | `priceforecast` service | `config` table | `pricefc/state` |
+| FX rates | `currency` service | `config` table | `fx/ecb_rates` |
+| Operator mode | API + HA bridge | `config` table | `mode` |
+| Manual grid target override | API + HA bridge | `config` table | `grid_target_w` |
+| Telemetry snapshots (crash recovery) | telemetry dumps | `telemetry` table | driver+type key |
+| Long-format TS (14 d) | control loop (`FlushSamples`) | `ts_samples` table | `(driver_id, metric_id, ts_ms)` |
+| Long-format TS (>14 d) | hourly rolloff | `<cold_dir>/YYYY/MM/DD.parquet` | UTC day |
+| Wide history (30 d, 5 s) | control loop (`RecordHistory`) | `history_hot` | `ts_ms` |
+| Wide history (365 d, 15 min) | `Prune` | `history_warm` | `ts_ms` |
+| Wide history (daily) | `Prune` | `history_cold` | `ts_ms` |
+| Devices | identity bootstrap (`main.go:607`) | `devices` table | `device_id` = `make:serial` / `mac:…` / `ep:…` |
+| Spot prices | `prices` service | `prices` table | `(zone, slot_ts_ms)` |
+| Weather forecasts | `forecast` service | `forecasts` table | `slot_ts_ms` |
+| Events | anywhere calling `RecordEvent` | `events` table | `ts_ms` |
+
+Retention constants in `go/internal/state/store.go`: `HotRetention =
+30*24h`, `WarmRetention = 365*24h`, `RecentRetention = 14*24h`
+(`store_ts.go:20`).
+
+## Configuration source of truth
+
+Single file (`config.yaml`, default path). Example:
+[`config.example.yaml`](../config.example.yaml). Semantics:
+[configuration.md](configuration.md).
+
+Hot-reload: `go/internal/configreload/watcher.go` uses `fsnotify` to
+watch the config file. On change it diffs against the live `cfg`,
+calls `reg.Reload` for driver add/remove/restart, and refreshes
+capacity maps under the shared mutex. The API's `POST /api/config`
+endpoint writes the same file atomically (`config.SaveAtomic`), so
+editing via the Settings UI and editing the file by hand are
+equivalent paths (see the diagram in
+[configuration.md](configuration.md)).
+
+A small set of bindings are read once at startup and not reloaded:
+state file path, parquet cold dir, API port, HA broker coordinates.
+
+## Where to read first
+
+In this order, for someone new to the codebase:
+
+1. [docs/site-convention.md](site-convention.md) — every number in
+   the system obeys it. Nothing below makes sense otherwise.
+2. This file.
+3. `docs/ml-models.md` (planned) — today read
+   [docs/ml-twins.md](ml-twins.md) for the digital twins and
+   [docs/mpc-planner.md](mpc-planner.md) for the planner internals.
+4. `docs/writing-a-driver.md` (planned) — today read
+   [docs/lua-drivers.md](lua-drivers.md) and
+   [docs/host-api.md](host-api.md).
+5. `go/cmd/forty-two-watts/main.go` — the orchestrator. One file,
+   ~770 lines, wires everything above together. Read top to bottom.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,322 @@
+# Operations
+
+The operator's guide. From "I have a fresh Raspberry Pi" to "I can debug a hung driver at 3am".
+
+Sign convention reminder: throughout this doc, `grid_w > 0` means **import** (buying from grid), `grid_w < 0` means **export** (selling). Battery `bat_w > 0` means **discharging** (battery → AC), `bat_w < 0` means **charging** (AC → battery). PV `pv_w` is always ≥ 0. See [site-convention.md](site-convention.md) for the full convention.
+
+## 1. Build + cross-compile
+
+Pure-Go build, no CGO, single static binary:
+
+```bash
+# On a dev machine (macOS / Linux), cross-compile for the Pi:
+cd /Users/fredde/repositories/forty-two-watts/go
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /tmp/forty-two-watts-arm64 ./cmd/forty-two-watts
+
+# Sanity check — should report arm64, statically linked
+file /tmp/forty-two-watts-arm64
+# → ELF 64-bit LSB executable, ARM aarch64, statically linked
+```
+
+For amd64: `GOARCH=amd64`.
+
+The Makefile has the usual pair of targets. Prefer these when iterating:
+
+```bash
+make build-arm64   # → bin/forty-two-watts-linux-arm64
+make build-amd64   # → bin/forty-two-watts-linux-amd64
+make release       # → release/forty-two-watts-linux-{arm64,amd64}.tar.gz (bundles binary + WASM + web + config.example.yaml)
+```
+
+`make release` bakes in the git tag via `-ldflags "-X main.Version=..."`, so the running binary reports its version in the startup log.
+
+## 2. Files to deploy
+
+The Pi needs:
+
+- **The binary** — single file, no runtime dependencies.
+- **`web/`** — static UI assets (`index.html`, `app.js`, `style.css`, `models.js`, `settings.js`, `plan.js`, `twins.js`, `favicon.svg`).
+- **`drivers/`** — the Lua driver files (`ferroamp.lua`, `sungrow.lua`, …) if you run the Lua runtime, or **`drivers-wasm/`** for the WASM-based drivers.
+- **`config.yaml`** — operator-edited; see [`config.example.yaml`](../config.example.yaml) for the schema and [configuration.md](configuration.md) for every field.
+
+Suggested layout on the Pi:
+
+```
+/home/fredde/forty-two-watts-go/
+├── forty-two-watts          # binary
+├── config.yaml              # local config (don't commit)
+├── web/                     # static UI
+├── drivers/                 # Lua drivers
+├── drivers-wasm/            # WASM drivers (optional)
+├── state.db                 # created on first run
+├── state.db-wal
+├── state.db-shm
+├── cold/                    # parquet rolloff (created on first run)
+└── forty-two-watts.log      # service log (if redirecting stdout/stderr)
+```
+
+The binary only takes two command-line flags:
+
+- `-config config.yaml` — path to the config file.
+- `-web web` — path to the static UI directory.
+
+Relative WASM driver paths in `config.yaml` are resolved against the config file's directory, so keep them side-by-side.
+
+## 3. systemd unit
+
+The repo ships [`deploy/forty-two-watts.service`](../deploy/forty-two-watts.service):
+
+```ini
+[Unit]
+Description=forty-two-watts EMS (Go + WASM port)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=fredde
+WorkingDirectory=/home/fredde/forty-two-watts-go
+ExecStart=/home/fredde/forty-two-watts-go/forty-two-watts -config config.yaml -web web
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:/home/fredde/forty-two-watts-go/forty-two-watts.log
+StandardError=inherit
+# Limit memory growth (RPi has 4GB).
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Notes:
+
+- `User=fredde` is a **template** — change for your install.
+- `WorkingDirectory=/home/fredde/forty-two-watts-go` — this is where `state.db`, `cold/`, and the log file are created, so pick a persistent path.
+- `Restart=on-failure` with `RestartSec=5` — the service comes back automatically after a crash.
+- `MemoryMax=512M` — Pi-friendly cap. The service typically sits at 50–80 MB resident (see §9).
+
+Install:
+
+```bash
+sudo cp deploy/forty-two-watts.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now forty-two-watts
+systemctl status forty-two-watts
+```
+
+## 4. Service lifecycle
+
+```bash
+sudo systemctl start forty-two-watts
+sudo systemctl stop forty-two-watts
+sudo systemctl restart forty-two-watts
+sudo systemctl reload forty-two-watts   # not supported — the unit has no ExecReload; use the hot-reload path instead (§6)
+```
+
+For a binary swap with minimum downtime:
+
+```bash
+scp /tmp/forty-two-watts-arm64 user@pi:~/forty-two-watts-go/forty-two-watts.new
+ssh user@pi 'sudo systemctl stop forty-two-watts && \
+  cd ~/forty-two-watts-go && \
+  mv forty-two-watts.new forty-two-watts && \
+  chmod +x forty-two-watts && \
+  sudo systemctl start forty-two-watts'
+```
+
+Typical stop → start window: 2–5 seconds. The service records a `shutdown` event on clean stop and a `startup` event on boot, both visible in the `events` table.
+
+## 5. Logs
+
+Because the unit uses `StandardOutput=append:…/forty-two-watts.log`, journald does **not** capture stdout — the log file is authoritative. `StandardError=inherit` means stderr goes to journald.
+
+```bash
+# Tail the file log
+tail -f /home/fredde/forty-two-watts-go/forty-two-watts.log
+
+# Recent stderr / service lifecycle via journald
+journalctl -u forty-two-watts -n 200 --no-pager
+journalctl -u forty-two-watts -f
+```
+
+forty-two-watts uses `slog` with the text handler at `LevelInfo`. Levels:
+
+- `INFO` — normal operation (startup, reloads, rolloff completions, driver state changes).
+- `WARN` — recoverable issues (driver send failure, stale site meter, config reload rejected).
+- `ERROR` — fatal or near-fatal (`load config`, `open state`, `http server`). The service either exits or restarts via systemd.
+
+Notable log lines you will look for:
+
+- `forty-two-watts starting version=… config=…` — every boot.
+- `config loaded site=… drivers=N` — config parsed OK.
+- `HTTP API listening addr=:8080` — UI is reachable.
+- `config watcher started path=…` — hot-reload is active.
+- `config reload: applied` — a successful `config.yaml` edit was picked up.
+- `site meter telemetry stale — idling batteries this cycle` — see §8.
+
+## 6. Hot-reload
+
+Edit `config.yaml` and save. `fsnotify` ([`go/internal/configreload/watcher.go`](../go/internal/configreload/watcher.go)) watches the file's directory, debounces editor saves for 500 ms, then re-parses the file and applies the diff to the running process.
+
+Look for `config reload: applied` in the log. If the new config has a syntax or validation error, the watcher logs `config reload failed err=…` and the service **keeps running the old config** — your site never ends up un-configured because of a typo.
+
+What the watcher can change live (no restart):
+
+- `site.grid_target_w`, `site.grid_tolerance_w`, `site.slew_rate_w`, `site.min_dispatch_interval_s`
+- Driver set (add / remove / reconfigure — the registry diffs and respawns)
+- Driver capacities (refreshed for dispatch + fuse guard)
+
+Changes that require a full restart (the watcher will not re-wire these):
+
+- `api.port`
+- `state.path`, `state.cold_dir`
+- HA MQTT bridge parameters
+- Planner enable/disable (MPC service is built once at startup)
+
+When in doubt, `sudo systemctl restart forty-two-watts`.
+
+## 7. Backup + restore
+
+Three things hold state:
+
+- **`state.db`** — SQLite (config, battery models, devices, prices, forecasts, recent TSDB tier). Highest priority.
+- **`cold/YYYY/MM/DD.parquet`** — long-format TS history for data > 14 days old. Medium priority (losing it loses history, not control).
+- **`config.yaml`** — operator-edited config. High priority; may not be reproducible from git.
+
+Backup (stop for a consistent SQLite snapshot):
+
+```bash
+# On the Pi
+cd ~/forty-two-watts-go
+sudo systemctl stop forty-two-watts
+tar czf ~/backup-$(date +%F).tgz state.db state.db-wal state.db-shm cold/ config.yaml
+sudo systemctl start forty-two-watts
+```
+
+Online backup is possible (SQLite is WAL-mode and survives `cp`), but cold backup is the safe default.
+
+Restore: stop the service, extract into `WorkingDirectory`, start the service. On first startup after restore, device-identity reconciliation and battery-model key migration are idempotent — nothing to do manually.
+
+## 8. Troubleshooting runbook
+
+### Driver hung (tick_count not advancing)
+
+**Symptom:** UI shows stale battery values; `/api/status` shows a fixed `tick_count` for a driver across multiple requests.
+
+**Confirm:**
+
+```bash
+for i in 1 2 3 4 5; do
+  curl -s localhost:8080/api/status | jq '.drivers'
+  sleep 2
+done
+```
+
+The tick should advance every control interval (default 5 s). If it doesn't, the driver VM is wedged.
+
+**Fix:** The watchdog (`site.watchdog_timeout_s`, default 60 s) auto-reverts stuck drivers to their autonomous defaults — you'll see `driver telemetry stale — marking offline + reverting to autonomous` in the log. For a full reset of MQTT/Modbus client state:
+
+```bash
+sudo systemctl restart forty-two-watts
+```
+
+### MQTT broker connection lost
+
+**Symptom:** Ferroamp telemetry frozen; `MQTT disconnected` or reconnect attempts in the log.
+
+**Confirm:**
+
+```bash
+tail -f /home/fredde/forty-two-watts-go/forty-two-watts.log | grep -i mqtt
+ping -c 3 192.168.1.X   # your broker IP
+```
+
+**Fix:** The paho MQTT client auto-reconnects — a short network hiccup self-heals. If the broker is down, bring it up. If credentials changed, edit `config.yaml` (the `mqtt.*` block) and save — hot-reload will respawn the driver.
+
+### Dispatch not following targets
+
+**Symptom:** Battery doesn't move toward the commanded target.
+
+**Confirm:** compare `dispatch[].target_w` vs `drivers.<name>.bat_w` in `/api/status`:
+
+```bash
+curl -s localhost:8080/api/status | jq '{targets: .dispatch, drivers: .drivers}'
+```
+
+**Common causes:**
+
+- `power_w` field not threaded through the driver payload (a real regression that was fixed; see commit `9237156`).
+- Driver forced into a manual/autonomous mode that conflicts with EMS commands.
+- Saturation curve in the battery model too restrictive — check `/api/models` for a pathological gain.
+- Sign confusion: remember `bat_w > 0` = discharging, `bat_w < 0` = charging.
+
+### PV prediction wildly off
+
+**Symptom:** `/api/pvmodel` shows huge β coefficients; the twin chart shows e.g. −13 kW for a 10 kW system.
+
+**Fix:** Reset the PV model; the sanity envelope will keep it in range thereafter.
+
+```bash
+curl -X POST localhost:8080/api/pvmodel/reset
+```
+
+### Battery model orphaned after rename
+
+**Symptom:** You rename a driver in `config.yaml` and the battery model for it appears "lost" in `/api/models`.
+
+**Fix:** It shouldn't actually be lost — models are re-keyed by `device_id`, which resolves the same physical hardware to the same key. Verify:
+
+```bash
+curl -s localhost:8080/api/devices | jq
+```
+
+If the device_id is endpoint-only (no serial yet) and you changed the IP / endpoint at the same time, the key *will* change and you'll get a cold-start. Restore the old endpoint, or accept re-learning.
+
+### Site meter stale → batteries idling
+
+**Symptom:** `WARN: site meter telemetry stale — idling batteries this cycle` in the log; batteries sit at 0 W regardless of demand.
+
+This is a **safety feature**, not a bug: stale grid readings would otherwise cause one battery to charge another. The control loop refuses to dispatch until the site meter recovers.
+
+**Fix:** Investigate the site meter driver (Ferroamp by default — check `site.meter_driver` in `config.yaml`). Common causes: MQTT broker lost, network partition, Ferroamp rebooted. Restart the service if the driver process itself is wedged.
+
+### Service won't start: port 8080 in use
+
+**Confirm:**
+
+```bash
+sudo lsof -i :8080
+```
+
+**Fix:** Kill the conflicting process — usually a stale forty-two-watts from a crash that didn't shut down cleanly. `sudo systemctl stop forty-two-watts` first (in case systemd is racing you), then kill the orphan, then `sudo systemctl start forty-two-watts`.
+
+### Config reload rejected
+
+**Symptom:** You edited `config.yaml` and saved, but no `config reload: applied` line appears — just a `config reload failed err=…`.
+
+**Fix:** The old config is still live; the site is safe. Read the error (usually a YAML syntax issue or a validation failure such as "no site meter"), fix, save again. If you want to force a full restart after a big change, `sudo systemctl restart forty-two-watts`.
+
+## 9. Resource expectations
+
+On a Raspberry Pi 4 (4 GB):
+
+| Resource | Typical | Notes |
+|---|---|---|
+| RAM (RSS) | 50–80 MB | Capped at 512 MB by `MemoryMax` in the unit |
+| CPU | < 5% idle | Brief spikes during MPC replan (~600 µs DP solve, every `planner.interval_min`) |
+| Disk (recent TSDB) | ~1 GB/month | `state.db` — auto-rolled off to `cold/` after 14 days |
+| Disk (cold archive) | ~100–200 MB/year | `cold/YYYY/MM/DD.parquet` — daily files, long-format |
+
+The rolloff loop runs once per hour and is cheap when nothing is due (a single `SELECT` returning 0 rows).
+
+## 10. Where state lives
+
+| File | Owner | Purpose | Backup priority |
+|---|---|---|---|
+| `state.db` | sqlite (WAL) | Config, models, devices, prices, forecasts, recent TSDB | High |
+| `state.db-wal`, `state.db-shm` | sqlite | WAL sidecars — include in backup | High |
+| `cold/YYYY/MM/DD.parquet` | rolloffLoop | Long-format TS history > 14 days | Medium |
+| `config.yaml` | operator | All operator-tunable settings | High |
+| `forty-two-watts.log` | service | Diagnostic log (stdout redirect) | Low |
+
+See [architecture.md](architecture.md) for the full data flow.


### PR DESCRIPTION
## Summary

Adds `docs/operations.md` — the operator-focused guide for running forty-two-watts on a Raspberry Pi.

Covers:

- Build + cross-compile (`CGO_ENABLED=0 GOOS=linux GOARCH=arm64`, Makefile targets)
- Files to deploy + suggested Pi layout
- The `deploy/forty-two-watts.service` unit (quoted verbatim)
- Service lifecycle + low-downtime binary swap recipe
- Log locations (file log vs journald split from the unit)
- Hot-reload semantics — what `fsnotify` applies live vs what needs a restart
- Backup + restore (SQLite WAL + cold parquet + config.yaml)
- Troubleshooting runbook — driver hung, MQTT drop, dispatch stuck, PV model runaway, battery model after rename, stale site meter, port conflict, config reload rejected
- Resource expectations on a Pi 4 (~50-80 MB RSS, <5% CPU idle)
- Where state lives (table)

All command-line flags, log strings, and service-unit content verified against source (`go/cmd/forty-two-watts/main.go`, `go/internal/configreload/watcher.go`, `deploy/forty-two-watts.service`, `Makefile`).

## Test plan

- [x] `cd go && go build ./...` clean
- [x] `cd go && go test -timeout 120s -count=1 ./...` all green (including e2e)
- [x] Bash code blocks pass `bash -n` syntax check
- [x] All internal markdown links resolve to existing files on this branch
- [x] systemd unit content matches `deploy/forty-two-watts.service` byte-for-byte