### PR TITLE
Docs: per-package CLAUDE.md for IO + plumbing layers

### DIFF
--- a/go/internal/api/CLAUDE.md
+++ b/go/internal/api/CLAUDE.md
@@ -1,0 +1,59 @@
+# api — HTTP REST + static UI server on :8080
+
+## What it does
+
+Single `http.ServeMux` that serves JSON endpoints for every operator-facing concern (health, status, config, mode, drivers, battery models, self-tune, history, prices, forecast, MPC, PV/load twins, series, devices, HA status) plus fall-through static file serving for the web UI. Uses Go 1.22+ method-scoped routing (`"GET /api/foo"`) so GET + POST can live on the same path. No WebSockets yet — clients poll.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Deps` | Container of pointers to every subsystem the handlers touch (`api.go:40`). |
+| `Server` | Owns `*http.ServeMux` + `*Deps`; returned by `New(deps)`. |
+
+`Deps` fields include `Tel *telemetry.Store`, `Ctrl *control.State` + `CtrlMu`, `State *state.Store`, `Capacities` + `CapMu`, `Cfg` + `CfgMu`, `Models` + `ModelsMu`, `SelfTune`, `Prices`, `Forecast`, `MPC`, `PVModel`, `LoadModel`, `HA`, `SaveConfig` (injected for testability), `WebDir`, `Version`. Nothing is auto-wired — `main.go` constructs and passes.
+
+## Public API surface
+
+- `New(deps *Deps) *Server`
+- `(*Server).Handler() http.Handler` — for `http.ListenAndServe`.
+- `(*Server).handle(methodPath, handler)` is internal; see `api.go:134`.
+
+Endpoint groups (route table is `api.go:95-130`):
+
+| Group | Routes |
+|---|---|
+| status | `GET /api/health`, `GET /api/status` |
+| control | `GET|POST /api/mode`, `POST /api/target`, `POST /api/peak_limit`, `POST /api/ev_charging` |
+| config | `GET|POST /api/config` |
+| drivers | `GET /api/drivers`, `GET /api/drivers/catalog` |
+| devices | `GET /api/devices` |
+| battery_models | `GET /api/battery_models`, `POST /api/battery_models/reset` |
+| self_tune | `POST /api/self_tune/start`, `GET /api/self_tune/status`, `POST /api/self_tune/cancel` |
+| history / series | `GET /api/history`, `GET /api/series`, `GET /api/series/catalog` |
+| prices / forecast | `GET /api/prices`, `GET /api/forecast` |
+| mpc | `GET /api/mpc/plan`, `POST /api/mpc/replan` |
+| twins | `GET /api/pvmodel`, `POST /api/pvmodel/reset`, `GET /api/loadmodel`, `POST /api/loadmodel/reset` |
+| ha | `GET /api/ha/status` |
+| static | `/` falls through to `Deps.WebDir` |
+
+## How it talks to neighbors
+
+Pure consumer. Every read goes through the corresponding package's public getters (`telemetry.Store.Get / AllHealth / ReadingsByType`, `state.Store.LoadHistory / LoadSeries / AllDevices`, `control.State.Mode / LastTargets`, `ha.Bridge.IsConnected / LastPublishMs`, …). Every write takes the package's mutex before mutating (`CtrlMu` for control state, `CapMu` for capacities, `ModelsMu` for models, `CfgMu` for config). `handlePostConfig` writes via the injected `SaveConfig` so tests can stub disk I/O.
+
+## What to read first
+
+1. `api.go:40-74` — the `Deps` struct documents the whole dependency graph.
+2. `api.go:95-130` — `routes()` is the complete route table.
+3. `api.go:134-140` — `handle()` shows how Go 1.22 method-scoped routing is used.
+4. `api.go:144-159` — `writeJSON` / `readJSON` are the only response helpers; 1 MB body cap on inputs.
+5. Any specific handler — most are 10-30 LOC of "take mutex, copy state, release, render".
+
+## What NOT to do
+
+- **Do NOT mutate state without the matching mutex.** Every handler that touches `Deps.Ctrl`, `Deps.Capacities`, `Deps.Models`, or `Deps.Cfg` must take the paired mutex and release it before writing the response.
+- **Do NOT add a route outside `routes()`.** Keeping the table in one place is the only way to see the whole surface. If you need dynamic registration, that's a design smell.
+- **Do NOT read unbounded request bodies.** `readJSON` caps at 1 MB (`api.go:153`); preserve that for new handlers.
+- **Do NOT couple a handler to a concrete implementation the other packages didn't expose.** If you reach for an unexported field you'll break `main.go`'s wiring. Extend the subsystem's public API first.
+- **Do NOT forget `Deps.SaveConfig`.** Config-writing handlers call it (not `os.WriteFile` directly) so tests can inject an in-memory fake.
+- **Do NOT add CORS logic per-handler.** `writeJSON` already sets `Access-Control-Allow-Origin: *` (`api.go:146`); duplicate headers confuse browsers.

--- a/go/internal/arp/CLAUDE.md
+++ b/go/internal/arp/CLAUDE.md
@@ -1,0 +1,30 @@
+# arp — best-effort IPv4 → MAC resolution for hardware-stable device identity
+
+## What it does
+
+Resolves an IPv4 address to its MAC on the local L2 segment so Modbus-TCP / HTTP / LAN-MQTT devices get a stable `device_id` even when they don't expose a serial number in their protocol. Pure Go; no CGo; no raw sockets. Linux reads `/proc/net/arp`; macOS shells out to `/usr/sbin/arp`. Before every lookup, a single 50 ms TCP probe is sent to one of `{80, 502, 1883}` to nudge the kernel ARP cache — the SYN packet triggers ARP even if the connect itself fails.
+
+## Key types
+
+No public types — one package-level function and one test-stub `readFile`.
+
+## Public API surface
+
+- `Lookup(ipStr string) (mac string, ok bool)` — returns `("", false)` for non-IPv4 input, cross-VLAN hosts, or "(incomplete)" entries (`arp.go:28`).
+- `readFile` (unexported, overridden in tests) — indirection over `os.ReadFile` so `lookupLinux` can be unit-tested against a fixture.
+
+## How it talks to neighbors
+
+`../drivers.Registry.ARPLookup` is set to `arp.Lookup` in `cmd/forty-two-watts/main.go:138`. At `Registry.Add` time, when a driver has an MQTT or Modbus config, the registry extracts the host string, calls `ARPLookup(host)`, and records the MAC on `HostEnv` via `SetMAC` (`drivers/registry.go:121-134`). That MAC then flows into `state.RegisterDevice` via `HostEnv.FullIdentity()`, producing a `mac:<addr>` device_id preferred over the `ep:<hash>` fallback. See `docs/site-convention.md` for how identity roots downstream state (battery models, history).
+
+## What to read first
+
+`arp.go` is one file. Read `Lookup` for the call path, then `lookupLinux` for the `/proc/net/arp` parse (flags field is ignored — "incomplete" presents as `00:00:00:00:00:00`, rejected at line 62) and `lookupDarwin` for the macOS `arp -n` parse including the single-digit-octet normalization at lines 84-86.
+
+## What NOT to do
+
+- **Do NOT expect cross-subnet resolution.** The kernel only ARPs within L2. If the device is behind a router, `Lookup` returns `("", false)` and that's intentional — device_id falls back to the endpoint hash (`drivers/registry.go:119-122` says "that's fine").
+- **Do NOT call `Lookup` from a hot path.** The TCP nudge is 50 ms × up-to-3 ports worst case. It's meant to run once at driver-Add time, not every poll.
+- **Do NOT add Windows support silently.** The current switch falls through to `("", false)` on non-linux/darwin (`arp.go:44-45`). A Windows implementation would need `GetIpNetTable` or `arp -a` parsing, and should be a new file.
+- **Do NOT rely on the probe for connectivity checks.** The probe is silent on failure by design — a closed port 80 still resolves ARP because the kernel sends the SYN. Use the driver's own protocol for "is the device up?".
+- **Do NOT normalize MACs elsewhere.** Both OS parsers already lowercase and zero-pad; keep consumers consuming the canonical `aa:bb:cc:dd:ee:ff` form.

--- a/go/internal/configreload/CLAUDE.md
+++ b/go/internal/configreload/CLAUDE.md
@@ -1,0 +1,34 @@
+# configreload — fsnotify watcher with debounced reload + per-section diff
+
+## What it does
+
+Watches the *directory* containing `config.yaml` (not the file itself — editor rename/atomic-save breaks file-level watchers), coalesces events with a 500 ms debounce, re-parses via `config.Load`, applies changes to the running `control.State` atomically, and dispatches a `(new, old)` diff to an `Applier` callback so subsystems that need restarting (drivers, prices, MPC, etc.) can decide per-section.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Applier` | `func(new, old *config.Config)` — called after a successful reload so the caller can diff each section and decide what to restart (`watcher.go:20`). |
+| `Watcher` | Holds the fsnotify handle, the shared config pointer + its `RWMutex`, and the control state + its `Mutex`. |
+
+## Public API surface
+
+- `New(path, cfgMu, cfg, ctrlMu, ctrl, applier) (*Watcher, error)` — returns `nil, err` if fsnotify setup or directory registration fails.
+- `(*Watcher).Start()` — spawns the watch goroutine; idempotent against restarts.
+- `(*Watcher).Stop()` — closes the stop channel and the fsnotify watcher.
+
+## How it talks to neighbors
+
+Calls `config.Load(path)` on each debounced event; on parse failure the old pointer is left intact (`watcher.go:100-102`) — atomic-switch guarantee. Applies control-layer scalars inline under `ctrlMu` (grid target, tolerance, slew rate, min dispatch interval — `watcher.go:111-123`). Everything else is punted to the `applier` callback wired in `cmd/forty-two-watts/main.go`, which is where driver-registry `Reload`, price-service restart, MPC re-config, etc. get triggered per section. No imports of `drivers`, `mpc`, `prices`, `ha` — keeps the watcher generic.
+
+## What to read first
+
+`watcher.go` — the whole package. Look at `loop()` (`watcher.go:70-96`) for the debounce pattern: events reset the 500 ms timer; only when it fires does `reload()` run. Then `reload()` (`watcher.go:98-136`) shows the atomic-switch order: parse first, mutate control state, then swap the `*cfg` pointer, then call `applier`.
+
+## What NOT to do
+
+- **Do NOT watch the file directly.** Editors commonly do write→rename to save atomically; `fsnotify` loses the inode. The package watches `filepath.Dir(path)` and filters by basename (`watcher.go:45-47`, `:82`). Don't "simplify" that.
+- **Do NOT skip the debounce.** A single editor save fires Write + Rename + Create in rapid succession; the 500 ms coalesce is what stops a triple-reload. If you need faster reloads, build a manual trigger on top, don't remove the timer.
+- **Do NOT apply every section inline.** Only the cheap control-scalar changes live in `reload()`. Driver restarts, price fetcher restarts, MPC re-planning, etc. all belong in the `applier` callback so subsystems can diff what *they* care about and avoid unnecessary restarts.
+- **Do NOT leave `*cfg` half-updated.** `reload` takes `cfgMu` for writing and does a full `*cfg = *newCfg` in one statement (`watcher.go:127-129`) — keep that single-assignment pattern so readers under `RLock` always see a consistent snapshot.
+- **Do NOT log-and-continue when parsing fails.** `reload` explicitly returns early on `config.Load` error (`watcher.go:100-103`); replacing that with a partial apply would silently drift the running system from disk.

--- a/go/internal/drivers/CLAUDE.md
+++ b/go/internal/drivers/CLAUDE.md
@@ -1,0 +1,51 @@
+# drivers — Lua/WASM driver host with capability-gated I/O
+
+## What it does
+
+Spawns one goroutine per device driver, running either a Lua 5.1 script (via `yuin/gopher-lua`) or a WASM module (via `tetratelabs/wazero`). Exposes a fixed lifecycle (`driver_init` → `driver_poll` loop + `driver_command`/`driver_default` → `driver_cleanup`) plus a capability-gated host API (log, emit, MQTT, Modbus, identity). Drivers are FAT: all protocol parsing, state machines, and retries live in the driver; the host only provides I/O and time.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Registry` | Owns running drivers, runs per-driver `runLoop`, handles add/remove/reload. |
+| `driverRuntime` (unexported interface) | Shared shape over Lua + WASM so `runLoop` is runtime-agnostic (`registry.go:46`). |
+| `LuaDriver` | gopher-lua VM bound to one `HostEnv` (`lua.go:47`). |
+| `Driver` | wazero module instance bound to one `HostEnv` (`runtime.go:35`). |
+| `Runtime` | Shared wazero runtime across WASM drivers (`runtime.go:18`). |
+| `HostEnv` | Per-driver context: capabilities, telemetry store, identity (`host.go:43`). |
+| `MQTTCap` / `ModbusCap` | Capability interfaces implemented by `../mqtt` and `../modbus` (`host.go:20`, `host.go:35`). |
+| `MQTTMessage` | Inbound message `{topic, payload}` drained via `PopMessages` (`host.go:29`). |
+| `CatalogEntry` | Metadata scraped from the `DRIVER={…}` block at the top of each `.lua` file (`catalog.go:15`). |
+
+## Public API surface
+
+- `NewRegistry(rt, tel)` + `Add / Remove / Reload / Send / SendDefault / ShutdownAll / Names / Env`.
+- `NewRuntime(ctx)` / `Runtime.Load(ctx, path, env)` / `Runtime.LoadBytes` for WASM.
+- `NewLuaDriver(path, env)` for Lua.
+- `NewHostEnv(name, tel)` + `WithMQTT / WithModbus / SetEndpoint / SetMAC`.
+- `HostEnv.Identity() / FullIdentity()` for `state.RegisterDevice` wiring.
+- `LoadCatalog(dir)` walks `.lua` files and extracts the DRIVER metadata table.
+- ABI constants: `StatusOk/Error/Unsupported`, `LogTrace…LogError`, `ModbusCoil…ModbusInput`, `ABIVersionMajor/Minor` (`abi.go`).
+
+## How it talks to neighbors
+
+`Registry.Add` resolves capabilities via the injected `MQTTFactory` / `ModbusFactory` / `ARPLookup` (wired in `cmd/forty-two-watts/main.go`). MAC resolution comes from `../arp`; endpoint is set from the MQTT/Modbus config. The HostEnv owns a pointer to `../telemetry.Store` — `emitTelemetry` routes structured pv/battery/meter readings through `Store.Update`, `emitMetric` routes scalar diagnostics through `Store.EmitMetric`, and each successful poll records a health tick via `DriverHealthMut`. The Lua backend adapts a `map[string]any` config at the boundary (`registry.go:70`), while WASM passes raw JSON (`runtime.go:248`). See `docs/lua-drivers.md` and `docs/host-api.md`.
+
+## What to read first
+
+1. `registry.go` — `Add`, `runLoop`, `Reload`, and the `driverRuntime` adapter layer.
+2. `host.go` — HostEnv + capability interfaces + identity fields.
+3. `lua.go` — registration of the `host.*` global and the gopher-lua bridge.
+4. `runtime.go` — wazero host module builder, lifecycle dispatch, WASI stdout→slog.
+5. `abi.go` — the stable WASM ABI (exports, imports, status codes).
+6. `catalog.go` — how the UI discovers available drivers.
+
+## What NOT to do
+
+- **Do NOT reuse an MQTT `clientID` across drivers.** `main.go:133` prefixes with `ftw-<name>` for a reason — brokers disconnect duplicates.
+- **Do NOT register a new driver backend by touching `runLoop` directly.** Add a new `driverRuntime` adapter alongside `wasmRuntime` / `luaRuntime` (`registry.go:55-79`) and let `Add` pick it by extension. Lua is the recommended path for new drivers.
+- **Do NOT share a wazero module across drivers.** `LoadBytes` closes the existing `host` module each time (`runtime.go:70`) — a shared runtime would need name-prefixed host modules.
+- **Do NOT call into a nil capability.** Gate every MQTT/Modbus access with the `env.MQTT != nil` / `env.Modbus != nil` check (the host proxies already do — see `host.go:197+`). Drivers get `ErrNoCapability` back.
+- **Do NOT assume ARP lookup succeeds.** Cross-VLAN devices return `("", false)`; identity must fall back to the endpoint hash (`registry.go:119-134`).
+- **Do NOT bypass the command channel.** All driver mutations go through `rd.cmdCh` so they serialize with `Poll` on the same goroutine. Calling `Command` directly from another goroutine is a data race against gopher-lua's single-threaded VM.

--- a/go/internal/forecast/CLAUDE.md
+++ b/go/internal/forecast/CLAUDE.md
@@ -1,0 +1,41 @@
+# forecast — weather fetcher + naive PV production estimate
+
+## What it does
+
+Fetches hourly weather (cloud cover + air temp, optionally shortwave irradiance) from one of two providers, derives a rough PV production curve from a geometric clear-sky model × cloud attenuation, and persists both the raw forecast and the PV estimate into `state.Store.SaveForecasts`. Runs a 3-hourly refresh goroutine for the lifetime of the process. Acts as the MPC fallback when the `pvmodel` digital-twin is disabled or cold.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Provider` | Interface every weather source implements (`Name() / Fetch(ctx, lat, lon)`). |
+| `RawForecast` | One hour of parsed upstream data (cloud %, temp, optional solar W/m²). |
+| `MetNoProvider` | api.met.no locationforecast/2.0/compact, no API key, UA required. |
+| `OpenWeatherProvider` | OpenWeatherMap One Call 3.0, API key required. |
+| `Service` | Owns a provider + `*state.Store` + lat/lon + rated PV W; runs the refresh loop. |
+
+## Public API surface
+
+- `NewMetNo(userAgent string) *MetNoProvider` — `userAgent` defaults to the app name if empty (`forecast.go:62`). met.no blocks default UAs.
+- `NewOpenWeather(apiKey string) *OpenWeatherProvider`.
+- `FromConfig(cfg *config.Weather, ratedPVW float64, st *state.Store, userAgent string) *Service` — returns `nil` if provider is `""` / `"none"` / unknown.
+- `(*Service).Start(ctx)` / `Stop()` — kicks the refresh loop; `Stop` waits for it to exit.
+- `(*Service).Load(sinceMs, untilMs)` — passthrough to `state.Store.LoadForecasts`.
+- `ClearSkyW(lat, lon, t)` — geometric solar irradiance on a horizontal surface (W/m²). Simplified Bird model; good enough for scaling.
+- `EstimatePVW(lat, lon, t, cloudPct, ratedW)` — `ratedW × (clear_sky_w / 1000) × (1 − cloud/100)^1.5`.
+
+## How it talks to neighbors
+
+Writes via `state.Store.SaveForecasts([]state.ForecastPoint)` and reads via `LoadForecasts` — that's the only persistence dependency. `cmd/forty-two-watts/main.go` constructs the Service from the `config.Weather` section and passes the `*Service` into `mpc.Service` (fallback PV curve) and `api.Deps.Forecast` (the `GET /api/forecast` handler). No import of `drivers`, `telemetry`, or `control` — forecasts are a pure input to the planner.
+
+## What to read first
+
+`forecast.go` is the whole package. Read top-to-bottom: the provider implementations (met.no @ `:54`, openweather @ `:124`), then the clear-sky math (`ClearSkyW` @ `:189`), then the two-line PV estimate (`EstimatePVW` @ `:225`), then the refresh loop in `(*Service).loop` at `:286`.
+
+## What NOT to do
+
+- **Do NOT treat `EstimatePVW` as a physics model.** It's a rough directional signal for MPC / pre-charge — full tilt/azimuth/soiling belongs in `pvmodel` (the RLS digital-twin adapts to actual production over time). Don't overfit here.
+- **Do NOT hit met.no without a User-Agent.** `NewMetNo("")` fills one in (`forecast.go:62`); a plain paho / default Go UA gets 403s.
+- **Do NOT refresh faster than hourly.** The scheduler is hard-coded to 3 h (`forecast.go:289`). Both providers have fair-use policies; faster polling gets you banned.
+- **Do NOT assume the forecast is always present.** Downstream consumers (`mpc`) must gracefully handle empty `LoadForecasts` — the service returns `nil` from `FromConfig` when weather is disabled, so the `*Service` pointer itself can be `nil`.
+- **Do NOT add a new provider without matching `Name()` to the config enum.** `FromConfig`'s switch (`forecast.go:258-265`) is the contract — a new provider also needs a config key documented in `docs/configuration.md`.

--- a/go/internal/ha/CLAUDE.md
+++ b/go/internal/ha/CLAUDE.md
@@ -1,0 +1,37 @@
+# ha — Home Assistant MQTT bridge (autodiscovery + state + commands)
+
+## What it does
+
+One-shot autodiscovery publisher + periodic state pump + command subscriber, all on a dedicated paho MQTT client separate from the per-driver clients in `../mqtt`. On connect it registers site-level sensors (grid/pv/battery/load/SoC/grid_target), a `select` for mode, a `number` for grid target, and four per-driver sensors (`meter_w`, `pv_w`, `bat_w`, `bat_soc_pct`); then it publishes values every `PublishIntervalS` seconds and listens for four command topics. The site sign convention from `docs/site-convention.md` is honored throughout — HA charts drop in without flipping signs.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Bridge` | The running service (paho client, pub loop, diagnostics counters). |
+| `CommandCallbacks` | Callbacks into the control layer: `SetMode / SetGridTarget / SetPeakLimit / SetEVCharging` (`bridge.go:28`). |
+
+## Public API surface
+
+- `Start(cfg, tel, ctrl, ctrlMu, driverNames, cb) (*Bridge, error)` — connects, publishes discovery, starts the publish loop.
+- `(*Bridge).Stop()` — closes the stop channel, waits for the loop, disconnects with 500 ms quiesce.
+- `(*Bridge).IsConnected() bool` / `BrokerAddr() string` / `LastPublishMs() int64` / `SensorsAnnounced() int` — diagnostics consumed by `/api/ha/status` in `../api`.
+
+## How it talks to neighbors
+
+Reads `../telemetry.Store` via `Get(driver, DerMeter/PV/Battery)` and `ReadingsByType` to aggregate per-driver smoothed values, then publishes under `forty-two-watts/state/<field>` for site aggregates and `forty-two-watts/driver/<name>/<field>` for per-driver rows (`bridge.go:357-361`). Discovery messages go under `homeassistant/sensor|select|number/forty_two_watts/…/config` (retained). Commands arrive on `forty-two-watts/cmd/{mode, grid_target_w, peak_limit_w, ev_charging_w}` and are forwarded to the injected `CommandCallbacks`; all callbacks run under the caller-supplied `ctrlMu` semantics. See `docs/ha-integration.md`.
+
+## What to read first
+
+1. `bridge.go:105-139` — `Start` wires the paho options, the `OnConnect` re-publishes discovery on every reconnect (HA de-dupes by `unique_id`, so it's safe).
+2. `bridge.go:163-244` — `publishDiscovery` is the schema — add a new HA entity here.
+3. `bridge.go:248-278` — `subscribeCommands` is the inbound routing table.
+4. `bridge.go:299-353` — `publishState` is where aggregation happens; this is what moves every 5 s.
+
+## What NOT to do
+
+- **Do NOT share the paho client with `../mqtt` or a driver.** The bridge uses `clientID = "forty-two-watts-ha"` and sets its own `OnConnectHandler` that re-publishes discovery — that's all wrong for a driver. Keep it isolated.
+- **Do NOT block in a subscribe callback.** The callbacks in `subscribeCommands` must return fast; if a callback needs heavy work, dispatch it onto a goroutine (current callbacks are atomic control-state setters, which is fine).
+- **Do NOT drop the site sign convention when adding a sensor.** `publishState` pulls `SmoothedW` values that are already signed per the convention; HA's `device_class: power` expects those signs. Flipping here would confuse every existing dashboard.
+- **Do NOT change `deviceID` or `topicPrefix` casually.** HA devices and retained discovery topics are keyed on them; a rename orphans every existing HA entity. Migrate with intention.
+- **Do NOT add QoS > 0 for telemetry.** Publish at QoS 0; the 5 s cadence makes QoS 1 storage-of-unacked messages an unnecessary memory hazard on long reconnects. Retained discovery is the exception (line 189).

--- a/go/internal/modbus/CLAUDE.md
+++ b/go/internal/modbus/CLAUDE.md
@@ -1,0 +1,35 @@
+# modbus — per-driver Modbus TCP capability built on simonvetter/modbus
+
+## What it does
+
+Wraps one `simonvetter/modbus.ModbusClient` per driver and implements `drivers.ModbusCap`. TCP-only (no serial/RTU). All calls are serialized behind a `sync.Mutex` so a driver's poll-read can't race its command-write on the same connection.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Capability` | `simonvetter/modbus.ModbusClient` + `sync.Mutex`. Implements `drivers.ModbusCap`. |
+
+## Public API surface
+
+- `Dial(host, port, unitID int) (*Capability, error)` — opens TCP, sets unit ID when `> 0`, 5 s timeout (`client.go:22-33`).
+- `(*Capability).Close() error` — releases the underlying socket.
+- `(*Capability).Read(addr, count uint16, kind int32) ([]uint16, error)` — `kind` uses the ABI constants from `drivers/abi.go` (`ModbusInput=3`, `ModbusHolding=2`). Anything else falls back to input registers (`client.go:47-51`).
+- `(*Capability).WriteSingle(addr, value uint16) error` — single holding register.
+- `(*Capability).WriteMulti(addr uint16, values []uint16) error` — bulk holding register write.
+
+## How it talks to neighbors
+
+`../drivers` Registry holds a `ModbusFactory` wired in `cmd/forty-two-watts/main.go:135-137` that calls `Dial(c.Host, c.Port, c.UnitID)` per driver. The returned `*Capability` is bound to the driver's `HostEnv.Modbus`. Lua drivers call `host.modbus_read / host.modbus_write / host.modbus_write_multi`; WASM drivers call the same names through their ABI exports (`drivers/runtime.go:152+`). The endpoint string `modbus://<host>:<port>` is recorded on the HostEnv for device-identity and the host IP gets ARP-resolved for MAC-stable `device_id`.
+
+## What to read first
+
+`client.go` — the entire package is ~68 LOC. Coils and discrete inputs are NOT currently implemented even though the ABI defines their codes (`ModbusCoil`, `ModbusDiscrete`). Add a switch case here if a driver needs them.
+
+## What NOT to do
+
+- **Do NOT share one `Capability` across drivers.** Mutex serializes the single socket; two drivers would stall each other. The factory builds one per driver on purpose.
+- **Do NOT add RTU/serial here without a separate type.** `sv.NewClient` is locked to `tcp://` URL form in `Dial` (`client.go:23`); a serial capability belongs in a sibling file (keep TCP free of serial-only timing code).
+- **Do NOT re-open on every call.** `Dial` opens once; reconnection comes from `simonvetter/modbus`'s internal retry. If a driver sees persistent errors it should log and surface health via `env.Telemetry.DriverHealthMut`.
+- **Do NOT decode `u32` / `i32` inside Lua by hand.** Use the `host.decode_u32_le` / `decode_u32_be` / `decode_i32_le` / `decode_i32_be` / `decode_i16` helpers exposed in `../drivers/lua.go:348-376` — Sungrow's little-endian pair order has caught people before.
+- **Do NOT pass a `kind` code outside `drivers.Modbus*`.** An unknown kind silently downgrades to input registers (`client.go:50`); that's a debugging nightmare if you treat it as "holding default".

--- a/go/internal/mqtt/CLAUDE.md
+++ b/go/internal/mqtt/CLAUDE.md
@@ -1,0 +1,35 @@
+# mqtt — per-driver MQTT capability built on paho.mqtt.golang
+
+## What it does
+
+Wraps one `paho.Client` per driver so each driver has its own broker connection, its own subscription set, and its own inbound message buffer. Implements `drivers.MQTTCap` (`Subscribe`, `Publish`, `PopMessages`). Auto-reconnect + 5 s connect-retry are on by default; inbound messages are buffered in a slice by the default publish handler and drained when the driver calls `host.mqtt_messages()`.
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Capability` | Wraps `paho.Client` + an inbound slice guarded by `sync.Mutex`. Implements `drivers.MQTTCap`. |
+
+## Public API surface
+
+- `Dial(host, port, username, password, clientID) (*Capability, error)` — connects, retries for 5 s, fails after 10 s total wait (`client.go:43`).
+- `(*Capability).Close()` — disconnects with 250 ms quiesce.
+- `(*Capability).Subscribe(topic string) error` — QoS 0, 5 s wait.
+- `(*Capability).Publish(topic string, payload []byte) error` — QoS 0, non-retained, 5 s wait.
+- `(*Capability).PopMessages() []drivers.MQTTMessage` — atomically drains and returns the inbound buffer.
+
+## How it talks to neighbors
+
+The `../drivers` registry holds an `MQTTFactory` function wired in `cmd/forty-two-watts/main.go:132-134` that calls `Dial(host, port, user, pass, "ftw-"+driverName)` for each driver that has an MQTT config. The returned `*Capability` is bound to the driver's `HostEnv` via `env.WithMQTT(cap)`; from then on the driver's Lua/WASM code calls `host.mqtt_subscribe` / `host.mqtt_publish` / `host.mqtt_messages`, which route through `drivers.MQTTCap`. The HA bridge (`../ha`) creates its own paho client — it does NOT go through this package.
+
+## What to read first
+
+`client.go` — the whole package is a single file. Pay attention to `SetDefaultPublishHandler` (`client.go:32`): every inbound message lands in `cap.incoming` regardless of topic, so make sure your driver only subscribes to topics it actually wants.
+
+## What NOT to do
+
+- **Do NOT reuse a `clientID` across drivers or processes.** Paho + broker behavior: the newer session kicks the older off. Always use the `ftw-<driver_name>` convention from `main.go`.
+- **Do NOT share one `Capability` between two drivers.** Each driver gets its own instance so subscriptions don't leak and `PopMessages` doesn't steal from a sibling.
+- **Do NOT add per-topic callbacks.** Messages are delivered through the default handler into the buffer, then pulled by the driver's poll loop — that's what keeps the Lua VM single-threaded (no callbacks into gopher-lua from paho goroutines).
+- **Do NOT assume messages survive restarts.** QoS is 0 and publish is non-retained; if a driver needs persistence it has to publish retained or use QoS 1/2 itself.
+- **Do NOT block the default publish handler.** It holds `cap.mu` while appending — keep the callback the cheap append it already is.


### PR DESCRIPTION
## Summary

- Adds a CLAUDE.md orientation brief to each of the eight IO / plumbing packages: `drivers`, `mqtt`, `modbus`, `arp`, `ha`, `api`, `forecast`, `configreload`.
- Each file follows the shared template: what it does / key types / public API surface / how it talks to neighbors / what to read first / what NOT to do — with file:line citations to the actual code.
- Cites the guard-rails that aren't obvious from reading one file (e.g. don't reuse MQTT clientIDs across drivers, don't watch the config file directly, don't call ARP lookup on a hot path, don't share a `Capability` between drivers).

## Test plan

- [x] `cd go && go build ./...` — clean
- [x] `cd go && go test -timeout 120s -count=1 ./...` — all green
- [x] Every type / function / file:line citation verified via Grep against the actual source
- [x] Every `docs/*.md` link in the new files resolves (api.md reference removed since that doc no longer exists on this branch)

Co-authored-by the harness; see commit trailer.