### PR TITLE
Docs: per-package CLAUDE.md for ML/optimization stack

### DIFF
--- a/go/internal/battery/CLAUDE.md
+++ b/go/internal/battery/CLAUDE.md
@@ -1,0 +1,119 @@
+# battery — per-battery ARX(1) online identification
+
+## What it does
+
+RLS identification of a first-order battery model `y(t+1) = a·y(t) + b·u(t)`
+fed one (command, actual) pair per control cycle. Tracks a per-SoC
+saturation envelope from observed peaks. Drives the cascade controller: at
+confidence > 0.5 the outer PI's command is inverted through the model to
+produce the setpoint; below 0.5 the PI drives the plant directly.
+
+## Math
+
+ARX(1) prediction + residual (`model.go:234-238`):
+
+```
+phi  = [y_prev, u_prev]
+pred = a*y_prev + b*u_prev
+err  = y_actual - pred
+```
+
+RLS with forgetting `lambda = 0.99` (~100-sample window, `model.go:20`):
+
+```
+K       = P*phi / (lambda + phi^T*P*phi)
+[a, b] += K * err                     (clamped: a in [0.1, 0.99], b in [-1.5, 1.5])
+P       = (P - K * phi^T * P) / lambda
+```
+
+Derived quantities (`model.go:98-132`):
+
+```
+steady_state_gain = b / (1 - a)           (display-clamped to [0.3, 1.5])
+time_constant_s   = -dt / ln(a)           (clamped to [0.05, 60] s)
+confidence        = min(n/200, 1) * (1 - varEMA/10000)
+```
+
+Outlier rejection: after 20 samples skip when `|err| > 5*sigma`
+(`model.go:240-247`, `OutlierSigma = 5`).
+
+Saturation curve: per-SoC bucket (5% wide) track max observed |actual|;
+slow decay `0.9999` per update so old peaks fade
+(`model.go:322-335`). New buckets only seed when `value >= MinSatSeedW =
+1000 W` (`model.go:338-350`) — guards against a self-reinforcing clamp loop
+inherited from the Rust port.
+
+Inverse (cascade use): `inverse(target) = target / gain` when
+`|gain| ∈ [0.3, 2.0]`, else pass-through (`model.go:181-188`).
+
+Health baseline: `SetBaseline(gain, tau)` stores a self-tune snapshot.
+`HealthScore = 1 - 2 * |gain - baseline| / |baseline|` (clamped
+[0, 1], `model.go:146-155`). `HealthDriftPerDay` is linear regression slope
+over `GainHistory` in gain/day (`model.go:159-177`).
+
+## Inputs / outputs
+
+Per cycle: `Update(command, actual, soc, dtS, nowMs)` where `command` and
+`actual` are site-sign W (+ charge, − discharge), `soc` is fraction in
+[0, 1], `dtS` is the control period. Returns `true` when RLS actually
+moved (sample was informative).
+
+Reads:
+
+- `SteadyStateGain()`, `TimeConstantS(dt)`, `Confidence()`, `HealthScore()`,
+  `HealthDriftPerDay()`.
+- `Inverse(target)`, `ClampToSaturation(target, soc) (clamped, wasClamped)`.
+
+## Training cadence + persistence
+
+Cadence: one `Update` per control cycle (typically 5 s). Low-signal gate
+skips `|u| < 100 W` or, after warm-up, `|Δy| < 20 W` (`model.go:222-232`).
+
+Persistence: `state.Store.SaveBatteryModel(device_id, json)` where
+`device_id` is the resolved hardware identifier — NOT `driver_name`
+(store.go:261-270). Legacy `driver_name`-keyed rows are upgraded by
+`state.Store.MigrateBatteryModelKeys()` on boot (`state/devices.go:111`).
+Save cadence: every ~60 s from the control loop (models are serialized via
+`json.Marshal` and passed into `SaveBatteryModel`, see `api.go:533`).
+
+`LoadAllBatteryModels` returns a map keyed by current `driver_name`
+(joined through the `devices` table) so renames don't orphan trained
+state.
+
+## Public API surface
+
+- `New(name) *Model`
+- `(*Model).Update(cmd, actual, soc, dtS, nowMs) bool`
+- `(*Model).Inverse(target) float64`
+- `(*Model).ClampToSaturation(target, soc) (float64, bool)`
+- `(*Model).SteadyStateGain() / .SteadyStateGainRaw() / .TimeConstantS(dt)`
+- `(*Model).Confidence() / .HealthScore() / .HealthDriftPerDay()`
+- `(*Model).SetBaseline(gain, tau, nowMs)` — written by `selftune`.
+- `(*Model).SetFromStepFit(gain, tauS, dtS)` — overwrites ARX with a
+  clean step fit and resets covariance to indicate high confidence.
+- Types `Model`, `SoCPoint`, `GainPoint`; constants
+  `DefaultForgetting`, `InitialCov`, `SoCBucket`, `SatDecay`,
+  `MinCommandForRLS`, `MinDeltaForRLS`, `OutlierSigma`, `GainHistoryLen`,
+  `MinSatSeedW`.
+
+## How it talks to neighbors
+
+- `control` cascade calls `Inverse` + `ClampToSaturation` each cycle, then
+  feeds `(command, actual)` back via `Update`.
+- `selftune` writes cleanly-fit baselines via `SetFromStepFit` +
+  `SetBaseline`, and the health endpoints read them back.
+- State store: `SaveBatteryModel` + `LoadAllBatteryModels` (`state/store.go`).
+- Operator-facing docs: `docs/battery-models.md`.
+
+## What NOT to do
+
+- Do not store under `driver_name` — always resolve to `device_id` first
+  (see `batteryModelKey` in `state/store.go`). Renames in config will
+  otherwise lose weeks of training.
+- Do not lower `OutlierSigma` below ~3; brief transients during PV clipping
+  otherwise bias `a` downward.
+- Do not seed new saturation buckets below `MinSatSeedW = 1000 W`. A small
+  first observation at a new SoC becomes a clamp ceiling the battery can
+  never exceed.
+- Do not run RLS when `|u| < MinCommandForRLS = 100 W`. At that magnitude
+  `b` is dominated by noise.

--- a/go/internal/loadmodel/CLAUDE.md
+++ b/go/internal/loadmodel/CLAUDE.md
@@ -1,0 +1,107 @@
+# loadmodel — household load predictor (hour-of-week + heating)
+
+## What it does
+
+168 hour-of-week EMA buckets plus an operator-configured heating
+coefficient. Captures the weekly pattern that dominates residential load
+(morning peak, evening peak, weekend shift) without any basis functions.
+Trust-weighted blend with a baked Swedish-home prior makes day-one
+predictions plausible while the model refines itself from telemetry.
+
+## Math
+
+Bucket index (`model.go:102-106`):
+
+```
+HourOfWeek(t) = ((weekday + 6) % 7) * 24 + hour   (Mon=0 .. Sun=6)
+```
+
+Per-bucket blend (`model.go:111-131`):
+
+```
+trust   = min(bucket.Samples / 8, 1)    (MinTrustSamples = 8)
+base    = trust*bucket.Mean + (1-trust)*typicalPrior(idx)
+heating = max(HeatingReferenceC - tempC, 0) * HeatingW_per_degC
+y       = base + heating                 (clamped to [0, 3*PeakW])
+```
+
+Bucket update (`model.go:161-175`) — exact running mean for first 10
+samples, then EMA with `alpha = 0.1`. Subtracts the current heating estimate
+so the bucket tracks "base" load only:
+
+```
+baseSample = max(actualLoadW - heatEst, 0)
+bucket.Mean += alpha * (baseSample - bucket.Mean)    (after 10 samples)
+```
+
+Outlier gate: after 50 global samples, reject `|err| > max(10*MAE, 200 W)`
+(`model.go:151-156`).
+
+Baked prior (`model.go:67-81`): overnight 300 W, morning peak ~2000 W at
+07:00, midday 600 W at 13:00, evening peak ~2500 W at 18:30 (19:00 on
+weekends, with softened morning). `HeatingReferenceC = 18 °C`.
+
+## Inputs / outputs
+
+Per sample: `(t, actualLoadW, tempC)` where actualLoadW is derived in
+`Service.sample` (`service.go:144`):
+
+```
+loadW = grid_w - pv_w - bat_w     (site sign, negative skipped)
+```
+
+`Predict(t) float64` returns expected W. Uses `TempFunc` if wired, else
+assumes `HeatingReferenceC` (no heating contribution).
+
+## Training cadence + persistence
+
+Sample every `SampleInterval = 60s` (`service.go:44`). Skips when the site
+meter reading isn't available or `loadW < 0` (driver transient,
+`service.go:131-150`).
+
+Persistence: `state.Store.SaveConfig("loadmodel/state", …)` — constant at
+`service.go:19`. Persists every `PersistEvery = 10` samples and on stop.
+
+Reset: `POST /api/loadmodel/reset`.
+
+`HeatingW_per_degC` is operator-set via `Service.SetHeatingCoef` (called
+from config reload). Not fit online — too noisy and entangled with bucket
+baseline (`model.go:179-184`).
+
+## Public API surface
+
+Model (`model.go`):
+
+- `NewModel(peakW) *Model`, `HourOfWeek(t) int`
+- `(Model).Predict(t, tempC) float64`, `.PredictNoTemp(t) float64`
+- `(*Model).Update(t, actualLoadW, tempC) bool`
+- `(Model).Quality() float64`
+- Constants `Buckets = 168`, `MinTrustSamples = 8`, `HeatingReferenceC = 18`.
+
+Service (`service.go`):
+
+- `NewService(st, tel, siteMeter, peakW) *Service`
+- `(*Service).Start(ctx)` / `.Stop()` / `.Reset()`
+- `(*Service).Predict(t) float64`, `.Model() Model`
+- `(*Service).SetHeatingCoef(w float64)`
+- Injected func type `TempFunc` (forecast integration).
+
+## How it talks to neighbors
+
+- MPC consumes `Service.Predict` via the `mpc.LoadPredictor` func type
+  (`mpc/service.go:22`, wired in `main.go`).
+- Site meter name passed in from config; reads via
+  `telemetry.Store.Get(siteMeter, DerMeter)` + aggregates PV + battery.
+- `TempFunc` injected from the forecast cache so the heating term is
+  forecast-aware when planning cold nights.
+
+## What NOT to do
+
+- Do not use this to learn heating sensitivity — leave
+  `HeatingW_per_degC` as an operator input. Online fit co-varies with the
+  bucket baseline and gives noise.
+- Never train on `loadW < 0`; transient flows during PI steps can appear
+  negative. `sample()` already skips, keep it that way (`service.go:145`).
+- Do not remove the "subtract heating before EMA" step — a bucket should
+  learn base load, not "base + this week's weather".
+- Do not change `Buckets` without migrating stored state.

--- a/go/internal/mpc/CLAUDE.md
+++ b/go/internal/mpc/CLAUDE.md
@@ -1,0 +1,109 @@
+# mpc — receding-horizon battery scheduler
+
+## What it does
+
+Dynamic programming over a discretized SoC × action × slot grid. Turns price
+forecast + PV forecast + load forecast + current SoC into a per-slot
+`battery_w` schedule for the next 48h. Re-plans every 15 min on a ticker,
+plus off-schedule whenever live PV/load drifts far enough from the current
+slot's prediction.
+
+## Math
+
+Backward Bellman recursion over `V[t][s]` = min expected cost from slot `t`
+onward starting at SoC bucket `s` (`mpc.go:246`):
+
+```
+V[t][s] = min over actions a of  cost(slot_t, a, s) + V[t+1][s']
+```
+
+State transition with efficiency (`mpc.go:264-274`):
+
+```
+a >= 0 (charge):    ΔSoC_Wh =  a * dt * charge_eff
+a <  0 (discharge): ΔSoC_Wh =  a * dt / discharge_eff
+```
+
+Per-slot cost, confidence-blended toward horizon mean (`mpc.go:192-215`):
+
+```
+effPrice = c*raw + (1-c)*mean     (c = slot.Confidence)
+cost = effPrice * gridKWh              if importing
+cost = -(SpotOre + bonus - fee) * |gridKWh|   if exporting
+```
+
+Terminal credit for leftover SoC: `-TerminalSoCPrice * kWh_remaining`
+(`mpc.go:240-243`), default = mean import price over horizon so the planner
+is SoC-neutral.
+
+Reactive replan: 15-min half-life leaky integral of `(actual - forecast)`
+for PV and load (`service.go:266-290`). Trigger when `|pvErrIntWh| > 500 Wh`
+or `|loadErrIntWh| > 400 Wh` (defaults at `service.go:104-105`), subject to
+60s cooldown (`MinReplanGap`).
+
+## Inputs / outputs
+
+Inputs:
+
+- `[]Slot` with `PriceOre` (consumer total), `SpotOre` (raw for export),
+  `PVW` (site-sign, ≤ 0), `LoadW` (site-sign, ≥ 0), `Confidence` in [0,1].
+- `Params`: mode, SoC bounds + grid size, action bounds + grid size,
+  charge/discharge efficiency, terminal SoC price, export bonus/fee.
+- Injected predictors (optional): `PVPredictor`, `LoadPredictor`,
+  `PricePredictor`, all `service.go:18-28`.
+
+Output: `Plan` — `Actions[]` with `BatteryW`, `GridW`, `SoCPct`,
+`CostOre`, `PVLimitW` (curtailment, 0 = none), `Reason` (human string).
+
+`Service.GridTargetAt(now)` returns `(gridW, true)` for the slot covering
+`now`; `(0, false)` when plan missing, older than `MaxPlanAge = 30m`
+(`service.go:125`), or out of horizon.
+
+## Training cadence + persistence
+
+Plan lives in memory only (`Service.last`, `service.go:87`). No persistence;
+the next tick recomputes from fresh prices + model predictions. Re-plans on
+`Interval` (15m default) or reactive trigger. Defaults per battery grid are
+51 SoC × 21 action × 193 slots for 48h at 15-min resolution.
+
+## Public API surface
+
+Core optimizer (`mpc.go`):
+
+- `Optimize(slots []Slot, p Params) Plan`
+- `Mode` + constants `ModeSelfConsumption` / `ModeCheapCharge` / `ModeArbitrage`
+- Types `Slot`, `Params`, `Action`, `Plan`.
+
+Service (`service.go`):
+
+- `New(st, tl, zone, defaults) *Service`
+- `(*Service).Start(ctx)` / `.Stop()` / `.Latest()` / `.Replan(ctx)`
+- `(*Service).GridTargetAt(now) (float64, bool)`
+- `(*Service).SetMode(ctx, Mode)`
+- `(*Service).LastReplanInfo() (time.Time, string)`
+- Predictor hook types `PVPredictor`, `LoadPredictor`, `PricePredictor`.
+
+## How it talks to neighbors
+
+- `control/dispatch.go:42` injects `Service.GridTargetAt` as `PlanTargetFunc`.
+  Control loop consults it each cycle; falls back to self-consumption when
+  `(_, false)` is returned.
+- Reads price history via `state.Store.LoadPrices` and forecast via
+  `LoadForecasts` (`service.go:324,343`).
+- Reads live PV / battery / meter via `telemetry.Store` for SoC + divergence
+  checks (`service.go:242-260`).
+- Optionally consumes `pvmodel.Service.Predict`, `loadmodel.Service.Predict`,
+  `priceforecast.Service.Predict` via the injected func hooks.
+- Operator-facing docs: `docs/mpc-planner.md`.
+
+## What NOT to do
+
+- Do not import pvmodel / loadmodel / priceforecast here — they're wired via
+  function-typed fields in `Service` to avoid import cycles.
+- Do not treat `Plan.TotalCostOre` as the DP objective: it is the
+  raw-price re-scoring for the UI. The DP minimizes the confidence-blended
+  objective (`mpc.go:350-365`).
+- Do not remove the `MaxPlanAge` staleness check — the control loop relies
+  on it to bail back to self-consumption if the planner has stalled.
+- Do not feed forecasted (synthesized) prices with `Confidence = 1.0`;
+  `buildSlots` marks `Source == "forecast"` rows with 0.6 (`service.go:489-494`).

--- a/go/internal/priceforecast/CLAUDE.md
+++ b/go/internal/priceforecast/CLAUDE.md
@@ -1,0 +1,108 @@
+# priceforecast — zone-aware spot-price forecaster
+
+## What it does
+
+168 hour-of-week EMA buckets per bidding zone + 12 monthly multipliers.
+Bayesian blend with a baked Nordic prior so day-one predictions already
+have the right morning/evening shape. Backfills spot prices for slots
+beyond the day-ahead publication cutoff so the MPC can plan the overnight
+arbitrage run even when tomorrow's prices aren't out yet.
+
+## Math
+
+Bucket index (`forecast.go:235-239`):
+
+```
+hourOfWeek(t) = ((weekday + 6) % 7) * 24 + hour    (UTC, Mon=0..Sun=6)
+```
+
+Bayesian blend per bucket (`forecast.go:192-204`):
+
+```
+posterior = (priorValue * PriorWeight + sum_observed) / (PriorWeight + n_observed)
+```
+
+With `PriorWeight = 8` (`forecast.go:163`) two real samples give
+80% prior + 20% fitted; 40 samples give 17% prior + 83% fitted. Month
+multipliers use the same blend but over normalized ratios
+(`forecast.go:209-222`).
+
+Prediction (`forecast.go:137-140`):
+
+```
+spot(t) = Bucket[hourOfWeek(t)] * Month[month(t)-1]
+```
+
+Baked prior shape (`forecast.go:79-121`): morning ramp 07–09 (×1.6), midday
+trough 11–14 (×0.55), evening peak 17–20 (×1.85), overnight 00–05 (×0.65),
+weekends softened. Base level 50–80 öre/kWh by zone
+(SE3/SE4/DK1/DK2/DE = 80, NO2/FI = 70, SE1/SE2/NO1/NO3/NO4 = 50). Monthly
+prior peaks in winter (Dec 1.40, Jan 1.35) and troughs in summer
+(Jul 0.70).
+
+## Inputs / outputs
+
+Fit input: `[]state.PricePoint` (spot öre/kWh, slot timestamp, zone) pulled
+from the last 90 days of `state.Store.LoadPrices` (`forecast.go:360-362`).
+
+Per-zone output: `ZoneModel.Predict(t) float64` in öre/kWh (raw spot,
+no tariff/VAT). MPC adds tariff + VAT before using it
+(`mpc/service.go:442-443`).
+
+## Training cadence + persistence
+
+Refits from history every `RefitInterval = 6h` (`forecast.go:246`).
+Needs ≥ 24 price rows to bother refitting (`forecast.go:369`).
+
+Persistence: whole `map[zone]*ZoneModel` JSON-blobbed via
+`state.Store.SaveConfig("pricefc/state", …)` (`forecast.go:243`). Restored
+on startup.
+
+Seed hook: `Service.SeedFromCSV(path)` ingests historical prices from a
+CSV (`zone,slot_ts_ms,spot_ore_kwh[,slot_len_min]`) via SQLite upsert,
+then kicks a refit. Idempotent — safe on every boot (`forecast.go:410-496`).
+
+## Public API surface
+
+Zone model (`forecast.go`):
+
+- `NewZoneModel(zone) *ZoneModel`
+- `(ZoneModel).Predict(t) float64`
+- `(*ZoneModel).FitFromHistory(pts []state.PricePoint)`
+- Constants `Buckets = 168`, `MinTrustSamples = 4`, `PriorWeight = 8`, `RefitInterval = 6h`.
+
+Service (`forecast.go`):
+
+- `NewService(st, zones []string) *Service`
+- `(*Service).Start(ctx)` / `.Stop()`
+- `(*Service).Predict(zone, t) float64`
+- `(*Service).Model(zone) *ZoneModel`
+- `(*Service).SeedFromCSV(path string) (int, error)`
+
+## How it talks to neighbors
+
+- MPC consumes `Service.Predict` via `mpc.PricePredictor`
+  (`mpc/service.go:28`). `extendPricesWithForecast` synthesizes price rows
+  for slots between the latest published end and the horizon end
+  (`mpc/service.go:410-454`), tagging them `source = "forecast"` so the
+  MPC sees `Confidence = 0.6` in `buildSlots` (`mpc/service.go:492-494`).
+- Reads history via `state.Store.LoadPrices`.
+- Effective price in the MPC: `effPrice = 0.6 * raw + 0.4 * mean` for
+  forecast slots (`mpc/mpc.go:195-197`).
+
+## How the Bayesian blend feels in practice
+
+One bucket sees zero samples after 30 days → still returns the baked
+prior. Two samples → 20% of the way toward observed. 40 samples → fitted
+value dominates. This is why sparse SE1 history never destroys the shape.
+
+## What NOT to do
+
+- Do not persist the whole prices table here — that's `state.Store`'s
+  job. This package only stores the fitted model.
+- Do not treat `Predict` output as consumer-total price; it's raw spot.
+  The MPC applies tariff + VAT before feeding to the optimizer.
+- Do not lower `PriorWeight` below ~4; the shape will collapse on thin
+  history and re-learn noise.
+- Do not break CSV idempotency — `SeedFromCSV` runs every boot in some
+  setups. Rely on SQLite upsert on `(zone, slot_ts_ms)`.

--- a/go/internal/pvmodel/CLAUDE.md
+++ b/go/internal/pvmodel/CLAUDE.md
@@ -1,0 +1,114 @@
+# pvmodel — self-learning PV digital twin
+
+## What it does
+
+Recursive-least-squares regression over 7 time-of-day features that maps
+clear-sky irradiance + cloud cover to AC output. Captures orientation,
+shading, and degradation the generic physics prior misses. Runs one RLS
+update per 60s sample during daylight; the MPC calls `Predict` to get the
+system-specific forecast for any future slot.
+
+## Math
+
+Feature vector (`model.go:75-95`, 7 terms, 1st + 2nd time-of-day harmonic):
+
+```
+x = [ 1,
+      clearsky_w,
+      clearsky_w * (1 - cloud/100)^1.5,
+      clearsky_w * sin(h),   clearsky_w * cos(h),
+      clearsky_w * sin(2h),  clearsky_w * cos(2h) ]
+      where h = 2*pi*hour_of_day/24
+```
+
+RLS update (`model.go:183-217`):
+
+```
+K   = P x / (lambda + x^T P x)
+beta = beta + K * (actual - beta.x)
+P   = (P - K x^T P) / lambda
+```
+
+Forgetting factor `lambda = 0.995` (~200-sample effective window).
+Cold-start: `beta = [0, 0, rated/1000, 0, 0, 0, 0]` reproduces the physics
+prior, so day-one predictions already behave (`model.go:66-70`).
+
+Cold-start blend (`model.go:129-133`):
+
+```
+trust = min(samples / 50, 1)
+y     = trust * learned + (1 - trust) * prior
+prior = rated * (clearsky/1000) * (1-cloud/100)^1.5
+```
+
+Output sanity envelope: if `y > 1.05 * rated` → return the physics prior
+instead (`model.go:140-143`). A wild RLS coefficient can't escape into the
+plan.
+
+Input outlier rejection (`model.go:149-180`):
+
+- `clearSkyW < 50` → skip (night, no signal).
+- `actualPVW < 0` → skip.
+- `actualPVW > 1.2 * rated` → skip (sensor glitch).
+- `|yHat| > 2 * rated` before fit → skip (prevents cascading bad samples).
+- After 50 samples: reject `|err| > max(10*MAE, 200 W)`.
+
+## Inputs / outputs
+
+Per sample: `(clearSkyW [W/m²], cloudPct [0..100], t, actualPVW [W,
+non-negative])`. Converted from telemetry inside `Service.sample`
+(PV telemetry is site-sign so `pvW = -SmoothedW`, `service.go:165-171`).
+
+`Predict(t, cloudPct)` → expected AC output in W, non-negative, capped.
+
+## Training cadence + persistence
+
+Sample + update every `SampleInterval = 60s` (`service.go:54`). Skip when
+`clearSky < 50 W/m²` (night) or telemetry shows `pvW < 1 W` (driver outage,
+`service.go:173-177`).
+
+Persistence: JSON-encoded `Model` saved via
+`state.Store.SaveConfig("pvmodel/state", …)` (constant in `service.go:15`).
+Loaded on boot via `LoadConfig` (`service.go:60-68`). Persisted every
+`PersistEvery = 10` samples and on shutdown.
+
+Reset: `POST /api/pvmodel/reset` → re-seeds with the physics prior.
+
+## Public API surface
+
+Model (`model.go`):
+
+- `NewModel(ratedW) *Model`, `Features(clearSkyW, cloudPct, t) [7]float64`
+- `(Model).Predict(clearSkyW, cloudPct, t) float64`
+- `(*Model).Update(clearSkyW, cloudPct, t, actualPVW) bool`
+- `(Model).Quality() float64`
+- Constants `NFeat = 7`, `WarmupSamples = 50`.
+
+Service (`service.go`):
+
+- `NewService(st, tel, clearSkyFn, cloudFn, ratedW) *Service`
+- `(*Service).Start(ctx)` / `.Stop()` / `.Reset()`
+- `(*Service).Predict(t, cloudPct) float64`, `.PredictNow()`, `.Model() Model`
+- Injected func types `ClearSkyFunc`, `CloudFunc` (decouples from
+  `forecast` and `sunpos`).
+
+## How it talks to neighbors
+
+- `main.go` wires `ClearSkyFunc` to `sunpos.ClearSkyW(t, lat, lon)` (or
+  equivalent) and `CloudFunc` to the forecast cache.
+- MPC consumes `Service.Predict` via the `mpc.PVPredictor` func type
+  (`mpc/service.go:18`, wired in `main.go`).
+- Reads live PV power from `telemetry.Store.ReadingsByType(DerPV)`.
+- UI overlays predicted vs actual via `PredictNow`.
+
+## What NOT to do
+
+- Never feed a night-time sample — `sample()` already guards with
+  `cs < 50`; keep that check if you refactor.
+- Do not drop the `1.2 * rated` input guard or the `1.05 * rated` output
+  envelope; an inverter restart transient of 15 kW on a 10 kW plant will
+  otherwise poison `beta`.
+- Do not persist on every sample — SQLite writes are not free. Keep the
+  `PersistEvery` batching.
+- Do not change `Beta[2] = rated/1000` on cold start. That coefficient is
+  the naive baseline and keeps day-one usable.

--- a/go/internal/selftune/CLAUDE.md
+++ b/go/internal/selftune/CLAUDE.md
@@ -1,0 +1,103 @@
+# selftune — closed-loop battery step-response calibration
+
+## What it does
+
+Drives each battery through a scripted step pattern, fits a first-order
+response to each step, and writes the aggregated (gain, τ) into the
+battery model as a trusted baseline. Used by the health endpoints to
+measure drift over time. One battery at a time, behind a
+coordinator-owned override that the control loop respects.
+
+## Math
+
+Step pattern (per battery, `selftune.go:56-73`):
+
+```
+stabilize → +1000 W → settle → -1000 W → settle
+          → +3000 W → settle → -3000 W → settle → fit → done
+```
+
+Sample collection runs only during the four active step_up/step_down
+phases (`Step.Collecting`).
+
+First-order fit over samples within one step (`fitStepResponse`,
+`selftune.go:129-174`):
+
+```
+y_ss    = mean of last 50% of samples
+delta   = y_ss - y_initial
+gain    = y_ss / u            (clamped to [0.3, 1.5])
+tau_s   = ElapsedS at which y crosses y_initial + 0.632*delta
+                              (clamped to [0.5, 30])
+```
+
+Fit rejected when `|u| < 100 W` or `|delta| < 50 W` — the response was
+too small to distinguish from noise.
+
+Aggregate (`selftune.go:302-324`): mean of valid fits across the 4 steps
+→ `battery.Model.SetFromStepFit(gain, tau, dtS)` (overwrites ARX + resets
+covariance) and `SetBaseline(gain, tau, nowMs)` (records it as the
+reference point for future drift detection).
+
+## Inputs / outputs
+
+Input: list of battery names + the current `dtS` + actual-lookup callback
+returning `(actualW, soc, ok)`.
+
+Output side effects on each `battery.Model`:
+
+- `A`, `B` overwritten from step fit (high-confidence covariance reset).
+- `BaselineGain`, `BaselineTauS`, `LastCalibrated` stored.
+- `ModelSnapshot` before/after held in memory for the UI.
+
+## Training cadence + persistence
+
+Triggered only by `POST /api/self_tune/start` (operator-initiated, never
+automatic — `api.go:111`). Cancel via `POST /api/self_tune/cancel`
+(`api.go:113`); status polled via `GET /api/self_tune/status`
+(`api.go:112`).
+
+Sequenced per-battery: when `CurrentIdx` increments past
+`len(Batteries)`, `Active = false` and the override lifts
+(`selftune.go:327-341`). Typical total runtime ≈ 2 min per battery
+(sum of `DurationS()` across the state machine).
+
+Persistence: none directly. The updated `battery.Model` is saved on the
+next normal save cycle via `state.Store.SaveBatteryModel`.
+
+## Public API surface
+
+- `NewCoordinator() *Coordinator`
+- `(*Coordinator).Start(names, models, dtS) error`
+- `(*Coordinator).Cancel()`
+- `(*Coordinator).Tick(actualLookup, models, dtS, nowMs)`
+- `(*Coordinator).CurrentCommand() (name, commandW, active)`
+- `(*Coordinator).IsTuning(name) bool`
+- `(*Coordinator).Status() Status`
+- Types `Step`, `Sample`, `stepFit`, `ModelSnapshot`, `Status`.
+- Step constants `StepStabilize`, `StepUpSmall`, `StepSettleUp`,
+  `StepDownSmall`, `StepSettleDown`, `StepUpLarge`, `StepSettleHighUp`,
+  `StepDownLarge`, `StepSettleHighDown`, `StepFit`, `StepDone`.
+
+## How it talks to neighbors
+
+- `control` dispatch calls `Coordinator.CurrentCommand()` each cycle; if
+  active for a given battery, it overrides the normal dispatch for that
+  one battery only (others keep following the MPC plan).
+- Writes into `battery.Model.SetFromStepFit` and `SetBaseline`.
+- API endpoints in `internal/api/api.go` (`/api/self_tune/*`).
+- `actualLookup` callback is wired to `telemetry.Store` reads.
+
+## What NOT to do
+
+- Do not drive two batteries in parallel — the coordinator sequences
+  deliberately. Simultaneous steps would couple through the shared
+  grid/PV baseline and corrupt the gain fits.
+- Do not feed the step samples into the normal RLS path; `SetFromStepFit`
+  bypasses the online learner because step data is qualitatively
+  different (clean input, unlike typical noisy operation).
+- Do not run self-tune below ~20% SoC or above ~80% — saturation curves
+  clip the response and the fit collapses to `gain = 1.0`. Operator UI
+  should gate this, but don't rely on it here.
+- Do not skip the `stabilize` opening step. The ARX fit assumes the
+  battery is at rest when `t = 0`.

--- a/go/internal/sunpos/CLAUDE.md
+++ b/go/internal/sunpos/CLAUDE.md
@@ -1,0 +1,115 @@
+# sunpos — solar position and plane-of-array irradiance
+
+## What it does
+
+Pure-physics solar geometry. Computes sun zenith/azimuth at a given lat/lon,
+clear-sky horizontal irradiance, and plane-of-array irradiance for an
+arbitrary tilt/azimuth panel. No fitted constants. Foundation for the
+upcoming auto-PV flow (per-array orientation fitted from a few clear-sky
+days) — currently unused in production; `pvmodel` still consumes the simpler
+`clearSkyW` from the forecast module.
+
+## Math
+
+Spencer (1971) series (`sunpos.go:36-47`). Accuracy ~0.05°, enough for
+getting the shape of the day right on an embedded EMS:
+
+```
+gamma = 2*pi*(doy - 1 + (hour-12)/24) / 365
+EoT   = 229.18*(0.000075
+              + 0.001868*cos(g)  - 0.032077*sin(g)
+              - 0.014615*cos(2g) - 0.040849*sin(2g))      [minutes]
+decl  = 0.006918
+      - 0.399912*cos(g)  + 0.070257*sin(g)
+      - 0.006758*cos(2g) + 0.000907*sin(2g)
+      - 0.002697*cos(3g) + 0.00148*sin(3g)                [radians]
+```
+
+Hour angle (`sunpos.go:50-54`): `ha = (tst/4 - 180) * pi/180` where
+`tst = hour*60 + EoT + 4*lon`.
+
+Zenith (`sunpos.go:58-62`):
+
+```
+cos(z) = sin(lat)*sin(decl) + cos(lat)*cos(decl)*cos(ha)
+```
+
+Azimuth via `atan2`, north-zero clockwise (`sunpos.go:70-74`):
+
+```
+az = atan2(-sin(ha), tan(decl)*cos(lat) - sin(lat)*cos(ha))
+```
+
+Negative results wrapped to [0, 2π).
+
+Angle of incidence for a panel at (tilt, pAz) (`sunpos.go:95-99`):
+
+```
+cos(aoi) = cos(z)*cos(tilt) + sin(z)*sin(tilt)*cos(sAz - pAz)
+```
+
+Clear-sky horizontal irradiance (`sunpos.go:117-124`) — extraterrestrial
+flux scaled by orbital distance (Spencer) and an atmospheric transmissivity
+`tau = 0.7`:
+
+```
+e0  = 1.000110 + 0.034221*cos(g) + 0.001280*sin(g)
+               + 0.000719*cos(2g) + 0.000077*sin(2g)
+DNI = I0 * e0                       (I0 = 1361 W/m^2)
+GHI = DNI * tau * cos(z)            (0 when sun below horizon)
+```
+
+POA with isotropic-sky diffuse + Erbs split (`sunpos.go:133-159`):
+
+```
+kd  = 0.2                     (fixed — we only have modeled GHI)
+DHI = GHI * kd
+DNI = (GHI - DHI) / cos(z)
+POA = DNI*cos(aoi) + DHI*(1 + cos(tilt))/2     (aoi <= 90)
+POA = DHI*(1 + cos(tilt))/2                    (aoi  > 90, sun behind)
+```
+
+## Inputs / outputs
+
+- `At(t, lat, lon) Position` — time in UTC, lat °N, lon °E. Returns
+  zenith + azimuth in degrees.
+- `AOI(sun, panelTiltDeg, panelAzDeg) float64` — degrees, in [0, 180].
+- `ClearSkyW(t, lat, lon) float64` — W/m² horizontal, non-negative.
+- `POA(t, lat, lon, panelTiltDeg, panelAzDeg) float64` — W/m² on panel.
+
+## Training cadence + persistence
+
+None. Pure deterministic function of `(time, lat, lon, tilt, azimuth)`.
+No state to persist, no samples to train on.
+
+## Public API surface
+
+- `type Position struct { ZenithDeg, AzimuthDeg float64 }`
+- `At(t time.Time, lat, lon float64) Position`
+- `AOI(sun Position, panelTiltDeg, panelAzDeg float64) float64`
+- `ClearSkyW(t time.Time, lat, lon float64) float64`
+- `POA(t time.Time, lat, lon, panelTiltDeg, panelAzDeg float64) float64`
+
+## How it talks to neighbors
+
+- `main.go` wires `ClearSkyW` behind `pvmodel.ClearSkyFunc` (or leaves the
+  naive forecast value; both signatures match).
+- Intended consumer of `POA`: the upcoming auto-PV fit — on clear-sky days
+  the predicted POA per candidate (tilt, azimuth) is regressed against
+  measured output to recover orientation per string.
+- `sunpos_test.go` has 5 tests (zenith at equinox noon, azimuth morning vs
+  afternoon, ClearSkyW sign, POA south-facing at noon, POA sun-behind
+  bound).
+
+## What NOT to do
+
+- Do not fit `tau` or `kd` to local data here. If site-specific
+  transmissivity matters, learn it in `pvmodel` where RLS already absorbs
+  the constant into `beta[2]`.
+- Do not pass local time — `At` expects UTC internally (`t.UTC()` is
+  called). Passing local-zone times will shift the day by up to 12 h.
+- Do not use `POA` as the PV forecast yet — the production pipeline goes
+  through `forecast` + `pvmodel`. `POA` is scaffolding for auto-PV.
+- Do not reorder the azimuth convention. `atan2(-sin(ha), …)` puts 0 at
+  north clockwise; any change silently breaks the PV orientation math
+  downstream.


### PR DESCRIPTION
## Summary

- Adds per-package `CLAUDE.md` orientation files for the learning +
  planning layer: `mpc`, `pvmodel`, `loadmodel`, `priceforecast`,
  `battery`, `selftune`, `sunpos`.
- Each file follows the shared template (what it does, math, I/O,
  training cadence + persistence, public API, neighbor wiring, footguns)
  and cites file:line anchors for the key algorithms and invariants
  (RLS update, DP recursion, Bayesian bucket blend, ARX(1), etc).
- No code changes; documentation only.

## Test plan

- [x] `cd go && go build ./...`
- [x] `cd go && go test -timeout 120s -count=1 ./...` (all packages green,
      including the e2e suite)
- [x] Spot-checked every cited function / constant via grep — all exist
      at the cited location.