### PR TITLE
docs: refresh root README + CLAUDE.md for v2.1 (Lua-first, TSDB, device identity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # forty-two-watts — project orientation
 
-Unified Home Energy Management System. This branch (`go-port`) is the
-Go + WASM driver implementation. Master still has the original Rust port.
+Unified Home Energy Management System. The Go port is now mainline on
+`master`; the historical Rust implementation lives alongside in `src/` +
+`Cargo.toml` and is frozen (see `MIGRATION_PLAN.md` for context).
 
 ## Mental model
 
@@ -12,39 +13,60 @@ place sign conversion happens — above it, every layer uses the site
 convention. Read `docs/site-convention.md` before touching any power-math
 code.
 
-**FAT drivers**: WASM modules do all protocol work. Host exposes only
-capabilities (MQTT, Modbus, time, log). No `decode_u32_le` or other
-protocol helpers in the host. Drivers use real libraries (serde_json,
-etc.) inside the sandbox.
+**Lua-first drivers**: `drivers/*.lua` loaded by `gopher-lua` are the
+primary driver path. Each driver file implements the lifecycle
+(`driver_init`, `driver_poll`, `driver_command`, `driver_default_mode`,
+`driver_cleanup`) and talks to hardware through the `host.*` capabilities
+exposed by `go/internal/drivers/lua.go`. WASM drivers (`wasm-drivers/*/`
+compiled into `drivers-wasm/*.wasm`) are still supported via the same
+Registry and capability interface — dispatch lives in
+`go/internal/drivers/registry.go` — but Lua is recommended for new
+drivers because it's hot-editable on the Pi and doesn't need a Rust
+toolchain.
 
 **Clamping discipline**: every clamp must protect against a *quantifiable
 risk*. Read `docs/clamping.md` for the seven current clamps and the
 saturation-curve feedback-loop bug we shipped then fixed.
+
+**Hardware-stable identity**: every device a driver talks to gets a
+`device_id` resolved in priority order — `make:serial` (from
+`host.set_make` + `host.set_sn`) > `mac:<arp-resolved>` (for TCP devices
+on the same L2) > `ep:<endpoint>` (fallback). Persistent state such as
+battery models is keyed on `device_id` internally, so renaming a driver
+in YAML or re-adding it doesn't orphan a trained model. See
+`go/internal/state/devices.go` and `go/internal/arp/arp.go`.
 
 ## Key packages
 
 | Package | Purpose |
 |---|---|
 | `go/internal/config` | YAML config + validation + atomic save |
-| `go/internal/state` | SQLite persistence + tiered history |
-| `go/internal/telemetry` | DerStore with Kalman per signal + driver health |
+| `go/internal/state` | SQLite persistence, tiered history, long-format TS + Parquet rolloff, devices |
+| `go/internal/telemetry` | DerStore with Kalman per signal + driver health + WatchdogScan |
 | `go/internal/control` | PI + dispatch modes + slew + fuse guard |
 | `go/internal/battery` | ARX(1) model + RLS + cascade + saturation curves |
 | `go/internal/selftune` | Step-response state machine + fitter |
-| `go/internal/drivers` | wazero runtime + ABI + registry |
+| `go/internal/drivers` | Lua host (`lua.go`) + wazero host (`runtime.go`) + shared Registry + capability ABI |
 | `go/internal/api` | HTTP endpoints (Go 1.22+ method mux) |
 | `go/internal/configreload` | fsnotify watcher + reload dispatch |
 | `go/internal/ha` | Home Assistant MQTT autodiscovery + bridge |
 | `go/internal/mqtt` | paho client wrapper implementing drivers.MQTTCap |
 | `go/internal/modbus` | simonvetter wrapper implementing drivers.ModbusCap |
-| `wasm-drivers/ferroamp` | Rust → wasm32-wasip1 Ferroamp driver |
-| `wasm-drivers/sungrow` | Rust → wasm32-wasip1 Sungrow driver |
-| `go/test/e2e` | Full-stack test: sims + main + WASM drivers + HTTP |
+| `go/internal/arp` | L2 MAC resolver for device identity (linux/darwin) |
+| `go/internal/sunpos` | Physics-only solar zenith/azimuth (Spencer 1971) |
+| `go/internal/priceforecast` | Price twin — fills beyond day-ahead publication |
+| `go/internal/loadmodel` | Household load twin (bucketed + heating coefficient) |
+| `go/internal/pvmodel` | PV twin (RLS over sunpos / cloud prior) |
+| `go/internal/mpc` | MPC planner — DP over SoC grid, 48 h horizon |
+| `drivers/` | Lua drivers (`ferroamp.lua`, `sungrow.lua`, …) |
+| `wasm-drivers/ferroamp` | Legacy Rust → wasm32-wasip1 Ferroamp driver |
+| `wasm-drivers/sungrow` | Legacy Rust → wasm32-wasip1 Sungrow driver |
+| `go/test/e2e` | Full-stack test: sims + main + drivers + HTTP |
 
 ## Building & testing
 
 ```bash
-make wasm         # compile .wasm drivers (needs wasm32-wasip1 Rust target)
+make wasm         # compile legacy .wasm drivers (needs wasm32-wasip1 Rust target)
 make test         # unit + integration tests
 make e2e          # full-stack end-to-end test
 make dev          # start sims + main app locally
@@ -52,28 +74,60 @@ make build-arm64  # cross-compile for RPi
 make release      # tarballs for deploy
 ```
 
-No CGo anywhere — pure Go + Rust → WASM. `go build` produces a static
-single-binary distribution.
+Lua drivers need no build step — `drivers/*.lua` ships verbatim with the
+release tarball and is loaded on startup. `make wasm` is only needed when
+you're actually shipping a `.wasm` module.
+
+No CGo anywhere — pure Go + embedded Lua 5.1 (gopher-lua) + optional
+Rust→WASM. `go build` produces a static single-binary distribution.
 
 ## Adding a new driver
 
-1. Copy `wasm-drivers/ferroamp/` as a template into `wasm-drivers/mydevice/`
-2. Implement `driver_init`, `driver_poll`, `driver_command`, `driver_default`,
-   `driver_cleanup` in `src/lib.rs`. Use `host::` helpers for I/O.
-3. Add `"mydevice"` to `WASM_DRIVERS` in the Makefile
-4. Add an entry to `config.yaml` with the appropriate `capabilities:` block
-5. Driver starts on next restart (or hot-reload via file watcher)
+1. Copy `drivers/ferroamp.lua` as a template to `drivers/mydevice.lua`.
+2. Implement `driver_init`, `driver_poll`, `driver_command`, and
+   (optionally) `driver_default_mode` / `driver_cleanup`. Use the
+   `host.*` helpers for I/O — full API in `go/internal/drivers/lua.go`.
+3. Call `host.set_make("…")` + `host.set_sn("…")` inside `driver_init`
+   as soon as you've read them off the device — that's what anchors
+   `device_id` to hardware identity.
+4. Use `host.emit_metric("name_unit", value)` for any scalar diagnostic
+   that doesn't fit the structured pv/battery/meter emit (temperatures,
+   DC voltages, MPPT currents, inverter heatsink, grid frequency). It
+   lands in the long-format TS DB, queryable for life.
+5. Add an entry to `config.yaml` with `lua: drivers/mydevice.lua` and
+   the appropriate `capabilities:` block.
+6. Driver starts on next restart (or hot-reload via the file watcher).
 
-The host ABI is stable across drivers — see
-`go/internal/drivers/abi.go` for the contract.
+Full walkthrough in `docs/writing-a-driver.md`.
 
-## WASM ABI
+## Lua driver host
+
+See the top-of-file comment in `go/internal/drivers/lua.go`. The `host`
+global exposes:
+
+- `host.log(level, msg)`, `host.millis()`, `host.set_poll_interval(ms)`
+- `host.set_make(s)`, `host.set_sn(s)` — anchors device identity
+- `host.emit("battery"|"pv"|"meter", {…})` — structured telemetry
+- `host.emit_metric(name, value)` — arbitrary scalar diagnostics into TS DB
+- `host.mqtt_sub/pub/messages`, `host.modbus_read/write/write_multi`
+- `host.decode_u32_le/be`, `host.decode_i32_le/be`, `host.decode_i16`
+- `host.json_encode/decode`
+
+MQTT / Modbus calls return an error string if the driver wasn't granted
+the capability in config.
+
+## WASM ABI (legacy)
+
+Still supported for any `.wasm` driver built against v2.0 of the host —
+`go/internal/drivers/runtime.go` + `abi.go` are unchanged. New drivers
+should prefer Lua.
 
 - Driver EXPORTS: `wasm_alloc`, `wasm_dealloc`, `driver_init`,
   `driver_poll`, `driver_command`, `driver_default`, `driver_cleanup`
 - Host IMPORTS (under `"host"` namespace): `log`, `millis`,
   `set_poll_interval`, `emit_telemetry`, `set_sn`, `set_make`,
-  `mqtt_{subscribe,publish,poll_messages}`, `modbus_{read,write_single,write_multi}`
+  `mqtt_{subscribe,publish,poll_messages}`,
+  `modbus_{read,write_single,write_multi}`
 - All string / byte-slice parameters use `(ptr: i32, len: i32)` pairs
   into driver memory. Driver allocates its own memory via `wasm_alloc`
   so the host can copy strings into it.
@@ -81,12 +135,43 @@ The host ABI is stable across drivers — see
 MQTT / Modbus functions return `ErrNoCapability` via status codes if
 the driver wasn't granted the relevant capability in config.
 
+## Time-series DB (long-format)
+
+Every `host.emit_metric` call lands in three SQLite tables defined in
+`go/internal/state/store.go` and written through
+`go/internal/state/store_ts.go`:
+
+- `ts_drivers(id, name)` — interned driver names
+- `ts_metrics(id, name, unit)` — interned metric names
+- `ts_samples(driver_id, metric_id, ts_ms, value)` — `WITHOUT ROWID,
+  STRICT`, PK clusters rows by (driver, metric, ts) so the typical
+  "metric X for driver Y over range Z" query is a sequential scan.
+
+Samples older than `RecentRetention` (14 days) roll off to daily Parquet
+files under `<state.cold_dir>/YYYY/MM/DD.parquet` — see
+`go/internal/state/parquet.go`. Rolloff runs hourly from
+`go/cmd/forty-two-watts/main.go` (`rolloffLoop`). Parquet files are
+zstd-compressed and dictionary-encoded on `driver` + `metric`, so a
+year of 50 metrics is typically a few GB.
+
+## Watchdog + safety
+
+The control loop (`go/cmd/forty-two-watts/main.go`, the `ticker.C`
+branch) runs `tel.WatchdogScan(timeout)` every cycle. Any driver whose
+last successful telemetry is older than `site.watchdog_timeout_s`
+(default 60 s) flips to offline and receives `DefaultMode` — which in
+every driver means "drop into autonomous self-consumption". The host
+also short-circuits the dispatch cycle when the configured site-meter
+driver is stale, because a stale grid reading causes one battery to
+charge another.
+
 ## Code conventions
 
 - `slog` for all logging
 - Explicit mutexes — no atomic tricks unless measurably needed
-- SQLite queries in `internal/state/store.go`, nothing embedded elsewhere
-- Driver code in Rust, not Go — sandbox guarantees + ecosystem libraries
+- SQLite queries in `internal/state/*.go`, nothing embedded elsewhere
+- Driver code in Lua (preferred) or Rust→WASM (legacy); the Go side
+  only owns capabilities, not protocol logic
 - Tests colocated with code, `_test.go` files
 - Integration tests in `go/test/e2e/` (separate package to keep public
   and internal concerns cleanly split)
@@ -101,11 +186,37 @@ the driver wasn't granted the relevant capability in config.
   scans. `Prune()` should be running periodically to age data to warm/cold.
 - **Tests fail with `drivers-wasm/*.wasm not found`**: run `make wasm`
   first. CI should always do `make wasm` before `make test`.
+- **Driver hung (tick_count not advancing)**: restart the service and
+  check `WatchdogScan` transitions in the logs — the loop should have
+  already flipped it offline and sent `DefaultMode`. If it didn't,
+  `tel.health[name].LastSuccess` never got bumped; confirm the driver
+  is actually calling `host.emit`.
+- **PV prediction wild**: the twin's RLS coefficients drifted on a
+  run of bad weather data. `POST /api/pvmodel/reset` wipes them and
+  falls back to the physics-only `sunpos` prior.
+- **Battery model orphaned after rename**: it shouldn't — models are
+  keyed on `device_id`, not driver name. Verify with `GET /api/devices`
+  that the rename preserved the same `device_id`. If not, the driver
+  isn't reporting a stable make+serial; fix it there.
 
 ## Docs for operators + devs
 
 - `docs/site-convention.md` — sign convention (must-read)
-- `docs/battery-models.md` — ARX(1), RLS, self-tune
+- `docs/architecture.md` — system overview, layers, data flow (NEW)
+- `docs/writing-a-driver.md` — Lua driver tutorial (NEW)
+- `docs/tsdb.md` — long-format TS schema + Parquet rolloff (NEW)
+- `docs/device-identity.md` — `device_id` resolution + ARP (NEW)
+- `docs/safety.md` — watchdog, clamps, fuse guard, stale-meter guard (NEW)
+- `docs/ml-models.md` — PV + load + price twins, MPC inputs (NEW)
+- `docs/api.md` — HTTP endpoint reference (NEW)
+- `docs/operations.md` — deploy, backup, upgrade, troubleshooting (NEW)
+- `docs/testing.md` — test strategy, sims, e2e recipe (NEW)
+- `docs/configuration.md` — YAML schema reference
+- `docs/battery-models.md` — ARX(1), RLS, cascade, self-tune
 - `docs/clamping.md` — the safety clamps
-- `docs/configuration.md` — YAML schema
-- `MIGRATION_PLAN.md` — why Go + WASM (for historical context)
+- `docs/mpc-planner.md` — MPC strategies, confidence blending
+- `docs/ml-twins.md` — older twin notes (superseded by ml-models.md)
+- `docs/ha-integration.md` — Home Assistant MQTT bridge
+- `docs/host-api.md` — legacy WASM driver ABI
+- `docs/lua-drivers.md` — earlier Lua driver notes (superseded by writing-a-driver.md)
+- `MIGRATION_PLAN.md` — historical: why Go + WASM (Rust→Go migration is complete)

--- a/README.md
+++ b/README.md
@@ -19,27 +19,55 @@ Three layers in one binary:
    pattern from its own telemetry. Feed slot-by-slot forecasts into
    the MPC.
 
-**This branch (`go-port`)** is the current mainline: **Go + WASM drivers**
-(via wazero). The previous Rust implementation lives on `master` and is
-unchanged.
+The Go port is now **mainline on `master`**. The previous Rust
+implementation lives alongside in `src/` + `Cargo.toml` and is frozen
+(see `MIGRATION_PLAN.md` for historical context).
+
+## What's new in v2.1+
+
+- **Lua drivers are now the primary path.** Drop a `.lua` file in
+  `drivers/`, no build step. WASM drivers still load via the same
+  registry and capability ABI, but Lua is recommended for anything new.
+  See [`docs/architecture.md`](docs/architecture.md) for the current
+  driver host and [`docs/writing-a-driver.md`](docs/writing-a-driver.md)
+  for the walkthrough.
+- **Long-format TSDB.** `ts_drivers` / `ts_metrics` / `ts_samples`
+  (WITHOUT ROWID, STRICT) in SQLite, with automatic daily Parquet
+  rolloff past 14 days. Drivers push arbitrary scalar diagnostics with
+  `host.emit_metric(name, value)`. Details in
+  [`docs/tsdb.md`](docs/tsdb.md).
+- **Hardware-stable device identity.** Every device gets a `device_id`
+  resolved as `make:serial` > `mac:<arp-resolved>` > `ep:<endpoint>`.
+  Battery models and other persistent state are keyed on `device_id`,
+  so renaming a driver no longer orphans training data. See
+  [`docs/device-identity.md`](docs/device-identity.md).
+- **`sunpos` package.** Physics-only solar position (Spencer 1971),
+  used as a prior for the data-driven PV twin and as groundwork for
+  upcoming auto-PV.
+- **Watchdog safety.** `tel.WatchdogScan` flips stale drivers offline
+  and reverts them to autonomous mode; a stale site-meter
+  short-circuits the dispatch cycle.
+
+Start with [`docs/architecture.md`](docs/architecture.md) for the
+top-of-funnel overview.
 
 ---
 
 ## Architecture in one sentence
 
 A Go binary runs the control loop, the HTTP API, and the Home Assistant
-bridge; WASM driver modules (one `.wasm` file per device type) do all
-protocol work — MQTT, Modbus, JSON parsing, bit twiddling — inside a
-capability-scoped sandbox with a tiny host ABI.
+bridge; Lua driver modules (one `.lua` file per device type, WASM still
+supported) do all protocol work — MQTT, Modbus, JSON parsing, bit
+twiddling — inside a capability-scoped sandbox with a tiny host API.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
 │                   forty-two-watts (Go)                          │
 │                                                                 │
-│  ┌──────────┐  ┌──────────┐   WASM driver modules (wazero)     │
-│  │ Ferroamp │  │ Sungrow  │   — fat. all protocol logic here.  │
-│  │  .wasm   │  │  .wasm   │                                    │
-│  └────┬─────┘  └────┬─────┘                                    │
+│  ┌──────────┐  ┌──────────┐   Lua drivers (gopher-lua)         │
+│  │ferroamp  │  │ sungrow  │   — fat. all protocol logic here.  │
+│  │  .lua    │  │  .lua    │   (legacy .wasm still supported    │
+│  └────┬─────┘  └────┬─────┘    via the same Registry/ABI)      │
 │       │              │                                          │
 │       ▼              ▼                                          │
 │  ┌──────────────────────────┐                                  │
@@ -52,39 +80,44 @@ capability-scoped sandbox with a tiny host ABI.
 │  │  Control loop              │  │  HTTP API + web UI     │    │
 │  │  PI + cascade + self-tune  │  │  :8080                 │    │
 │  │  + ARX(1) RLS per battery  │  └────────────────────────┘    │
+│  │  + watchdog / stale-meter  │                                 │
 │  └──────────────┬────────────┘                                  │
 │                 │                 ┌────────────────────────┐    │
 │                 └────────────────▶│  HA MQTT bridge         │    │
 │                                   │  (autodiscovery)        │    │
 │                                   └────────────────────────┘    │
 │  ┌──────────────────────────┐                                  │
-│  │  SQLite state DB         │  config, events, battery models, │
-│  │  (tiered history)        │  history hot/warm/cold tiers,    │
-│  └──────────────────────────┘  prices, forecasts, twin state   │
+│  │  SQLite state DB         │  config, events, devices,        │
+│  │  + tiered history        │  battery models (keyed on        │
+│  │  + long-format TS (14d)  │  device_id), history hot/warm/   │
+│  │  + Parquet cold (>14d)   │  cold tiers, prices, forecasts   │
+│  └──────────────────────────┘                                  │
 │                                                                 │
 │  ┌──────────────────────────┐   ┌────────────────────────┐     │
 │  │  MPC planner (15 min)    │◀──│  Digital twins (1 min) │     │
 │  │  • DP over SoC grid      │   │  • pvmodel (RLS)       │     │
 │  │  • 48 h horizon          │   │  • loadmodel (buckets) │     │
 │  │  • three strategies      │   │  • priceforecast       │     │
-│  │  • confidence blending   │   │  • baked cold-start    │     │
-│  │  • per-slot reasons      │   │    priors + auto-fit   │     │
+│  │  • confidence blending   │   │  • sunpos prior        │     │
+│  │  • per-slot reasons      │   │    (physics-only)      │     │
 │  └────────────┬─────────────┘   └────────────────────────┘     │
 │               │  grid_target_w per slot                         │
 │               └─────▶ consumed by the control loop above        │
 └────────────────────────────────────────────────────────────────┘
 ```
 
-Read the whole story: [`MIGRATION_PLAN.md`](MIGRATION_PLAN.md)
+Architecture walkthrough: [`docs/architecture.md`](docs/architecture.md)
 Sign convention (critical): [`docs/site-convention.md`](docs/site-convention.md)
+Historical migration rationale: [`MIGRATION_PLAN.md`](MIGRATION_PLAN.md)
 
 ## Quick start
 
-Prereqs: Go 1.22+, Rust stable + `wasm32-wasip1` target (for building
-driver modules), `make`.
+Prereqs: Go 1.22+, `make`. Rust + `wasm32-wasip1` only needed if you
+want to build legacy WASM drivers — the default Lua drivers need
+nothing more.
 
 ```bash
-# Build WASM drivers + Go binaries, run the full local stack with simulators
+# Build Go binaries + (if present) WASM drivers, run the full local stack with simulators
 make dev
 
 # Open the UI
@@ -105,12 +138,22 @@ SH10RT (Modbus TCP) with realistic first-order battery response.
   factor, capability-aware saturation curves, hardware-health drift
 - **Self-tune** — 3-minute step-response calibration per battery to set
   a clean baseline; safety-gated by confidence
-- **WASM drivers** — FAT drivers. The host provides only capabilities
-  (MQTT, Modbus, time, logging). Each driver does its own protocol
-  parsing, state management, command translation. No `host.decode_*`
-  functions; everything lives inside the sandbox.
-- **Hot-reload** — config.yaml + settings UI round-trip, file watcher
+- **Lua drivers** — FAT drivers. The host provides only capabilities
+  (MQTT, Modbus, time, logging, TS metric emit). Each driver does its
+  own protocol parsing, state management, command translation. WASM
+  drivers still load through the same Registry for anyone shipping a
+  `.wasm` binary from v2.0.
+- **Hardware-stable device identity** — `make:serial` >
+  `mac:<arp-resolved>` > `ep:<endpoint>`. Persistent state (battery
+  models, calibration history) survives driver renames.
+- **Watchdog** — stale drivers flip offline and revert to autonomous
+  mode; stale site-meter short-circuits the dispatch cycle.
+- **Hot-reload** — `config.yaml` + settings UI round-trip, file watcher
   applies changes live for 99% of settings
+- **Long-format TSDB** — `host.emit_metric(name, value)` lands
+  diagnostics in an interned SQLite schema (`ts_samples`,
+  WITHOUT ROWID, STRICT). Past 14 days rolls off to daily Parquet
+  files for long-term retention.
 - **Tiered history** — 30d at 5s, 12mo at 15min buckets, forever at 1d
   buckets. Pure SQL aggregation (SQLite, no CGo).
 - **Home Assistant MQTT** — autodiscovery publishes sensors for grid,
@@ -119,7 +162,7 @@ SH10RT (Modbus TCP) with realistic first-order battery response.
 ## Deploy to a Raspberry Pi
 
 ```bash
-# One-time: make sure rustup has wasm32-wasip1 installed
+# One-time (only needed if you ship WASM drivers): wasm32-wasip1 toolchain
 rustup target add wasm32-wasip1
 
 # Build the release tarballs (arm64 + amd64)
@@ -136,8 +179,10 @@ gh release create v1.0.0 release/*.tar.gz --generate-notes
 
 | Need | Choice | Why |
 |---|---|---|
+| Lua runtime | [gopher-lua](https://github.com/yuin/gopher-lua) | Pure Go Lua 5.1, zero CGo |
 | WASM runtime | [wazero](https://wazero.io) | Zero CGo, zero deps, prod-ready |
 | State DB | [modernc.org/sqlite](https://gitlab.com/cznic/sqlite) | Pure Go SQLite, SQL queries for history |
+| Parquet (cold tier) | [parquet-go/parquet-go](https://github.com/parquet-go/parquet-go) | Pure Go, zstd + dictionary encoding |
 | MQTT client | eclipse/paho.mqtt.golang | Battle-tested |
 | MQTT broker (tests/sim) | mochi-mqtt/server | Embeddable |
 | Modbus TCP | simonvetter/modbus | Both client and server |
@@ -160,27 +205,34 @@ forty-two-watts/
 │   │   └── sim-sungrow/       # Modbus TCP Sungrow fake
 │   ├── internal/
 │   │   ├── api/               # HTTP handlers
+│   │   ├── arp/               # L2 MAC resolver (linux/darwin)
 │   │   ├── battery/           # ARX(1) + RLS + cascade
 │   │   ├── config/            # YAML + validation
 │   │   ├── configreload/      # fsnotify watcher
 │   │   ├── control/           # PI + dispatch modes + fuse guard
-│   │   ├── drivers/           # wazero runtime + registry + host ABI
+│   │   ├── drivers/           # Lua host + wazero host + registry
 │   │   ├── ha/                # Home Assistant MQTT bridge
+│   │   ├── loadmodel/         # household load twin
+│   │   ├── mpc/               # MPC planner (DP over SoC grid)
 │   │   ├── mqtt/              # paho wrapper
 │   │   ├── modbus/            # simonvetter wrapper
+│   │   ├── priceforecast/     # price twin (fills past day-ahead)
+│   │   ├── pvmodel/           # PV twin (RLS over sunpos/cloud)
 │   │   ├── selftune/          # step-response calibration
-│   │   ├── state/             # SQLite + tiered history
-│   │   └── telemetry/         # DER store + Kalman + health
+│   │   ├── state/             # SQLite + tiered history + long-format TS + Parquet + devices
+│   │   ├── sunpos/            # solar position (Spencer 1971)
+│   │   └── telemetry/         # DER store + Kalman + health + watchdog
 │   └── test/e2e/              # full-stack integration test
+├── drivers/                   # Lua drivers (ferroamp.lua, sungrow.lua, …)
 ├── wasm-drivers/
-│   ├── ferroamp/              # Rust → wasm32-wasip1
+│   ├── ferroamp/              # legacy Rust → wasm32-wasip1
 │   └── sungrow/               #     (~280 LOC each)
 ├── drivers-wasm/              # compiled .wasm modules (gitignored)
 ├── web/                       # static UI (HTML/CSS/JS)
-├── docs/                      # architecture docs
+├── docs/                      # architecture + operator docs
 ├── config.example.yaml        # sample config
 ├── Makefile                   # build orchestration
-└── MIGRATION_PLAN.md          # full rationale for the Go + WASM port
+└── MIGRATION_PLAN.md          # historical Rust→Go migration rationale
 ```
 
 ## Testing
@@ -190,7 +242,7 @@ make test        # all unit + integration tests (Go + Rust)
 make e2e         # full-stack end-to-end test (simulates real hardware)
 ```
 
-The e2e test stands up both simulators, loads the compiled WASM drivers,
+The e2e test stands up both simulators, loads the compiled drivers,
 runs the control loop, and verifies:
 - Drivers load, initialize, emit telemetry
 - Site sign convention holds (PV −, grid + for import, bat + for charge)
@@ -207,11 +259,17 @@ runs the control loop, and verifies:
 - [`docs/clamping.md`](docs/clamping.md) — the seven clamps and why each matters
 - [`docs/configuration.md`](docs/configuration.md) — full YAML schema reference
 - [`docs/mpc-planner.md`](docs/mpc-planner.md) — MPC strategies, confidence blending, decision reasons
-- [`docs/ml-twins.md`](docs/ml-twins.md) — PV + load + price digital twins
+- [`docs/ml-twins.md`](docs/ml-twins.md) — PV + load + price digital twins (older, being superseded)
 - [`docs/ha-integration.md`](docs/ha-integration.md) — Home Assistant MQTT bridge
-- [`docs/host-api.md`](docs/host-api.md) — WASM driver ABI
-- [`docs/lua-drivers.md`](docs/lua-drivers.md) — legacy Lua driver format
-- [`MIGRATION_PLAN.md`](MIGRATION_PLAN.md) — why Go + WASM, library evaluations
+- [`docs/host-api.md`](docs/host-api.md) — legacy WASM driver ABI
+- [`docs/lua-drivers.md`](docs/lua-drivers.md) — earlier Lua driver notes
+- [`MIGRATION_PLAN.md`](MIGRATION_PLAN.md) — historical: why Go + WASM, library evaluations
+
+These docs are being added by parallel work and will resolve once the
+sibling PRs land — the `docs/architecture.md` and `docs/writing-a-driver.md`
+links referenced at the top of this README are part of that set:
+`architecture.md`, `ml-models.md`, `tsdb.md`, `device-identity.md`,
+`safety.md`, `writing-a-driver.md`, `api.md`, `operations.md`, `testing.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

Update the root README.md and CLAUDE.md to reflect the v2.1+ state of the Go port (now mainline on `master`).

- Drivers are now **Lua-first** via gopher-lua (`drivers/*.lua`, hot-editable, no build step). WASM drivers still load through the same `Registry`/capability ABI for anyone shipping a `.wasm` from v2.0 — see `go/internal/drivers/lua.go` and `go/internal/drivers/registry.go`.
- Document the **long-format TSDB** (`ts_drivers` / `ts_metrics` / `ts_samples`, `WITHOUT ROWID, STRICT`) and daily Parquet rolloff past 14 days (`go/internal/state/store_ts.go`, `go/internal/state/parquet.go`). New Lua API `host.emit_metric(name, value)`.
- Document **hardware-stable device identity**: `make:serial` > `mac:<arp-resolved>` > `ep:<endpoint>`, with battery models keyed on `device_id` (`go/internal/state/devices.go`, `go/internal/arp/arp.go`).
- Document **watchdog safety**: `tel.WatchdogScan(timeout)` flips stale drivers offline + reverts them to autonomous mode; site-meter-stale skips the dispatch cycle (`go/cmd/forty-two-watts/main.go`).
- Add the new `sunpos`, `arp`, `priceforecast`, `loadmodel`, `pvmodel`, `mpc` packages and the `drivers/` Lua directory to the package table and repo layout.
- Expand the "When things look weird" failure-mode section with hung driver / stale PV twin / orphaned battery model entries.
- Mark the WASM ABI section as **legacy**.
- List all the new operator/dev docs produced by the parallel units so readers know what's coming.
- Mark `MIGRATION_PLAN.md` as historical — Rust→Go migration is complete.

Site sign convention (positive W = into site across grid-meter boundary) is unchanged.

## Notes for reviewers

Several of the `docs/*.md` paths I reference (architecture, writing-a-driver, tsdb, device-identity, safety, ml-models, api, operations, testing) are being created by **sibling PRs in the parallel docs sweep**. Their links will resolve once those PRs land. I've called that out explicitly in the README's Documentation section. Nothing in this PR links to a file that neither exists today nor is being produced by a companion unit.

## Test plan

- [x] `cd go && go build ./...` clean
- [x] `cd go && go test -timeout 120s -count=1 ./...` green (all packages)
- [x] All linked existing doc paths verified present on disk
- [x] New config / endpoint references (`site.watchdog_timeout_s`, `/api/pvmodel/reset`, `/api/devices`) grep-verified in the codebase before mentioning
- [ ] Merge ordering: land after or together with the docs the Documentation section promises

🤖 Generated with [Claude Code](https://claude.com/claude-code)