### PR TITLE
support for pixii control, solaredge (w/o meter) + some UI improvements

### DIFF
--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -4,8 +4,21 @@
 -- Register type: ALL HOLDING (FC 0x03)
 -- Uses SunSpec scale factors (signed i16 exponents → value * 10^sf)
 --
--- Ported from sourceful-hugin/device-support/drivers/lua/pixii.lua
--- (read-only; control path not yet implemented).
+-- Read path ported from sourceful-hugin/device-support/drivers/lua/pixii.lua.
+-- Control path (active power setpoint) implemented against the Pixii
+-- PowerShaper Modbus Mapping doc 13300 rev 2.0 (page 15 note about
+-- control modes "simple" / "use control power activate"):
+--
+--   39903  Handshake counter (uint16)  — must be ticked at least once
+--                                         per 60 s or the system drops
+--                                         to idle.
+--   39905/06  Power regulation set-point (int32 W, generator frame)
+--                                         — must be written atomically
+--                                         as a two-register multi-write.
+--
+-- "Generator reference frame" inverts the EMS sign convention: positive
+-- setpoint = discharge on the Pixii side, positive power_w = charge on
+-- the EMS side. The driver negates at the setpoint boundary.
 
 DRIVER = {
   id           = "pixii",
@@ -29,7 +42,15 @@ DRIVER = {
 
 PROTOCOL = "modbus"
 
+-- Pixii control registers (doc 13300, section "Register addresses below 40000")
+local REG_HEARTBEAT   = 39903  -- uint16, 0..100, must tick >= 1/min
+local REG_SETPOINT_HI = 39905  -- int32 MSB (big-endian, paired with 39906)
+local REG_SETPOINT_LO = 39906  -- int32 LSB
+
 local sn_read = false
+-- Handshake counter, bumped every poll so the Pixii never times out to idle.
+-- Any change is sufficient; we just walk 0..99 and wrap.
+local hb_tick = 0
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -85,6 +106,11 @@ end
 ----------------------------------------------------------------------------
 
 function driver_poll()
+    -- Keep the handshake counter moving so the Pixii never times out
+    -- to idle. Pixii only requires that the value changes; 0..99 wrap.
+    hb_tick = (hb_tick + 1) % 100
+    pcall(host.modbus_write, REG_HEARTBEAT, hb_tick)
+
     -- Read serial number once from SunSpec Common Model (offset 52 from
     -- the common block → absolute 40052, 16 regs ASCII).
     if not sn_read then
@@ -276,18 +302,69 @@ function driver_poll()
 end
 
 ----------------------------------------------------------------------------
--- Control (read-only — not implemented)
+-- Control: active power setpoint (demand response)
 ----------------------------------------------------------------------------
+-- EMS convention on the 42W side: power_w > 0 = charge, < 0 = discharge.
+-- Pixii 39905/06 uses generator reference frame (positive = discharge),
+-- so the sign is flipped at the setpoint boundary. The two registers
+-- MUST be written atomically as a single write-multiple (FC 0x10) so
+-- the Pixii doesn't see a half-updated int32 — doc 13300 page 15 is
+-- explicit about this.
+
+-- Encode a signed int32 watt value into two big-endian u16 registers.
+-- Lua numbers are 64-bit doubles so the two's-complement math stays
+-- exact for any realistic setpoint (< ~2^53).
+local function encode_i32_be(value)
+    local raw = math.floor(value + 0.5)
+    if raw < 0 then raw = raw + 0x100000000 end
+    local hi = math.floor(raw / 0x10000) % 0x10000
+    local lo = raw % 0x10000
+    return hi, lo
+end
+
+local function write_setpoint_w(pixii_w)
+    local hi, lo = encode_i32_be(pixii_w)
+    local err = host.modbus_write_multi(REG_SETPOINT_HI, { hi, lo })
+    if err ~= nil and err ~= "" then
+        host.log("warn", "Pixii: setpoint write failed: " .. tostring(err))
+        return false
+    end
+    -- Bump the heartbeat on every command too — the dispatch tick is
+    -- often faster than the poll tick, and we don't want the Pixii to
+    -- edge into idle right after we told it to move.
+    hb_tick = (hb_tick + 1) % 100
+    pcall(host.modbus_write, REG_HEARTBEAT, hb_tick)
+    return true
+end
+
+local function set_battery_power(power_w)
+    -- Flip EMS → generator frame.
+    local pixii_w = -power_w
+    host.log("debug", "Pixii: setpoint ems_w=" .. tostring(power_w)
+        .. " pixii_w=" .. tostring(pixii_w))
+    return write_setpoint_w(pixii_w)
+end
 
 function driver_command(action, power_w, cmd)
-    host.log("info", "Pixii control not yet implemented: " .. tostring(action))
+    if action == "init" then
+        return true
+    elseif action == "battery" then
+        return set_battery_power(power_w or 0)
+    elseif action == "curtail_disable" or action == "deinit" then
+        return set_battery_power(0)
+    end
+    host.log("debug", "Pixii: unsupported action=" .. tostring(action))
     return false
 end
 
+-- Watchdog fallback: site-meter stale or driver-host decided to bail.
+-- Return the Pixii to idle (setpoint 0). The PI loop will re-assert
+-- its desired setpoint on the next cycle once telemetry recovers.
 function driver_default_mode()
-    -- No-op: read-only driver, nothing to revert.
+    host.log("info", "Pixii: watchdog → setpoint 0")
+    set_battery_power(0)
 end
 
 function driver_cleanup()
-    -- Nothing to clean up.
+    set_battery_power(0)
 end

--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -24,8 +24,8 @@ DRIVER = {
 --   Battery w: positive = charging  (load), negative = discharging (source)
 --   Meter   w: positive = importing,        negative = exporting
 --
--- Pixii native meter reports negative = import (utility-perspective), so we
--- negate meter power/current to line up with the site convention.
+-- On this Pixii firmware the native meter already reports positive = import,
+-- matching the site convention, so W and A are passed through unchanged.
 
 PROTOCOL = "modbus"
 
@@ -244,33 +244,33 @@ function driver_poll()
         import_wh = scale(host.decode_u32_be(imp_regs[1], imp_regs[2]), meter_energy_sf)
     end
 
-    -- Pixii native: negative=import. Site convention: positive=import.
-    -- Negate W and A (voltage is always positive magnitude, leave alone).
+    -- Native Pixii meter already uses site convention (+import / -export),
+    -- so values are passed through without a sign flip.
     host.emit("meter", {
-        w         = -meter_w,
-        l1_w      = -l1_w,
-        l2_w      = -l2_w,
-        l3_w      = -l3_w,
+        w         = meter_w,
+        l1_w      = l1_w,
+        l2_w      = l2_w,
+        l3_w      = l3_w,
         l1_v      = l1_v,
         l2_v      = l2_v,
         l3_v      = l3_v,
-        l1_a      = -l1_a,
-        l2_a      = -l2_a,
-        l3_a      = -l3_a,
+        l1_a      = l1_a,
+        l2_a      = l2_a,
+        l3_a      = l3_a,
         hz        = meter_hz,
         import_wh = import_wh,
         export_wh = export_wh,
     })
-    host.emit_metric("meter_l1_w", -l1_w)
-    host.emit_metric("meter_l2_w", -l2_w)
-    host.emit_metric("meter_l3_w", -l3_w)
-    host.emit_metric("meter_l1_v",  l1_v)
-    host.emit_metric("meter_l2_v",  l2_v)
-    host.emit_metric("meter_l3_v",  l3_v)
-    host.emit_metric("meter_l1_a", -l1_a)
-    host.emit_metric("meter_l2_a", -l2_a)
-    host.emit_metric("meter_l3_a", -l3_a)
-    host.emit_metric("grid_hz",     meter_hz)
+    host.emit_metric("meter_l1_w", l1_w)
+    host.emit_metric("meter_l2_w", l2_w)
+    host.emit_metric("meter_l3_w", l3_w)
+    host.emit_metric("meter_l1_v", l1_v)
+    host.emit_metric("meter_l2_v", l2_v)
+    host.emit_metric("meter_l3_v", l3_v)
+    host.emit_metric("meter_l1_a", l1_a)
+    host.emit_metric("meter_l2_a", l2_a)
+    host.emit_metric("meter_l3_a", l3_a)
+    host.emit_metric("grid_hz",    meter_hz)
 
     return 5000
 end

--- a/drivers/solaredge_pv.lua
+++ b/drivers/solaredge_pv.lua
@@ -1,0 +1,214 @@
+-- solaredge_pv.lua
+-- SolarEdge inverter driver, PV-only variant (SunSpec over Modbus TCP).
+-- Emits: PV. READ-ONLY.
+--
+-- Clone of drivers/solaredge.lua with the SunSpec Model 203 meter block
+-- stripped out — use this when the grid meter comes from a different
+-- driver (e.g. the Pixii PowerShaper via its Model 203 chain) and you
+-- only want PV generation from the SolarEdge inverter.
+
+DRIVER = {
+  id           = "solaredge-pv",
+  name         = "SolarEdge inverter (PV only)",
+  manufacturer = "SolarEdge",
+  version      = "1.0.0",
+  protocols    = { "modbus" },
+  capabilities = { "pv" },
+  description  = "SolarEdge HD-Wave / StorEdge PV-only via Modbus TCP (SunSpec).",
+  homepage     = "https://www.solaredge.com",
+  authors      = { "forty-two-watts contributors" },
+  tested_models = { "HD-Wave", "StorEdge" },
+}
+--
+-- SunSpec register map. This SolarEdge gateway serves FC 0x03 (holding)
+-- only; FC 0x04 (input) times out, so every read uses "holding".
+--
+--   Common block (device identity):
+--     40052-40067  SN (16 regs, ASCII, null-padded)
+--
+--   Inverter model (101/102/103):
+--     40083        AC power (I16)        * 10^ac_power_sf
+--     40084        AC power SF (I16)
+--     40085        Frequency (U16)       * 10^hz_sf
+--     40086        Frequency SF (I16)
+--     40093-40094  Lifetime Wh (U32 BE)  * 10^energy_sf
+--     40095        Energy SF (I16)
+--     40103        Heat-sink °C (I16)    * 10^temp_sf
+--     40106        Temp SF (I16)
+--     40123        MPPT current SF (I16)
+--     40124        MPPT voltage SF (I16)
+--     40140-40141  MPPT1 A/V (U16 each)
+--     40160-40161  MPPT2 A/V (U16 each)
+--
+-- Sign translation to site convention (positive = into site):
+--   AC power out of the inverter = generation → PV w = -ac_w.
+
+PROTOCOL = "modbus"
+
+-- Cached per-device metadata. Scale factors are factory-set constants
+-- (SunSpec guarantees they never change during a session), so we read
+-- them once and cache.
+local sn_read = false
+local sf_cache = nil
+
+----------------------------------------------------------------------------
+-- SunSpec helpers
+----------------------------------------------------------------------------
+
+local POW10 = {
+    [-6] = 1e-6, [-5] = 1e-5, [-4] = 1e-4, [-3] = 1e-3,
+    [-2] = 1e-2, [-1] = 1e-1, [0] = 1,
+    [1] = 10, [2] = 100, [3] = 1000, [4] = 10000, [5] = 100000, [6] = 1e6,
+}
+
+-- SunSpec scale factors use 0x8000 (= -32768 after i16 decode) as a
+-- "not implemented" sentinel. Treat that as 0 (don't scale).
+local function pow10(sf)
+    if sf == -32768 then return 1 end
+    local p = POW10[sf]
+    if p ~= nil then return p end
+    return 1
+end
+
+local function scale(value, sf)
+    return value * pow10(sf)
+end
+
+local function read_sf(addr)
+    local ok, regs = pcall(host.modbus_read, addr, 1, "holding")
+    if ok and regs then
+        return host.decode_i16(regs[1])
+    end
+    return 0
+end
+
+local function load_scale_factors()
+    return {
+        ac_power = read_sf(40084),
+        hz       = read_sf(40086),
+        energy   = read_sf(40095),
+        temp     = read_sf(40106),
+        mppt_a   = read_sf(40123),
+        mppt_v   = read_sf(40124),
+    }
+end
+
+local function decode_ascii(regs, n)
+    local s = ""
+    for i = 1, n do
+        local r = regs[i] or 0
+        local hi = math.floor(r / 256)
+        local lo = r % 256
+        if hi > 32 and hi < 127 then s = s .. string.char(hi) end
+        if lo > 32 and lo < 127 then s = s .. string.char(lo) end
+    end
+    return s
+end
+
+----------------------------------------------------------------------------
+-- Lifecycle
+----------------------------------------------------------------------------
+
+function driver_init(config)
+    host.set_make("SolarEdge")
+end
+
+function driver_poll()
+    -- ---- Serial number (SunSpec common block, one-shot) ----
+    if not sn_read then
+        local ok_sn, sn_regs = pcall(host.modbus_read, 40052, 16, "holding")
+        if ok_sn and sn_regs then
+            local sn = decode_ascii(sn_regs, 16)
+            if #sn > 0 then
+                host.set_sn(sn)
+                sn_read = true
+            end
+        end
+    end
+
+    -- ---- Scale factors (cached one-shot) ----
+    if sf_cache == nil then
+        sf_cache = load_scale_factors()
+    end
+    local sf = sf_cache
+
+    -- ---- Inverter AC ----
+
+    -- AC power: 40083, I16
+    local ok_acw, acw_regs = pcall(host.modbus_read, 40083, 1, "holding")
+    local ac_w = 0
+    if ok_acw and acw_regs then
+        ac_w = scale(host.decode_i16(acw_regs[1]), sf.ac_power)
+    end
+
+    -- Frequency: 40085, U16
+    local ok_hz, hz_regs = pcall(host.modbus_read, 40085, 1, "holding")
+    local hz = 0
+    if ok_hz and hz_regs then
+        hz = scale(hz_regs[1], sf.hz)
+    end
+
+    -- Lifetime energy: 40093-40094, U32 BE (Wh once scaled)
+    local ok_le, le_regs = pcall(host.modbus_read, 40093, 2, "holding")
+    local lifetime_wh = 0
+    if ok_le and le_regs then
+        lifetime_wh = scale(host.decode_u32_be(le_regs[1], le_regs[2]), sf.energy)
+    end
+
+    -- Heat-sink temperature: 40103, I16
+    local ok_temp, temp_regs = pcall(host.modbus_read, 40103, 1, "holding")
+    local temp_c = 0
+    if ok_temp and temp_regs then
+        temp_c = scale(host.decode_i16(temp_regs[1]), sf.temp)
+    end
+
+    -- MPPT1 A/V: 40140-40141, U16 each
+    local ok_m1, m1_regs = pcall(host.modbus_read, 40140, 2, "holding")
+    local mppt1_a, mppt1_v = 0, 0
+    if ok_m1 and m1_regs then
+        mppt1_a = scale(m1_regs[1], sf.mppt_a)
+        mppt1_v = scale(m1_regs[2], sf.mppt_v)
+    end
+
+    -- MPPT2 A/V: 40160-40161, U16 each
+    local ok_m2, m2_regs = pcall(host.modbus_read, 40160, 2, "holding")
+    local mppt2_a, mppt2_v = 0, 0
+    if ok_m2 and m2_regs then
+        mppt2_a = scale(m2_regs[1], sf.mppt_a)
+        mppt2_v = scale(m2_regs[2], sf.mppt_v)
+    end
+
+    -- Emit PV (site convention: generation is negative W)
+    host.emit("pv", {
+        w           = -ac_w,
+        mppt1_v     = mppt1_v,
+        mppt1_a     = mppt1_a,
+        mppt2_v     = mppt2_v,
+        mppt2_a     = mppt2_a,
+        lifetime_wh = lifetime_wh,
+        temp_c      = temp_c,
+    })
+    host.emit_metric("pv_mppt1_v",      mppt1_v)
+    host.emit_metric("pv_mppt1_a",      mppt1_a)
+    host.emit_metric("pv_mppt2_v",      mppt2_v)
+    host.emit_metric("pv_mppt2_a",      mppt2_a)
+    host.emit_metric("inverter_temp_c", temp_c)
+    host.emit_metric("grid_hz",         hz)
+
+    return 5000
+end
+
+----------------------------------------------------------------------------
+-- Control (read-only driver — command stubs)
+----------------------------------------------------------------------------
+
+function driver_command(action, power_w, cmd)
+    host.log("debug", "SolarEdge: read-only driver, ignoring action=" .. tostring(action))
+    return false
+end
+
+function driver_default_mode()
+end
+
+function driver_cleanup()
+end

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -180,10 +180,15 @@ func main() {
 				}
 			}
 			reg.Reload(ctx, newCfg.Drivers)
-			// Refresh capacities
+			// Refresh capacities — mutate the existing map in place so
+			// Deps.Capacities (a map header captured at init) sees the
+			// update. Rebinding the local variable would orphan the
+			// reference the api server still holds.
 			capMu.Lock()
-			capacities = driverCapacitiesFrom(newCfg.Drivers)
-			_ = capacities // intentional — keep reference in scope
+			for k := range capacities { delete(capacities, k) }
+			for k, v := range driverCapacitiesFrom(newCfg.Drivers) {
+				capacities[k] = v
+			}
 			capMu.Unlock()
 		})
 	if err != nil {

--- a/web/app.js
+++ b/web/app.js
@@ -25,10 +25,6 @@
     grid: [],
     pv: [],
     load: [],
-    ferroamp_bat: [],
-    sungrow_bat: [],
-    ferroamp_target: [],
-    sungrow_target: [],
     timestamps: [],
     // Energy counters (cumulative Wh, today-scoped)
     e_import: [],
@@ -38,6 +34,69 @@
     e_discharged: [],
     e_load: [],
   };
+
+  // Per-battery-driver chart series. Discovered dynamically from the
+  // /api/status drivers map (any driver exposing bat_w is treated as a
+  // battery source). Shape: { [driverName]: { bat: [...], target: [...] } }.
+  // Kept separate from chartHistory so the Object.keys(...).shift() loops
+  // below don't stumble over a nested object.
+  var chartBatteries = {};
+
+  // Deterministic color palette for battery series — each driver gets a
+  // stable color based on name hash so reload is consistent.
+  var BATTERY_PALETTE = [
+    "#f59e0b", "#8b5cf6", "#ec4899", "#06b6d4",
+    "#eab308", "#14b8a6", "#f43f5e", "#a855f7",
+  ];
+  function batteryColor(name) {
+    var h = 0;
+    for (var i = 0; i < name.length; i++) {
+      h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+    }
+    return BATTERY_PALETTE[Math.abs(h) % BATTERY_PALETTE.length];
+  }
+  // A driver name → presentation label. Capitalize first letter so
+  // "pixii" → "Pixii"; everything else passes through as-is.
+  function batteryLabel(name) {
+    if (!name) return name;
+    return name.charAt(0).toUpperCase() + name.slice(1);
+  }
+
+  // Ensure a battery-driver slot exists. Backfills bat/target arrays
+  // with zeros up to current timestamps length so row indices align
+  // with the other chartHistory series.
+  function ensureBatteryDriver(name) {
+    if (chartBatteries[name]) return chartBatteries[name];
+    var pad = chartHistory.timestamps.length;
+    var slot = { bat: new Array(pad).fill(0), target: new Array(pad).fill(0) };
+    chartBatteries[name] = slot;
+    syncBatteryLegend();
+    return slot;
+  }
+
+  // Append a legend item for any newly-discovered battery driver. Uses
+  // the same markup as the static legend entries so the click handler
+  // (delegated on #chart-legend) picks them up automatically.
+  function syncBatteryLegend() {
+    var host = document.getElementById("chart-legend");
+    if (!host) return;
+    Object.keys(chartBatteries).forEach(function (name) {
+      var key = "bat:" + name;
+      if (host.querySelector('[data-toggle="' + cssEscape(key) + '"]')) return;
+      var span = document.createElement("span");
+      span.className = "legend-item";
+      span.dataset.toggle = key;
+      if (legendHidden[key]) span.classList.add("legend-off");
+      var swatch = document.createElement("span");
+      swatch.className = "legend-color";
+      swatch.style.background = batteryColor(name);
+      span.appendChild(swatch);
+      span.appendChild(document.createTextNode(" " + batteryLabel(name)));
+      host.appendChild(span);
+    });
+  }
+  // Minimal CSS.escape polyfill (legend keys contain ':').
+  function cssEscape(s) { return String(s).replace(/[^a-zA-Z0-9_-]/g, function(c) { return "\\" + c; }); }
 
   // Latest MPC plan — refreshed every 30s. Drives the forward-looking
   // dashed PV + Load forecast on the live chart (right-hand segment
@@ -131,14 +190,13 @@
     // threw inside renderDispatch, which is between renderDrivers and
     // pushChartData, so the chart starved while ticks kept incrementing.)
     try {
-      var fd0 = (data.drivers || {}).ferroamp || {};
-      var sd0 = (data.drivers || {}).sungrow || {};
-      var ft0 = 0, st0 = 0;
-      (data.dispatch || []).forEach(function(d) {
-        if (d.driver === "ferroamp") ft0 = d.target_w;
-        if (d.driver === "sungrow") st0 = d.target_w;
+      // Build a {driver → target_w} index from the dispatch array so the
+      // per-battery push below doesn't need an inner loop.
+      var targetsByDriver = {};
+      (data.dispatch || []).forEach(function (d) {
+        if (d && d.driver) targetsByDriver[d.driver] = d.target_w || 0;
       });
-      pushChartData(data, fd0.bat_w||0, sd0.bat_w||0, ft0, st0);
+      pushChartData(data, targetsByDriver);
     } catch (e) { console.error("pushChartData error:", e); }
 
     // Version (live from API — survives stale browser cache of index.html)
@@ -261,7 +319,7 @@
     // Timestamp is updated in fetchStatus (before render, so it's robust to render errors)
   }
 
-  function pushChartData(data, ferroBat, sunBat, ferroTarget, sunTarget) {
+  function pushChartData(data, targetsByDriver) {
     var t = (data.energy && data.energy.today) || {};
     var now = Date.now();
     // Dedupe via JS-side push timer ONLY — never compare against server timestamps
@@ -273,10 +331,6 @@
     chartHistory.grid.push(data.grid_w);
     chartHistory.pv.push(data.pv_w);
     chartHistory.load.push(data.load_w || 0);
-    chartHistory.ferroamp_bat.push(ferroBat);
-    chartHistory.sungrow_bat.push(sunBat);
-    chartHistory.ferroamp_target.push(ferroTarget);
-    chartHistory.sungrow_target.push(sunTarget);
     chartHistory.timestamps.push(now);
     chartHistory.e_import.push(t.import_wh || 0);
     chartHistory.e_export.push(t.export_wh || 0);
@@ -284,8 +338,37 @@
     chartHistory.e_charged.push(t.bat_charged_wh || 0);
     chartHistory.e_discharged.push(t.bat_discharged_wh || 0);
     chartHistory.e_load.push(t.load_wh || 0);
+
+    // Per-battery-driver push. Any driver in data.drivers that exposes
+    // bat_w is considered battery-capable and gets its own chart series.
+    var drivers = data.drivers || {};
+    var seenBatteries = {};
+    Object.keys(drivers).forEach(function (name) {
+      var d = drivers[name] || {};
+      if (d.bat_w == null) return;
+      seenBatteries[name] = true;
+      var slot = ensureBatteryDriver(name);
+      slot.bat.push(d.bat_w || 0);
+      slot.target.push((targetsByDriver && targetsByDriver[name]) || 0);
+    });
+    // Drivers that have history but didn't report this cycle: push a
+    // 0 so index alignment with chartHistory.timestamps stays intact.
+    // (Keeps the line continuous; the driver offline/gap is already
+    // visible through the driver card's status indicator.)
+    Object.keys(chartBatteries).forEach(function (name) {
+      if (seenBatteries[name]) return;
+      var slot = chartBatteries[name];
+      slot.bat.push(0);
+      slot.target.push(0);
+    });
+
     if (chartHistory.grid.length > CHART_POINTS) {
       Object.keys(chartHistory).forEach(function(k) { chartHistory[k].shift(); });
+      Object.keys(chartBatteries).forEach(function (name) {
+        var slot = chartBatteries[name];
+        slot.bat.shift();
+        slot.target.shift();
+      });
     }
     lastDataTs = now;
     // Fire a discrete pulse for this new data point — heartbeat feel
@@ -335,14 +418,20 @@
       ];
     } else {
       series = [
-        { data: chartHistory.grid,            color: "#ef4444", width: 2,   dash: [],     name: "Grid",         fill: true,  toggle: "grid" },
-        { data: chartHistory.pv,              color: "#22c55e", width: 2,   dash: [],     name: "PV",           fill: true,  toggle: "pv" },
-        { data: chartHistory.load,            color: "#e2e8f0", width: 1.5, dash: [],     name: "Load",         fill: false, toggle: "load" },
-        { data: chartHistory.ferroamp_bat,    color: "#f59e0b", width: 2,   dash: [],     name: "Ferroamp",     fill: false, toggle: "ferroamp" },
-        { data: chartHistory.ferroamp_target, color: "#f59e0b", width: 1.5, dash: [6, 4], name: "Ferroamp tgt", fill: false, toggle: "ferroamp" },
-        { data: chartHistory.sungrow_bat,     color: "#8b5cf6", width: 2,   dash: [],     name: "Sungrow",      fill: false, toggle: "sungrow" },
-        { data: chartHistory.sungrow_target,  color: "#8b5cf6", width: 1.5, dash: [6, 4], name: "Sungrow tgt",  fill: false, toggle: "sungrow" },
+        { data: chartHistory.grid, color: "#ef4444", width: 2,   dash: [], name: "Grid", fill: true,  toggle: "grid" },
+        { data: chartHistory.pv,   color: "#22c55e", width: 2,   dash: [], name: "PV",   fill: true,  toggle: "pv" },
+        { data: chartHistory.load, color: "#e2e8f0", width: 1.5, dash: [], name: "Load", fill: false, toggle: "load" },
       ];
+      // Append one actual/target pair per discovered battery driver.
+      // Stable order so chart colors don't jump as the driver set grows.
+      Object.keys(chartBatteries).sort().forEach(function (name) {
+        var slot = chartBatteries[name];
+        var color = batteryColor(name);
+        var toggle = "bat:" + name;
+        var label = batteryLabel(name);
+        series.push({ data: slot.bat,    color: color, width: 2,   dash: [],     name: label,         fill: false, toggle: toggle });
+        series.push({ data: slot.target, color: color, width: 1.5, dash: [6, 4], name: label + " tgt", fill: false, toggle: toggle });
+      });
       // Respect click-to-hide from legend.
       series = series.filter(function (s) { return !legendHidden[s.toggle]; });
     }
@@ -713,16 +802,21 @@
       { name: "Charged",    data: chartHistory.e_charged,    color: "#3b82f6" },
       { name: "Discharged", data: chartHistory.e_discharged, color: "#f59e0b" },
       { name: "Load",       data: chartHistory.e_load,       color: "#e2e8f0" },
-    ] : [
-      { name: "Grid",     data: chartHistory.grid,     color: "#ef4444" },
-      { name: "PV",       data: chartHistory.pv,       color: "#22c55e" },
-      { name: "Load",     data: chartHistory.load,     color: "#e2e8f0" },
+    ] : (function () {
+      var rows = [
+        { name: "Grid", data: chartHistory.grid, color: "#ef4444" },
+        { name: "PV",   data: chartHistory.pv,   color: "#22c55e" },
+        { name: "Load", data: chartHistory.load, color: "#e2e8f0" },
+      ];
       // Battery rows render their target inline as "actual W (→ target W)"
       // so it's visually obvious the two numbers are the same metric — one
-      // measured, one commanded. See drawHoverOverlay's value formatter.
-      { name: "Ferroamp", data: chartHistory.ferroamp_bat, color: "#f59e0b", target: chartHistory.ferroamp_target },
-      { name: "Sungrow",  data: chartHistory.sungrow_bat,  color: "#8b5cf6", target: chartHistory.sungrow_target },
-    ];
+      // measured, one commanded. See value formatter below.
+      Object.keys(chartBatteries).sort().forEach(function (name) {
+        var slot = chartBatteries[name];
+        rows.push({ name: batteryLabel(name), data: slot.bat, color: batteryColor(name), target: slot.target });
+      });
+      return rows;
+    })();
 
     var ts = chartHistory.timestamps[i] || 0;
     var timeStr = ts > 0 ? new Date(ts).toLocaleTimeString() : "";
@@ -1168,19 +1262,15 @@
         if (!data || !data.items) return;
         // Populate chart history from persisted data
         Object.keys(chartHistory).forEach(function(k) { chartHistory[k] = []; });
+        // Reset the dynamic battery set and rediscover from the history
+        // items themselves — drivers that existed earlier but no longer
+        // appear in /api/status will simply not be recreated.
+        chartBatteries = {};
         data.items.forEach(function (it) {
-          var fd = (it.drivers || {}).ferroamp || {};
-          var sd = (it.drivers || {}).sungrow || {};
-          var ft = (it.targets || {}).ferroamp || 0;
-          var st = (it.targets || {}).sungrow || 0;
           var et = it.energy_today || {};
           chartHistory.grid.push(it.grid_w || 0);
           chartHistory.pv.push(it.pv_w || 0);
           chartHistory.load.push(it.load_w || 0);
-          chartHistory.ferroamp_bat.push(fd.bat_w || 0);
-          chartHistory.sungrow_bat.push(sd.bat_w || 0);
-          chartHistory.ferroamp_target.push(ft);
-          chartHistory.sungrow_target.push(st);
           chartHistory.timestamps.push(it.ts || 0);
           chartHistory.e_import.push(et.import_wh || 0);
           chartHistory.e_export.push(et.export_wh || 0);
@@ -1188,7 +1278,27 @@
           chartHistory.e_charged.push(et.bat_charged_wh || 0);
           chartHistory.e_discharged.push(et.bat_discharged_wh || 0);
           chartHistory.e_load.push(et.load_wh || 0);
+
+          // Per-battery discovery from this item's drivers + targets maps.
+          var itDrivers = it.drivers || {};
+          var itTargets = it.targets || {};
+          var seen = {};
+          Object.keys(itDrivers).forEach(function (name) {
+            var d = itDrivers[name] || {};
+            if (d.bat_w == null) return;
+            seen[name] = true;
+            var slot = ensureBatteryDriver(name);
+            slot.bat.push(d.bat_w || 0);
+            slot.target.push(itTargets[name] || 0);
+          });
+          Object.keys(chartBatteries).forEach(function (name) {
+            if (seen[name]) return;
+            var slot = chartBatteries[name];
+            slot.bat.push(0);
+            slot.target.push(0);
+          });
         });
+        syncBatteryLegend();
         renderChart();
       })
       .catch(function () { /* silent */ });

--- a/web/index.html
+++ b/web/index.html
@@ -184,8 +184,8 @@
           <span class="legend-item" data-toggle="pv_fc"><span class="legend-color legend-dash" style="border-color:#86efac"></span> PV fc</span>
           <span class="legend-item" data-toggle="load"><span class="legend-color" style="background:#e2e8f0"></span> Load</span>
           <span class="legend-item" data-toggle="load_fc"><span class="legend-color legend-dash" style="border-color:#fde68a"></span> Load fc</span>
-          <span class="legend-item" data-toggle="ferroamp"><span class="legend-color" style="background:#f59e0b"></span> Ferroamp</span>
-          <span class="legend-item" data-toggle="sungrow"><span class="legend-color" style="background:#8b5cf6"></span> Sungrow</span>
+          <!-- Battery driver legend items are appended dynamically by app.js
+               as each battery-capable driver appears in /api/status. -->
         </div>
         <!-- Hidden view toggle kept for app.js compatibility -->
         <div id="view-buttons" style="display:none">


### PR DESCRIPTION
- Support for controlling Pixii
- Support for SolarEdges without meter
- Removed hard coded sungrow & ferroamp from live charts, reading configured devices instead