### PR TITLE
telemetry: add DerEV type (EV charging Unit 1/5)

### DIFF
--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -14,9 +14,10 @@ const (
 	DerMeter DerType = iota
 	DerPV
 	DerBattery
+	DerEV
 )
 
-// String returns the canonical string form ("meter", "pv", "battery").
+// String returns the canonical string form ("meter", "pv", "battery", "ev").
 func (d DerType) String() string {
 	switch d {
 	case DerMeter:
@@ -25,6 +26,8 @@ func (d DerType) String() string {
 		return "pv"
 	case DerBattery:
 		return "battery"
+	case DerEV:
+		return "ev"
 	}
 	return "unknown"
 }
@@ -38,6 +41,8 @@ func ParseDerType(s string) (DerType, error) {
 		return DerPV, nil
 	case "battery":
 		return DerBattery, nil
+	case "ev":
+		return DerEV, nil
 	}
 	return 0, fmt.Errorf("unknown der type %q", s)
 }

--- a/go/internal/telemetry/telemetry_test.go
+++ b/go/internal/telemetry/telemetry_test.go
@@ -161,7 +161,7 @@ func TestReadingPreservesData(t *testing.T) {
 // ---- DerType ----
 
 func TestDerTypeRoundtrip(t *testing.T) {
-	for _, name := range []string{"meter", "pv", "battery"} {
+	for _, name := range []string{"meter", "pv", "battery", "ev"} {
 		d, err := ParseDerType(name)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

First unit in the EV charging Phase 1 rollout. Pure enum expansion — adds \`DerEV\` alongside the existing \`DerMeter\` / \`DerPV\` / \`DerBattery\`.

No behavioral change. The wiring that actually uses \`DerEV\` (host.emit acceptance, dispatch-clamp summation, pilot driver) lands in follow-up PRs so each step can be validated on live hardware between merges.

## Context

See the plan in \`~/.claude/plans/zazzy-foraging-hinton.md\`. 42W already has the dispatch-level clamp that prevents home batteries discharging into an active EV charger (\`go/internal/control/dispatch.go:199-202\`). Today it's driven by a manual slider; this rollout closes the loop with a real driver.

## Test plan

- [x] \`go test ./...\` passes (includes updated \`TestDerTypeRoundtrip\` covering \"ev\").
- [x] Existing drivers unaffected (\`DerMeter\` / \`DerPV\` / \`DerBattery\` keep their iota values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)