### PR TITLE
docs: describe host.emit("ev") for driver authors (EV Unit 2/5)

### DIFF
--- a/docs/writing-a-driver.md
+++ b/docs/writing-a-driver.md
@@ -179,7 +179,21 @@ host.emit("battery", {
     charge_wh    = 98765,
     discharge_wh = 54321,
 })
+
+host.emit("ev", {
+    w          = 7200,  -- required. Charge power in W (positive when pulling
+                        -- from the grid). Zero when plug is idle.
+    connected  = true,  -- required. Plug inserted in the car.
+    charging   = true,  -- required. Current is actually flowing.
+    session_wh = 14500, -- optional. Energy delivered this plug session.
+    max_a      = 16,    -- optional. Charger current cap.
+    phases     = 3,     -- optional. 1 or 3.
+})
 ```
+
+EV readings feed directly into the dispatch clamp that keeps home
+batteries from discharging into the car (`dispatch.go`). If your driver
+only knows `w`, set `connected = (w > 0)` and `charging = (w > 0)`.
 
 For anything that doesn't fit the pv/battery/meter shape — temperatures,
 DC voltages, MPPT currents, grid frequency — use:

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -13,7 +13,7 @@
 // surfaced as a `host` global in the Lua VM:
 //
 //	host.log(level, msg)            -- level: "debug"|"info"|"warn"|"error"
-//	host.emit(table)                -- telemetry: {type="battery", w=…, soc=…}
+//	host.emit(type, table)          -- type: "meter"|"pv"|"battery"|"ev"
 //	host.millis()                   -- ms since driver start
 //	host.set_poll_interval(ms)
 //	host.set_sn(s)                  -- device serial (metadata)
@@ -179,9 +179,19 @@ func registerHost(L *lua.LState, env *HostEnv) {
 		return 0
 	}))
 
-	// host.emit("meter"|"pv"|"battery", { w=…, soc=… })
+	// host.emit("meter"|"pv"|"battery"|"ev", { w=…, soc=…, connected=…, charging=… })
 	// The type string is prepended to the table as a `type` field and
 	// the whole thing serialized as the JSON the WASM host expects.
+	// Allowed fields per type:
+	//   meter   -> w, l1_w, l2_w, l3_w, l1_v, l2_v, l3_v, l1_a, l2_a, l3_a, freq_hz
+	//   pv      -> w, mppt1_v, mppt1_a, mppt2_v, mppt2_a, dc_v
+	//   battery -> w, soc, dc_v, dc_a, temp_c
+	//   ev      -> w (charge power, positive when charging),
+	//              connected (bool, plug inserted),
+	//              charging (bool, current flowing),
+	//              session_wh (optional, kWh for current session * 1000),
+	//              max_a (optional, charger current limit),
+	//              phases (optional, 1 or 3)
 	host.RawSetString("emit", L.NewFunction(func(L *lua.LState) int {
 		typ := L.CheckString(1)
 		tbl := L.CheckTable(2)


### PR DESCRIPTION
## Summary

Documents the \`\"ev\"\` emit type on both sides of the driver contract:

- \`go/internal/drivers/lua.go\` — top-of-file comment + inline docstring list \`\"ev\"\` alongside \`\"meter\"|\"pv\"|\"battery\"\` and enumerate the allowed fields (\`w\`, \`connected\`, \`charging\`, \`session_wh\`, \`max_a\`, \`phases\`).
- \`docs/writing-a-driver.md\` §3.2 — new \`host.emit(\"ev\", {…})\` example with field meanings and a note about the dispatch clamp.

Zero code change. The actual acceptance was unlocked by Unit 1 (\`DerEV\` in \`telemetry.ParseDerType\`). This PR just tells driver authors the type exists.

## Test plan

- [x] \`go test ./internal/drivers/\` passes.
- [x] Markdown renders (checked links + code fences locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)