### PR TITLE
control: fold live DerEV readings into the EV clamp (EV Unit 3/5)

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -376,3 +376,37 @@ func TestEVChargingSignalExcludedFromGrid(t *testing.T) {
 		}
 	}
 }
+
+func TestEVChargingSignalOverriddenByDerEVReading(t *testing.T) {
+	// A DerEV driver reports 4000W. EVChargingW was 0 (no manual slider).
+	// After ComputeDispatch, EVChargingW must reflect the live reading
+	// so the dispatch clamp works against real hardware.
+	store := seedStore(5000, []struct{ name string; currentW, soc float64 }{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("easee", telemetry.DerEV, 4000, nil, nil)
+	store.DriverHealthMut("easee").RecordSuccess()
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.EVChargingW = 0
+	st.SlewRateW = 100000
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.EVChargingW != 4000 {
+		t.Errorf("expected EVChargingW to be overridden by live EV reading = 4000, got %f", st.EVChargingW)
+	}
+}
+
+func TestEVChargingManualPreservedWhenNoDriver(t *testing.T) {
+	// No DerEV reading. The manual slider value (1500W) must survive —
+	// we don't want an offline / stale driver to silently zero it out.
+	store := seedStore(1500, []struct{ name string; currentW, soc float64 }{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.EVChargingW = 1500
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.EVChargingW != 1500 {
+		t.Errorf("expected EVChargingW manual value 1500 to survive, got %f", st.EVChargingW)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -196,6 +196,17 @@ func ComputeDispatch(
 	if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
 		rawGridW = r.SmoothedW
 	}
+	// Live EV charger readings override the manual slider on each tick —
+	// hardware truth beats guesses. Only override when something >0 is
+	// actually being reported, so an offline / stale EV driver doesn't
+	// silently zero out a user-set manual value.
+	var evSum float64
+	for _, r := range store.ReadingsByType(telemetry.DerEV) {
+		evSum += r.SmoothedW
+	}
+	if evSum > 0 {
+		state.EVChargingW = evSum
+	}
 	// EV signal: subtract EV load from grid so batteries don't try to cover it.
 	// EV is always a positive import at the meter; subtracting it makes the
 	// "effective grid" the controller works on the house-side portion only.


### PR DESCRIPTION
## Summary

Lets the existing EV clamp (\`dispatch.go:199-202\`) pull its value from live driver readings instead of only the manual slider. Five-line addition in \`ComputeDispatch\`: sum \`ReadingsByType(DerEV)\` and write the result to \`state.EVChargingW\` when >0, so a Lua driver emitting \`host.emit(\"ev\", {...})\` drives the clamp automatically.

**Guard**: only override when the sum is positive. An offline / stale EV driver must not silently zero out a user-set manual override.

## Test plan

- [x] New tests \`TestEVChargingSignalOverriddenByDerEVReading\` + \`TestEVChargingManualPreservedWhenNoDriver\`.
- [x] Existing \`TestEVChargingSignalExcludedFromGrid\` still passes.
- [x] Full suite green.
- [ ] Live validation on homelab-rpi after this + #34 land.

Depends on #34 (DerEV enum). Rebase if merge order differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)