### PR TITLE
control: slew from actual battery power, not stale command

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -410,3 +410,67 @@ func TestEVChargingManualPreservedWhenNoDriver(t *testing.T) {
 		t.Errorf("expected EVChargingW manual value 1500 to survive, got %f", st.EVChargingW)
 	}
 }
+
+// ---- Slew rate anchor ----
+
+// xorath's reported bug: battery at 10% SoC was commanded -5000 W the
+// previous cycle but physically responded with 0 W (empty). When the user
+// removed EV load creating surplus, the PI wanted +2000 W, but slew
+// anchored on the stale -5000 W command capped new command at
+// -5000 + 500 = -4500 W. Reversing direction took 5000/500 = 10 cycles
+// (~50 s at 5 s interval). Anchoring slew on actual smoothed power
+// (which was 0 W, not -5000 W) lets dispatch pivot within one slew step.
+func TestSlewAnchorsOnActualNotStaleCommand(t *testing.T) {
+	// Battery: previous command -5000 W, actual output 0 W (empty).
+	// Grid: -2000 W (surplus → PI wants to charge the battery).
+	store := seedStore(-2000, []struct{ name string; currentW, soc float64 }{
+		{"pixii", 0, 0.10}, // at SoC min, actual bat_w = 0 despite command
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 500
+	// Seed the stale command — this is what the dispatch stored after
+	// last cycle, when it commanded -5000 W and the battery couldn't
+	// comply.
+	st.PrevTargets["pixii"] = -5000
+	// Note: no battery called "ferroamp" in this store, so dispatch
+	// skips it as unavailable. Only pixii is in the game.
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"pixii": 10000}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 dispatch target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// With actual-anchored slew (anchor = 0 W), one step toward +W
+	// should land the command in (0, +500]. With the old stale-anchored
+	// slew it would land at -4500 W.
+	if got < 0 {
+		t.Errorf("expected positive (charge) target, got %f W — slew still anchored to stale command", got)
+	}
+	if got > st.SlewRateW+1e-6 {
+		t.Errorf("expected target within one slew step of 0 W actual, got %f W", got)
+	}
+}
+
+// Ensure normal in-tracking operation (actual ≈ command) still respects
+// the slew limit from the actual. This prevents the fix from letting the
+// PI jump more than slew_rate per cycle when the battery is tracking well.
+func TestSlewRespectsRateWhenTracking(t *testing.T) {
+	// Battery actively discharging at -1000 W, both actual and prev command.
+	store := seedStore(1500, []struct{ name string; currentW, soc float64 }{
+		{"pixii", -1000, 0.6},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 500
+	st.PrevTargets["pixii"] = -1000
+	// PI will want a big discharge to cover the +1500 import.
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"pixii": 10000}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Anchor is actual -1000; one slew step toward negative lands at -1500.
+	if math.Abs(got-(-1500)) > 1e-6 {
+		t.Errorf("expected slewed target = -1500 W (anchor -1000 + step -500), got %f W", got)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -294,17 +294,38 @@ func ComputeDispatch(
 	}
 
 	// ---- Slew rate limit per driver ----
+	//
+	// Slew FROM the battery's actual measured output (SmoothedW), not
+	// from the previous command. When the battery can't meet a command
+	// (e.g. SoC at min and commanded to discharge, SoC at max and
+	// commanded to charge, or driver offline), the command stays pinned
+	// far from reality. Using the stored command as the slew anchor then
+	// forces `|target - stale_command| / slew_rate` cycles of ramping
+	// before the direction reverses — a 5 kW stale command with a 500
+	// W/cycle slew at 5 s interval means 50 s of wasted export before
+	// the surplus-absorb starts.
+	//
+	// Using actual-smoothed-W is the truth about where the battery is,
+	// and lets the dispatch pivot immediately when the setpoint reverses.
+	// Falls back to the previous command if no reading is available
+	// (driver just started, or stale telemetry).
 	for i := range raw {
-		if prev, ok := state.PrevTargets[raw[i].Driver]; ok {
-			delta := raw[i].TargetW - prev
-			if math.Abs(delta) > state.SlewRateW {
-				sign := 1.0
-				if delta < 0 {
-					sign = -1.0
-				}
-				raw[i].TargetW = prev + sign*state.SlewRateW
-				raw[i].Clamped = true
+		anchor, hasAnchor := state.PrevTargets[raw[i].Driver]
+		if r := store.Get(raw[i].Driver, telemetry.DerBattery); r != nil {
+			anchor = r.SmoothedW
+			hasAnchor = true
+		}
+		if !hasAnchor {
+			continue
+		}
+		delta := raw[i].TargetW - anchor
+		if math.Abs(delta) > state.SlewRateW {
+			sign := 1.0
+			if delta < 0 {
+				sign = -1.0
 			}
+			raw[i].TargetW = anchor + sign*state.SlewRateW
+			raw[i].Clamped = true
 		}
 	}
 


### PR DESCRIPTION
## Summary

@xorath caught this live: when a battery can't physically meet a command (SoC at min/max, offline, fault) the previous *command* stays pinned far from reality. The slew-rate limiter then anchors on that stale value, so reversing direction takes \`|stale_command - new_target| / slew_rate\` cycles before the battery actually pivots.

### Repro (xorath's)

1. Pixii at 10 % SoC, commanded -5000 W. Actual output: 0 W (empty).
2. User stops EV charging → site now has surplus. PI wants +2000 W (charge from surplus).
3. Old slew: \`anchor = -5000\`, \`delta = 7000\`, caps at +500/cycle → new command is \`-5000 + 500 = -4500\` W.
4. Takes 14 cycles (~70 s at 5 s interval) before the direction actually reverses. 70 s of wasted export.

## Fix

One region in \`go/internal/control/dispatch.go\` — anchor slew on \`store.Get(driver, DerBattery).SmoothedW\` (the truth) when available, falling back to the previous command when not (e.g. driver just started).

When the battery is tracking its command (actual ≈ prev_command), the behavior is unchanged — normal slew-rate limit applies from actual. When the battery can't comply, actual stays at 0 and the dispatcher pivots within one slew step.

## Test plan

- [x] \`TestSlewAnchorsOnActualNotStaleCommand\` — empty battery, stale -5000 W command, want +2000: actual-anchored slew lands in \`(0, +500]\`, not at \`-4500\`.
- [x] \`TestSlewRespectsRateWhenTracking\` — tracking at -1000 W, PI wants big discharge: command capped at \`-1500\` (anchor -1000 + step -500), proving the slew rate itself still binds.
- [x] All existing \`go test ./internal/control/\` pass.
- [x] Full \`go test ./...\` green including e2e.
- [ ] Verify live on homelab-rpi with EV toggle scenario once we're back on a planner mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)