### PR TITLE
control+mpc: plan is a scheduler, not a regulator

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -343,7 +343,7 @@ func main() {
 		mpcSvc.Start(ctx)
 		defer mpcSvc.Stop()
 		// Inject plan → control.State so planner modes can override grid_target.
-		ctrl.PlanTarget = mpcSvc.GridTargetAt
+		ctrl.PlanTarget = mpcSvc.SlotAt
 		slog.Info("mpc planner started",
 			"mode", mpcSvc.Defaults.Mode,
 			"capacity_wh", mpcSvc.Defaults.CapacityWh,

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -37,9 +37,14 @@ func (m Mode) IsPlannerMode() bool {
 }
 
 // PlanTargetFunc is injected by main.go: given the current time, returns
-// (grid_target_w, ok). When ok=false, the plan is stale/missing and the
-// control loop falls back to self_consumption with grid_target_w = 0.
-type PlanTargetFunc func(now time.Time) (float64, bool)
+// the plan's directive for the current slot. When ok=false, the plan is
+// stale/missing and the control loop falls back to self_consumption with
+// grid_target=0.
+//
+// Returns (mode_string, grid_target_w, ok). mode_string maps to a Mode
+// constant; the dispatch uses its existing mode logic for HOW batteries
+// respond. The plan is a scheduler, not a regulator.
+type PlanTargetFunc func(now time.Time) (string, float64, bool)
 
 // DispatchTarget is one command to issue to a single battery driver.
 // `TargetW` is in site sign convention:
@@ -142,34 +147,32 @@ func ComputeDispatch(
 	driverCapacities map[string]float64,
 	fuseMaxW float64,
 ) []DispatchTarget {
-	// ---- Planner modes: override grid_target from the plan ----
-	// We don't mutate state.Mode — the operator's selected mode is
-	// preserved for display. Once the grid_target is set from the plan,
-	// the rest of this function behaves like self_consumption: PI chases
-	// the target we just set. The downstream switches special-case this
-	// by treating planner modes as self_consumption.
+	// ---- Planner modes: the plan is a scheduler, not a regulator ----
+	// The plan decides WHEN each strategy applies (self-consumption now,
+	// charge at 02:00, export at 17:00). The EMS's existing mode logic
+	// decides HOW batteries respond every 5 s based on the live meter.
+	//
+	// The planner's PlanSlot.Mode replaces the effective mode for this
+	// cycle. PlanSlot.GridW overrides the grid target when the slot's
+	// mode needs it (e.g. charge → target = +max_charge). For self-
+	// consumption slots, grid_target is always 0.
+	effectiveMode := state.Mode
 	if state.Mode.IsPlannerMode() {
-		var target float64
+		var modeStr string
+		var gridW float64
 		ok := false
 		if state.PlanTarget != nil {
-			target, ok = state.PlanTarget(time.Now())
+			modeStr, gridW, ok = state.PlanTarget(time.Now())
 		}
 		if ok {
-			state.SetGridTarget(target)
+			effectiveMode = Mode(modeStr)
+			state.SetGridTarget(gridW)
 			state.PlanStale = false
 		} else {
-			// Plan missing or stale. Fail-safe: self_consumption with
-			// target=0. Operator sees PlanStale=true.
+			effectiveMode = ModeSelfConsumption
 			state.SetGridTarget(0)
 			state.PlanStale = true
 		}
-	}
-
-	// effectiveMode collapses planner modes into self_consumption for
-	// the rest of this function. Real state.Mode is untouched.
-	effectiveMode := state.Mode
-	if effectiveMode.IsPlannerMode() {
-		effectiveMode = ModeSelfConsumption
 	}
 
 	// ---- Idle + Charge short-circuits ----

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -124,32 +124,58 @@ func (s *Service) Latest() *Plan {
 // single missed replan doesn't flip us into fallback.
 const MaxPlanAge = 30 * time.Minute
 
-// GridTargetAt returns the plan's grid-power target for the slot
-// containing `now`. Returns (0, false) if the plan is missing, stale,
-// or `now` is outside the plan's horizon.
-//
-// The result is already in site sign convention (+ import, − export).
-func (s *Service) GridTargetAt(now time.Time) (float64, bool) {
+// SlotAt returns the plan's directive for the slot containing `now`.
+// Returns (mode, grid_target_w, ok). Dispatch uses `mode` to select
+// the EMS strategy and `grid_target_w` as the PI setpoint. The plan is
+// a scheduler (decides WHEN); the EMS is the regulator (decides HOW).
+func (s *Service) SlotAt(now time.Time) (string, float64, bool) {
 	if s == nil {
-		return 0, false
+		return "", 0, false
 	}
 	s.mu.RLock()
 	p := s.last
 	s.mu.RUnlock()
 	if p == nil {
-		return 0, false
+		return "", 0, false
 	}
 	if time.Since(time.UnixMilli(p.GeneratedAtMs)) > MaxPlanAge {
-		return 0, false
+		return "", 0, false
 	}
 	nowMs := now.UnixMilli()
 	for _, a := range p.Actions {
 		end := a.SlotStartMs + int64(a.SlotLenMin)*60*1000
 		if nowMs >= a.SlotStartMs && nowMs < end {
-			return a.GridW, true
+			return actionToSlot(a, s.Defaults.Mode)
 		}
 	}
-	return 0, false
+	return "", 0, false
+}
+
+// actionToSlot translates an MPC action into (mode_string, grid_target_w, true).
+// The mapping from planner-mode + action to EMS mode:
+//   - self_consumption → always self_consumption with grid_target=0
+//   - cheap_charge → "charge" when the plan says charge, otherwise self_consumption
+//   - arbitrage → "charge" / "peak_shaving" (for export) / self_consumption
+func actionToSlot(a Action, plannerMode Mode) (string, float64, bool) {
+	switch plannerMode {
+	case ModeSelfConsumption:
+		return "self_consumption", 0, true
+	case ModeCheapCharge:
+		if a.BatteryW > 100 {
+			return "charge", 0, true
+		}
+		return "self_consumption", 0, true
+	case ModeArbitrage:
+		if a.BatteryW > 100 {
+			return "charge", 0, true
+		}
+		if a.BatteryW < -100 {
+			return "peak_shaving", a.GridW, true
+		}
+		return "self_consumption", 0, true
+	default:
+		return "self_consumption", 0, true
+	}
 }
 
 // SetMode changes the planner's operating mode and forces an immediate


### PR DESCRIPTION
## Summary

Fixes the broken planner_self mode that was commanding batteries to charge at 100% SoC and thrashing between charge/discharge every cycle.

### Root cause

The old wiring used the plan's forecast \`grid_w\` as the PI setpoint. When actual load drifted from the forecast (household appliances cycling on/off), the PI over-corrected in the wrong direction — commanding charge when it should idle, or discharge when SoC was empty.

### New design

The plan is a **scheduler** (decides WHEN), not a regulator (decides HOW). \`SlotAt()\` translates each slot's \`(battery_w, planner_mode)\` into an EMS mode string + grid target that dispatch already knows how to execute:

| Planner mode | Plan says charge | Plan says idle | Plan says discharge |
|---|---|---|---|
| \`planner_self\` | self_consumption (target=0) | self_consumption (target=0) | self_consumption (target=0) |
| \`planner_cheap\` | charge | self_consumption (target=0) | self_consumption (target=0) |
| \`planner_arbitrage\` | charge | self_consumption (target=0) | peak_shaving (target=plan grid_w) |

For \`planner_self\`, the effective mode is ALWAYS \`self_consumption\` with \`grid_target=0\`. The PI drives batteries to cover load from SoC and charge from PV surplus — the same behavior as bare self_consumption. The planner's schedule decides when to switch strategies (e.g. cheap_charge at night), but never overrides the PI's real-time regulation.

### Breaking change

\`PlanTargetFunc\` signature changed from \`func(time.Time) (float64, bool)\` to \`func(time.Time) (string, float64, bool)\` — returns \`(mode_string, grid_w, ok)\` instead of just \`(grid_w, ok)\`. Only consumer is \`main.go\` which is updated.

## Test plan

- [x] \`go test ./internal/control/\` — all pass including EV + slew tests.
- [x] \`go test ./internal/mpc/\` — all pass.
- [x] Full \`go test ./...\` green including e2e.
- [ ] Deploy to homelab-rpi, switch to \"Smart self-consumption (planner)\", verify batteries discharge to cover load with grid near 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)