### PR TITLE
drivers: fix 9 P1 bugs from Codex review

### DIFF
--- a/drivers/ferroamp_modbus.lua
+++ b/drivers/ferroamp_modbus.lua
@@ -263,6 +263,13 @@ function driver_command(action, power_w, cmd)
         return true
 
     elseif action == "battery" then
+        if power_w == 0 then
+            -- Zero setpoint: release to auto mode instead of holding the
+            -- inverter in forced-zero power mode.
+            host.modbus_write(6000, 0)  -- auto mode
+            host.log("debug", "Ferroamp Modbus: battery ref 0 → auto mode")
+            return true
+        end
         -- Site convention: positive power_w = charge
         -- Ferroamp: negative kW = charge → negate, convert W to kW
         local ref_kw = -power_w / 1000

--- a/drivers/fronius.lua
+++ b/drivers/fronius.lua
@@ -15,7 +15,7 @@ DRIVER = {
   manufacturer = "Fronius",
   version      = "1.0.0",
   protocols    = { "modbus" },
-  capabilities = { "meter", "pv", "battery" },
+  capabilities = { "pv", "battery" },
   description  = "Fronius Symo / Primo GEN24 hybrid inverters via Modbus TCP (SunSpec).",
   homepage     = "https://www.fronius.com",
   authors      = { "forty-two-watts contributors" },
@@ -273,38 +273,11 @@ function driver_poll()
     })
     host.emit_metric("battery_dc_v", bat_v)
 
-    -- ------------------------------------------------------------- Meter
-    -- Fronius SunSpec inverter model reports AC output power only — it
-    -- does not expose a grid-side meter. We derive a meter-shaped emission
-    -- from the inverter's AC values so the UI/API has per-phase data; the
-    -- site grid meter should normally come from a separate driver
-    -- (fronius_smart_meter / p1_meter / etc.) flagged `is_site_meter: true`.
-    local l1_w = l1_v * l1_a
-    local l2_w = l2_v * l2_a
-    local l3_w = l3_v * l3_a
-
-    host.emit("meter", {
-        w    = ac_w,
-        l1_w = l1_w,
-        l2_w = l2_w,
-        l3_w = l3_w,
-        l1_v = l1_v,
-        l2_v = l2_v,
-        l3_v = l3_v,
-        l1_a = l1_a,
-        l2_a = l2_a,
-        l3_a = l3_a,
-        hz   = hz,
-    })
-    host.emit_metric("meter_l1_w", l1_w)
-    host.emit_metric("meter_l2_w", l2_w)
-    host.emit_metric("meter_l3_w", l3_w)
-    host.emit_metric("meter_l1_v", l1_v)
-    host.emit_metric("meter_l2_v", l2_v)
-    host.emit_metric("meter_l3_v", l3_v)
-    host.emit_metric("meter_l1_a", l1_a)
-    host.emit_metric("meter_l2_a", l2_a)
-    host.emit_metric("meter_l3_a", l3_a)
+    -- NOTE: This driver does NOT emit meter telemetry. A Fronius inverter is
+    -- NOT a grid meter — its AC output represents inverter production, not the
+    -- grid boundary. Operators need a separate meter driver (fronius_smart_meter.lua,
+    -- sdm630.lua, p1_meter.lua, etc.) with `is_site_meter: true` in config.yaml
+    -- for accurate grid power readings.
 
     return 5000
 end

--- a/drivers/huawei.lua
+++ b/drivers/huawei.lua
@@ -223,11 +223,14 @@ function driver_poll()
 
     -- Meter total power: 37113-37114, I32 BE, watts.
     -- Huawei sign: positive = export, negative = import. Negate for site convention.
+    -- If this read fails, skip the entire meter emit so the watchdog catches
+    -- staleness — publishing zeros would mislead the control loop.
     local ok_mw, mw_regs = pcall(host.modbus_read, 37113, 2, "holding")
-    local meter_w = 0
-    if ok_mw and mw_regs then
-        meter_w = host.decode_i32_be(mw_regs[1], mw_regs[2])
+    if not ok_mw or not mw_regs then
+        host.log("warn", "Huawei: meter power read failed, skipping emit")
+        return 5000
     end
+    local meter_w = host.decode_i32_be(mw_regs[1], mw_regs[2])
 
     -- Grid frequency: 37118, I16 × 0.01 Hz
     local ok_hz, hz_regs = pcall(host.modbus_read, 37118, 1, "holding")

--- a/drivers/kostal.lua
+++ b/drivers/kostal.lua
@@ -71,10 +71,12 @@ end
 
 function driver_poll()
     -- -----------------------------------------------------------------
-    -- Serial number (SunSpec Common Model 1: regs 40020-40035, 32 chars)
+    -- Serial number (SunSpec Common Model 1: SN at regs 40052-40067,
+    -- 16 regs = 32 chars ASCII. NOTE: 40004-40019 is Md (manufacturer),
+    -- 40020-40035 is Opt (model string) — NOT serial number.)
     -- -----------------------------------------------------------------
     if not sn_read then
-        local ok_sn, sn_regs = pcall(host.modbus_read, 40020, 16, "holding")
+        local ok_sn, sn_regs = pcall(host.modbus_read, 40052, 16, "holding")
         if ok_sn and sn_regs then
             local sn = ""
             for i = 1, 16 do

--- a/drivers/sdm630.lua
+++ b/drivers/sdm630.lua
@@ -47,19 +47,18 @@ local function decode_f32_be(hi, lo)
 end
 
 -- Read a block of F32 BE values starting at `addr`. Returns an array of
--- `count` floats, or an array of zeros on read failure.
+-- `count` floats on success, or nil on read failure.
 local function read_f32_block(addr, count)
     local regs_needed = count * 2
     local ok, regs = pcall(host.modbus_read, addr, regs_needed, "input")
+    if not ok or not regs or #regs < regs_needed then
+        return nil
+    end
     local out = {}
-    if ok and regs and #regs >= regs_needed then
-        for i = 1, count do
-            local hi = regs[(i - 1) * 2 + 1]
-            local lo = regs[(i - 1) * 2 + 2]
-            out[i] = decode_f32_be(hi, lo)
-        end
-    else
-        for i = 1, count do out[i] = 0 end
+    for i = 1, count do
+        local hi = regs[(i - 1) * 2 + 1]
+        local lo = regs[(i - 1) * 2 + 2]
+        out[i] = decode_f32_be(hi, lo)
     end
     return out
 end
@@ -80,17 +79,15 @@ end
 ----------------------------------------------------------------------------
 
 function driver_poll()
-    -- Per-phase voltage (V): registers 0-5, three F32 BE pairs.
-    local volts = read_f32_block(0, 3)
-    local l1_v, l2_v, l3_v = volts[1], volts[2], volts[3]
-
-    -- Per-phase current (A): registers 6-11, three F32 BE pairs.
-    local amps = read_f32_block(6, 3)
-    local l1_a, l2_a, l3_a = amps[1], amps[2], amps[3]
-
     -- Per-phase active power (W): registers 12-17, three F32 BE pairs.
     -- SDM630 reports signed watts (import positive) — aligns with site convention.
+    -- If this primary read fails, skip the entire emit so the watchdog catches
+    -- staleness — publishing zeros would mislead the control loop.
     local watts = read_f32_block(12, 3)
+    if watts == nil then
+        host.log("warn", "SDM630: power read failed, skipping emit")
+        return 5000
+    end
     local l1_w, l2_w, l3_w = watts[1], watts[2], watts[3]
 
     -- Total active power: register 52-53. Sum of phases is preferred for
@@ -98,17 +95,32 @@ function driver_poll()
     local total_w = l1_w + l2_w + l3_w
     if total_w == 0 then
         local tw = read_f32_block(52, 1)
-        total_w = tw[1]
+        if tw then total_w = tw[1] end
     end
+
+    -- Per-phase voltage (V): registers 0-5, three F32 BE pairs.
+    -- Diagnostic reads — failures are not fatal.
+    local volts = read_f32_block(0, 3)
+    local l1_v, l2_v, l3_v = 0, 0, 0
+    if volts then l1_v, l2_v, l3_v = volts[1], volts[2], volts[3] end
+
+    -- Per-phase current (A): registers 6-11, three F32 BE pairs.
+    local amps = read_f32_block(6, 3)
+    local l1_a, l2_a, l3_a = 0, 0, 0
+    if amps then l1_a, l2_a, l3_a = amps[1], amps[2], amps[3] end
 
     -- Grid frequency: registers 70-71, F32 BE Hz.
     local hz_block = read_f32_block(70, 1)
-    local hz = hz_block[1]
+    local hz = 0
+    if hz_block then hz = hz_block[1] end
 
     -- Import/export energy: registers 72-75, two F32 BE kWh values → Wh.
     local energy = read_f32_block(72, 2)
-    local import_wh = energy[1] * 1000
-    local export_wh = energy[2] * 1000
+    local import_wh, export_wh = 0, 0
+    if energy then
+        import_wh = energy[1] * 1000
+        export_wh = energy[2] * 1000
+    end
 
     host.emit("meter", {
         w         = total_w,

--- a/drivers/sma.lua
+++ b/drivers/sma.lua
@@ -237,24 +237,24 @@ function driver_poll()
 
     --------------------------------------------------------------- Meter --
 
-    -- Meter total power: 30885-30886, U32 BE, watts (+ = import)
+    -- Meter total power: 30885-30886, I32 BE, watts (signed: + = import, - = export)
     local ok_mw, mw_regs = pcall(host.modbus_read, 30885, 2, "input")
     local meter_w = 0
     if ok_mw and mw_regs then
-        local v = host.decode_u32_be(mw_regs[1], mw_regs[2])
-        if u32_valid(v) then meter_w = v end
+        local v = host.decode_i32_be(mw_regs[1], mw_regs[2])
+        if i32_valid(v) then meter_w = v end
     end
 
-    -- Per-phase meter power: 30887-30892, U32 BE pairs, watts
+    -- Per-phase meter power: 30887-30892, I32 BE pairs, watts (signed)
     local ok_mpw, mpw_regs = pcall(host.modbus_read, 30887, 6, "input")
     local l1_w, l2_w, l3_w = 0, 0, 0
     if ok_mpw and mpw_regs then
-        local v1 = host.decode_u32_be(mpw_regs[1], mpw_regs[2])
-        local v2 = host.decode_u32_be(mpw_regs[3], mpw_regs[4])
-        local v3 = host.decode_u32_be(mpw_regs[5], mpw_regs[6])
-        if u32_valid(v1) then l1_w = v1 end
-        if u32_valid(v2) then l2_w = v2 end
-        if u32_valid(v3) then l3_w = v3 end
+        local v1 = host.decode_i32_be(mpw_regs[1], mpw_regs[2])
+        local v2 = host.decode_i32_be(mpw_regs[3], mpw_regs[4])
+        local v3 = host.decode_i32_be(mpw_regs[5], mpw_regs[6])
+        if i32_valid(v1) then l1_w = v1 end
+        if i32_valid(v2) then l2_w = v2 end
+        if i32_valid(v3) then l3_w = v3 end
     end
 
     -- Grid frequency: 30901-30902, U32 BE × 0.01 Hz

--- a/drivers/solaredge.lua
+++ b/drivers/solaredge.lua
@@ -70,8 +70,12 @@ PROTOCOL = "modbus"
 -- Cached per-device metadata. Scale factors are factory-set constants
 -- (SunSpec guarantees they never change during a session), so we read
 -- them once and cache. That cuts 11 Modbus round trips per poll.
+-- However, if the first read attempt fails (returns zeros), we retry on
+-- subsequent polls until all SFs are non-zero or we exhaust retries.
 local sn_read = false
 local sf_cache = nil
+local sf_retries = 0
+local SF_MAX_RETRIES = 5
 
 ----------------------------------------------------------------------------
 -- SunSpec helpers
@@ -167,9 +171,23 @@ function driver_poll()
         end
     end
 
-    -- ---- Scale factors (cached one-shot) ----
-    if sf_cache == nil then
+    -- ---- Scale factors (cached with retry on zero reads) ----
+    -- A failed modbus read returns 0 from read_sf(), which would cause raw
+    -- register values to be emitted unscaled — wrong by orders of magnitude.
+    -- Re-read all SFs until none are 0 or we exhaust retries.
+    local need_sf_read = (sf_cache == nil)
+    if not need_sf_read and sf_retries < SF_MAX_RETRIES then
+        for _, v in pairs(sf_cache) do
+            if v == 0 then need_sf_read = true; break end
+        end
+    end
+    if need_sf_read then
         sf_cache = load_scale_factors()
+        sf_retries = sf_retries + 1
+        if sf_retries >= SF_MAX_RETRIES then
+            host.log("warn", "SolarEdge: accepting scale factors after "
+                .. tostring(SF_MAX_RETRIES) .. " retries (some may be 0)")
+        end
     end
     local sf = sf_cache
 

--- a/drivers/victron.lua
+++ b/drivers/victron.lua
@@ -58,11 +58,12 @@ function driver_poll()
     -- PV (solar generation)
     ------------------------------------------------------------------
 
-    -- PV AC-coupled output power: register 808 (U16, W)
-    local ok_pvac, pvac_regs = pcall(host.modbus_read, 808, 1, "holding")
+    -- PV AC-coupled output power: registers 808/809/810 (U16, W per phase L1/L2/L3).
+    -- Sum all three phases for total AC-coupled PV.
+    local ok_pvac, pvac_regs = pcall(host.modbus_read, 808, 3, "holding")
     local pv_ac_w = 0
     if ok_pvac and pvac_regs then
-        pv_ac_w = pvac_regs[1]
+        pv_ac_w = (pvac_regs[1] or 0) + (pvac_regs[2] or 0) + (pvac_regs[3] or 0)
     end
 
     -- PV DC-coupled MPPT output power: register 850 (U16, W)
@@ -84,24 +85,15 @@ function driver_poll()
     -- Meter (grid connection point)
     ------------------------------------------------------------------
 
-    -- Grid block: 820-828 in one atomic read.
-    --   820/821/822 — per-phase power (I16, W), import positive (matches site)
-    --   823/824/825 — per-phase voltage (U16, 0.1 V)
-    --   826/827/828 — per-phase current (I16, 0.1 A)
-    local ok_grid, grid_regs = pcall(host.modbus_read, 820, 9, "holding")
+    -- Grid per-phase power: 820/821/822 (I16, W), import positive (matches site).
+    -- NOTE: 823-825 are genset power (not voltage), 826 is active-input source
+    -- (not current). Only 820-822 are grid power registers on Venus OS unit 100.
+    local ok_grid, grid_regs = pcall(host.modbus_read, 820, 3, "holding")
     local l1_w, l2_w, l3_w = 0, 0, 0
-    local l1_v, l2_v, l3_v = 0, 0, 0
-    local l1_a, l2_a, l3_a = 0, 0, 0
     if ok_grid and grid_regs then
         l1_w = host.decode_i16(grid_regs[1])
         l2_w = host.decode_i16(grid_regs[2])
         l3_w = host.decode_i16(grid_regs[3])
-        l1_v = grid_regs[4] * 0.1
-        l2_v = grid_regs[5] * 0.1
-        l3_v = grid_regs[6] * 0.1
-        l1_a = host.decode_i16(grid_regs[7]) * 0.1
-        l2_a = host.decode_i16(grid_regs[8]) * 0.1
-        l3_a = host.decode_i16(grid_regs[9]) * 0.1
     end
 
     local grid_total_w = l1_w + l2_w + l3_w
@@ -111,24 +103,12 @@ function driver_poll()
         l1_w = l1_w,
         l2_w = l2_w,
         l3_w = l3_w,
-        l1_v = l1_v,
-        l2_v = l2_v,
-        l3_v = l3_v,
-        l1_a = l1_a,
-        l2_a = l2_a,
-        l3_a = l3_a,
     })
 
     -- Diagnostics: long-format TS DB
     host.emit_metric("meter_l1_w", l1_w)
     host.emit_metric("meter_l2_w", l2_w)
     host.emit_metric("meter_l3_w", l3_w)
-    host.emit_metric("meter_l1_v", l1_v)
-    host.emit_metric("meter_l2_v", l2_v)
-    host.emit_metric("meter_l3_v", l3_v)
-    host.emit_metric("meter_l1_a", l1_a)
-    host.emit_metric("meter_l2_a", l2_a)
-    host.emit_metric("meter_l3_a", l3_a)
 
     ------------------------------------------------------------------
     -- Battery


### PR DESCRIPTION
## Summary

Fixes 9 out of 11 P1 driver bugs flagged by Codex. 2 invalid (growatt + pixii — Codex checked Rust host, Go host has the helpers).

| Driver | Fix |
|--------|-----|
| huawei | Return early on meter read failure |
| victron | Aggregate PV L1-L3; remove bogus genset meter fields |
| sdm630 | Return early on power read failure |
| sma | Decode meter power as signed i32_be |
| fronius | Remove host.emit(\"meter\") — not a grid meter |
| solaredge | Retry failed SF reads; batch-read pattern |
| kostal | Read SN from correct SunSpec register |
| ferroamp_modbus | Zero setpoint → auto mode |

- [x] \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)