### PR TITLE
fix: 5 Go-side P1 bugs from Codex review

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 The operator's guide. From "I have a fresh Raspberry Pi" to "I can debug a hung driver at 3am".
 
-Sign convention reminder: throughout this doc, `grid_w > 0` means **import** (buying from grid), `grid_w < 0` means **export** (selling). Battery `bat_w > 0` means **discharging** (battery → AC), `bat_w < 0` means **charging** (AC → battery). PV `pv_w` is always ≥ 0. See [site-convention.md](site-convention.md) for the full convention.
+Sign convention reminder: throughout this doc, `grid_w > 0` means **import** (buying from grid), `grid_w < 0` means **export** (selling). Battery `bat_w > 0` means **charging** (load, draws from grid), `bat_w < 0` means **discharging** (source, reduces import). PV `pv_w` is always ≤ 0 (generation pushes energy into the site). See [site-convention.md](site-convention.md) for the full convention.
 
 ## 1. Build + cross-compile
 
@@ -248,7 +248,7 @@ curl -s localhost:8080/api/status | jq '{targets: .dispatch, drivers: .drivers}'
 - `power_w` field not threaded through the driver payload (a real regression that was fixed; see commit `9237156`).
 - Driver forced into a manual/autonomous mode that conflicts with EMS commands.
 - Saturation curve in the battery model too restrictive — check `/api/models` for a pathological gain.
-- Sign confusion: remember `bat_w > 0` = discharging, `bat_w < 0` = charging.
+- Sign confusion: remember `bat_w > 0` = charging (load), `bat_w < 0` = discharging (source).
 
 ### PV prediction wildly off
 

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -46,6 +46,10 @@ func (m Mode) IsPlannerMode() bool {
 // respond. The plan is a scheduler, not a regulator.
 type PlanTargetFunc func(now time.Time) (string, float64, bool)
 
+// MaxCommandW is the hard per-command power cap (±5 kW). Used by both
+// clampWithSoC (distribution) and the post-slew re-clamp.
+const MaxCommandW = 5000
+
 // DispatchTarget is one command to issue to a single battery driver.
 // `TargetW` is in site sign convention:
 //   + = charge the battery (battery becomes a load, site imports more)
@@ -205,6 +209,9 @@ func ComputeDispatch(
 	// silently zero out a user-set manual value.
 	var evSum float64
 	for _, r := range store.ReadingsByType(telemetry.DerEV) {
+		if h := store.DriverHealth(r.Driver); h == nil || !h.IsOnline() {
+			continue
+		}
 		evSum += r.SmoothedW
 	}
 	if evSum > 0 {
@@ -332,6 +339,22 @@ func ComputeDispatch(
 		}
 	}
 
+	// ---- Re-clamp after slew ----
+	// The slew anchor is the battery's actual output (SmoothedW). If the
+	// battery was already beyond the ±5 kW per-command cap (e.g. after a
+	// manual restart, external control, or driver returning an out-of-range
+	// reading), the slewed target inherits the overshoot. Re-apply the
+	// hard per-command cap so we never issue a command outside safe bounds.
+	for i := range raw {
+		if raw[i].TargetW > MaxCommandW {
+			raw[i].TargetW = MaxCommandW
+			raw[i].Clamped = true
+		} else if raw[i].TargetW < -MaxCommandW {
+			raw[i].TargetW = -MaxCommandW
+			raw[i].Clamped = true
+		}
+	}
+
 	// ---- Fuse guard ----
 	raw = applyFuseGuard(raw, store, fuseMaxW)
 
@@ -451,13 +474,12 @@ func clampWithSoC(target, soc float64) (float64, bool) {
 		wasClamped = true
 	}
 	// Per-command cap
-	const maxPower = 5000
-	if math.Abs(clamped) > maxPower {
+	if math.Abs(clamped) > MaxCommandW {
 		sign := 1.0
 		if clamped < 0 {
 			sign = -1.0
 		}
-		clamped = sign * maxPower
+		clamped = sign * MaxCommandW
 		wasClamped = true
 	}
 	return clamped, wasClamped

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -155,7 +155,7 @@ func (s *Service) SlotAt(now time.Time) (string, float64, bool) {
 // The mapping from planner-mode + action to EMS mode:
 //   - self_consumption → always self_consumption with grid_target=0
 //   - cheap_charge → "charge" when the plan says charge, otherwise self_consumption
-//   - arbitrage → "charge" / "peak_shaving" (for export) / self_consumption
+//   - arbitrage → "charge" / "self_consumption" (with negative grid target for export) / self_consumption
 func actionToSlot(a Action, plannerMode Mode) (string, float64, bool) {
 	switch plannerMode {
 	case ModeSelfConsumption:
@@ -170,7 +170,12 @@ func actionToSlot(a Action, plannerMode Mode) (string, float64, bool) {
 			return "charge", 0, true
 		}
 		if a.BatteryW < -100 {
-			return "peak_shaving", a.GridW, true
+			// Planned discharge-to-export: use self_consumption with a
+			// negative grid target so the PI actively drives grid negative
+			// (i.e. discharges batteries to export). peak_shaving doesn't
+			// work here because it only reacts to over-peak import and
+			// won't push the grid into export territory.
+			return "self_consumption", a.GridW, true
 		}
 		return "self_consumption", 0, true
 	default:

--- a/go/internal/ocpp/config.go
+++ b/go/internal/ocpp/config.go
@@ -6,6 +6,10 @@ package ocpp
 // Charge points connect via ws://<bind>:<port>/<chargerId>; the chargerId
 // segment becomes the driver name in telemetry.Store and shows up in
 // /api/devices and /api/status.drivers.
+//
+// NOTE: Bind is advisory-only — the ocpp-go library does not expose a
+// bind-address parameter, so the listener currently binds to 0.0.0.0
+// regardless of this field. See the TODO in server.go.
 type Config struct {
 	Enabled            bool   `yaml:"enabled"`
 	Bind               string `yaml:"bind"`

--- a/go/internal/ocpp/server.go
+++ b/go/internal/ocpp/server.go
@@ -73,6 +73,14 @@ func Start(ctx context.Context, cfg *Config, tel *telemetry.Store) (*Server, err
 		slog.Info("OCPP central system listening",
 			"bind", cfg.Bind, "port", cfg.Port, "path", cfg.Path,
 			"basic_auth", cfg.Username != "")
+		// TODO: cfg.Bind is not honored here. The ocpp-go library's
+		// CentralSystem.Start(port, path) and ws.Server.Start(port, path)
+		// only accept a port — there is no SetAddr or bind-address parameter.
+		// To support bind-address natively we would need to either:
+		//   (a) upstream a PR to ocpp-go adding a SetListenAddr method, or
+		//   (b) create our own net.Listener bound to cfg.Bind:cfg.Port and
+		//       serve the ws.Server's http.Handler on it.
+		// For now cfg.Bind is advisory-only (documented in Config).
 		// cs.Start blocks until cs.Stop is called.
 		s.cs.Start(cfg.Port, fmt.Sprintf("%s{ws}", cfg.Path))
 	}()


### PR DESCRIPTION
## Summary

| File | Fix |
|------|-----|
| docs/operations.md | Correct inverted sign convention |
| dispatch.go:205 | Skip offline EV drivers in evSum |
| ocpp server.go | Document bind-address limitation |
| dispatch.go:327 | Re-clamp slewed targets to ±5kW cap |
| mpc/service.go:173 | Arbitrage discharge → self_consumption with negative grid_target |

- [x] \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)