### PR TITLE
Docs: fix driver-catalog count and host-api header

### DIFF
--- a/docs/driver-catalog.md
+++ b/docs/driver-catalog.md
@@ -6,7 +6,7 @@ in `drivers/` that follows the v2.1 host API (see
 
 ## At a glance
 
-17 drivers covering 15 manufacturers across 2 protocols. Read-only: 11.
+18 drivers covering 15 manufacturers across 2 protocols. Read-only: 12.
 With control: 6.
 
 Protocols in use: Modbus TCP, MQTT.
@@ -33,6 +33,7 @@ back to the device; read-only drivers only emit telemetry.
 | SMA Sunny Tripower / Sunny Boy Storage | SMA | Modbus | battery, meter, pv | no | Sunny Tripower 10.0, Sunny Boy Storage 3.7 | `drivers/sma.lua` |
 | Sofar HYD-ES / HYD-EP | Sofar | Modbus | battery, meter, pv | no | HYD 6000-ES, HYD 20KTL-3PH | `drivers/sofar.lua` |
 | SolarEdge HD-Wave / StorEdge | SolarEdge | Modbus | meter, pv | no | SE10K, StorEdge SE7600A-US | `drivers/solaredge.lua` |
+| SolarEdge inverter (PV only) | SolarEdge | Modbus | pv | no | HD-Wave, StorEdge | `drivers/solaredge_pv.lua` |
 | Solis hybrid inverter | Solis | Modbus | battery, meter, pv | yes | RHI-6K-48ES-5G, S6-EH3P10K-H | `drivers/solis.lua` |
 | Sungrow SH Hybrid Inverter | Sungrow | Modbus | battery, meter, pv | yes | SH5.0RT, SH6.0RT, SH8.0RT, SH10RT | `drivers/sungrow.lua` |
 | Victron Cerbo GX / Venus GX | Victron | Modbus | battery, meter, pv | no | Cerbo GX, Venus GX | `drivers/victron.lua` |

--- a/docs/host-api.md
+++ b/docs/host-api.md
@@ -1,9 +1,12 @@
 # Host API Reference
 
-> Legacy WASM ABI reference. For the current Lua driver path, see
-> [writing-a-driver.md](writing-a-driver.md).
+> Complete reference for the `host` capability interface exposed to both
+> **Lua** and **WASM** driver runtimes. For a tutorial-style introduction
+> to writing Lua drivers, see [writing-a-driver.md](writing-a-driver.md).
+> The authoritative Lua-specific source is the top-of-file comment in
+> `go/internal/drivers/lua.go`.
 
-The `host` table is available to all Lua drivers. It provides functions for logging, device communication, data decoding, JSON handling, and telemetry emission. These are the same APIs available on the Sourceful Zap gateway, so drivers are portable between forty-two-watts and the Zap.
+The `host` table is available to all Lua drivers (and an equivalent set of host imports is available to legacy WASM drivers under the `"host"` namespace). It provides functions for logging, device communication, data decoding, JSON handling, and telemetry emission. These are the same APIs available on the Sourceful Zap gateway, so drivers are portable between forty-two-watts and the Zap.
 
 ## Core
 


### PR DESCRIPTION
## Summary
- **driver-catalog.md**: Updated driver count from 17 to 18 and read-only count from 11 to 12. Added the missing `solaredge_pv.lua` (PV-only SolarEdge variant) row to the table with correct metadata from the driver's `DRIVER` block.
- **host-api.md**: Updated the header and intro paragraph — the old text said "Legacy WASM ABI reference" but the document covers both Lua and WASM functions. Now accurately describes coverage of both runtimes and cross-references the authoritative Lua source (`go/internal/drivers/lua.go`).

## Test plan
- [x] `cd go && go test ./...` — all tests pass (docs-only changes)
- [ ] Verify driver count matches `ls drivers/*.lua | wc -l` = 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)