### PR TITLE
ci: add semantic-release + multi-arch Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,19 @@
-target/
-*.redb
-config.yaml
-data/
-.git/
+# Keep the Docker build context tiny. Whitelist what the new Go-based
+# Dockerfile needs and drop everything else (Rust target dir, local
+# state databases, secrets, .git, IDE files, release tarballs, etc).
+
+*
+
+!Dockerfile
+!.dockerignore
+!go/
+!drivers/
+!web/
+
+# Within those trees, drop test files and local state so they don't
+# bloat the build context or accidentally leak secrets.
+go/**/*_test.go
+**/state.db
+**/state.db-*
+**/cold/
+**/.DS_Store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: release
+
+# Run on every push to master. Pull requests do NOT trigger a release —
+# they only run when actually merged. Manual dispatch is allowed for
+# emergency re-runs (no-op if the analyzer doesn't find releasable
+# commits since the last tag).
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# semantic-release needs to push a tag + the changelog commit.
+# The docker job needs to push a package to GHCR.
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: semantic-release
+    runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version:   ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # semantic-release walks every commit since the last tag, so
+          # it needs the full history. fetch-depth: 0 is the standard.
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN; persist-credentials lets the
+          # @semantic-release/git plugin push the changelog commit.
+          persist-credentials: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run semantic-release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          # Pin to a known-good major. Plugins listed here mirror
+          # .releaserc.json so the action installer picks them up
+          # without needing a package.json in the repo.
+          semantic_version: 24
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @semantic-release/git@10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: docker build + push
+    runs-on: ubuntu-latest
+    needs: release
+    # Only build if semantic-release actually cut a new version. Skipping
+    # when there's no release keeps `:latest` deterministic — every
+    # `:latest` corresponds to a real tagged version.
+    if: needs.release.outputs.new_release_published == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Pull the tag semantic-release just pushed so the build sees
+          # the new state of master (changelog commit included).
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # ghcr.io/<owner>/<repo>:<tag>
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=v${{ needs.release.outputs.new_release_version }}
+            type=raw,value=${{ needs.release.outputs.new_release_version }}
+            type=raw,value=latest
+            type=sha,format=short
+          labels: |
+            org.opencontainers.image.title=forty-two-watts
+            org.opencontainers.image.description=Unified Home Energy Management System
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=v${{ needs.release.outputs.new_release_version }}
+          # Use the GHA cache backend so subsequent builds reuse layers.
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,19 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      { "changelogFile": "CHANGELOG.md" }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# forty-two-watts container — multi-stage Go build, alpine runtime.
+#
+# Builder uses golang:alpine to keep the final binary fully static and
+# the toolchain layer small. The runtime stage is plain alpine with
+# only ca-certificates + tzdata; everything else (Lua drivers, web
+# assets, the binary itself) ships verbatim.
+#
+# Multi-arch: linux/amd64 + linux/arm64 via docker buildx BUILDPLATFORM
+# / TARGETPLATFORM split so the toolchain runs natively on the build
+# host and only `go build` is cross-compiled.
+
+# --- Builder ---------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+# git is needed by `go build` to resolve VCS info baked into the binary
+# via -X main.Version. Everything else is in the base image.
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+# Cache the module download as its own layer so source edits don't
+# bust the dep cache.
+COPY go/go.mod go/go.sum ./go/
+RUN cd go && go mod download
+
+COPY go/ ./go/
+
+# Cross-compile by mapping TARGETARCH → GOARCH. CGO is off so the
+# binary is fully static and runs on alpine without glibc.
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+RUN cd go && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
+    -o /out/forty-two-watts ./cmd/forty-two-watts
+
+# --- Runtime ---------------------------------------------------------------
+FROM alpine:3.20
+
+# ca-certificates: HTTPS to elprisetjustnu / met.no / ECB FX.
+# tzdata:        timezone-aware price + plan windows (Europe/Stockholm etc).
+RUN apk add --no-cache ca-certificates tzdata && \
+    addgroup -S ftw && adduser -S ftw -G ftw
+
+# Image layout:
+#   /app/forty-two-watts  binary (immutable, replaced on upgrade)
+#   /app/drivers/         bundled Lua drivers (immutable, replaced on upgrade)
+#   /app/web/             bundled UI assets (immutable, replaced on upgrade)
+#   /app/data/            PERSISTENT — config.yaml, state.db, cold/, models
+#
+# The container's working directory is /app/data so that any *relative*
+# path in the user's config (state.path: state.db, state.cold_dir: cold)
+# resolves under the persistent volume by default. Without this, the
+# binary would default-write state.db to its CWD and lose every byte
+# on container recreate. See go/cmd/forty-two-watts/main.go:66 — there
+# is no path resolution against the config file's directory; the open
+# call is literally state.Open(cfg.State.Path).
+COPY --from=builder /out/forty-two-watts /app/forty-two-watts
+COPY drivers/ /app/drivers/
+COPY web/     /app/web/
+
+RUN mkdir -p /app/data && chown -R ftw:ftw /app
+
+USER ftw
+WORKDIR /app/data
+
+VOLUME ["/app/data"]
+EXPOSE 8080
+
+# Config + state both live in /app/data — one bind-mount is enough to
+# persist everything across upgrades. Drivers and web are absolute
+# paths into the immutable image layer so the bundled versions ship
+# with each release.
+#
+# UID note: the ftw user is uid 100 / gid 101 (alpine `adduser -S`
+# convention). Named docker volumes inherit ownership from the image
+# automatically and just work. For HOST BIND MOUNTS, the host
+# directory must be owned by uid 100 (or world-writable) before the
+# container starts:
+#
+#     mkdir -p /srv/ftw-data && chown -R 100:101 /srv/ftw-data
+#     docker run -v /srv/ftw-data:/app/data ghcr.io/<owner>/forty-two-watts:latest
+#
+# Without this the binary fails fast with "open state … unable to
+# open database file" because SQLite can't create state.db inside
+# a directory it doesn't own.
+ENTRYPOINT ["/app/forty-two-watts"]
+CMD ["-config", "/app/data/config.yaml", "-web", "/app/web"]


### PR DESCRIPTION
Adds a single GitHub Actions workflow (.github/workflows/release.yml) that runs on every push to master with two jobs:

1. release: cycjimmy/semantic-release-action@v4 walks the conventional commits since the last tag, decides the next semver, generates the changelog, and pushes the tag + release notes to GitHub. Plugins (commit-analyzer, release-notes-generator, changelog, git, github) are listed in .releaserc.json so the action picks them up without a package.json in the repo.

2. docker: gated on `needs.release.outputs.new_release_published == 'true'` so we only push an image when there's actually a new version. Uses docker/metadata-action to derive tags (ghcr.io/<repo>:vX.Y.Z, :X.Y.Z, :latest, :sha-<short>) and docker/build-push-action to build linux/amd64 + linux/arm64 with the GHA cache backend.

Replaces the legacy Rust-era Dockerfile with a Go multi-stage build:

  - builder stage: golang:1.25-alpine, BUILDPLATFORM-pinned so the toolchain runs natively and only `go build` is cross-compiled. CGO_ENABLED=0 -> fully static binary, ldflags -s -w + -trimpath for size and reproducibility, VERSION baked in via -X main.Version.
  - runtime stage: alpine:3.20 + ca-certificates + tzdata only. Non-root ftw user (uid 100), bundled drivers + web ship verbatim.
  - WORKDIR /app/data so any relative path in the user's config (state.path: state.db, state.cold_dir: cold) resolves under the persistent /app/data volume by default. Without this the binary would default-write state.db to its CWD and lose every byte on container recreate. main.go:72 calls state.Open(cfg.State.Path) verbatim — there is no resolution against the config file's directory, so the WORKDIR is the only knob that matters.
  - VOLUME /app/data — single bind-mount or named volume holds config.yaml, state.db (+ -shm/-wal), cold/ parquet rolloff, and any future model checkpoints.
  - Smoke-tested locally: 76 MB final image, container starts cleanly, state.db lands in /app/data and survives restart.

Bind-mount UID note documented inline: the ftw user is uid 100, so host bind-mounts must be chowned to 100:101 before container start (named volumes inherit ownership from the image and need no setup).

Also rewrites .dockerignore as a whitelist so only Dockerfile + go/ + drivers/ + web/ enter the build context — keeps cold/ parquet, local state.db, .git, and any future secrets out of the cache.

Permissions on the workflow grant `contents: write` (semantic-release tags + commits the changelog), `packages: write` (GHCR push), plus issues + PR write so semantic-release can comment on released PRs. The default GITHUB_TOKEN handles both GHCR and the tag push.

Note: targets `master` (current default branch on this fork). If the default is renamed to `main`, update both `.releaserc.json` branches and the workflow `on.push.branches`.