### PR TITLE
feat: Easee Cloud driver + host.http_get/post

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -1,0 +1,220 @@
+-- Easee Cloud EV Charger Driver
+-- Emits: EV
+-- Protocol: HTTPS (Easee Cloud REST API)
+--
+-- Authenticates with the user's Easee account (email + password from
+-- config), polls charger state every 5 seconds, and emits DerEV
+-- readings so the dispatch clamp keeps home batteries from feeding
+-- the car.
+--
+-- Config example:
+--   drivers:
+--     - name: easee
+--       lua: drivers/easee_cloud.lua
+--       capabilities:
+--         http:
+--           allowed_hosts: ["api.easee.com"]
+--       config:
+--         email: "user@example.com"
+--         password: "secret"
+--         serial: "EHHZBKPF"    # optional — auto-detected if omitted
+
+DRIVER = {
+  id           = "easee-cloud",
+  name         = "Easee Cloud",
+  manufacturer = "Easee",
+  version      = "1.0.0",
+  protocols    = { "http" },
+  capabilities = { "ev" },
+  description  = "Easee Home/Charge via Cloud REST API. No local protocol needed.",
+  homepage     = "https://easee.com",
+  authors      = { "forty-two-watts contributors" },
+  tested_models = { "Home", "Charge" },
+}
+
+PROTOCOL = "http"
+
+local BASE_URL = "https://api.easee.com/api"
+local access_token = nil
+local refresh_token = nil
+local token_expires_at = 0   -- millis
+local charger_serial = nil
+
+-- ---- Auth helpers ----
+
+local function login(email, password)
+    local body = host.json_encode({userName = email, password = password})
+    local resp, err = host.http_post(BASE_URL .. "/accounts/login", body)
+    if err then
+        host.log("error", "Easee login failed: " .. tostring(err))
+        return false
+    end
+    local data = host.json_decode(resp)
+    if not data or not data.accessToken then
+        host.log("error", "Easee login: no accessToken in response")
+        return false
+    end
+    access_token = data.accessToken
+    refresh_token = data.refreshToken
+    -- expiresIn is seconds; convert to absolute millis
+    local expires_in = data.expiresIn or 3600
+    token_expires_at = host.millis() + (expires_in * 1000) - 60000 -- refresh 1 min early
+    host.log("info", "Easee: logged in, token expires in " .. expires_in .. "s")
+    return true
+end
+
+local function do_refresh()
+    if not access_token or not refresh_token then return false end
+    local body = host.json_encode({
+        accessToken = access_token,
+        refreshToken = refresh_token
+    })
+    local resp, err = host.http_post(BASE_URL .. "/accounts/refresh_token", body)
+    if err then
+        host.log("warn", "Easee token refresh failed: " .. tostring(err))
+        return false
+    end
+    local data = host.json_decode(resp)
+    if not data or not data.accessToken then
+        host.log("warn", "Easee refresh: no accessToken, will re-login")
+        return false
+    end
+    access_token = data.accessToken
+    refresh_token = data.refreshToken
+    local expires_in = data.expiresIn or 3600
+    token_expires_at = host.millis() + (expires_in * 1000) - 60000
+    host.log("debug", "Easee: token refreshed")
+    return true
+end
+
+local function ensure_auth(email, password)
+    if access_token and host.millis() < token_expires_at then
+        return true
+    end
+    -- Try refresh first, fall back to full login
+    if access_token and do_refresh() then
+        return true
+    end
+    return login(email, password)
+end
+
+local function auth_headers()
+    return {Authorization = "Bearer " .. (access_token or "")}
+end
+
+-- ---- API helpers ----
+
+local function get_chargers()
+    local resp, err = host.http_get(BASE_URL .. "/chargers", auth_headers())
+    if err then return nil, err end
+    return host.json_decode(resp), nil
+end
+
+local function get_state(serial)
+    local resp, err = host.http_get(
+        BASE_URL .. "/chargers/" .. serial .. "/state",
+        auth_headers()
+    )
+    if err then return nil, err end
+    return host.json_decode(resp), nil
+end
+
+-- ---- State mapping ----
+-- Easee chargerOpMode:
+--   1 = disconnected (standby)
+--   2 = awaiting start (connected, not charging)
+--   3 = charging
+--   4 = completed
+--   5 = error
+--   6 = ready to charge
+
+local email, password
+
+function driver_init(config)
+    host.set_make("Easee")
+
+    email = config and config.email
+    password = config and config.password
+    charger_serial = config and config.serial
+
+    if not email or not password then
+        host.log("error", "Easee: email and password required in driver config")
+        return
+    end
+
+    if not ensure_auth(email, password) then
+        host.log("error", "Easee: initial login failed")
+        return
+    end
+
+    -- Auto-detect serial if not provided
+    if not charger_serial then
+        local chargers, err = get_chargers()
+        if err or not chargers or #chargers == 0 then
+            host.log("error", "Easee: could not list chargers: " .. tostring(err))
+            return
+        end
+        charger_serial = chargers[1].id
+        host.log("info", "Easee: auto-detected charger " .. charger_serial)
+    end
+
+    host.set_sn(charger_serial)
+    host.log("info", "Easee: driver initialized for " .. charger_serial)
+end
+
+function driver_poll()
+    if not charger_serial or not email then
+        return 10000
+    end
+
+    if not ensure_auth(email, password) then
+        host.log("warn", "Easee: auth failed, skipping poll")
+        return 10000
+    end
+
+    local state, err = get_state(charger_serial)
+    if err or not state then
+        host.log("warn", "Easee: state poll failed: " .. tostring(err))
+        return 10000
+    end
+
+    local op_mode = state.chargerOpMode or 1
+    local power_w = (state.totalPower or 0) * 1000  -- kW → W
+    local session_wh = (state.sessionEnergy or 0) * 1000  -- kWh → Wh
+    local connected = (op_mode >= 2 and op_mode <= 6)
+    local charging = (op_mode == 3)
+
+    host.emit("ev", {
+        w          = power_w,
+        connected  = connected,
+        charging   = charging,
+        session_wh = session_wh,
+    })
+
+    -- Diagnostic metrics
+    if state.voltage then
+        host.emit_metric("ev_voltage_v", state.voltage)
+    end
+    if state.outputCurrent then
+        host.emit_metric("ev_current_a", state.outputCurrent)
+    end
+    if state.lifetimeEnergy then
+        host.emit_metric("ev_lifetime_kwh", state.lifetimeEnergy)
+    end
+
+    return 5000
+end
+
+function driver_command(action, power_w, cmd)
+    -- Phase 1: read-only. No control commands yet.
+    return false
+end
+
+function driver_default_mode()
+    -- No-op — cloud charger manages itself.
+end
+
+function driver_cleanup()
+    access_token = nil
+    refresh_token = nil
+end

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -97,6 +97,11 @@ type Driver struct {
 	// Unset capabilities are explicitly denied.
 	Capabilities Capabilities `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
 
+	// Driver-specific config: arbitrary key/value map passed to
+	// driver_init(config) in Lua. Used for credentials, device addresses,
+	// thresholds, etc. that don't fit the generic capabilities model.
+	Config map[string]any `yaml:"config,omitempty" json:"config,omitempty"`
+
 	// Legacy protocol fields (equivalent to capabilities, still accepted
 	// for backwards compatibility with master-branch configs).
 	MQTT   *MQTTConfig   `yaml:"mqtt,omitempty" json:"mqtt,omitempty"`
@@ -336,8 +341,8 @@ func (c *Config) Validate() error {
 		if d.WASM == "" && d.Lua == "" {
 			return fmt.Errorf("driver %q: must specify `wasm` or `lua`", d.Name)
 		}
-		if d.EffectiveMQTT() == nil && d.EffectiveModbus() == nil {
-			return fmt.Errorf("driver %q: must have mqtt or modbus capability", d.Name)
+		if d.EffectiveMQTT() == nil && d.EffectiveModbus() == nil && d.Capabilities.HTTP == nil {
+			return fmt.Errorf("driver %q: must have mqtt, modbus, or http capability", d.Name)
 		}
 	}
 	if siteMeters == 0 {

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -26,6 +26,8 @@
 //	host.modbus_write_multi(addr, values)
 //	host.json_decode(s)             -- convenience JSON → Lua table
 //	host.json_encode(t)             -- Lua table → JSON string
+//	host.http_get(url, headers)     -- HTTP GET, returns (body, nil) or (nil, err)
+//	host.http_post(url, body, headers) -- HTTP POST, returns (body, nil) or (nil, err)
 //
 // Lua 5.1 via yuin/gopher-lua — pure Go, zero CGo, one allocation-aware
 // interpreter per driver. The whole thing is ~350 LOC vs ~850 for the
@@ -36,7 +38,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	net_http "net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -406,6 +411,88 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			return 2
 		}
 		L.Push(lua.LString(string(b)))
+		return 1
+	}))
+
+	// ---- HTTP capability ----
+	// host.http_get(url, headers?) → (body, nil) or (nil, error_string)
+	// host.http_post(url, body, headers?) → (body, nil) or (nil, error_string)
+	// headers is an optional Lua table {["Content-Type"]="application/json", ...}
+	httpClient := &net_http.Client{Timeout: 15 * time.Second}
+
+	applyHeaders := func(req *net_http.Request, L *lua.LState, argIdx int) {
+		tbl := L.OptTable(argIdx, nil)
+		if tbl == nil {
+			return
+		}
+		tbl.ForEach(func(k, v lua.LValue) {
+			if ks, ok := k.(lua.LString); ok {
+				req.Header.Set(string(ks), v.String())
+			}
+		})
+	}
+
+	host.RawSetString("http_get", L.NewFunction(func(L *lua.LState) int {
+		url := L.CheckString(1)
+		req, err := net_http.NewRequest("GET", url, nil)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		applyHeaders(req, L, 2)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB cap
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		if resp.StatusCode >= 400 {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))))
+			return 2
+		}
+		L.Push(lua.LString(string(body)))
+		return 1
+	}))
+
+	host.RawSetString("http_post", L.NewFunction(func(L *lua.LState) int {
+		url := L.CheckString(1)
+		payload := L.CheckString(2)
+		req, err := net_http.NewRequest("POST", url, strings.NewReader(payload))
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		req.Header.Set("Content-Type", "application/json")
+		applyHeaders(req, L, 3)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		if resp.StatusCode >= 400 {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body))))
+			return 2
+		}
+		L.Push(lua.LString(string(body)))
 		return 1
 	}))
 

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -127,7 +127,12 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 	var drv driverRuntime = &luaRuntime{LuaDriver: luaDrv}
 
-	if err := drv.Init(ctx, nil); err != nil {
+	// Pass the driver's config map as JSON to driver_init.
+	var initCfg []byte
+	if cfg.Config != nil {
+		initCfg, _ = json.Marshal(cfg.Config)
+	}
+	if err := drv.Init(ctx, initCfg); err != nil {
 		drv.Cleanup(ctx)
 		return fmt.Errorf("driver_init: %w", err)
 	}


### PR DESCRIPTION
## Summary

Easee EV charger integration via Cloud REST API. No OCPP needed — just email + password.

### New Lua host functions
- \`host.http_get(url, headers?)\` → body or error
- \`host.http_post(url, body, headers?)\` → body or error

### New driver: \`drivers/easee_cloud.lua\`
- OAuth2 login + token refresh
- Polls \`/api/chargers/{serial}/state\` every 5s
- Emits \`DerEV\` readings (power, connected, charging, session_wh)
- Auto-detects charger serial if not specified

### Config example
\`\`\`yaml
drivers:
  - name: easee
    lua: drivers/easee_cloud.lua
    capabilities:
      http:
        allowed_hosts: [api.easee.com]
    config:
      email: user@example.com
      password: secret
      serial: EHHZBKPF  # optional
\`\`\`

### Verified live
Deployed to homelab-rpi, logged into Easee Cloud, charger EHHZBKPF (FW 340) polling successfully. \`ev_charging_w=0\` (idle), \`status=ok\`, 0 errors.

## TODO (follow-up)
- [ ] Credential storage (env var or encrypted config field)
- [ ] Settings UI field for Easee email/password
- [ ] Phase 2: control commands (start/stop/set current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)