### PR TITLE
Add EV Charger settings tab

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,7 @@
         <button data-tab="weather">Weather</button>
         <button data-tab="batteries">Batteries</button>
         <button data-tab="ha">Home Assistant</button>
+        <button data-tab="ev">EV Charger</button>
       </div>
       <div class="modal-body" id="settings-body">
         <!-- Filled by JS -->

--- a/web/settings.js
+++ b/web/settings.js
@@ -80,6 +80,8 @@
       var path = input.dataset.path;
       var val = input.type === "number" ? parseFloat(input.value) : input.value;
       if (input.type === "number" && isNaN(val)) val = 0;
+      // Don't overwrite a saved password with empty string when user hasn't typed anything
+      if (input.type === "password" && val === "" && getByPath(currentConfig, path, "")) return;
       setByPath(currentConfig, path, val);
     });
   }
@@ -404,6 +406,72 @@
           refresh();
           window._haStatusTimer && clearInterval(window._haStatusTimer);
           window._haStatusTimer = setInterval(refresh, 5000);
+        }, 0);
+        break;
+
+      case "ev":
+        if (!currentConfig.ev_charger) currentConfig.ev_charger = {};
+        var evHasPassword = !!getByPath(currentConfig, "ev_charger.password", "");
+        html = '<div id="ev-status-indicator" class="ha-status-indicator">checking…</div>' +
+          '<fieldset><legend>EV Charger</legend>' +
+          selectField("Provider", "ev_charger.provider", ["easee"], "easee",
+            "Cloud service provider for the EV charger. Currently only Easee is supported.") +
+          field("Email", "ev_charger.email", "text", "",
+            "Account email for the charger cloud service.") +
+          '<label>Password ' + help("Account password for the charger cloud service.") + '</label>' +
+          '<input type="password" data-path="ev_charger.password" value="" placeholder="' + (evHasPassword ? '••••••••' : '') + '">' +
+          field("Charger serial", "ev_charger.serial", "text", "",
+            "Serial number of the charger. Leave empty to auto-detect the first charger on the account.") +
+          '</fieldset>' +
+          '<p style="color:var(--text-dim);font-size:0.8rem;margin-top:8px">' +
+          'Credentials are used to authenticate with the Easee Cloud API. ' +
+          'The charger serial is optional — if left empty the driver will use the first charger found on your account.' +
+          '</p>';
+        setTimeout(function () {
+          var pwInput = bodyEl.querySelector('[data-path="ev_charger.password"]');
+          if (pwInput) {
+            pwInput.addEventListener("focus", function () {
+              pwInput.placeholder = "";
+            });
+            pwInput.addEventListener("blur", function () {
+              if (!pwInput.value && evHasPassword) {
+                pwInput.placeholder = "••••••••";
+              }
+            });
+          }
+
+          var el = document.getElementById("ev-status-indicator");
+          if (!el) return;
+          function refresh() {
+            fetch("/api/status").then(function(r){return r.json();}).then(function(d) {
+              var drivers = d.drivers || [];
+              var easee = null;
+              for (var i = 0; i < drivers.length; i++) {
+                if ((drivers[i].name || "").toLowerCase().indexOf("easee") >= 0) {
+                  easee = drivers[i];
+                  break;
+                }
+              }
+              if (!easee) {
+                el.className = "ha-status-indicator ha-off";
+                el.textContent = "○  no Easee driver configured";
+                return;
+              }
+              if (easee.status === "ok" || easee.status === "online") {
+                el.className = "ha-status-indicator ha-ok";
+                el.textContent = "● charger connected  ·  " + (easee.device_id || easee.name);
+              } else {
+                el.className = "ha-status-indicator ha-warn";
+                el.textContent = "⚠  charger " + (easee.status || "unknown") + "  —  check credentials";
+              }
+            }).catch(function(){
+              el.className = "ha-status-indicator ha-warn";
+              el.textContent = "? status endpoint unreachable";
+            });
+          }
+          refresh();
+          window._evStatusTimer && clearInterval(window._evStatusTimer);
+          window._evStatusTimer = setInterval(refresh, 5000);
         }, 0);
         break;
     }


### PR DESCRIPTION
## Summary
- Adds an "EV Charger" tab to the Settings modal with fields for provider (Easee), email, password, and charger serial
- Password field uses type="password" with placeholder masking — never reveals the stored value
- Status indicator polls `/api/status` to show whether the Easee driver is connected
- Writes config under `ev_charger` key, matching the pattern used by other settings tabs
- Fixes a generic issue where empty password fields would overwrite saved passwords on save

## Test plan
- [ ] Open Settings modal, verify "EV Charger" tab appears after "Home Assistant"
- [ ] Click tab, verify fields render: Provider dropdown (Easee), Email, Password, Charger serial
- [ ] Enter credentials and save — verify `ev_charger` key appears in config
- [ ] Reopen settings — verify email/serial are populated, password shows dots placeholder
- [ ] Verify status indicator shows charger status (or "no Easee driver configured")
- [ ] `cd go && go test ./...` passes (web-only changes, no backend impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)