### PR TITLE
Fix 4 P1 bugs from Codex review

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -222,7 +222,8 @@ function driver_command(action, power_w, cmd)
     elseif action == "ev_resume" then
         return post_command("/commands/resume_charging")
     elseif action == "ev_set_current" then
-        local amps = math.floor((power_w or 0) / 230)
+        -- Easee dynamicChargerCurrent is per-phase amps; assume 3-phase.
+        local amps = math.floor((power_w or 0) / 230 / 3)
         local body = host.json_encode({dynamicChargerCurrent = amps})
         local _, err = host.http_post(
             BASE_URL .. "/chargers/" .. charger_serial .. "/settings",

--- a/drivers/huawei.lua
+++ b/drivers/huawei.lua
@@ -126,22 +126,6 @@ function driver_poll()
         pv_gen_wh = host.decode_u32_be(yield_regs[1], yield_regs[2]) * 0.01 * 1000
     end
 
-    -- Emit PV telemetry (site convention: generation is negative).
-    host.emit("pv", {
-        w           = -pv_w,
-        mppt1_v     = pv1_v,
-        mppt1_a     = pv1_a,
-        mppt2_v     = pv2_v,
-        mppt2_a     = pv2_a,
-        lifetime_wh = pv_gen_wh,
-        temp_c      = inv_temp,
-    })
-    host.emit_metric("pv_mppt1_v",      pv1_v)
-    host.emit_metric("pv_mppt1_a",      pv1_a)
-    host.emit_metric("pv_mppt2_v",      pv2_v)
-    host.emit_metric("pv_mppt2_a",      pv2_a)
-    host.emit_metric("inverter_temp_c", inv_temp)
-
     -- ---- Battery ----
 
     -- Battery power: 37001-37002, I32 BE, watts
@@ -188,19 +172,6 @@ function driver_poll()
         bat_discharge_wh = host.decode_u32_be(benergy_regs[3], benergy_regs[4]) * 0.01 * 1000
     end
 
-    host.emit("battery", {
-        w            = bat_w,
-        v            = bat_v,
-        a            = bat_a,
-        soc          = bat_soc,
-        temp_c       = bat_temp,
-        charge_wh    = bat_charge_wh,
-        discharge_wh = bat_discharge_wh,
-    })
-    host.emit_metric("battery_dc_v",    bat_v)
-    host.emit_metric("battery_dc_a",    bat_a)
-    host.emit_metric("battery_temp_c",  bat_temp)
-
     -- ---- Meter ----
 
     -- Per-phase voltage: 37101-37106, I32 BE × 0.1 pairs (L1 V, L2 V, L3 V)
@@ -223,11 +194,12 @@ function driver_poll()
 
     -- Meter total power: 37113-37114, I32 BE, watts.
     -- Huawei sign: positive = export, negative = import. Negate for site convention.
-    -- If this read fails, skip the entire meter emit so the watchdog catches
-    -- staleness — publishing zeros would mislead the control loop.
+    -- If this read fails, skip ALL emits so the watchdog catches staleness —
+    -- emitting PV/battery while meter is down would keep the driver "healthy"
+    -- but give the control loop a stale grid reading.
     local ok_mw, mw_regs = pcall(host.modbus_read, 37113, 2, "holding")
     if not ok_mw or not mw_regs then
-        host.log("warn", "Huawei: meter power read failed, skipping emit")
+        host.log("warn", "Huawei: meter power read failed, skipping all emits")
         return 5000
     end
     local meter_w = host.decode_i32_be(mw_regs[1], mw_regs[2])
@@ -255,6 +227,38 @@ function driver_poll()
         l2_w = host.decode_i32_be(lpw_regs[3], lpw_regs[4])
         l3_w = host.decode_i32_be(lpw_regs[5], lpw_regs[6])
     end
+
+    -- ---- All reads succeeded — emit everything ----
+
+    -- PV telemetry (site convention: generation is negative).
+    host.emit("pv", {
+        w           = -pv_w,
+        mppt1_v     = pv1_v,
+        mppt1_a     = pv1_a,
+        mppt2_v     = pv2_v,
+        mppt2_a     = pv2_a,
+        lifetime_wh = pv_gen_wh,
+        temp_c      = inv_temp,
+    })
+    host.emit_metric("pv_mppt1_v",      pv1_v)
+    host.emit_metric("pv_mppt1_a",      pv1_a)
+    host.emit_metric("pv_mppt2_v",      pv2_v)
+    host.emit_metric("pv_mppt2_a",      pv2_a)
+    host.emit_metric("inverter_temp_c", inv_temp)
+
+    -- Battery telemetry.
+    host.emit("battery", {
+        w            = bat_w,
+        v            = bat_v,
+        a            = bat_a,
+        soc          = bat_soc,
+        temp_c       = bat_temp,
+        charge_wh    = bat_charge_wh,
+        discharge_wh = bat_discharge_wh,
+    })
+    host.emit_metric("battery_dc_v",    bat_v)
+    host.emit_metric("battery_dc_a",    bat_a)
+    host.emit_metric("battery_temp_c",  bat_temp)
 
     -- Negate meter power + per-phase power + per-phase current to site convention
     -- (positive = import from grid).

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -333,6 +333,16 @@ func (incoming *Config) PreserveMaskedSecrets(existing *Config) {
 					}
 				}
 			}
+			// Restore MQTT password in capabilities block.
+			if incoming.Drivers[i].Capabilities.MQTT != nil && ed.Capabilities.MQTT != nil &&
+				incoming.Drivers[i].Capabilities.MQTT.Password == "" {
+				incoming.Drivers[i].Capabilities.MQTT.Password = ed.Capabilities.MQTT.Password
+			}
+			// Restore MQTT password in legacy block.
+			if incoming.Drivers[i].MQTT != nil && ed.MQTT != nil &&
+				incoming.Drivers[i].MQTT.Password == "" {
+				incoming.Drivers[i].MQTT.Password = ed.MQTT.Password
+			}
 			break
 		}
 	}

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -46,6 +46,7 @@ type HostEnv struct {
 	Telemetry  *telemetry.Store
 	MQTT       MQTTCap    // nil → mqtt_* calls return ErrNoCapability
 	Modbus     ModbusCap  // nil → modbus_* calls return ErrNoCapability
+	HTTP       bool       // false → http_* calls return ErrNoCapability
 	Start      time.Time  // monotonic start; host.millis() computed from here
 
 	mu sync.Mutex
@@ -78,6 +79,9 @@ func (h *HostEnv) WithMQTT(m MQTTCap) *HostEnv { h.MQTT = m; return h }
 
 // WithModbus binds a Modbus capability.
 func (h *HostEnv) WithModbus(m ModbusCap) *HostEnv { h.Modbus = m; return h }
+
+// WithHTTP enables the HTTP capability.
+func (h *HostEnv) WithHTTP() *HostEnv { h.HTTP = true; return h }
 
 // millis returns monotonic milliseconds since host startup.
 func (h *HostEnv) millis() int64 {

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -433,6 +433,11 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	}
 
 	host.RawSetString("http_get", L.NewFunction(func(L *lua.LState) int {
+		if !env.HTTP {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("http: capability not granted"))
+			return 2
+		}
 		url := L.CheckString(1)
 		req, err := net_http.NewRequest("GET", url, nil)
 		if err != nil {
@@ -464,6 +469,11 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	}))
 
 	host.RawSetString("http_post", L.NewFunction(func(L *lua.LState) int {
+		if !env.HTTP {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("http: capability not granted"))
+			return 2
+		}
 		url := L.CheckString(1)
 		payload := L.CheckString(2)
 		req, err := net_http.NewRequest("POST", url, strings.NewReader(payload))

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -120,6 +120,9 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 			if mac, ok := r.ARPLookup(mb.Host); ok { env.SetMAC(mac) }
 		}
 	}
+	if cfg.Capabilities.HTTP != nil {
+		env.WithHTTP()
+	}
 
 	luaDrv, err := NewLuaDriver(cfg.Lua, env)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes 4 of 6 P1 bugs flagged by Codex review comments on recently merged PRs. The remaining 2 were already fixed.

- **easee_cloud.lua**: `ev_set_current` derived amps as `power_w / 230` but Easee's `dynamicChargerCurrent` is per-phase amps for a 3-phase charger. Fixed to `power_w / 230 / 3`.
- **config.go**: `PreserveMaskedSecrets()` restored `drivers[].config["password"]` but not `drivers[].capabilities.mqtt.password` or `drivers[].mqtt.password`. Fixed to also restore MQTT passwords in both capabilities and legacy blocks.
- **lua.go / host.go / registry.go**: `host.http_get` and `host.http_post` had no capability gate — any Lua driver could make HTTP calls without being granted the `http` capability. Added `HTTP bool` field to `HostEnv`, capability check in both functions, and wiring in `registry.Add`.
- **huawei.lua**: Early return on meter read failure skipped the meter emit but PV and battery were already emitted, keeping the driver "healthy" from the watchdog's perspective. Moved ALL emits to after ALL reads succeed.

### Verified already fixed (skipped)

- **Bug 3** (EV settings path): `web/settings.js` correctly writes `ev_charger.*` and the Go struct has `json:"ev_charger,omitempty"` — fixed in PR #58.
- **Bug 6** (MPC arbitrage discharge): `service.go:178` already returns `"self_consumption", a.GridW, true` for arbitrage discharge — fixed in PR #46/#47.

## Test plan

- [x] `go test ./...` passes (all 26 packages)
- [ ] Manual test: Easee EV charger set-current command on a 3-phase installation
- [ ] Manual test: save config with masked MQTT password via settings UI and verify it persists
- [ ] Manual test: Lua driver without HTTP capability gets error when calling `host.http_get`
- [ ] Manual test: Huawei driver with meter offline shows as stale in watchdog

🤖 Generated with [Claude Code](https://claude.com/claude-code)