### PR TITLE
fix: P2 review comments — control, MPC, drivers, UI, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ top-of-funnel overview.
 
 ## Supported devices
 
-17 Lua drivers covering 15 manufacturers — Ferroamp, Sungrow, Solis,
+19 Lua drivers covering 16 manufacturers — Ferroamp, Sungrow, Solis,
 Huawei, Deye, SMA, Fronius, SolarEdge, Eastron SDM, Pixii, Kostal,
-GoodWe, Growatt, Sofar, Victron. Six drivers participate in EMS
-dispatch control; the rest are read-only telemetry.
+GoodWe, Growatt, Sofar, Victron, Easee. Seven drivers participate in
+EMS dispatch control; the rest are read-only telemetry.
 
 See [`docs/driver-catalog.md`](docs/driver-catalog.md) for the full
 table (protocols, capabilities, control, tested models) and
@@ -126,9 +126,8 @@ Historical migration rationale: [`MIGRATION_PLAN.md`](MIGRATION_PLAN.md)
 
 ## Quick start
 
-Prereqs: Go 1.22+, `make`. Rust + `wasm32-wasip1` only needed if you
-want to build legacy WASM drivers — the default Lua drivers need
-nothing more.
+Prereqs: Go 1.22+, `make`. That's it — the default Lua drivers need
+no additional toolchain.
 
 ```bash
 # Build Go binaries + (if present) WASM drivers, run the full local stack with simulators
@@ -196,9 +195,6 @@ build step.
 ## Deploy to a Raspberry Pi
 
 ```bash
-# One-time (only needed if you ship WASM drivers): wasm32-wasip1 toolchain
-rustup target add wasm32-wasip1
-
 # Build the release tarballs (arm64 + amd64)
 make release
 

--- a/docs/driver-catalog.md
+++ b/docs/driver-catalog.md
@@ -6,10 +6,10 @@ in `drivers/` that follows the v2.1 host API (see
 
 ## At a glance
 
-18 drivers covering 15 manufacturers across 2 protocols. Read-only: 12.
-With control: 6.
+19 drivers covering 16 manufacturers across 3 protocols (Modbus TCP,
+MQTT, HTTP/REST). Read-only: 12. With control: 7.
 
-Protocols in use: Modbus TCP, MQTT.
+Protocols in use: Modbus TCP, MQTT, HTTP/REST.
 
 ## Drivers
 
@@ -20,6 +20,7 @@ back to the device; read-only drivers only emit telemetry.
 | Driver | Manufacturer | Protocol | Capabilities | Control | Tested models | File |
 |---|---|---|---|---|---|---|
 | Deye hybrid inverter | Deye | Modbus | battery, meter, pv | yes | SUN-5K-SG03LP1-EU, SUN-8K-SG04LP3-EU, SUN-12K-SG04LP3-EU | `drivers/deye.lua` |
+| Easee Cloud | Easee | HTTP | ev | yes | Home, Charge | `drivers/easee_cloud.lua` |
 | Eastron SDM630 / SDM72D-M | Eastron | Modbus | meter | no | SDM630-Modbus, SDM72D-M | `drivers/sdm630.lua` |
 | Ferroamp EnergyHub (MQTT) | Ferroamp | MQTT | battery, meter, pv | yes | EnergyHub XL, EnergyHub Wall | `drivers/ferroamp.lua` |
 | Ferroamp EnergyHub (Modbus) | Ferroamp | Modbus | battery, meter, pv | yes | EnergyHub XL, EnergyHub Wall | `drivers/ferroamp_modbus.lua` |

--- a/docs/host-api.md
+++ b/docs/host-api.md
@@ -1,12 +1,16 @@
 # Host API Reference
 
-> Complete reference for the `host` capability interface exposed to both
-> **Lua** and **WASM** driver runtimes. For a tutorial-style introduction
-> to writing Lua drivers, see [writing-a-driver.md](writing-a-driver.md).
-> The authoritative Lua-specific source is the top-of-file comment in
+> Complete reference for the `host` capability interface exposed to
+> **Lua** driver runtimes. For a tutorial-style introduction to writing
+> Lua drivers, see [writing-a-driver.md](writing-a-driver.md). The
+> authoritative Lua-specific source is the top-of-file comment in
 > `go/internal/drivers/lua.go`.
+>
+> **Note:** The legacy WASM driver runtime has been removed from the
+> codebase. This document covers the Lua host API only. For historical
+> WASM ABI details, see the git history of `go/internal/drivers/runtime.go`.
 
-The `host` table is available to all Lua drivers (and an equivalent set of host imports is available to legacy WASM drivers under the `"host"` namespace). It provides functions for logging, device communication, data decoding, JSON handling, and telemetry emission. These are the same APIs available on the Sourceful Zap gateway, so drivers are portable between forty-two-watts and the Zap.
+The `host` table is available to all Lua drivers. It provides functions for logging, device communication, data decoding, JSON handling, and telemetry emission. These are the same APIs available on the Sourceful Zap gateway, so drivers are portable between forty-two-watts and the Zap.
 
 ## Core
 

--- a/docs/writing-a-driver-with-claude-code.md
+++ b/docs/writing-a-driver-with-claude-code.md
@@ -76,18 +76,11 @@ place of the Modbus helpers.
 As soon as the file exists, tell Claude Code to verify it parses:
 
 ```
-Now run `cd go && go test -count=1 -run TestCatalog ./internal/drivers/`
-and fix anything the catalog loader rejects.
-```
-
-Then the Lua lifecycle harness:
-
-```
-Now run `cd go && go test -count=1 -run TestLuaDriver
+Now run `cd go && go test -count=1 -run TestLuaDriverLifecycle
 ./internal/drivers/` and fix any load/runtime errors.
 ```
 
-Both tests are fast (<2 s). They catch the most common mistakes: the
+This test is fast (<2 s). It catches the most common mistakes: the
 DRIVER regex failing, missing lifecycle functions, and syntax errors
 in the Lua source.
 

--- a/drivers/ferroamp_modbus.lua
+++ b/drivers/ferroamp_modbus.lua
@@ -225,7 +225,7 @@ function driver_poll()
 
     -- Battery SoC: input 6016, float32, percent → 0-1 fraction
     local ok_soc, soc_regs = pcall(host.modbus_read, 6016, 2, "input")
-    local bat_soc = 0
+    local bat_soc = nil
     if ok_soc and soc_regs then bat_soc = decode_f32_ws_at(soc_regs, 1) / 100 end
 
     -- Battery energy: discharge at 6064, charge at 6068, float32, kWh (8 regs)
@@ -236,12 +236,15 @@ function driver_poll()
         bat_charge_wh    = decode_f32_ws_at(be_regs, 5) * 1000   -- 6068-6069
     end
 
-    host.emit("battery", {
+    -- Omit soc from the emit table when the read failed — emitting 0
+    -- would cause the control loop to think the battery is empty.
+    local bat_data = {
         w            = bat_w,
-        soc          = bat_soc,
         charge_wh    = bat_charge_wh,
         discharge_wh = bat_discharge_wh,
-    })
+    }
+    if bat_soc ~= nil then bat_data.soc = bat_soc end
+    host.emit("battery", bat_data)
 
     return 5000
 end

--- a/drivers/solaredge.lua
+++ b/drivers/solaredge.lua
@@ -182,7 +182,17 @@ function driver_poll()
         end
     end
     if need_sf_read then
-        sf_cache = load_scale_factors()
+        local fresh = load_scale_factors()
+        if sf_cache == nil then
+            -- First read: accept everything (zeros will trigger retries).
+            sf_cache = fresh
+        else
+            -- Merge: only overwrite with non-zero values so a transient
+            -- read failure doesn't clobber a previously good SF.
+            for k, v in pairs(fresh) do
+                if v ~= 0 then sf_cache[k] = v end
+            end
+        end
         sf_retries = sf_retries + 1
         if sf_retries >= SF_MAX_RETRIES then
             host.log("warn", "SolarEdge: accepting scale factors after "

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -177,6 +177,9 @@ func main() {
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
+			// Regenerate the synthetic EV charger driver entry from the
+			// high-level ev_charger config, matching what main() does at startup.
+			newCfg.InjectEVChargerDriver()
 			// Resolve relative paths
 			for i := range newCfg.Drivers {
 				if newCfg.Drivers[i].WASM != "" && !filepath.IsAbs(newCfg.Drivers[i].WASM) {

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -174,7 +174,9 @@ func ComputeDispatch(
 			state.SetGridTarget(gridW)
 			state.PlanStale = false
 		} else {
-			slog.Warn("mpc plan stale — falling back to self_consumption")
+			if !state.PlanStale {
+				slog.Warn("mpc plan stale — falling back to self_consumption")
+			}
 			effectiveMode = ModeSelfConsumption
 			state.SetGridTarget(0)
 			state.PlanStale = true

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -662,6 +662,9 @@ func lookupCloud(forecasts []state.ForecastPoint, ts int64) float64 {
 
 // lookupPV finds the forecast row whose slot covers ts and returns its PV
 // estimate (W, non-negative). Returns 0 if no forecast or no estimate.
+// Strictly respects slot boundaries: does NOT carry forward beyond the last
+// forecast slot, because doing so would project stale PV into nighttime or
+// far-future slots where the forecast didn't cover.
 func lookupPV(forecasts []state.ForecastPoint, ts int64) float64 {
 	if len(forecasts) == 0 {
 		return 0
@@ -679,17 +682,15 @@ func lookupPV(forecasts []state.ForecastPoint, ts int64) float64 {
 			}
 			return 0
 		}
-		// Fall back: if before first, or between rows, use the preceding row.
+		// Fall back: if between rows, use the preceding row (interpolation
+		// within the forecast range only).
 		if ts < f.SlotTsMs && i > 0 {
 			if prev := forecasts[i-1]; prev.PVWEstimated != nil {
 				return *prev.PVWEstimated
 			}
 		}
 	}
-	// After last row — use last known
-	if last := forecasts[len(forecasts)-1]; last.PVWEstimated != nil {
-		return *last.PVWEstimated
-	}
+	// After last row — return 0 (no forecast coverage).
 	return 0
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1287,6 +1287,9 @@
         });
         chartView = e.target.dataset.view;
         if (chartTitle) chartTitle.textContent = chartView === "energy" ? "Energy (cumulative today)" : "Power";
+        // Reset cached layout so the y-axis snaps to the new view's range
+        // instead of lerp-ing from the previous view's scale.
+        chartLayout = null;
         updateLegend();
         renderChart();
       }

--- a/web/settings.js
+++ b/web/settings.js
@@ -444,7 +444,20 @@
           if (!el) return;
           function refresh() {
             fetch("/api/status").then(function(r){return r.json();}).then(function(d) {
-              var drivers = d.drivers || [];
+              // drivers may be an object keyed by name or an array — normalize.
+              var rawDrivers = d.drivers || {};
+              var drivers = [];
+              if (Array.isArray(rawDrivers)) {
+                drivers = rawDrivers;
+              } else {
+                Object.keys(rawDrivers).forEach(function(k) {
+                  var entry = rawDrivers[k];
+                  if (typeof entry === "object" && entry !== null) {
+                    if (!entry.name) entry.name = k;
+                    drivers.push(entry);
+                  }
+                });
+              }
               var easee = null;
               for (var i = 0; i < drivers.length; i++) {
                 if ((drivers[i].name || "").toLowerCase().indexOf("easee") >= 0) {


### PR DESCRIPTION
## Summary

- **dispatch.go**: Rate-limit stale-plan warning to log only on false-to-true transition instead of every cycle
- **mpc/service.go**: Stop `lookupPV` from carrying forward the last forecast PV value into slots beyond the forecast range (was projecting stale daytime PV into nighttime slots)
- **main.go**: Call `InjectEVChargerDriver()` in the config reload callback so EV driver regenerates on config changes
- **solaredge.lua**: Merge scale factors on retry instead of replacing — a transient zero read no longer clobbers a previously good SF value
- **ferroamp_modbus.lua**: Omit `soc` from battery emit when the SoC register read fails, instead of emitting 0 (which makes the control loop think the battery is empty)
- **app.js**: Reset `chartLayout` on power/energy view switch so the y-axis snaps to the new range instead of lerp-ing from the old scale
- **settings.js**: Normalize `drivers` from `/api/status` as either object or array for EV charger status indicator
- **Docs**: Mark WASM as removed in host-api.md, update driver count to 19 (with easee_cloud.lua), remove Rust/WASM prerequisites from README, fix test names in claude-code guide

## Test plan

- [x] `go test ./...` passes (all 27 packages)
- [ ] Manual: verify stale-plan warning appears once then stops in logs
- [ ] Manual: verify power/energy chart toggle snaps y-axis immediately
- [ ] Manual: verify EV status indicator works when `/api/status` returns drivers as object

🤖 Generated with [Claude Code](https://claude.com/claude-code)