### PR TITLE
feat: config/UI improvements -- kWh display, secure EV password, planner tab

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -63,9 +63,6 @@ func main() {
 	}
 	slog.Info("config loaded", "site", cfg.Site.Name, "drivers", len(cfg.Drivers))
 
-	// ---- Auto-generate EV charger driver from high-level config ----
-	cfg.InjectEVChargerDriver()
-
 	// ---- Open persistent state (SQLite) ----
 	statePath := "state.db"
 	coldDir := "cold"
@@ -82,6 +79,16 @@ func main() {
 	if err := st.RecordEvent("startup"); err != nil {
 		slog.Warn("failed to persist startup event", "err", err)
 	}
+
+	// ---- Restore EV charger password from state.db (not stored in YAML) ----
+	if cfg.EVCharger != nil {
+		if pw, ok := st.LoadConfig("ev_charger_password"); ok {
+			cfg.EVCharger.Password = pw
+		}
+	}
+
+	// ---- Auto-generate EV charger driver from high-level config ----
+	cfg.InjectEVChargerDriver()
 
 	// ---- Telemetry store ----
 	tel := telemetry.NewStore()
@@ -177,6 +184,12 @@ func main() {
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
+			// Restore EV charger password from state.db (not in YAML).
+			if newCfg.EVCharger != nil {
+				if pw, ok := st.LoadConfig("ev_charger_password"); ok {
+					newCfg.EVCharger.Password = pw
+				}
+			}
 			// Regenerate the synthetic EV charger driver entry from the
 			// high-level ev_charger config, matching what main() does at startup.
 			newCfg.InjectEVChargerDriver()

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -34,6 +34,15 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
 )
 
+const (
+	// evPasswordKey is the state.db key for the EV charger password
+	// (stored outside config.yaml for security).
+	evPasswordKey = "ev_charger_password"
+	// maskedPlaceholder is sent to the UI to indicate a password is set
+	// without revealing the actual value.
+	maskedPlaceholder = "••••••••"
+)
+
 // Deps is the full set of runtime dependencies the API handlers need.
 // One instance is shared across all handlers; mutations use the contained
 // mutexes from each package.
@@ -396,7 +405,18 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	s.deps.CfgMu.RLock()
 	cfg := *s.deps.Cfg
 	s.deps.CfgMu.RUnlock()
-	writeJSON(w, 200, cfg.MaskSecrets())
+	masked := cfg.MaskSecrets()
+	// EV charger password lives in state.db, not YAML. Signal to the UI
+	// that a password is set by using a masked placeholder (MaskSecrets
+	// blanked it to "").
+	if masked.EVCharger != nil {
+		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok && pw != "" {
+			cp := *masked.EVCharger
+			cp.Password = maskedPlaceholder
+			masked.EVCharger = &cp
+		}
+	}
+	writeJSON(w, 200, masked)
 }
 
 func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
@@ -409,11 +429,30 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	s.deps.CfgMu.RLock()
 	newCfg.PreserveMaskedSecrets(s.deps.Cfg)
 	s.deps.CfgMu.RUnlock()
+
+	// EV charger password: persist to state.db instead of config.yaml.
+	// Empty or the masked placeholder means "keep existing"; a new value
+	// means the user typed a real password.
+	if newCfg.EVCharger != nil {
+		pw := newCfg.EVCharger.Password
+		if pw != "" && pw != maskedPlaceholder {
+			if err := s.deps.State.SaveConfig(evPasswordKey, pw); err != nil {
+				slog.Warn("failed to persist ev_charger_password", "err", err)
+			}
+		}
+		// Restore the real password into the in-memory config so
+		// InjectEVChargerDriver (called by the config-reload watcher)
+		// sees it.
+		if stored, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			newCfg.EVCharger.Password = stored
+		}
+	}
+
 	if err := newCfg.Validate(); err != nil {
 		writeJSON(w, 400, map[string]string{"error": "validation: " + err.Error()})
 		return
 	}
-	// Persist atomically
+	// Persist atomically (Password has yaml:"-" so it won't appear in YAML)
 	if err := s.deps.SaveConfig(s.deps.ConfigPath, &newCfg); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "save failed: " + err.Error()})
 		return

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -48,10 +48,14 @@ type OCPP struct {
 // EVCharger is the high-level EV charger config written by the Settings UI.
 // The backend auto-generates a Lua driver entry from this on startup so
 // users never touch raw driver YAML for their EV charger.
+//
+// Password is stored in state.db (key "ev_charger_password"), NOT in config.yaml.
+// It is populated at runtime by main.go after loading state and by the API
+// handler on POST /api/config.
 type EVCharger struct {
 	Provider string `yaml:"provider" json:"provider"` // "easee" (only option for now)
 	Email    string `yaml:"email" json:"email"`
-	Password string `yaml:"password" json:"password"`
+	Password string `yaml:"-" json:"password"` // persisted in state.db, not YAML
 	Serial   string `yaml:"serial,omitempty" json:"serial,omitempty"`
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -37,6 +37,7 @@
         <button data-tab="price">Price</button>
         <button data-tab="weather">Weather</button>
         <button data-tab="batteries">Batteries</button>
+        <button data-tab="planner">Planner</button>
         <button data-tab="ha">Home Assistant</button>
         <button data-tab="ev">EV Charger</button>
       </div>

--- a/web/settings.js
+++ b/web/settings.js
@@ -80,6 +80,10 @@
       var path = input.dataset.path;
       var val = input.type === "number" ? parseFloat(input.value) : input.value;
       if (input.type === "number" && isNaN(val)) val = 0;
+      // Scale display units back to internal units (e.g. kWh -> Wh)
+      if (input.type === "number" && input.dataset.unitScale) {
+        val = val * parseFloat(input.dataset.unitScale);
+      }
       // Don't overwrite a saved password with empty string when user hasn't typed anything
       if (input.type === "password" && val === "" && getByPath(currentConfig, path, "")) return;
       setByPath(currentConfig, path, val);
@@ -144,6 +148,13 @@
           field("Slew rate (W/cycle)", "site.slew_rate_w", "number", 500) +
           '</div><div>' +
           field("Min dispatch interval (s)", "site.min_dispatch_interval_s", "number", 5) +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+          field("Smoothing alpha", "site.smoothing_alpha", "number", 0.3,
+            "EMA smoothing factor for the grid reading (0-1). Lower = smoother but slower response.") +
+          '</div><div>' +
+          field("PI gain", "site.gain", "number", 0.5,
+            "Proportional gain of the PI controller. Higher = more aggressive correction.") +
           '</div></div>' +
           '<div class="field-row"><div>' +
           field("Control interval (s)", "site.control_interval_s", "number", 5) +
@@ -229,8 +240,8 @@
             '<label>Driver file ' + help('Path to the .wasm (or legacy .lua) driver. Absolute or relative to the config file directory.') + '</label>' +
             '<input type="text" data-path="drivers.' + idx + '.' + fmtKind + '" value="' + escHtml(driverFile) + '">' +
             '</div><div>' +
-            '<label>Battery capacity (Wh) ' + help('Nameplate storage capacity in watt-hours. Used for SoC scaling and MPC planning.') + '</label>' +
-            '<input type="number" data-path="drivers.' + idx + '.battery_capacity_wh" value="' + (d.battery_capacity_wh || 0) + '">' +
+            '<label>Battery capacity (kWh) ' + help('Nameplate storage capacity in kilowatt-hours. Stored internally as Wh.') + '</label>' +
+            '<input type="number" step="0.1" data-path="drivers.' + idx + '.battery_capacity_wh" data-unit-scale="1000" value="' + ((d.battery_capacity_wh || 0) / 1000) + '">' +
             '</div></div>' +
             '<label><input type="checkbox" data-checkbox-path="drivers.' + idx + '.is_site_meter"' + (d.is_site_meter ? ' checked' : '') + '> Site meter ' + help('Exactly one driver should be the site meter — its grid reading defines the point-of-measurement the PI loop balances.') + '</label>';
           if (mqtt) {
@@ -358,6 +369,47 @@
               '</fieldset>';
           }
         });
+        break;
+
+      case "planner":
+        if (!currentConfig.planner) currentConfig.planner = {};
+        html = '<fieldset><legend>MPC Planner</legend>' +
+          '<label><input type="checkbox" data-checkbox-path="planner.enabled"' + (currentConfig.planner.enabled ? ' checked' : '') + '> Enabled ' +
+          help('Enable the MPC planner. When active it overrides manual mode with an optimised schedule.') + '</label>' +
+          selectField("Mode", "planner.mode", ["self_consumption", "cheap_charge", "arbitrage"], "self_consumption",
+            "self_consumption = minimise grid import. cheap_charge = charge batteries during cheapest hours. arbitrage = buy low / sell high.") +
+          '<div class="field-row"><div>' +
+          field("SoC min (%)", "planner.soc_min_pct", "number", 10,
+            "Lowest SoC the planner will discharge to (percent). 10 = 10%.") +
+          '</div><div>' +
+          field("SoC max (%)", "planner.soc_max_pct", "number", 90,
+            "Highest SoC the planner will charge to (percent). 90 = 90%.") +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+          field("Base load (W)", "planner.base_load_w", "number", 0,
+            "Constant household load estimate used when the load twin has no data yet.") +
+          '</div><div>' +
+          field("Horizon (hours)", "planner.horizon_hours", "number", 48,
+            "Planning horizon in hours. 48 h covers two day-ahead price windows.") +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+          field("Replan interval (min)", "planner.interval_min", "number", 15,
+            "How often the planner re-solves. Lower = more responsive but more CPU.") +
+          '</div><div>' +
+          field("Export value (ore/kWh)", "planner.export_ore_per_kwh", "number", 0,
+            "Override export value. 0 = use mean spot price.") +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+          field("Charge efficiency", "planner.charge_efficiency", "number", 0.95,
+            "Round-trip charge efficiency (0-1). 0.95 = 5% loss charging.") +
+          '</div><div>' +
+          field("Discharge efficiency", "planner.discharge_efficiency", "number", 0.95,
+            "Round-trip discharge efficiency (0-1). 0.95 = 5% loss discharging.") +
+          '</div></div>' +
+          '</fieldset>' +
+          '<p style="color:var(--text-dim);font-size:0.8rem;margin-top:8px">' +
+          'The planner requires working price + weather forecasts. When disabled the system runs in the manual mode set on the Control page.' +
+          '</p>';
         break;
 
       case "ha":


### PR DESCRIPTION
## Summary

- **kWh display**: Battery capacity field in Settings > Devices now shows kWh instead of Wh, with automatic unit conversion (x1000) at the read/write boundary via a generic `data-unit-scale` attribute on the input element.
- **Secure EV password**: Easee charger password moved from `config.yaml` (plaintext on disk) to `state.db` using the existing `SaveConfig`/`LoadConfig` k/v store. The `EVCharger.Password` field now has `yaml:"-"` so it never serializes to YAML. The API GET endpoint returns a masked placeholder when a password is set; POST detects the placeholder and preserves the existing password.
- **Planner tab**: New Settings tab exposes all `planner.*` config fields (mode, SoC min/max, horizon, replan interval, efficiencies, base load, export value) that were previously only editable by hand in YAML.
- **Control tab completeness**: Added missing `smoothing_alpha` and `gain` fields to the Control tab.

## Test plan

- [x] `go test ./...` passes (all 24 packages)
- [ ] Open Settings > Devices, verify battery capacity shows in kWh (e.g. 13.5 not 13500)
- [ ] Save config with a battery capacity of 10 kWh, reload, verify it persists as 10000 Wh internally
- [ ] Open Settings > EV Charger, set a password, save, verify it does NOT appear in config.yaml
- [ ] Reload Settings > EV Charger, verify placeholder dots indicate a password is stored
- [ ] Open Settings > Planner, verify all fields render and save correctly
- [ ] Open Settings > Control, verify smoothing alpha and PI gain fields are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)