### PR TITLE
fix: add HTTP capability support for easee

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -28,6 +28,7 @@ DRIVER = {
   capabilities = { "ev" },
   description  = "Easee Home/Charge via Cloud REST API. No local protocol needed.",
   homepage     = "https://easee.com",
+  http_hosts   = { "api.easee.com" },
   authors      = { "forty-two-watts contributors" },
   tested_models = { "Home", "Charge" },
 }

--- a/go/internal/drivers/catalog.go
+++ b/go/internal/drivers/catalog.go
@@ -22,6 +22,7 @@ type CatalogEntry struct {
 	Version            string         `json:"version,omitempty"`
 	Protocols          []string       `json:"protocols,omitempty"`            // mqtt / modbus / http
 	Capabilities       []string       `json:"capabilities,omitempty"`         // meter / pv / battery
+	HTTPHosts          []string       `json:"http_hosts,omitempty"`
 	Description        string         `json:"description,omitempty"`
 	Homepage           string         `json:"homepage,omitempty"`
 	ConnectionDefaults map[string]any `json:"connection_defaults,omitempty"`
@@ -91,6 +92,7 @@ func parseCatalogEntry(path string) (CatalogEntry, error) {
 	e.Homepage = pickString(block, "homepage")
 	e.Protocols = pickList(block, "protocols")
 	e.Capabilities = pickList(block, "capabilities")
+	e.HTTPHosts = pickList(block, "http_hosts")
 	e.ConnectionDefaults = pickKVBlock(block, "connection_defaults")
 	return e, nil
 }

--- a/web/settings.js
+++ b/web/settings.js
@@ -202,6 +202,7 @@
               opt.textContent = (e.name || e.filename) + "  —  " + (e.manufacturer || "?") + "  [" + protoLabel + "]" + (e.version ? "  v" + e.version : "");
               opt.dataset.protocols = protoLabel;
               opt.dataset.id = e.id || "";
+              opt.dataset.httpHosts = (e.http_hosts || []).join(",");
               sel.appendChild(opt);
             });
           });
@@ -217,6 +218,10 @@
             driver.capabilities = {};
             if (protocols.indexOf("mqtt") >= 0) driver.capabilities.mqtt = { host: "", port: 1883 };
             if (protocols.indexOf("modbus") >= 0) driver.capabilities.modbus = { host: "", port: 502, unit_id: 1 };
+            if (protocols.indexOf("http") >= 0) {
+              var hosts = (chosen.dataset.httpHosts || "").split(",").filter(Boolean);
+              driver.capabilities.http = { allowed_hosts: hosts };
+            }
             currentConfig.drivers.push(driver);
             renderTab("devices");
           });
@@ -227,7 +232,8 @@
           var cap = d.capabilities || {};
           var mqtt = cap.mqtt || d.mqtt; // legacy fallback
           var modbus = cap.modbus || d.modbus;
-          var protocol = mqtt ? "mqtt" : (modbus ? "modbus" : "?");
+          var httpCap = cap.http;
+          var protocol = mqtt ? "mqtt" : (modbus ? "modbus" : (httpCap ? "http" : "?"));
           var driverFile = d.wasm || d.lua || "(none)";
           var fmtKind = d.wasm ? "wasm" : (d.lua ? "lua" : "?");
           html += '<div class="device-item">' +
@@ -301,7 +307,8 @@
           selectField("Zone", "price.zone", ["SE1","SE2","SE3","SE4","NO1","NO2","NO3","NO4","DK1","DK2","FI","DE"], "SE3") +
           selectField("Currency", "price.currency", ["SEK", "NOK", "DKK", "EUR"], "SEK") +
           '<div class="field-row"><div>' +
-          field("Grid tariff (öre/kWh)", "price.grid_tariff_ore_kwh", "number", 60) +
+          field("Grid tariff excl. VAT (öre/kWh)", "price.grid_tariff_ore_kwh", "number", 60,
+            "Per-kWh network/distribution fee from your DSO (elnätsavgift), excluding VAT. This is the cost of moving electricity over the wire, independent of the spot price.") +
           '</div><div>' +
           field("VAT (%)", "price.vat_percent", "number", 25) +
           '</div></div>' +


### PR DESCRIPTION
- Frontend now handles the "http" protocol when adding drivers from the catalog, setting capabilities.http.allowed_hosts from the driver's http_hosts metadata. Fixes "must have mqtt, modbus, or http capability" validation error when adding cloud-based drivers like Easee.
- Added http_hosts to easee_cloud.lua DRIVER metadata and HTTPHosts field to CatalogEntry so the catalog API exposes it.
- Updated grid tariff label to "excl. VAT" with tooltip clarifying it's the DSO network fee, not a spot price component.