### PR TITLE
feat: EV cloud driver improvements — observations API, provider patte…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ data/
 *.test
 *.out
 
-# WASM build artifacts
-/wasm-drivers/**/target/
-*.wasm.gz
-
 # Local config for simulators
 config.local.yaml
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,7 @@
 # forty-two-watts — project orientation
 
-Unified Home Energy Management System. The Go port is now mainline on
-`master`; the historical Rust implementation lives alongside in `src/` +
-`Cargo.toml` and is frozen (see `MIGRATION_PLAN.md` for context).
+Unified Home Energy Management System, written in Go with Lua drivers.
+See `MIGRATION_PLAN.md` for the historical Rust→Go migration context.
 
 ## Mental model
 
@@ -13,16 +12,12 @@ place sign conversion happens — above it, every layer uses the site
 convention. Read `docs/site-convention.md` before touching any power-math
 code.
 
-**Lua-first drivers**: `drivers/*.lua` loaded by `gopher-lua` are the
-primary driver path. Each driver file implements the lifecycle
-(`driver_init`, `driver_poll`, `driver_command`, `driver_default_mode`,
+**Lua drivers**: `drivers/*.lua` loaded by `gopher-lua` are the only
+driver path. Each driver file implements the lifecycle (`driver_init`,
+`driver_poll`, `driver_command`, `driver_default_mode`,
 `driver_cleanup`) and talks to hardware through the `host.*` capabilities
-exposed by `go/internal/drivers/lua.go`. WASM drivers (`wasm-drivers/*/`
-compiled into `drivers-wasm/*.wasm`) are still supported via the same
-Registry and capability interface — dispatch lives in
-`go/internal/drivers/registry.go` — but Lua is recommended for new
-drivers because it's hot-editable on the Pi and doesn't need a Rust
-toolchain.
+exposed by `go/internal/drivers/lua.go`. Drivers are hot-editable on the
+Pi and need no build step.
 
 **Clamping discipline**: every clamp must protect against a *quantifiable
 risk*. Read `docs/clamping.md` for the seven current clamps and the
@@ -46,7 +41,7 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/internal/control` | PI + dispatch modes + slew + fuse guard |
 | `go/internal/battery` | ARX(1) model + RLS + cascade + saturation curves |
 | `go/internal/selftune` | Step-response state machine + fitter |
-| `go/internal/drivers` | Lua host (`lua.go`) + wazero host (`runtime.go`) + shared Registry + capability ABI |
+| `go/internal/drivers` | Lua host (`lua.go`) + Registry + capability interfaces |
 | `go/internal/api` | HTTP endpoints (Go 1.22+ method mux) |
 | `go/internal/configreload` | fsnotify watcher + reload dispatch |
 | `go/internal/ha` | Home Assistant MQTT autodiscovery + bridge |
@@ -59,14 +54,11 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/internal/pvmodel` | PV twin (RLS over sunpos / cloud prior) |
 | `go/internal/mpc` | MPC planner — DP over SoC grid, 48 h horizon |
 | `drivers/` | Lua drivers (`ferroamp.lua`, `sungrow.lua`, …) |
-| `wasm-drivers/ferroamp` | Legacy Rust → wasm32-wasip1 Ferroamp driver |
-| `wasm-drivers/sungrow` | Legacy Rust → wasm32-wasip1 Sungrow driver |
 | `go/test/e2e` | Full-stack test: sims + main + drivers + HTTP |
 
 ## Building & testing
 
 ```bash
-make wasm         # compile legacy .wasm drivers (needs wasm32-wasip1 Rust target)
 make test         # unit + integration tests
 make e2e          # full-stack end-to-end test
 make dev          # start sims + main app locally
@@ -75,11 +67,10 @@ make release      # tarballs for deploy
 ```
 
 Lua drivers need no build step — `drivers/*.lua` ships verbatim with the
-release tarball and is loaded on startup. `make wasm` is only needed when
-you're actually shipping a `.wasm` module.
+release tarball and is loaded on startup.
 
-No CGo anywhere — pure Go + embedded Lua 5.1 (gopher-lua) + optional
-Rust→WASM. `go build` produces a static single-binary distribution.
+No CGo anywhere — pure Go + embedded Lua 5.1 (gopher-lua). `go build`
+produces a static single-binary distribution.
 
 ## Adding a new driver
 
@@ -113,27 +104,8 @@ global exposes:
 - `host.decode_u32_le/be`, `host.decode_i32_le/be`, `host.decode_i16`
 - `host.json_encode/decode`
 
-MQTT / Modbus calls return an error string if the driver wasn't granted
-the capability in config.
-
-## WASM ABI (legacy)
-
-Still supported for any `.wasm` driver built against v2.0 of the host —
-`go/internal/drivers/runtime.go` + `abi.go` are unchanged. New drivers
-should prefer Lua.
-
-- Driver EXPORTS: `wasm_alloc`, `wasm_dealloc`, `driver_init`,
-  `driver_poll`, `driver_command`, `driver_default`, `driver_cleanup`
-- Host IMPORTS (under `"host"` namespace): `log`, `millis`,
-  `set_poll_interval`, `emit_telemetry`, `set_sn`, `set_make`,
-  `mqtt_{subscribe,publish,poll_messages}`,
-  `modbus_{read,write_single,write_multi}`
-- All string / byte-slice parameters use `(ptr: i32, len: i32)` pairs
-  into driver memory. Driver allocates its own memory via `wasm_alloc`
-  so the host can copy strings into it.
-
-MQTT / Modbus functions return `ErrNoCapability` via status codes if
-the driver wasn't granted the relevant capability in config.
+MQTT / Modbus / HTTP calls return an error string if the driver wasn't
+granted the capability in config.
 
 ## Time-series DB (long-format)
 
@@ -170,8 +142,7 @@ charge another.
 - `slog` for all logging
 - Explicit mutexes — no atomic tricks unless measurably needed
 - SQLite queries in `internal/state/*.go`, nothing embedded elsewhere
-- Driver code in Lua (preferred) or Rust→WASM (legacy); the Go side
-  only owns capabilities, not protocol logic
+- Driver code in Lua; the Go side only owns capabilities, not protocol logic
 - Tests colocated with code, `_test.go` files
 - Integration tests in `go/test/e2e/` (separate package to keep public
   and internal concerns cleanly split)
@@ -184,8 +155,6 @@ charge another.
   cascade bypasses the inverse model (gates on confidence intentionally).
 - **History queries slow**: check `idx_hot_ts` is there; SQL uses range
   scans. `Prune()` should be running periodically to age data to warm/cold.
-- **Tests fail with `drivers-wasm/*.wasm not found`**: run `make wasm`
-  first. CI should always do `make wasm` before `make test`.
 - **Driver hung (tick_count not advancing)**: restart the service and
   check `WatchdogScan` transitions in the logs — the loop should have
   already flipped it offline and sent `DefaultMode`. If it didn't,
@@ -217,6 +186,5 @@ charge another.
 - `docs/mpc-planner.md` — MPC strategies, confidence blending
 - `docs/ml-twins.md` — older twin notes (superseded by ml-models.md)
 - `docs/ha-integration.md` — Home Assistant MQTT bridge
-- `docs/host-api.md` — legacy WASM driver ABI
 - `docs/lua-drivers.md` — earlier Lua driver notes (superseded by writing-a-driver.md)
-- `MIGRATION_PLAN.md` — historical: why Go + WASM (Rust→Go migration is complete)
+- `MIGRATION_PLAN.md` — historical: Rust→Go migration context (migration is complete)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,7 @@
 # forty-two-watts — project orientation
 
-Unified Home Energy Management System. The Go port is now mainline on
-`master`; the historical Rust implementation lives alongside in `src/` +
-`Cargo.toml` and is frozen (see `MIGRATION_PLAN.md` for context).
+Unified Home Energy Management System, written in Go with Lua drivers.
+See `MIGRATION_PLAN.md` for the historical Rust→Go migration context.
 
 ## Mental model
 
@@ -13,16 +12,12 @@ place sign conversion happens — above it, every layer uses the site
 convention. Read `docs/site-convention.md` before touching any power-math
 code.
 
-**Lua-first drivers**: `drivers/*.lua` loaded by `gopher-lua` are the
-primary driver path. Each driver file implements the lifecycle
-(`driver_init`, `driver_poll`, `driver_command`, `driver_default_mode`,
+**Lua drivers**: `drivers/*.lua` loaded by `gopher-lua` are the only
+driver path. Each driver file implements the lifecycle (`driver_init`,
+`driver_poll`, `driver_command`, `driver_default_mode`,
 `driver_cleanup`) and talks to hardware through the `host.*` capabilities
-exposed by `go/internal/drivers/lua.go`. WASM drivers (`wasm-drivers/*/`
-compiled into `drivers-wasm/*.wasm`) are still supported via the same
-Registry and capability interface — dispatch lives in
-`go/internal/drivers/registry.go` — but Lua is recommended for new
-drivers because it's hot-editable on the Pi and doesn't need a Rust
-toolchain.
+exposed by `go/internal/drivers/lua.go`. Drivers are hot-editable on the
+Pi and need no build step.
 
 **Clamping discipline**: every clamp must protect against a *quantifiable
 risk*. Read `docs/clamping.md` for the seven current clamps and the
@@ -46,7 +41,7 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/internal/control` | PI + dispatch modes + slew + fuse guard |
 | `go/internal/battery` | ARX(1) model + RLS + cascade + saturation curves |
 | `go/internal/selftune` | Step-response state machine + fitter |
-| `go/internal/drivers` | Lua host (`lua.go`) + wazero host (`runtime.go`) + shared Registry + capability ABI |
+| `go/internal/drivers` | Lua host (`lua.go`) + Registry + capability interfaces |
 | `go/internal/api` | HTTP endpoints (Go 1.22+ method mux) |
 | `go/internal/configreload` | fsnotify watcher + reload dispatch |
 | `go/internal/ha` | Home Assistant MQTT autodiscovery + bridge |
@@ -59,14 +54,11 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/internal/pvmodel` | PV twin (RLS over sunpos / cloud prior) |
 | `go/internal/mpc` | MPC planner — DP over SoC grid, 48 h horizon |
 | `drivers/` | Lua drivers (`ferroamp.lua`, `sungrow.lua`, …) |
-| `wasm-drivers/ferroamp` | Legacy Rust → wasm32-wasip1 Ferroamp driver |
-| `wasm-drivers/sungrow` | Legacy Rust → wasm32-wasip1 Sungrow driver |
 | `go/test/e2e` | Full-stack test: sims + main + drivers + HTTP |
 
 ## Building & testing
 
 ```bash
-make wasm         # compile legacy .wasm drivers (needs wasm32-wasip1 Rust target)
 make test         # unit + integration tests
 make e2e          # full-stack end-to-end test
 make dev          # start sims + main app locally
@@ -75,11 +67,10 @@ make release      # tarballs for deploy
 ```
 
 Lua drivers need no build step — `drivers/*.lua` ships verbatim with the
-release tarball and is loaded on startup. `make wasm` is only needed when
-you're actually shipping a `.wasm` module.
+release tarball and is loaded on startup.
 
-No CGo anywhere — pure Go + embedded Lua 5.1 (gopher-lua) + optional
-Rust→WASM. `go build` produces a static single-binary distribution.
+No CGo anywhere — pure Go + embedded Lua 5.1 (gopher-lua). `go build`
+produces a static single-binary distribution.
 
 ## Adding a new driver
 
@@ -113,27 +104,8 @@ global exposes:
 - `host.decode_u32_le/be`, `host.decode_i32_le/be`, `host.decode_i16`
 - `host.json_encode/decode`
 
-MQTT / Modbus calls return an error string if the driver wasn't granted
-the capability in config.
-
-## WASM ABI (legacy)
-
-Still supported for any `.wasm` driver built against v2.0 of the host —
-`go/internal/drivers/runtime.go` + `abi.go` are unchanged. New drivers
-should prefer Lua.
-
-- Driver EXPORTS: `wasm_alloc`, `wasm_dealloc`, `driver_init`,
-  `driver_poll`, `driver_command`, `driver_default`, `driver_cleanup`
-- Host IMPORTS (under `"host"` namespace): `log`, `millis`,
-  `set_poll_interval`, `emit_telemetry`, `set_sn`, `set_make`,
-  `mqtt_{subscribe,publish,poll_messages}`,
-  `modbus_{read,write_single,write_multi}`
-- All string / byte-slice parameters use `(ptr: i32, len: i32)` pairs
-  into driver memory. Driver allocates its own memory via `wasm_alloc`
-  so the host can copy strings into it.
-
-MQTT / Modbus functions return `ErrNoCapability` via status codes if
-the driver wasn't granted the relevant capability in config.
+MQTT / Modbus / HTTP calls return an error string if the driver wasn't
+granted the capability in config.
 
 ## Time-series DB (long-format)
 
@@ -170,8 +142,7 @@ charge another.
 - `slog` for all logging
 - Explicit mutexes — no atomic tricks unless measurably needed
 - SQLite queries in `internal/state/*.go`, nothing embedded elsewhere
-- Driver code in Lua (preferred) or Rust→WASM (legacy); the Go side
-  only owns capabilities, not protocol logic
+- Driver code in Lua; the Go side only owns capabilities, not protocol logic
 - Tests colocated with code, `_test.go` files
 - Integration tests in `go/test/e2e/` (separate package to keep public
   and internal concerns cleanly split)
@@ -184,8 +155,6 @@ charge another.
   cascade bypasses the inverse model (gates on confidence intentionally).
 - **History queries slow**: check `idx_hot_ts` is there; SQL uses range
   scans. `Prune()` should be running periodically to age data to warm/cold.
-- **Tests fail with `drivers-wasm/*.wasm not found`**: run `make wasm`
-  first. CI should always do `make wasm` before `make test`.
 - **Driver hung (tick_count not advancing)**: restart the service and
   check `WatchdogScan` transitions in the logs — the loop should have
   already flipped it offline and sent `DefaultMode`. If it didn't,
@@ -217,6 +186,5 @@ charge another.
 - `docs/mpc-planner.md` — MPC strategies, confidence blending
 - `docs/ml-twins.md` — older twin notes (superseded by ml-models.md)
 - `docs/ha-integration.md` — Home Assistant MQTT bridge
-- `docs/host-api.md` — legacy WASM driver ABI
 - `docs/lua-drivers.md` — earlier Lua driver notes (superseded by writing-a-driver.md)
-- `MIGRATION_PLAN.md` — historical: why Go + WASM (Rust→Go migration is complete)
+- `MIGRATION_PLAN.md` — historical: Rust→Go migration context (migration is complete)

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,4 +86,4 @@ EXPOSE 8080
 # open database file" because SQLite can't create state.db inside
 # a directory it doesn't own.
 ENTRYPOINT ["/app/forty-two-watts"]
-CMD ["-config", "/app/data/config.yaml", "-web", "/app/web"]
+CMD ["-config", "/app/data/config.yaml", "-web", "/app/web", "-drivers", "/app/drivers"]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,4 @@
-# forty-two-watts config example (Go + WASM port)
+# forty-two-watts config example
 # Copy to config.yaml and edit for your site.
 
 site:
@@ -17,13 +17,13 @@ fuse:
   voltage: 230
 
 # ----------------------------------------------------------------------
-# Drivers — WASM modules with per-driver capabilities.
+# Drivers — Lua scripts with per-driver capabilities.
 # Capabilities are the ONLY way the sandbox talks to the outside world.
 # A driver with only mqtt capability can't touch modbus, and vice versa.
 # ----------------------------------------------------------------------
 drivers:
   - name: ferroamp
-    wasm: drivers-wasm/ferroamp.wasm
+    lua: drivers/ferroamp.lua
     is_site_meter: true              # exactly one driver must have this
     battery_capacity_wh: 15200
     capabilities:
@@ -34,7 +34,7 @@ drivers:
         password: ferroampExtApi
 
   - name: sungrow
-    wasm: drivers-wasm/sungrow.wasm
+    lua: drivers/sungrow.lua
     battery_capacity_wh: 9600
     capabilities:
       modbus:

--- a/deploy/forty-two-watts.service
+++ b/deploy/forty-two-watts.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=forty-two-watts EMS (Go + WASM port)
+Description=forty-two-watts EMS
 After=network-online.target
 Wants=network-online.target
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,36 @@
+# forty-two-watts — Home Energy Management System
+#
+# Pulls the pre-built multi-arch image (linux/amd64 + linux/arm64) from
+# GitHub Container Registry. No local build needed.
+#
+#   Start:    docker compose up -d
+#   Logs:     docker compose logs -f
+#   Upgrade:  docker compose pull && docker compose up -d
+#   Stop:     docker compose down
+#
+# Persistent state — config.yaml, state.db, battery models, cold/
+# Parquet files — lives in ./data and survives image upgrades. The
+# directory must be owned by uid 100 / gid 101 so the container's ftw
+# user can write to it. If you set this up manually (instead of via
+# scripts/install.sh), run:
+#
+#   mkdir -p ./data && sudo chown -R 100:101 ./data
+
 services:
-  home-ems:
-    build: .
-    image: home-ems:latest
-    container_name: home-ems
+  forty-two-watts:
+    image: ghcr.io/frahlg/forty-two-watts:latest
+    container_name: forty-two-watts
     restart: unless-stopped
-    network_mode: host  # needed for MQTT/Modbus access to local devices
+
+    # Host networking is required for:
+    #   - Modbus TCP to inverters / meters on the LAN
+    #   - MQTT brokers on the LAN (no port forwarding)
+    #   - mDNS-based drivers (e.g. Sourceful Zap at zap.local)
+    #
+    # If you don't have any local hardware (e.g. you're just evaluating
+    # the UI) you can drop this line and add `ports: ["8080:8080"]`
+    # instead, at the cost of losing mDNS/broadcast driver discovery.
+    network_mode: host
+
     volumes:
       - ./data:/app/data
-    environment:
-      - RUST_LOG=home_ems=info

--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -40,6 +40,15 @@ local access_token = nil
 local refresh_token = nil
 local token_expires_at = 0   -- millis
 local charger_serial = nil
+local phases = 3   -- populated from config.phases (if present) in driver_init
+
+-- Easee error bodies have historically echoed submitted form data
+-- (credentials, tokens). Strip the body and keep only the status prefix
+-- so nothing sensitive ever lands in the driver log.
+local function redact_http_err(err)
+    if err == nil then return "request failed" end
+    return tostring(err):match("^(HTTP %d+)") or "request failed"
+end
 
 -- ---- Auth helpers ----
 
@@ -47,11 +56,7 @@ local function login(email, password)
     local body = host.json_encode({userName = email, password = password})
     local resp, err = host.http_post(BASE_URL .. "/accounts/login", body)
     if err then
-        -- Easee validation errors have been observed to echo submitted form
-        -- data in the response body. Log only the status prefix so the
-        -- password can't leak into disk logs.
-        local status_only = tostring(err):match("^(HTTP %d+)") or "request failed"
-        host.log("error", "Easee login failed: " .. status_only)
+        host.log("error", "Easee login failed: " .. redact_http_err(err))
         return false
     end
     local data = host.json_decode(resp)
@@ -76,7 +81,7 @@ local function do_refresh()
     })
     local resp, err = host.http_post(BASE_URL .. "/accounts/refresh_token", body)
     if err then
-        host.log("warn", "Easee token refresh failed: " .. tostring(err))
+        host.log("warn", "Easee token refresh failed: " .. redact_http_err(err))
         return false
     end
     local data = host.json_decode(resp)
@@ -216,6 +221,16 @@ function driver_init(config)
     if email == "" then email = nil end
     if password == "" then password = nil end
 
+    -- Phases: default to 3 since that's the common European install.
+    -- Users on a single-phase service (Easee Home <11 kW) must set
+    -- `phases: 1` in config, otherwise amperage math for ev_set_current
+    -- is 3x under-requested and can fall below the 6 A Easee minimum
+    -- (silently halting the session).
+    if config and tonumber(config.phases) then
+        local p = math.floor(tonumber(config.phases))
+        if p == 1 or p == 2 or p == 3 then phases = p end
+    end
+
     if not email or not password then
         host.log("error", "Easee: email and password required in driver config")
         return
@@ -230,7 +245,7 @@ function driver_init(config)
     if not charger_serial then
         local chargers, cerr = get_chargers()
         if cerr or not chargers or #chargers == 0 then
-            host.log("error", "Easee: could not list chargers: " .. tostring(cerr))
+            host.log("error", "Easee: could not list chargers: " .. redact_http_err(cerr))
             return
         end
         charger_serial = chargers[1].id
@@ -253,7 +268,7 @@ function driver_poll()
 
     local obs, err = get_observations(charger_serial)
     if err or not obs then
-        host.log("warn", "Easee: observations poll failed: " .. tostring(err))
+        host.log("warn", "Easee: observations poll failed: " .. redact_http_err(err))
         return 10000
     end
 
@@ -284,7 +299,7 @@ function driver_poll()
         is_online               = is_online,
         cable_locked            = cable_locked,
         max_a                   = dyn_current,                 -- current dynamic limit (A)
-        phases                  = 3,                           -- Easee defaults 3-phase
+        phases                  = phases,                      -- from config.phases; default 3
     })
 
     if obs[OBS_VOLTAGE] then
@@ -320,8 +335,16 @@ function driver_command(action, power_w, cmd)
     elseif action == "ev_resume" then
         return post_command("/commands/resume_charging")
     elseif action == "ev_set_current" then
-        -- Easee dynamicChargerCurrent is per-phase amps; assume 3-phase.
-        local amps = math.floor((power_w or 0) / 230 / 3)
+        -- Easee dynamicChargerCurrent is per-phase amps, so divide by the
+        -- configured phase count. Round (not floor) so a request like
+        -- 4000 W on 3φ produces 6 A (4000/3/230≈5.8) rather than 5 A
+        -- which the charger would reject as below its 6 A minimum.
+        local amps = math.floor(((power_w or 0) / 230 / phases) + 0.5)
+        -- Clamp to the Easee 0..32 A permitted band. 0 pauses the session
+        -- cleanly; anything <6 A the charger rejects as below minimum, so
+        -- normalise those to 0 to avoid a silent "no current" state.
+        if amps > 0 and amps < 6 then amps = 0 end
+        if amps > 32 then amps = 32 end
         local body = host.json_encode({dynamicChargerCurrent = amps})
         local _, err = host.http_post(
             BASE_URL .. "/chargers/" .. charger_serial .. "/settings",

--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -47,7 +47,11 @@ local function login(email, password)
     local body = host.json_encode({userName = email, password = password})
     local resp, err = host.http_post(BASE_URL .. "/accounts/login", body)
     if err then
-        host.log("error", "Easee login failed: " .. tostring(err))
+        -- Easee validation errors have been observed to echo submitted form
+        -- data in the response body. Log only the status prefix so the
+        -- password can't leak into disk logs.
+        local status_only = tostring(err):match("^(HTTP %d+)") or "request failed"
+        host.log("error", "Easee login failed: " .. status_only)
         return false
     end
     local data = host.json_decode(resp)
@@ -112,14 +116,17 @@ local function get_chargers()
 end
 
 -- Observation IDs (from developer.easee.com/docs/charger-observation-ids)
-local OBS_OP_MODE        = 109
-local OBS_TOTAL_POWER    = 120
-local OBS_SESSION_ENERGY = 121
+local OBS_DYN_CURRENT     = 48
+local OBS_REASON_NO_CUR   = 96
+local OBS_CABLE_LOCKED    = 103
+local OBS_OP_MODE         = 109
+local OBS_TOTAL_POWER     = 120
+local OBS_SESSION_ENERGY  = 121
 local OBS_LIFETIME_ENERGY = 124
-local OBS_VOLTAGE        = 194
-local OBS_CURRENT        = 183
+local OBS_CURRENT         = 183
+local OBS_VOLTAGE         = 194
 
-local OBS_IDS = "109,120,121,124,194,183"
+local OBS_IDS = "48,96,103,109,120,121,124,183,194"
 
 local function get_observations(serial)
     local url = "https://api.easee.com/state/" .. serial .. "/observations?ids=" .. OBS_IDS
@@ -255,8 +262,16 @@ function driver_poll()
     local session_wh = (obs[OBS_SESSION_ENERGY] or 0) * 1000  -- kWh → Wh
     local connected = (op_mode >= 2 and op_mode <= 6)
     local charging = (op_mode == 3)
+    -- op_mode 0 is the sentinel Easee emits when the cloud hasn't heard
+    -- from the unit recently. Anything else means the charger itself is
+    -- responsive even when no car is plugged in.
+    local is_online = (op_mode ~= 0)
 
-    local reason_code = state.reasonForNoCurrent
+    local reason_code = obs[OBS_REASON_NO_CUR]
+    local cable_locked = obs[OBS_CABLE_LOCKED]
+    if cable_locked ~= nil then cable_locked = (cable_locked == 1 or cable_locked == true) end
+    local dyn_current = obs[OBS_DYN_CURRENT]
+
     host.emit("ev", {
         w                       = power_w,
         connected               = connected,
@@ -266,9 +281,9 @@ function driver_poll()
         state_label             = OP_MODE_LABELS[op_mode] or "unknown",
         reason_no_current       = reason_code,                 -- int: 0=ok; why NOT drawing current
         reason_no_current_label = reason_code and REASON_LABELS[reason_code], -- nil if 0/ok, string otherwise
-        is_online               = state.isOnline,              -- Easee cloud considers charger online
-        cable_locked            = state.cableLocked,
-        max_a                   = state.dynamicChargerCurrent, -- current dynamic limit (A)
+        is_online               = is_online,
+        cable_locked            = cable_locked,
+        max_a                   = dyn_current,                 -- current dynamic limit (A)
         phases                  = 3,                           -- Easee defaults 3-phase
     })
 
@@ -281,11 +296,8 @@ function driver_poll()
     if obs[OBS_LIFETIME_ENERGY] then
         host.emit_metric("ev_lifetime_kwh", obs[OBS_LIFETIME_ENERGY])
     end
-    if state.dynamicChargerCurrent then
-        host.emit_metric("ev_dynamic_current_a", state.dynamicChargerCurrent)
-    end
-    if state.temperature then
-        host.emit_metric("ev_temp_c", state.temperature)
+    if dyn_current then
+        host.emit_metric("ev_dynamic_current_a", dyn_current)
     end
 
     return 5000

--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -111,17 +111,34 @@ local function get_chargers()
     return host.json_decode(resp), nil
 end
 
-local function get_state(serial)
-    local resp, err = host.http_get(
-        BASE_URL .. "/chargers/" .. serial .. "/state",
-        auth_headers()
-    )
+-- Observation IDs (from developer.easee.com/docs/charger-observation-ids)
+local OBS_OP_MODE        = 109
+local OBS_TOTAL_POWER    = 120
+local OBS_SESSION_ENERGY = 121
+local OBS_LIFETIME_ENERGY = 124
+local OBS_VOLTAGE        = 194
+local OBS_CURRENT        = 183
+
+local OBS_IDS = "109,120,121,124,194,183"
+
+local function get_observations(serial)
+    local url = "https://api.easee.com/state/" .. serial .. "/observations?ids=" .. OBS_IDS
+    local resp, err = host.http_get(url, auth_headers())
     if err then return nil, err end
-    return host.json_decode(resp), nil
+    local decoded = host.json_decode(resp)
+    if not decoded then return nil, "decode failed" end
+    local list = decoded.observations or decoded
+    local obs = {}
+    for _, item in ipairs(list) do
+        if item.id then
+            obs[item.id] = tonumber(item.value) or item.value
+        end
+    end
+    return obs, nil
 end
 
 -- ---- State mapping ----
--- Easee chargerOpMode:
+-- Easee chargerOpMode (observation 109):
 --   1 = disconnected (standby)
 --   2 = awaiting start (connected, not charging)
 --   3 = charging
@@ -186,6 +203,11 @@ function driver_init(config)
     email = config and config.email
     password = config and config.password
     charger_serial = config and config.serial
+    -- UI writes "" for an unselected <select>. In Lua "" is truthy, so the
+    -- auto-detect branch below would never fire without this normalization.
+    if charger_serial == "" then charger_serial = nil end
+    if email == "" then email = nil end
+    if password == "" then password = nil end
 
     if not email or not password then
         host.log("error", "Easee: email and password required in driver config")
@@ -199,13 +221,13 @@ function driver_init(config)
 
     -- Auto-detect serial if not provided
     if not charger_serial then
-        local chargers, err = get_chargers()
-        if err or not chargers or #chargers == 0 then
-            host.log("error", "Easee: could not list chargers: " .. tostring(err))
+        local chargers, cerr = get_chargers()
+        if cerr or not chargers or #chargers == 0 then
+            host.log("error", "Easee: could not list chargers: " .. tostring(cerr))
             return
         end
         charger_serial = chargers[1].id
-        host.log("info", "Easee: auto-detected charger " .. charger_serial)
+        host.log("info", "Easee: auto-detected charger " .. tostring(charger_serial))
     end
 
     host.set_sn(charger_serial)
@@ -222,15 +244,15 @@ function driver_poll()
         return 10000
     end
 
-    local state, err = get_state(charger_serial)
-    if err or not state then
-        host.log("warn", "Easee: state poll failed: " .. tostring(err))
+    local obs, err = get_observations(charger_serial)
+    if err or not obs then
+        host.log("warn", "Easee: observations poll failed: " .. tostring(err))
         return 10000
     end
 
-    local op_mode = state.chargerOpMode or 1
-    local power_w = (state.totalPower or 0) * 1000  -- kW → W
-    local session_wh = (state.sessionEnergy or 0) * 1000  -- kWh → Wh
+    local op_mode = obs[OBS_OP_MODE] or 1
+    local power_w = (obs[OBS_TOTAL_POWER] or 0) * 1000  -- kW → W
+    local session_wh = (obs[OBS_SESSION_ENERGY] or 0) * 1000  -- kWh → Wh
     local connected = (op_mode >= 2 and op_mode <= 6)
     local charging = (op_mode == 3)
 
@@ -250,15 +272,14 @@ function driver_poll()
         phases                  = 3,                           -- Easee defaults 3-phase
     })
 
-    -- Diagnostic metrics
-    if state.voltage then
-        host.emit_metric("ev_voltage_v", state.voltage)
+    if obs[OBS_VOLTAGE] then
+        host.emit_metric("ev_voltage_v", obs[OBS_VOLTAGE])
     end
-    if state.outputCurrent then
-        host.emit_metric("ev_current_a", state.outputCurrent)
+    if obs[OBS_CURRENT] then
+        host.emit_metric("ev_current_a", obs[OBS_CURRENT])
     end
-    if state.lifetimeEnergy then
-        host.emit_metric("ev_lifetime_kwh", state.lifetimeEnergy)
+    if obs[OBS_LIFETIME_ENERGY] then
+        host.emit_metric("ev_lifetime_kwh", obs[OBS_LIFETIME_ENERGY])
     end
     if state.dynamicChargerCurrent then
         host.emit_metric("ev_dynamic_current_a", state.dynamicChargerCurrent)

--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -63,14 +63,26 @@ PROTOCOL = "http"
 
 local zap_host = "zap.local"
 local p1_serial = nil
-local pv_serials = {}   -- list of inverter serials that carry an enabled pv DER
+local pv_serials = {}     -- list of inverter serials that carry an enabled pv DER
+local discovered   = false  -- true once discover_devices has succeeded
+                             -- (even with zero PV). Prevents re-hitting
+                             -- /api/devices every poll on meter-only sites.
 
--- Backoff state for discovery / data failures: no point hammering the
--- gateway when it's unreachable.
+-- Backoff state for *discovery* (/api/devices) failures. Separate from
+-- data-fetch failures: discovery backoff must NOT gate the site meter
+-- data poll, or a transient /api/devices glitch silently stalls the
+-- site meter for up to 60 s and trips the watchdog on every network
+-- hiccup.
 local discovery_last_attempt = 0
 local discovery_backoff_ms   = 0
 local DISCOVERY_BACKOFF_MIN  = 2000
 local DISCOVERY_BACKOFF_MAX  = 60000
+
+-- Rediscover after this many consecutive P1 data-fetch failures. The
+-- P1 serial could rotate on a dev gateway reboot, so we fall back to a
+-- fresh discovery if data keeps failing.
+local p1_fail_count       = 0
+local P1_FAIL_REDISCOVER  = 10
 
 local function base_url()
     -- Accept both "zap.local" and "http://zap.local" styles.
@@ -180,61 +192,65 @@ function driver_init(config)
 end
 
 function driver_poll()
-    -- Phase 1: discover P1 + PV inverters if we don't know them yet.
-    if not p1_serial or #pv_serials == 0 then
-        -- Skip if the user pinned config.serial and we already have it;
-        -- otherwise run discovery whenever p1 is missing OR we haven't
-        -- enumerated inverters yet.
-        local need_discovery = (not p1_serial) or (p1_serial and #pv_serials == 0)
-        if need_discovery then
-            if in_backoff() then
-                return 1000
-            end
-            local p1, pvs, err = discover_devices()
-            if err then
-                bump_backoff()
-                host.log("warn", "Zap: discovery failed: " .. tostring(err)
-                    .. " (retry in " .. discovery_backoff_ms .. "ms)")
-                return 1000
-            end
-            if not p1_serial then
-                p1_serial = p1
-                host.set_sn(p1_serial)
-                host.log("info", "Zap: discovered P1 meter " .. p1_serial)
-            end
-            pv_serials = pvs
-            if #pv_serials > 0 then
-                host.log("info", "Zap: discovered " .. #pv_serials
-                    .. " PV inverter(s): " .. table.concat(pv_serials, ","))
-            else
-                host.log("info", "Zap: no PV inverters found")
-            end
-            clear_backoff()
+    -- Phase 1: discover P1 + PV inverters once. Re-run only if a flag
+    -- explicitly invalidates the cached set (e.g. persistent P1-fetch
+    -- failures re-trigger it below). For meter-only Zap deploys, this
+    -- means we don't re-hit /api/devices every poll logging "no PV
+    -- inverters found" — discovery latches after the first success.
+    if not discovered then
+        if in_backoff() then
+            return 1000
         end
+        local p1, pvs, err = discover_devices()
+        if err then
+            bump_backoff()
+            host.log("warn", "Zap: discovery failed: " .. tostring(err)
+                .. " (retry in " .. discovery_backoff_ms .. "ms)")
+            return 1000
+        end
+        if not p1_serial then
+            p1_serial = p1
+            host.set_sn(p1_serial)
+            host.log("info", "Zap: discovered P1 meter " .. p1_serial)
+        end
+        pv_serials = pvs
+        if #pv_serials > 0 then
+            host.log("info", "Zap: discovered " .. #pv_serials
+                .. " PV inverter(s): " .. table.concat(pv_serials, ","))
+        else
+            host.log("info", "Zap: no PV inverters found")
+        end
+        discovered = true
+        clear_backoff()
     end
 
     -- Phase 2: poll the P1 meter.
+    -- P1 fetch failures get their OWN counter — they must NOT gate the
+    -- discovery backoff (which applies to /api/devices only). A transient
+    -- HTTP glitch should just log and let the next 1 s tick retry; after
+    -- N consecutive failures we invalidate the cached discovery and
+    -- fall back to /api/devices in case the Zap rebooted / the P1 serial
+    -- rotated.
     local data, err = fetch_device(p1_serial)
     if err then
-        bump_backoff()
-        host.log("warn", "Zap: P1 data fetch failed: " .. tostring(err)
-            .. " (retry in " .. discovery_backoff_ms .. "ms)")
-        -- If the Zap was rebooted the serial may have rotated (unlikely
-        -- on real hardware but possible on dev gateways). Force re-discovery
-        -- on persistent failure.
-        if discovery_backoff_ms >= DISCOVERY_BACKOFF_MAX then
-            host.log("warn", "Zap: repeated failures — will re-discover devices")
+        p1_fail_count = p1_fail_count + 1
+        host.log("warn", "Zap: P1 data fetch failed (" .. p1_fail_count
+            .. "/" .. P1_FAIL_REDISCOVER .. "): " .. tostring(err))
+        if p1_fail_count >= P1_FAIL_REDISCOVER then
+            host.log("warn", "Zap: repeated P1 failures — will re-discover devices")
             p1_serial = nil
             pv_serials = {}
+            discovered = false
+            p1_fail_count = 0
         end
         return 1000
     end
     if not data.meter then
-        bump_backoff()
+        p1_fail_count = p1_fail_count + 1
         host.log("warn", "Zap: P1 payload missing `meter` block")
         return 1000
     end
-    clear_backoff()
+    p1_fail_count = 0
 
     local m = data.meter
     local meter = {
@@ -348,5 +364,7 @@ end
 function driver_cleanup()
     p1_serial = nil
     pv_serials = {}
+    discovered = false
+    p1_fail_count = 0
     clear_backoff()
 end

--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -283,7 +283,12 @@ function driver_poll()
                 -- offline (i16 32768, u32 huge values); anything above
                 -- 10× rated or otherwise clearly bogus → treat as 0.
                 local rated = tonumber(pv.rated_power_W) or 0
-                local cap = rated > 0 and (rated * 10) or 1e6
+                -- When the inverter doesn't report a rated power, fall back
+                -- to 16 A × 3 φ × 230 V ≈ 11 kW — a residential upper bound.
+                -- A looser cap (e.g. 1 MW) would let a single bogus reading
+                -- from an offline inverter propagate into site PV and swing
+                -- the control loop into aggressive charge.
+                local cap = rated > 0 and (rated * 10) or 11040
                 local w = sane(pv.W, cap) or 0
                 total_w = total_w + w
                 local gen = sane(pv.total_generation_Wh, 1e12) or 0

--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -35,9 +35,13 @@
 --
 -- Sign convention (SITE = positive W flows INTO the site):
 --   meter.w: positive = importing from grid, negative = exporting
---   pv.w   : negative = generating (source).  Zap reports generation as
---            positive W, so the driver negates at the boundary.
--- The Zap P1 meter already reports import-positive, so no meter flip.
+--   pv.w   : negative = generating (source).
+-- The Zap already reports both in site convention directly:
+--   P1 meter.W is positive when importing (verified against a house
+--   drawing +208 W on L1, -62 W on L2, -179 W on L3 ⇒ net -33 W export).
+--   Inverter pv.W is negative when generating (SolarEdge SE at 2745 W
+--   of generation reports pv.W = -2745). So we pass both through
+--   unchanged — no boundary sign flip.
 
 DRIVER = {
   id           = "sourceful-zap",
@@ -315,9 +319,10 @@ function driver_poll()
             end
         end
         if any then
-            -- Site convention: PV generation is a source → negative W.
-            host.emit("pv", { w = -total_w, lifetime_wh = total_gen_wh })
-            host.emit_metric("pv_w", -total_w)
+            -- The Zap already reports pv.W as negative when the inverter
+            -- is generating — matches site convention. Pass through as-is.
+            host.emit("pv", { w = total_w, lifetime_wh = total_gen_wh })
+            host.emit_metric("pv_w", total_w)
         end
     end
 

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -112,11 +112,15 @@ func main() {
 	ctrl := control.NewState(cfg.Site.GridTargetW, cfg.Site.GridToleranceW, cfg.SiteMeterDriver())
 	ctrl.SlewRateW = cfg.Site.SlewRateW
 	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
-	// Restore persisted mode + target if present
+	// Restore persisted mode + target if present. The planner variants
+	// have to be listed too — without them the strategy the user picked in
+	// the UI (planner_self / planner_cheap / planner_arbitrage) is silently
+	// dropped on restart and the dashboard appears to forget the selection.
 	if v, ok := st.LoadConfig("mode"); ok {
 		switch control.Mode(v) {
 		case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
-			control.ModeCharge, control.ModePriority, control.ModeWeighted:
+			control.ModeCharge, control.ModePriority, control.ModeWeighted,
+			control.ModePlannerSelf, control.ModePlannerCheap, control.ModePlannerArbitrage:
 			ctrl.Mode = control.Mode(v)
 		}
 	}
@@ -373,6 +377,21 @@ func main() {
 		defer mpcSvc.Stop()
 		// Inject plan → control.State so planner modes can override grid_target.
 		ctrl.PlanTarget = mpcSvc.SlotAt
+		// If the restored control mode is a planner variant, push the
+		// corresponding mpc.Mode so the plan is built with the strategy
+		// the user actually picked — not whatever cfg.planner.mode says.
+		if ctrl.Mode.IsPlannerMode() {
+			var mm mpc.Mode
+			switch ctrl.Mode {
+			case control.ModePlannerSelf:
+				mm = mpc.ModeSelfConsumption
+			case control.ModePlannerCheap:
+				mm = mpc.ModeCheapCharge
+			case control.ModePlannerArbitrage:
+				mm = mpc.ModeArbitrage
+			}
+			mpcSvc.SetMode(ctx, mm)
+		}
 		slog.Info("mpc planner started",
 			"mode", mpcSvc.Defaults.Mode,
 			"capacity_wh", mpcSvc.Defaults.CapacityWh,

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -716,6 +716,26 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		slog.Warn("mpc: no battery capacity — skipping")
 		return nil
 	}
+	// Clamp aggregate charge/discharge to the grid fuse capacity. The
+	// control loop's fuse guard enforces this per-tick anyway, but a
+	// planner that schedules 45 kW of charge through a 16 A fuse (11 kW)
+	// produces SoC projections that can never be realised — the optimiser
+	// "charges" to 100% in the plan while the battery barely budges in
+	// reality, and every downstream decision (when to discharge, when to
+	// idle, what the total cost looks like) is based on that fantasy.
+	// Cheaper to keep the plan feasible up-front.
+	if fuseMaxW := cfg.Fuse.MaxPowerW(); fuseMaxW > 0 {
+		if maxChg > fuseMaxW {
+			slog.Info("mpc: clamping MaxChargeW to fuse capacity",
+				"requested_w", maxChg, "fuse_w", fuseMaxW)
+			maxChg = fuseMaxW
+		}
+		if maxDis > fuseMaxW {
+			slog.Info("mpc: clamping MaxDischargeW to fuse capacity",
+				"requested_w", maxDis, "fuse_w", fuseMaxW)
+			maxDis = fuseMaxW
+		}
+	}
 	pl := cfg.Planner
 	zone := "SE3"
 	if cfg.Price != nil && cfg.Price.Zone != "" {

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -50,7 +50,20 @@ var Version = "dev"
 func main() {
 	configPath := flag.String("config", "config.yaml", "Path to config.yaml")
 	webDir := flag.String("web", "web", "Path to static web UI directory")
+	driverDirFlag := flag.String("drivers", "", "Path to drivers directory (default: <config-dir>/drivers)")
 	flag.Parse()
+
+	// Drivers default to a sibling of the config file (historical layout:
+	// config.yaml + drivers/ + seed/ + state.db all under one dir). Docker
+	// breaks that convention because /app/data is a host bind mount while
+	// drivers are baked into the image at /app/drivers — the flag lets the
+	// CMD point at the immutable image location.
+	resolveDriverDir := func() string {
+		if *driverDirFlag != "" {
+			return *driverDirFlag
+		}
+		return filepath.Join(filepath.Dir(*configPath), "drivers")
+	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
@@ -60,8 +73,7 @@ func main() {
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		if isConfigMissing(err) {
-			driverDir := filepath.Join(filepath.Dir(*configPath), "drivers")
-			runBootstrap(*configPath, *webDir, driverDir)
+			runBootstrap(*configPath, *webDir, resolveDriverDir())
 			return
 		}
 		slog.Error("load config", "err", err)
@@ -378,6 +390,7 @@ func main() {
 		State: st,
 		CapMu: capMu, Capacities: capacities,
 		CfgMu: cfgMu, Cfg: cfg, ConfigPath: *configPath,
+		DriverDir: resolveDriverDir(),
 		Models: models, ModelsMu: modelsMu,
 		SelfTune: selfTune,
 		DtS:        float64(cfg.Site.ControlIntervalS),

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1,5 +1,4 @@
 // forty-two-watts — Home Energy Management System.
-// Go + WASM driver port. See /MIGRATION_PLAN.md.
 //
 // Don't Panic 🐬
 package main
@@ -140,7 +139,7 @@ func main() {
 	// ---- Self-tune coordinator ----
 	selfTune := selftune.NewCoordinator()
 
-	// ---- WASM driver registry ----
+	// ---- Driver registry ----
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	reg := drivers.NewRegistry(tel)
@@ -151,15 +150,12 @@ func main() {
 		return modbuscli.Dial(c.Host, c.Port, c.UnitID)
 	}
 	reg.ARPLookup = arp.Lookup
-	// Spawn initial drivers
+	// Spawn initial drivers. config.Load has already joined relative Lua
+	// paths with the config directory — nothing to resolve here.
 	for _, d := range cfg.Drivers {
 		if d.Disabled {
 			slog.Info("driver skipped (disabled)", "name", d.Name)
 			continue
-		}
-		// Resolve relative WASM paths against config dir
-		if d.WASM != "" && !filepath.IsAbs(d.WASM) {
-			d.WASM = filepath.Join(filepath.Dir(*configPath), d.WASM)
 		}
 		if err := reg.Add(ctx, d); err != nil {
 			slog.Warn("failed to spawn driver", "name", d.Name, "err", err)
@@ -198,13 +194,8 @@ func main() {
 					newCfg.EVCharger.Password = pw
 				}
 			}
-			// Regenerate the synthetic EV charger driver entry from the
-			// Resolve relative paths
-			for i := range newCfg.Drivers {
-				if newCfg.Drivers[i].WASM != "" && !filepath.IsAbs(newCfg.Drivers[i].WASM) {
-					newCfg.Drivers[i].WASM = filepath.Join(filepath.Dir(*configPath), newCfg.Drivers[i].WASM)
-				}
-			}
+			// Driver paths are already resolved by config.Load; no extra
+			// work needed here.
 			reg.Reload(ctx, newCfg.Drivers)
 			// Refresh capacities — mutate the existing map in place so
 			// Deps.Capacities (a map header captured at init) sees the

--- a/go/cmd/sim-sungrow/e2e_test.go
+++ b/go/cmd/sim-sungrow/e2e_test.go
@@ -285,7 +285,7 @@ func TestE2E_ReadPVTopology(t *testing.T) {
 	}
 }
 
-// Sanity: the sample register dump in test log shows exactly what the Lua/WASM
+// Sanity: the sample register dump in test log shows exactly what the Lua
 // driver is about to read. If it looks wrong to a human, it's probably wrong.
 func TestE2E_SampleRegisterDump(t *testing.T) {
 	cfg := sungrow.Default()

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -58,6 +58,7 @@ type Deps struct {
 	CfgMu      *sync.RWMutex
 	Cfg        *config.Config
 	ConfigPath string
+	DriverDir  string // where to scan for Lua drivers (default: <config-dir>/drivers)
 	Models     map[string]*battery.Model
 	ModelsMu   *sync.Mutex
 	SelfTune   *selftune.Coordinator
@@ -675,8 +676,12 @@ func (s *Server) handleDrivers(w http.ResponseWriter, r *http.Request) {
 // drivers/ directory, parsed from each .lua file's DRIVER metadata.
 // Used by the Settings UI to offer an "Add from catalog" dropdown.
 func (s *Server) handleDriversCatalog(w http.ResponseWriter, r *http.Request) {
-	// Catalog lives next to the config file by convention.
-	dir := filepath.Join(filepath.Dir(s.deps.ConfigPath), "drivers")
+	// Default is next to the config file; overridable via -drivers for
+	// deployments (Docker) where drivers live in the image, not the data volume.
+	dir := s.deps.DriverDir
+	if dir == "" {
+		dir = filepath.Join(filepath.Dir(s.deps.ConfigPath), "drivers")
+	}
 	entries, err := drivers.LoadCatalog(dir)
 	if err != nil {
 		writeJSON(w, 200, map[string]any{"path": dir, "entries": []any{}, "error": err.Error()})

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -525,9 +525,8 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 				slog.Warn("failed to persist ev_charger_password", "err", err)
 			}
 		}
-		// Restore the real password into the in-memory config so
-		// InjectEVChargerDriver (called by the config-reload watcher)
-		// sees it.
+		// Restore the real password into the in-memory config so the
+		// config-reload watcher sees it on the next apply.
 		if stored, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
 			newCfg.EVCharger.Password = stored
 		}

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/config"
 	"github.com/frahlg/forty-two-watts/go/internal/control"
 	"github.com/frahlg/forty-two-watts/go/internal/drivers"
+	"github.com/frahlg/forty-two-watts/go/internal/evcloud"
 	"github.com/frahlg/forty-two-watts/go/internal/forecast"
 	"github.com/frahlg/forty-two-watts/go/internal/ha"
 	"github.com/frahlg/forty-two-watts/go/internal/loadmodel"
@@ -80,8 +81,8 @@ type Deps struct {
 	// Optional: HA MQTT bridge (nil if disabled).
 	HA *ha.Bridge
 
-	// Driver registry — used by lifecycle endpoints (restart/disable/enable).
-	// Nil disables those endpoints (returns 503).
+	// Driver registry — used by lifecycle endpoints (restart/disable/enable)
+	// and EV command dispatch. Nil disables those endpoints (returns 503).
 	Registry *drivers.Registry
 
 	Version string
@@ -145,6 +146,9 @@ func (s *Server) routes() {
 	s.handle("GET  /api/series/catalog", s.handleSeriesCatalog)
 	s.handle("GET  /api/devices", s.handleDevices)
 	s.handle("GET  /api/scan", s.handleScan)
+	s.handle("GET  /api/ev/status", s.handleEVStatus)
+	s.handle("POST /api/ev/command", s.handleEVCommand)
+	s.handle("POST /api/ev/chargers", s.handleEVChargers)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.
@@ -484,6 +488,9 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	cfg := *s.deps.Cfg
 	s.deps.CfgMu.RUnlock()
 	masked := cfg.MaskSecrets()
+	// Strip resolved driver paths back to config-relative form so the UI
+	// doesn't display (and round-trip) paths like "../drivers/foo.lua".
+	masked.UnresolveDriverPaths(filepath.Dir(s.deps.ConfigPath))
 	// EV charger password lives in state.db, not YAML. Signal to the UI
 	// that a password is set by using a masked placeholder (MaskSecrets
 	// blanked it to "").
@@ -1245,4 +1252,111 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	// Always-revalidate so version bumps land immediately
 	w.Header().Set("Cache-Control", "no-cache, must-revalidate")
 	http.ServeFile(w, r, clean)
+}
+
+// GET /api/ev/status — detailed EV charger state for the dashboard modal.
+func (s *Server) handleEVStatus(w http.ResponseWriter, r *http.Request) {
+	readings := s.deps.Tel.ReadingsByType(telemetry.DerEV)
+	if len(readings) == 0 {
+		writeJSON(w, 200, map[string]any{"connected": false})
+		return
+	}
+	rd := readings[0]
+	resp := map[string]any{
+		"driver":  rd.Driver,
+		"w":       rd.RawW,
+		"updated": rd.UpdatedAt,
+	}
+	if len(rd.Data) > 0 {
+		var data map[string]any
+		if err := json.Unmarshal(rd.Data, &data); err == nil {
+			for k, v := range data {
+				resp[k] = v
+			}
+		}
+	}
+	writeJSON(w, 200, resp)
+}
+
+// POST /api/ev/command — send a command to the EV charger driver.
+//
+// Action is validated against an allowlist of known Lua-driver verbs so the
+// API doesn't silently 200-OK a typo'd action: the Lua command hook returns
+// no value for unknown actions, which looks like success to the registry.
+var validEVActions = map[string]bool{
+	"ev_start":       true,
+	"ev_pause":       true,
+	"ev_resume":      true,
+	"ev_set_current": true,
+}
+
+func (s *Server) handleEVCommand(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Action string `json:"action"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if !validEVActions[req.Action] {
+		writeJSON(w, 400, map[string]string{"error": "unsupported action"})
+		return
+	}
+	if s.deps.Registry == nil {
+		writeJSON(w, 503, map[string]string{"error": "driver registry not available"})
+		return
+	}
+	readings := s.deps.Tel.ReadingsByType(telemetry.DerEV)
+	if len(readings) == 0 {
+		writeJSON(w, 404, map[string]string{"error": "no EV driver active"})
+		return
+	}
+	driverName := readings[0].Driver
+	payload, _ := json.Marshal(map[string]any{"action": req.Action})
+	if err := s.deps.Registry.Send(r.Context(), driverName, payload); err != nil {
+		writeJSON(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 200, map[string]string{"status": "ok"})
+}
+
+// POST /api/ev/chargers — authenticate with an EV cloud provider and list chargers.
+func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Provider string `json:"provider"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid request"})
+		return
+	}
+	if req.Provider == "" {
+		req.Provider = "easee"
+	}
+	if req.Email == "" {
+		writeJSON(w, 400, map[string]string{"error": "email required"})
+		return
+	}
+	if req.Password == "" {
+		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			req.Password = pw
+		}
+	}
+	if req.Password == "" {
+		writeJSON(w, 400, map[string]string{"error": "password required"})
+		return
+	}
+
+	p, err := evcloud.Get(req.Provider)
+	if err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	chargers, err := p.ListChargers(req.Email, req.Password)
+	if err != nil {
+		writeJSON(w, 502, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 200, chargers)
 }

--- a/go/internal/api/api_test.go
+++ b/go/internal/api/api_test.go
@@ -1,10 +1,64 @@
 package api
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 func TestParseRangeSupports48h(t *testing.T) {
 	const want = 48 * 60 * 60 * 1000
 	if got := parseRange("48h"); got != want {
 		t.Fatalf("parseRange(48h) = %d, want %d", got, want)
+	}
+}
+
+// handleEVCommand rejects anything not in the allowlist with 400. The Lua
+// driver's command hook silently returns nil for unknown actions, so
+// without this gate the API would 200-OK typos.
+func TestHandleEVCommandRejectsUnknownActions(t *testing.T) {
+	srv := New(&Deps{}) // registry/tel unset — the 400 branches run first
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"unknown action", `{"action":"ev_nuke"}`, http.StatusBadRequest},
+		{"empty action", `{"action":""}`, http.StatusBadRequest},
+		{"missing action field", `{}`, http.StatusBadRequest},
+		{"malformed json", `{`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/ev/command", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+			if rr.Code != tc.want {
+				t.Fatalf("body=%s: got status %d, want %d (body: %s)", tc.body, rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+// Allowlisted actions pass the action-validation gate. With a nil
+// Registry they then short-circuit to 503, which confirms they got past
+// the 400 branch without us needing a real driver registry.
+func TestHandleEVCommandAcceptsAllowlistedActions(t *testing.T) {
+	srv := New(&Deps{})
+
+	for action := range validEVActions {
+		t.Run(action, func(t *testing.T) {
+			body := `{"action":"` + action + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/api/ev/command", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+			if rr.Code != http.StatusServiceUnavailable {
+				t.Fatalf("action=%q: got status %d, want 503 (body: %s)", action, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -100,12 +100,11 @@ func (f Fuse) MaxPowerW() float64 {
 	return f.MaxAmps * f.Voltage * float64(f.Phases)
 }
 
-// Driver is one driver entry. In the Go/WASM port, WASM is the primary format.
-// Lua is kept as a legacy fallback (not implemented in go-port initially).
+// Driver is one driver entry. Each driver is a Lua script loaded by
+// the driver host at startup (or on hot-reload via the file watcher).
 type Driver struct {
 	Name               string  `yaml:"name" json:"name"`
-	WASM               string  `yaml:"wasm,omitempty" json:"wasm,omitempty"` // path to .wasm file
-	Lua                string  `yaml:"lua,omitempty" json:"lua,omitempty"`  // legacy, path to .lua file
+	Lua                string  `yaml:"lua,omitempty" json:"lua,omitempty"` // path to .lua file
 	IsSiteMeter        bool    `yaml:"is_site_meter,omitempty" json:"is_site_meter,omitempty"`
 	BatteryCapacityWh  float64 `yaml:"battery_capacity_wh,omitempty" json:"battery_capacity_wh,omitempty"`
 	// Disabled skips this driver at startup / reload. Set via the UI when
@@ -365,39 +364,6 @@ func (incoming *Config) PreserveMaskedSecrets(existing *Config) {
 	}
 }
 
-// InjectEVChargerDriver auto-generates a driver entry from EVCharger config.
-// If a driver named "easee" already exists it is replaced; otherwise a new
-// entry is appended. This lets the Settings UI write ev_charger config and
-// never worry about raw driver YAML.
-func (c *Config) InjectEVChargerDriver() {
-	if c.EVCharger == nil || c.EVCharger.Provider != "easee" {
-		return
-	}
-	ev := c.EVCharger
-	drvCfg := map[string]any{
-		"email":    ev.Email,
-		"password": ev.Password,
-	}
-	if ev.Serial != "" {
-		drvCfg["serial"] = ev.Serial
-	}
-	d := Driver{
-		Name: "easee",
-		Lua:  "drivers/easee_cloud.lua",
-		Capabilities: Capabilities{
-			HTTP: &HTTPCapability{AllowedHosts: []string{"api.easee.com"}},
-		},
-		Config: drvCfg,
-	}
-	for i, existing := range c.Drivers {
-		if existing.Name == "easee" {
-			c.Drivers[i] = d
-			return
-		}
-	}
-	c.Drivers = append(c.Drivers, d)
-}
-
 // Load parses a config file from disk. Returns a fully-validated Config.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
@@ -407,7 +373,7 @@ func Load(path string) (*Config, error) {
 	return Parse(data, filepath.Dir(path))
 }
 
-// Parse parses config bytes and validates. baseDir resolves driver WASM paths.
+// Parse parses config bytes and validates. baseDir resolves driver Lua paths.
 func Parse(data []byte, baseDir string) (*Config, error) {
 	var c Config
 	if err := yaml.Unmarshal(data, &c); err != nil {
@@ -421,14 +387,10 @@ func Parse(data []byte, baseDir string) (*Config, error) {
 	return &c, nil
 }
 
-// ResolveDriverPaths joins relative Lua/WASM driver paths with baseDir.
+// ResolveDriverPaths joins relative Lua driver paths with baseDir.
 func (c *Config) ResolveDriverPaths(baseDir string) {
 	for i := range c.Drivers {
 		c.Drivers[i].Lua = stripLeadingDotDot(c.Drivers[i].Lua)
-		c.Drivers[i].WASM = stripLeadingDotDot(c.Drivers[i].WASM)
-		if c.Drivers[i].WASM != "" && !filepath.IsAbs(c.Drivers[i].WASM) {
-			c.Drivers[i].WASM = filepath.Join(baseDir, c.Drivers[i].WASM)
-		}
 		if c.Drivers[i].Lua != "" && !filepath.IsAbs(c.Drivers[i].Lua) {
 			c.Drivers[i].Lua = filepath.Join(baseDir, c.Drivers[i].Lua)
 		}
@@ -451,7 +413,6 @@ func stripLeadingDotDot(p string) string {
 func (c *Config) UnresolveDriverPaths(baseDir string) {
 	for i := range c.Drivers {
 		c.Drivers[i].Lua = relToBaseDir(baseDir, c.Drivers[i].Lua)
-		c.Drivers[i].WASM = relToBaseDir(baseDir, c.Drivers[i].WASM)
 	}
 }
 
@@ -548,8 +509,8 @@ func (c *Config) Validate() error {
 		if d.IsSiteMeter {
 			siteMeters++
 		}
-		if d.WASM == "" && d.Lua == "" {
-			return fmt.Errorf("driver %q: must specify `wasm` or `lua`", d.Name)
+		if d.Lua == "" {
+			return fmt.Errorf("driver %q: must specify `lua`", d.Name)
 		}
 		if d.EffectiveMQTT() == nil && d.EffectiveModbus() == nil && d.Capabilities.HTTP == nil {
 			return fmt.Errorf("driver %q: must have mqtt, modbus, or http capability", d.Name)
@@ -590,7 +551,6 @@ func SaveAtomic(path string, c *Config) error {
 		copy(drivers, out.Drivers)
 		for i := range drivers {
 			drivers[i].Lua = relDriverPath(baseDir, drivers[i].Lua)
-			drivers[i].WASM = relDriverPath(baseDir, drivers[i].WASM)
 		}
 		out.Drivers = drivers
 	}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -416,8 +417,15 @@ func Parse(data []byte, baseDir string) (*Config, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
-	// Resolve relative driver paths
+	c.ResolveDriverPaths(baseDir)
+	return &c, nil
+}
+
+// ResolveDriverPaths joins relative Lua/WASM driver paths with baseDir.
+func (c *Config) ResolveDriverPaths(baseDir string) {
 	for i := range c.Drivers {
+		c.Drivers[i].Lua = stripLeadingDotDot(c.Drivers[i].Lua)
+		c.Drivers[i].WASM = stripLeadingDotDot(c.Drivers[i].WASM)
 		if c.Drivers[i].WASM != "" && !filepath.IsAbs(c.Drivers[i].WASM) {
 			c.Drivers[i].WASM = filepath.Join(baseDir, c.Drivers[i].WASM)
 		}
@@ -425,7 +433,40 @@ func Parse(data []byte, baseDir string) (*Config, error) {
 			c.Drivers[i].Lua = filepath.Join(baseDir, c.Drivers[i].Lua)
 		}
 	}
-	return &c, nil
+}
+
+func stripLeadingDotDot(p string) string {
+	for strings.HasPrefix(p, "../") {
+		p = p[3:]
+	}
+	return p
+}
+
+// UnresolveDriverPaths converts resolved driver paths back to config-relative form.
+//
+// Paths that are outside baseDir (filepath.Rel would yield a ../-prefixed
+// result) are left absolute — otherwise the next ResolveDriverPaths would
+// strip the leading ../ via stripLeadingDotDot and silently re-anchor the
+// driver under baseDir.
+func (c *Config) UnresolveDriverPaths(baseDir string) {
+	for i := range c.Drivers {
+		c.Drivers[i].Lua = relToBaseDir(baseDir, c.Drivers[i].Lua)
+		c.Drivers[i].WASM = relToBaseDir(baseDir, c.Drivers[i].WASM)
+	}
+}
+
+func relToBaseDir(baseDir, p string) string {
+	if p == "" {
+		return p
+	}
+	rel, err := filepath.Rel(baseDir, p)
+	if err != nil {
+		return p
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return p
+	}
+	return rel
 }
 
 // applyDefaults fills in sensible zero-value defaults.

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -260,3 +260,102 @@ func TestSaveAtomicRoundtrip(t *testing.T) {
 func pretty(f float64) string {
 	return fmt.Sprintf("%g", f)
 }
+
+// The path-normalization helpers pulled in with the EV cloud driver PR
+// have three separate jobs that can silently conflict: stripLeadingDotDot
+// removes "../" prefixes, ResolveDriverPaths joins relative paths against
+// baseDir, and UnresolveDriverPaths goes back to config-relative form
+// before the YAML hits disk. The interesting failure is the pair —
+// Unresolve followed by Resolve must be the identity, including when the
+// driver file lives OUTSIDE baseDir (Copilot #11). Without the
+// out-of-tree guard, an absolute path like /opt/drivers/foo.lua round-
+// trips to "../opt/drivers/foo.lua" → stripLeadingDotDot → "opt/drivers/
+// foo.lua" → baseDir-joined to the wrong place.
+func TestStripLeadingDotDot(t *testing.T) {
+	cases := map[string]string{
+		"":                       "",
+		"drivers/x.lua":          "drivers/x.lua",
+		"../drivers/x.lua":       "drivers/x.lua",
+		"../../../drivers/x.lua": "drivers/x.lua",
+		"/abs/drivers/x.lua":     "/abs/drivers/x.lua",
+		"/etc/../driver/foo.lua": "/etc/../driver/foo.lua", // non-leading "../" preserved
+	}
+	for in, want := range cases {
+		if got := stripLeadingDotDot(in); got != want {
+			t.Errorf("stripLeadingDotDot(%q): got %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveDriverPaths(t *testing.T) {
+	baseDir := "/etc/ftw"
+	c := &Config{Drivers: []Driver{
+		{Name: "rel", Lua: "drivers/a.lua"},
+		{Name: "absin", Lua: "/etc/ftw/drivers/b.lua"},
+		{Name: "absout", Lua: "/opt/drivers/c.lua"},
+		{Name: "escape", Lua: "../../secrets/d.lua"},
+		{Name: "empty"},
+	}}
+	c.ResolveDriverPaths(baseDir)
+	want := map[string]string{
+		"rel":    "/etc/ftw/drivers/a.lua", // joined with baseDir
+		"absin":  "/etc/ftw/drivers/b.lua", // already absolute, untouched
+		"absout": "/opt/drivers/c.lua",     // absolute outside baseDir, untouched
+		"escape": "/etc/ftw/secrets/d.lua", // leading "../" stripped, then joined
+		"empty":  "",
+	}
+	for _, d := range c.Drivers {
+		if d.Lua != want[d.Name] {
+			t.Errorf("resolve %s: got %q, want %q", d.Name, d.Lua, want[d.Name])
+		}
+	}
+}
+
+func TestUnresolveDriverPathsRoundtrip(t *testing.T) {
+	baseDir := "/etc/ftw"
+	original := []Driver{
+		{Name: "rel", Lua: "drivers/a.lua"},
+		{Name: "absin", Lua: "/etc/ftw/drivers/b.lua"}, // absolute but inside baseDir
+		{Name: "absout", Lua: "/opt/drivers/c.lua"},    // absolute outside baseDir — must stay absolute
+		{Name: "empty"},
+	}
+	c := &Config{Drivers: append([]Driver(nil), original...)}
+	c.ResolveDriverPaths(baseDir)
+	c.UnresolveDriverPaths(baseDir)
+
+	// After Unresolve, relative / in-tree absolute paths collapse back
+	// to baseDir-relative; out-of-tree absolutes must stay absolute so
+	// the next Resolve doesn't strip a "../" from filepath.Rel and
+	// silently re-anchor the driver under baseDir (Copilot #11).
+	got := map[string]string{}
+	for _, d := range c.Drivers {
+		got[d.Name] = d.Lua
+	}
+	if got["rel"] != "drivers/a.lua" {
+		t.Errorf("rel: got %q, want drivers/a.lua", got["rel"])
+	}
+	if got["absin"] != "drivers/b.lua" {
+		t.Errorf("absin: got %q, want drivers/b.lua", got["absin"])
+	}
+	if got["absout"] != "/opt/drivers/c.lua" {
+		t.Errorf("absout: got %q, want /opt/drivers/c.lua (must remain absolute)", got["absout"])
+	}
+	if got["empty"] != "" {
+		t.Errorf("empty: got %q, want empty string", got["empty"])
+	}
+
+	// Re-resolving must produce the same absolute paths as the first
+	// Resolve — the UI save/load cycle relies on this being a fixed point.
+	c.ResolveDriverPaths(baseDir)
+	want := map[string]string{
+		"rel":    "/etc/ftw/drivers/a.lua",
+		"absin":  "/etc/ftw/drivers/b.lua",
+		"absout": "/opt/drivers/c.lua",
+		"empty":  "",
+	}
+	for _, d := range c.Drivers {
+		if d.Lua != want[d.Name] {
+			t.Errorf("re-resolve %s: got %q, want %q", d.Name, d.Lua, want[d.Name])
+		}
+	}
+}

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -13,7 +13,7 @@ fuse:
   max_amps: 16
 drivers:
   - name: ferroamp
-    wasm: drivers/ferroamp.wasm
+    lua: drivers/ferroamp.lua
     is_site_meter: true
     capabilities:
       mqtt:
@@ -53,9 +53,9 @@ func TestRelativeDriverPathResolved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join("/base/dir", "drivers/ferroamp.wasm")
-	if c.Drivers[0].WASM != want {
-		t.Errorf("wasm path: got %s want %s", c.Drivers[0].WASM, want)
+	want := filepath.Join("/base/dir", "drivers/ferroamp.lua")
+	if c.Drivers[0].Lua != want {
+		t.Errorf("lua path: got %s want %s", c.Drivers[0].Lua, want)
 	}
 }
 
@@ -77,7 +77,7 @@ site: { name: x }
 fuse: { max_amps: 16 }
 drivers:
   - name: a
-    wasm: a.wasm
+    lua: a.lua
     capabilities:
       mqtt: { host: 1.1.1.1 }
 api: { port: 8080 }
@@ -94,11 +94,11 @@ site: { name: x }
 fuse: { max_amps: 16 }
 drivers:
   - name: a
-    wasm: a.wasm
+    lua: a.lua
     is_site_meter: true
     capabilities: { mqtt: { host: 1.1.1.1 } }
   - name: a
-    wasm: b.wasm
+    lua: b.lua
     capabilities: { mqtt: { host: 2.2.2.2 } }
 api: { port: 8080 }
 `
@@ -113,7 +113,7 @@ site: { name: x }
 fuse: { max_amps: 16 }
 drivers:
   - name: a
-    wasm: a.wasm
+    lua: a.lua
     is_site_meter: true
 api: { port: 8080 }
 `
@@ -122,7 +122,7 @@ api: { port: 8080 }
 	}
 }
 
-func TestRejectsDriverWithoutWasmOrLua(t *testing.T) {
+func TestRejectsDriverWithoutLua(t *testing.T) {
 	yaml := `
 site: { name: x }
 fuse: { max_amps: 16 }
@@ -133,7 +133,7 @@ drivers:
 api: { port: 8080 }
 `
 	if _, err := Parse([]byte(yaml), "."); err == nil {
-		t.Fatal("expected error for driver without wasm/lua")
+		t.Fatal("expected error for driver without lua")
 	}
 }
 
@@ -143,7 +143,7 @@ site: { name: x }
 fuse: { max_amps: 16 }
 drivers:
   - name: a
-    wasm: a.wasm
+    lua: a.lua
     is_site_meter: true
     mqtt: { host: 192.168.1.100, username: ext }
 api: { port: 8080 }
@@ -174,7 +174,7 @@ site: { name: x, smoothing_alpha: ` + pretty(bad) + ` }
 fuse: { max_amps: 16 }
 drivers:
   - name: a
-    wasm: a.wasm
+    lua: a.lua
     is_site_meter: true
     capabilities: { mqtt: { host: 1.1.1.1 } }
 api: { port: 8080 }
@@ -191,7 +191,7 @@ site: { name: Full }
 fuse: { max_amps: 16 }
 drivers:
   - name: f
-    wasm: f.wasm
+    lua: f.lua
     is_site_meter: true
     capabilities: { mqtt: { host: 1.1.1.1 } }
 api: { port: 8080 }

--- a/go/internal/configreload/watcher_test.go
+++ b/go/internal/configreload/watcher_test.go
@@ -21,7 +21,7 @@ fuse:
   max_amps: 16
 drivers:
   - name: ferroamp
-    wasm: drivers/ferroamp.wasm
+    lua: drivers/ferroamp.lua
     is_site_meter: true
     capabilities:
       mqtt:
@@ -85,7 +85,7 @@ fuse:
   max_amps: 16
 drivers:
   - name: ferroamp
-    wasm: drivers/ferroamp.wasm
+    lua: drivers/ferroamp.lua
     is_site_meter: true
     capabilities:
       mqtt:

--- a/go/internal/drivers/CLAUDE.md
+++ b/go/internal/drivers/CLAUDE.md
@@ -1,51 +1,44 @@
-# drivers — Lua/WASM driver host with capability-gated I/O
+# drivers — Lua driver host with capability-gated I/O
 
 ## What it does
 
-Spawns one goroutine per device driver, running either a Lua 5.1 script (via `yuin/gopher-lua`) or a WASM module (via `tetratelabs/wazero`). Exposes a fixed lifecycle (`driver_init` → `driver_poll` loop + `driver_command`/`driver_default` → `driver_cleanup`) plus a capability-gated host API (log, emit, MQTT, Modbus, identity). Drivers are FAT: all protocol parsing, state machines, and retries live in the driver; the host only provides I/O and time.
+Spawns one goroutine per device driver, running a Lua 5.1 script via `yuin/gopher-lua`. Exposes a fixed lifecycle (`driver_init` → `driver_poll` loop + `driver_command`/`driver_default` → `driver_cleanup`) plus a capability-gated host API (log, emit, MQTT, Modbus, HTTP, identity). Drivers are FAT: all protocol parsing, state machines, and retries live in the driver; the host only provides I/O and time.
 
 ## Key types
 
 | Type | Purpose |
 |---|---|
 | `Registry` | Owns running drivers, runs per-driver `runLoop`, handles add/remove/reload. |
-| `driverRuntime` (unexported interface) | Shared shape over Lua + WASM so `runLoop` is runtime-agnostic (`registry.go:46`). |
-| `LuaDriver` | gopher-lua VM bound to one `HostEnv` (`lua.go:47`). |
-| `Driver` | wazero module instance bound to one `HostEnv` (`runtime.go:35`). |
-| `Runtime` | Shared wazero runtime across WASM drivers (`runtime.go:18`). |
-| `HostEnv` | Per-driver context: capabilities, telemetry store, identity (`host.go:43`). |
-| `MQTTCap` / `ModbusCap` | Capability interfaces implemented by `../mqtt` and `../modbus` (`host.go:20`, `host.go:35`). |
-| `MQTTMessage` | Inbound message `{topic, payload}` drained via `PopMessages` (`host.go:29`). |
-| `CatalogEntry` | Metadata scraped from the `DRIVER={…}` block at the top of each `.lua` file (`catalog.go:15`). |
+| `driverRuntime` (unexported interface) | Shape `runLoop` works against so per-runtime details stay out of it (`registry.go`). |
+| `LuaDriver` | gopher-lua VM bound to one `HostEnv` (`lua.go`). |
+| `HostEnv` | Per-driver context: capabilities, telemetry store, identity (`host.go`). |
+| `MQTTCap` / `ModbusCap` | Capability interfaces implemented by `../mqtt` and `../modbus` (`host.go`). |
+| `MQTTMessage` | Inbound message `{topic, payload}` drained via `PopMessages` (`host.go`). |
+| `CatalogEntry` | Metadata scraped from the `DRIVER={…}` block at the top of each `.lua` file (`catalog.go`). |
 
 ## Public API surface
 
-- `NewRegistry(rt, tel)` + `Add / Remove / Reload / Send / SendDefault / ShutdownAll / Names / Env`.
-- `NewRuntime(ctx)` / `Runtime.Load(ctx, path, env)` / `Runtime.LoadBytes` for WASM.
+- `NewRegistry(tel)` + `Add / Remove / Reload / Restart / RestartByName / Send / SendDefault / ShutdownAll / Names / Env`.
 - `NewLuaDriver(path, env)` for Lua.
-- `NewHostEnv(name, tel)` + `WithMQTT / WithModbus / SetEndpoint / SetMAC`.
+- `NewHostEnv(name, tel)` + `WithMQTT / WithModbus / WithHTTP / SetEndpoint / SetMAC`.
 - `HostEnv.Identity() / FullIdentity()` for `state.RegisterDevice` wiring.
 - `LoadCatalog(dir)` walks `.lua` files and extracts the DRIVER metadata table.
-- ABI constants: `StatusOk/Error/Unsupported`, `LogTrace…LogError`, `ModbusCoil…ModbusInput`, `ABIVersionMajor/Minor` (`abi.go`).
+- Constants: `ModbusCoil` / `ModbusDiscrete` / `ModbusHolding` / `ModbusInput` for modbus read kinds.
 
 ## How it talks to neighbors
 
-`Registry.Add` resolves capabilities via the injected `MQTTFactory` / `ModbusFactory` / `ARPLookup` (wired in `cmd/forty-two-watts/main.go`). MAC resolution comes from `../arp`; endpoint is set from the MQTT/Modbus config. The HostEnv owns a pointer to `../telemetry.Store` — `emitTelemetry` routes structured pv/battery/meter readings through `Store.Update`, `emitMetric` routes scalar diagnostics through `Store.EmitMetric`, and each successful poll records a health tick via `DriverHealthMut`. The Lua backend adapts a `map[string]any` config at the boundary (`registry.go:70`), while WASM passes raw JSON (`runtime.go:248`). See `docs/lua-drivers.md` and `docs/host-api.md`.
+`Registry.Add` resolves capabilities via the injected `MQTTFactory` / `ModbusFactory` / `ARPLookup` (wired in `cmd/forty-two-watts/main.go`). MAC resolution comes from `../arp`; endpoint is set from the MQTT/Modbus config. The HostEnv owns a pointer to `../telemetry.Store` — `emitTelemetry` routes structured pv/battery/meter readings through `Store.Update`, `emitMetric` routes scalar diagnostics through `Store.EmitMetric`, and each successful poll records a health tick via `DriverHealthMut`. The Lua backend adapts a `map[string]any` config at the boundary (`registry.go`). See `docs/writing-a-driver.md` and `docs/host-api.md`.
 
 ## What to read first
 
 1. `registry.go` — `Add`, `runLoop`, `Reload`, and the `driverRuntime` adapter layer.
 2. `host.go` — HostEnv + capability interfaces + identity fields.
 3. `lua.go` — registration of the `host.*` global and the gopher-lua bridge.
-4. `runtime.go` — wazero host module builder, lifecycle dispatch, WASI stdout→slog.
-5. `abi.go` — the stable WASM ABI (exports, imports, status codes).
-6. `catalog.go` — how the UI discovers available drivers.
+4. `catalog.go` — how the UI discovers available drivers.
 
 ## What NOT to do
 
-- **Do NOT reuse an MQTT `clientID` across drivers.** `main.go:133` prefixes with `ftw-<name>` for a reason — brokers disconnect duplicates.
-- **Do NOT register a new driver backend by touching `runLoop` directly.** Add a new `driverRuntime` adapter alongside `wasmRuntime` / `luaRuntime` (`registry.go:55-79`) and let `Add` pick it by extension. Lua is the recommended path for new drivers.
-- **Do NOT share a wazero module across drivers.** `LoadBytes` closes the existing `host` module each time (`runtime.go:70`) — a shared runtime would need name-prefixed host modules.
-- **Do NOT call into a nil capability.** Gate every MQTT/Modbus access with the `env.MQTT != nil` / `env.Modbus != nil` check (the host proxies already do — see `host.go:197+`). Drivers get `ErrNoCapability` back.
-- **Do NOT assume ARP lookup succeeds.** Cross-VLAN devices return `("", false)`; identity must fall back to the endpoint hash (`registry.go:119-134`).
+- **Do NOT reuse an MQTT `clientID` across drivers.** `main.go` prefixes with `ftw-<name>` for a reason — brokers disconnect duplicates.
+- **Do NOT call into a nil capability.** Gate every MQTT/Modbus/HTTP access with the `env.MQTT != nil` / `env.Modbus != nil` / `env.HTTP` check (the host proxies already do — see `host.go`). Drivers get `ErrNoCapability` back.
+- **Do NOT assume ARP lookup succeeds.** Cross-VLAN devices return `("", false)`; identity must fall back to the endpoint hash.
 - **Do NOT bypass the command channel.** All driver mutations go through `rd.cmdCh` so they serialize with `Poll` on the same goroutine. Calling `Command` directly from another goroutine is a data race against gopher-lua's single-threaded VM.

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -1,7 +1,6 @@
-// Lua driver host — a pure-Go alternative to the WASM host.
+// Lua driver host.
 //
-// Drivers are plain .lua files that implement the same lifecycle as the
-// WASM ones:
+// Drivers are plain .lua files that implement the driver lifecycle:
 //
 //	driver_init()          — subscribe MQTT topics, read Modbus SN, etc.
 //	driver_poll()          — called every N seconds; emit telemetry
@@ -9,8 +8,8 @@
 //	driver_cleanup()       — optional, called on shutdown
 //	driver_default_mode()  — optional, called when driver goes offline
 //
-// The host exposes the same capability-gated helpers as the WASM ABI,
-// surfaced as a `host` global in the Lua VM:
+// The host exposes a capability-gated API surfaced as a `host` global in
+// the Lua VM:
 //
 //	host.log(level, msg)            -- level: "debug"|"info"|"warn"|"error"
 //	host.emit(type, table)          -- type: "meter"|"pv"|"battery"|"ev"
@@ -31,8 +30,7 @@
 //	host.http_post(url, body, headers) -- HTTP POST, returns (body, nil) or (nil, err)
 //
 // Lua 5.1 via yuin/gopher-lua — pure Go, zero CGo, one allocation-aware
-// interpreter per driver. The whole thing is ~350 LOC vs ~850 for the
-// WASM runtime + its Rust driver scaffolding.
+// interpreter per driver.
 package drivers
 
 import (
@@ -187,7 +185,7 @@ func registerHost(L *lua.LState, env *HostEnv) {
 
 	// host.emit("meter"|"pv"|"battery"|"ev", { w=…, soc=…, connected=…, charging=… })
 	// The type string is prepended to the table as a `type` field and
-	// the whole thing serialized as the JSON the WASM host expects.
+	// the whole thing is serialized as JSON before hitting the telemetry store.
 	// Allowed fields per type:
 	//   meter   -> w, l1_w, l2_w, l3_w, l1_v, l2_v, l3_v, l1_a, l2_a, l3_a, freq_hz
 	//   pv      -> w, mppt1_v, mppt1_a, mppt2_v, mppt2_a, dc_v

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"sync"
 	"time"
 
@@ -82,7 +83,7 @@ type driverCmd struct {
 }
 
 // Add spawns a driver. Returns error if the driver config is invalid or
-// the WASM module can't be loaded.
+// the Lua script can't be loaded.
 func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	r.mu.Lock()
 	if _, exists := r.rec[cfg.Name]; exists {
@@ -152,12 +153,7 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	r.rec[cfg.Name] = rd
 	r.mu.Unlock()
 	go r.runLoop(rd)
-	kind := "lua"
-	path := cfg.Lua
-	if cfg.WASM != "" {
-		kind, path = "wasm", cfg.WASM
-	}
-	slog.Info("driver added", "name", cfg.Name, "kind", kind, "path", path)
+	slog.Info("driver added", "name", cfg.Name, "path", cfg.Lua)
 	return nil
 }
 
@@ -280,9 +276,9 @@ func (r *Registry) ShutdownAll() {
 }
 
 // Reload diffs a new driver list against running state and applies add/
-// remove/restart. Drivers with changed wasm path / capabilities are restarted.
-// Drivers marked Disabled are treated as "not in the new list" — running
-// ones get stopped, missing ones are not added.
+// remove/restart. Drivers with changed lua path, capabilities, or config
+// map are restarted. Drivers marked Disabled are treated as "not in the
+// new list" — running ones get stopped, missing ones are not added.
 func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 	// Filter out disabled drivers — they behave like removed from the
 	// registry's perspective but remain in config.yaml for re-enable.
@@ -361,7 +357,7 @@ func findDriver(list []config.Driver, name string) (config.Driver, bool) {
 }
 
 func sameDriverConfig(a, b config.Driver) bool {
-	if a.WASM != b.WASM || a.Lua != b.Lua ||
+	if a.Lua != b.Lua ||
 		a.IsSiteMeter != b.IsSiteMeter ||
 		a.BatteryCapacityWh != b.BatteryCapacityWh ||
 		a.Disabled != b.Disabled {
@@ -381,21 +377,9 @@ func sameDriverConfig(a, b config.Driver) bool {
 	// Compare the free-form Config map. Previously omitted, so a changed
 	// cloud-driver password in drivers[i].config.password was silently
 	// ignored by the hot-reload diff — the driver kept running with the
-	// stale credentials. Deep-equal via JSON is coarse but correct for the
-	// stringly-typed config map we actually use.
-	if !sameConfigMap(a.Config, b.Config) {
-		return false
-	}
-	return true
-}
-
-// sameConfigMap compares two driver Config maps. Nil and empty are
-// treated as equal. Uses JSON marshal so order of keys doesn't matter.
-func sameConfigMap(a, b map[string]any) bool {
-	if len(a) == 0 && len(b) == 0 {
+	// stale credentials. DeepEqual also treats nil and empty maps as equal.
+	if len(a.Config) == 0 && len(b.Config) == 0 {
 		return true
 	}
-	ja, _ := json.Marshal(a)
-	jb, _ := json.Marshal(b)
-	return string(ja) == string(jb)
+	return reflect.DeepEqual(a.Config, b.Config)
 }

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -193,7 +193,9 @@ func (r *Registry) runLoop(rd *runningDriver) {
 	}
 }
 
-// Remove stops and cleans up a driver. Idempotent.
+// Remove stops and cleans up a driver. Idempotent. Also wipes the
+// driver's entry from the telemetry store so the API status + UI stop
+// showing a stale card for a driver that's no longer in config.
 func (r *Registry) Remove(name string) {
 	r.mu.Lock()
 	rd, ok := r.rec[name]
@@ -205,6 +207,9 @@ func (r *Registry) Remove(name string) {
 	r.mu.Unlock()
 	close(rd.stop)
 	<-rd.done
+	if r.tel != nil {
+		r.tel.Remove(name)
+	}
 	slog.Info("driver removed", "name", name)
 }
 

--- a/go/internal/evcloud/easee.go
+++ b/go/internal/evcloud/easee.go
@@ -1,41 +1,91 @@
 package evcloud
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 )
 
-func init() { Register("easee", Easee{}) }
+// easeeDefaultBaseURL is the Easee cloud API base URL. Split out so
+// tests can inject an httptest.Server URL via NewEasee.
+const easeeDefaultBaseURL = "https://api.easee.com/api"
 
-// Easee implements Provider for the Easee Cloud API.
-type Easee struct{}
+// easeeDefaultTimeout bounds every HTTP call so a stalled TCP
+// connection to api.easee.com can't tie up the HTTP handler goroutine
+// indefinitely. 15 s matches what the rest of the codebase uses for
+// external HTTP calls (see e.g. drivers/lua.go HTTP capability).
+const easeeDefaultTimeout = 15 * time.Second
 
-// Bounded timeout so a stalled TCP connection to api.easee.com cannot tie
-// up the HTTP handler goroutine indefinitely. 15s matches what the rest
-// of the codebase uses for external HTTP calls.
-var easeeClient = &http.Client{Timeout: 15 * time.Second}
+func init() { Register("easee", NewEasee()) }
 
-func (Easee) ListChargers(email, password string) ([]Charger, error) {
-	token, err := easeeLogin(email, password)
+// Easee implements Provider for the Easee Cloud API. The HTTP client
+// and base URL are injectable so tests can point at an httptest.Server
+// and production code can plug in a custom transport (retries, tracing,
+// etc.) without touching this package.
+type Easee struct {
+	client  *http.Client
+	baseURL string
+}
+
+// NewEasee builds an Easee provider pointed at the production API with
+// the standard 15 s timeout.
+func NewEasee() *Easee {
+	return &Easee{
+		client:  &http.Client{Timeout: easeeDefaultTimeout},
+		baseURL: easeeDefaultBaseURL,
+	}
+}
+
+// WithHTTPClient returns a copy of e using the supplied client. Intended
+// for tests (inject a client whose Transport points at httptest.Server)
+// and for wiring transports with custom round-trippers.
+func (e *Easee) WithHTTPClient(c *http.Client) *Easee {
+	cp := *e
+	cp.client = c
+	return &cp
+}
+
+// WithBaseURL returns a copy of e pointed at the given base URL (no
+// trailing slash). Paired with WithHTTPClient for httptest wiring.
+func (e *Easee) WithBaseURL(u string) *Easee {
+	cp := *e
+	cp.baseURL = u
+	return &cp
+}
+
+// ListChargers logs in with the given credentials and returns the
+// chargers on the account.
+func (e *Easee) ListChargers(email, password string) ([]Charger, error) {
+	token, err := e.login(email, password)
 	if err != nil {
 		return nil, err
 	}
-	return easeeListChargers(token)
+	return e.listChargers(token)
 }
 
-func easeeLogin(email, password string) (string, error) {
-	body, _ := json.Marshal(map[string]string{"userName": email, "password": password})
-	resp, err := easeeClient.Post("https://api.easee.com/api/accounts/login", "application/json", strings.NewReader(string(body)))
+func (e *Easee) login(email, password string) (string, error) {
+	body, err := json.Marshal(map[string]string{"userName": email, "password": password})
+	if err != nil {
+		return "", fmt.Errorf("login: marshal: %w", err)
+	}
+	req, err := http.NewRequest("POST", e.baseURL+"/accounts/login", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("login: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("login request: %w", err)
 	}
 	defer resp.Body.Close()
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode >= 400 {
+		// Status-only message — the body on a 4xx can echo the submitted
+		// credentials, and "invalid email or password" is the only
+		// actionable info we can surface anyway.
 		return "", fmt.Errorf("login: HTTP %d", resp.StatusCode)
 	}
 	var tok struct {
@@ -47,10 +97,13 @@ func easeeLogin(email, password string) (string, error) {
 	return tok.AccessToken, nil
 }
 
-func easeeListChargers(token string) ([]Charger, error) {
-	req, _ := http.NewRequest("GET", "https://api.easee.com/api/chargers", nil)
+func (e *Easee) listChargers(token string) ([]Charger, error) {
+	req, err := http.NewRequest("GET", e.baseURL+"/chargers", nil)
+	if err != nil {
+		return nil, fmt.Errorf("chargers: %w", err)
+	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := easeeClient.Do(req)
+	resp, err := e.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("chargers request: %w", err)
 	}

--- a/go/internal/evcloud/easee.go
+++ b/go/internal/evcloud/easee.go
@@ -1,0 +1,74 @@
+package evcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func init() { Register("easee", Easee{}) }
+
+// Easee implements Provider for the Easee Cloud API.
+type Easee struct{}
+
+// Bounded timeout so a stalled TCP connection to api.easee.com cannot tie
+// up the HTTP handler goroutine indefinitely. 15s matches what the rest
+// of the codebase uses for external HTTP calls.
+var easeeClient = &http.Client{Timeout: 15 * time.Second}
+
+func (Easee) ListChargers(email, password string) ([]Charger, error) {
+	token, err := easeeLogin(email, password)
+	if err != nil {
+		return nil, err
+	}
+	return easeeListChargers(token)
+}
+
+func easeeLogin(email, password string) (string, error) {
+	body, _ := json.Marshal(map[string]string{"userName": email, "password": password})
+	resp, err := easeeClient.Post("https://api.easee.com/api/accounts/login", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("login request: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("login: HTTP %d", resp.StatusCode)
+	}
+	var tok struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := json.Unmarshal(raw, &tok); err != nil || tok.AccessToken == "" {
+		return "", fmt.Errorf("login: no token in response")
+	}
+	return tok.AccessToken, nil
+}
+
+func easeeListChargers(token string) ([]Charger, error) {
+	req, _ := http.NewRequest("GET", "https://api.easee.com/api/chargers", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := easeeClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("chargers request: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("chargers: HTTP %d", resp.StatusCode)
+	}
+	var list []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("chargers: decode: %w", err)
+	}
+	out := make([]Charger, len(list))
+	for i, ch := range list {
+		out[i] = Charger{ID: ch.ID, Name: ch.Name}
+	}
+	return out, nil
+}

--- a/go/internal/evcloud/easee_test.go
+++ b/go/internal/evcloud/easee_test.go
@@ -1,0 +1,120 @@
+package evcloud
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEaseeListChargers covers the happy path end-to-end against an
+// httptest.Server. Demonstrates that the client + base URL injection
+// actually works.
+func TestEaseeListChargers(t *testing.T) {
+	var loginHits, chargerHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/accounts/login":
+			loginHits++
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]string
+			_ = json.Unmarshal(body, &req)
+			if req["userName"] != "user@example.com" || req["password"] != "hunter2" {
+				http.Error(w, "bad creds", http.StatusUnauthorized)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "tok-abc"})
+		case "/chargers":
+			chargerHits++
+			if r.Header.Get("Authorization") != "Bearer tok-abc" {
+				http.Error(w, "missing bearer", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`[{"id":"EH123","name":"Garage"},{"id":"EH456","name":"Driveway"}]`))
+		default:
+			http.Error(w, "unknown route", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	e := NewEasee().WithHTTPClient(srv.Client()).WithBaseURL(srv.URL)
+	got, err := e.ListChargers("user@example.com", "hunter2")
+	if err != nil {
+		t.Fatalf("ListChargers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("chargers: got %d, want 2 — %+v", len(got), got)
+	}
+	if got[0].ID != "EH123" || got[0].Name != "Garage" {
+		t.Errorf("charger[0]: got %+v, want {EH123 Garage}", got[0])
+	}
+	if got[1].ID != "EH456" {
+		t.Errorf("charger[1]: got %+v, want {EH456 Driveway}", got[1])
+	}
+	if loginHits != 1 || chargerHits != 1 {
+		t.Errorf("hits: login=%d chargers=%d, want 1/1", loginHits, chargerHits)
+	}
+}
+
+// TestEaseeLoginRejectsBadCreds verifies a 401 from /accounts/login
+// surfaces as a status-only error. The submitted password must not
+// leak into the error message even if the upstream echoes it.
+func TestEaseeLoginRejectsBadCreds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Echo the body back on error — this is the footgun the redact
+		// comment in easee.go warns about.
+		body, _ := io.ReadAll(r.Body)
+		http.Error(w, "invalid login: "+string(body), http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	e := NewEasee().WithHTTPClient(srv.Client()).WithBaseURL(srv.URL)
+	_, err := e.ListChargers("user@example.com", "supersecret")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "supersecret") {
+		t.Errorf("password leaked into error message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "HTTP 401") {
+		t.Errorf("expected 'HTTP 401' in error, got: %v", err)
+	}
+}
+
+// TestEaseeTimeoutBounded is the regression test for the bug this
+// refactor fixes: a server that hangs forever must not wedge the
+// caller. We configure a 200 ms client timeout and make sure the
+// request returns an error within a generous ceiling.
+func TestEaseeTimeoutBounded(t *testing.T) {
+	// srv.Close() blocks on stalled handlers, so unblock them (close
+	// the channel) BEFORE srv.Close() runs. Defers are LIFO: the last
+	// defer registered runs first. srv must be constructed first so we
+	// can register its Close(), then register close(block) afterwards.
+	srv := httptest.NewServer(nil)
+	defer srv.Close()
+	block := make(chan struct{})
+	defer close(block)
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // stall indefinitely
+	})
+
+	client := &http.Client{Timeout: 200 * time.Millisecond}
+	e := NewEasee().WithHTTPClient(client).WithBaseURL(srv.URL)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := e.ListChargers("a@b", "c")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListChargers did not return within 2s despite 200ms client timeout")
+	}
+}

--- a/go/internal/evcloud/evcloud.go
+++ b/go/internal/evcloud/evcloud.go
@@ -1,0 +1,50 @@
+package evcloud
+
+import "fmt"
+
+// Charger is the common representation returned by all providers.
+type Charger struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+// Provider can authenticate with a cloud EV charger service and list
+// the chargers on the account.
+type Provider interface {
+	ListChargers(email, password string) ([]Charger, error)
+}
+
+var providers = map[string]Provider{}
+
+// Register adds a named provider. Call from init().
+//
+// Panics on nil or duplicate registration — both indicate a programming
+// error (two packages claiming the same provider string would otherwise
+// race on init-order and silently pick the last one).
+func Register(name string, p Provider) {
+	if p == nil {
+		panic(fmt.Sprintf("evcloud: Register(%q): nil provider", name))
+	}
+	if _, exists := providers[name]; exists {
+		panic(fmt.Sprintf("evcloud: Register(%q): provider already registered", name))
+	}
+	providers[name] = p
+}
+
+// Get returns the provider for the given name or an error.
+func Get(name string) (Provider, error) {
+	p, ok := providers[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown ev cloud provider: %q", name)
+	}
+	return p, nil
+}
+
+// Names returns all registered provider names.
+func Names() []string {
+	out := make([]string, 0, len(providers))
+	for k := range providers {
+		out = append(out, k)
+	}
+	return out
+}

--- a/go/internal/modbus/CLAUDE.md
+++ b/go/internal/modbus/CLAUDE.md
@@ -20,7 +20,7 @@ Wraps one `simonvetter/modbus.ModbusClient` per driver and implements `drivers.M
 
 ## How it talks to neighbors
 
-`../drivers` Registry holds a `ModbusFactory` wired in `cmd/forty-two-watts/main.go:135-137` that calls `Dial(c.Host, c.Port, c.UnitID)` per driver. The returned `*Capability` is bound to the driver's `HostEnv.Modbus`. Lua drivers call `host.modbus_read / host.modbus_write / host.modbus_write_multi`; WASM drivers call the same names through their ABI exports (`drivers/runtime.go:152+`). The endpoint string `modbus://<host>:<port>` is recorded on the HostEnv for device-identity and the host IP gets ARP-resolved for MAC-stable `device_id`.
+`../drivers` Registry holds a `ModbusFactory` wired in `cmd/forty-two-watts/main.go` that calls `Dial(c.Host, c.Port, c.UnitID)` per driver. The returned `*Capability` is bound to the driver's `HostEnv.Modbus`. Lua drivers call `host.modbus_read / host.modbus_write / host.modbus_write_multi`, which route through `drivers.ModbusCap`. The endpoint string `modbus://<host>:<port>` is recorded on the HostEnv for device-identity and the host IP gets ARP-resolved for MAC-stable `device_id`.
 
 ## What to read first
 

--- a/go/internal/mqtt/CLAUDE.md
+++ b/go/internal/mqtt/CLAUDE.md
@@ -20,7 +20,7 @@ Wraps one `paho.Client` per driver so each driver has its own broker connection,
 
 ## How it talks to neighbors
 
-The `../drivers` registry holds an `MQTTFactory` function wired in `cmd/forty-two-watts/main.go:132-134` that calls `Dial(host, port, user, pass, "ftw-"+driverName)` for each driver that has an MQTT config. The returned `*Capability` is bound to the driver's `HostEnv` via `env.WithMQTT(cap)`; from then on the driver's Lua/WASM code calls `host.mqtt_subscribe` / `host.mqtt_publish` / `host.mqtt_messages`, which route through `drivers.MQTTCap`. The HA bridge (`../ha`) creates its own paho client — it does NOT go through this package.
+The `../drivers` registry holds an `MQTTFactory` function wired in `cmd/forty-two-watts/main.go` that calls `Dial(host, port, user, pass, "ftw-"+driverName)` for each driver that has an MQTT config. The returned `*Capability` is bound to the driver's `HostEnv` via `env.WithMQTT(cap)`; from then on the driver's Lua code calls `host.mqtt_subscribe` / `host.mqtt_publish` / `host.mqtt_messages`, which route through `drivers.MQTTCap`. The HA bridge (`../ha`) creates its own paho client — it does NOT go through this package.
 
 ## What to read first
 

--- a/go/internal/mqtt/client.go
+++ b/go/internal/mqtt/client.go
@@ -1,5 +1,4 @@
-// Package mqtt provides an MQTT capability wrapper suitable for binding
-// per-driver in the WASM runtime.
+// Package mqtt provides an MQTT capability wrapper for per-driver binding.
 package mqtt
 
 import (

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -296,6 +296,22 @@ func (s *Store) DriverHealthMut(name string) *DriverHealth {
 	return h
 }
 
+// Remove drops all in-memory state for a driver: readings, Kalman
+// filters, and the health entry. Called from the driver Registry when
+// a driver is removed from config (or restarted — the next Update will
+// repopulate) so the API status + UI stop rendering the stale card.
+// Historical TS-DB samples are NOT touched; they stay queryable.
+func (s *Store) Remove(driver string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range []DerType{DerMeter, DerPV, DerBattery, DerEV} {
+		k := key(driver, t)
+		delete(s.readings, k)
+		delete(s.filters, k)
+	}
+	delete(s.health, driver)
+}
+
 // AllHealth returns a snapshot of all driver health entries.
 func (s *Store) AllHealth() map[string]DriverHealth {
 	s.mu.RLock(); defer s.mu.RUnlock()

--- a/go/test/e2e/stack_test.go
+++ b/go/test/e2e/stack_test.go
@@ -329,10 +329,33 @@ func setupStack(t *testing.T) *stack {
 		}
 	}()
 
-	// Give drivers time to init + first telemetry to flow. Sungrow polls at
-	// 2s intervals so we need at least 2.5s for both to have emitted.
-	time.Sleep(3 * time.Second)
+	// Wait until the ferroamp driver has received and parsed its first
+	// MQTT message (pv_w becomes non-zero). The old fixed 3s sleep was
+	// tuned for the WASM driver runtime; Lua's `driver_init` + first MQTT
+	// round-trip is slower and variable, which caused /api/status to be
+	// read before any telemetry had landed.
+	s.waitForPV(10 * time.Second)
 	return s
+}
+
+func (s *stack) waitForPV(timeout time.Duration) {
+	s.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(s.baseURL() + "/api/status")
+		if err == nil {
+			var status map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&status)
+			resp.Body.Close()
+			if pv, ok := status["pv_w"].(float64); ok && pv != 0 {
+				return
+			}
+		} else if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	s.t.Fatalf("timed out after %s waiting for pv_w telemetry", timeout)
 }
 
 func (s *stack) Close() {

--- a/go/test/e2e/stack_test.go
+++ b/go/test/e2e/stack_test.go
@@ -4,8 +4,7 @@
 // self-tune runs, battery models learn.
 //
 // Run with:  go test ./go/test/e2e -timeout 120s -v
-// Skipped unless drivers-wasm/ferroamp.wasm and sungrow.wasm are present
-// (build them first with `make wasm`).
+// Uses the repo's drivers/ferroamp.lua + drivers/sungrow.lua scripts.
 package e2e
 
 import (
@@ -60,11 +59,11 @@ func findRepoRoot(t *testing.T) string {
 	return ""
 }
 
-func findWASM(t *testing.T, name string) string {
+func findLuaDriver(t *testing.T, name string) string {
 	root := findRepoRoot(t)
-	p := filepath.Join(root, "drivers-wasm", name+".wasm")
+	p := filepath.Join(root, "drivers", name+".lua")
 	if _, err := os.Stat(p); err != nil {
-		t.Skipf("drivers-wasm/%s.wasm not found — run `make wasm` first", name)
+		t.Skipf("drivers/%s.lua not found", name)
 	}
 	return p
 }
@@ -204,21 +203,21 @@ func setupStack(t *testing.T) *stack {
 
 	time.Sleep(200 * time.Millisecond)
 
-	// ---- Build cfg + open state + start wazero + drivers ----
+	// ---- Build cfg + open state + start drivers ----
 	s.cfg = &config.Config{
 		Site:  config.Site{Name: "e2e", ControlIntervalS: 1, GridTargetW: 0, GridToleranceW: 42, SmoothingAlpha: 0.3, SlewRateW: 2000, MinDispatchIntervalS: 1},
 		Fuse:  config.Fuse{MaxAmps: 16, Phases: 3, Voltage: 230},
 		API:   config.API{Port: s.apiPort},
 		Drivers: []config.Driver{
 			{
-				Name: "ferroamp", WASM: findWASM(t, "ferroamp"),
+				Name: "ferroamp", Lua: findLuaDriver(t, "ferroamp"),
 				IsSiteMeter: true, BatteryCapacityWh: 15200,
 				Capabilities: config.Capabilities{
 					MQTT: &config.MQTTConfig{Host: "127.0.0.1", Port: s.mqttPort},
 				},
 			},
 			{
-				Name: "sungrow", WASM: findWASM(t, "sungrow"),
+				Name: "sungrow", Lua: findLuaDriver(t, "sungrow"),
 				BatteryCapacityWh: 9600,
 				Capabilities: config.Capabilities{
 					Modbus: &config.ModbusConfig{Host: "127.0.0.1", Port: s.modbusPort, UnitID: 1},

--- a/scripts/deploy-go.sh
+++ b/scripts/deploy-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Deploy the Go port to a remote host. Drop-in replacement for the Rust-era
-# scripts/deploy.sh but points at the Go binary + WASM driver tarball.
+# Deploy forty-two-watts to a remote host — ships the Go binary + Lua
+# drivers + web assets.
 #
 # Usage:
 #   ./scripts/deploy-go.sh homelab-rpi [version]
@@ -56,12 +56,12 @@ ssh "$HOST" "
     # Backup current binary
     [ -f forty-two-watts ] && cp forty-two-watts forty-two-watts.bak
 
-    # Swap binary + web + drivers-wasm (config.yaml + *.db untouched)
+    # Swap binary + web + drivers (config.yaml + *.db untouched)
     cp .deploy-staging/$BINARY forty-two-watts
     chmod +x forty-two-watts
-    rm -rf web drivers-wasm
+    rm -rf web drivers
     cp -r .deploy-staging/web web
-    cp -r .deploy-staging/drivers-wasm drivers-wasm
+    cp -r .deploy-staging/drivers drivers
     rm -rf .deploy-staging
 
     echo 'Binary updated to $VERSION'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,6 +82,15 @@ if ! $SUDO docker compose version >/dev/null 2>&1; then
   $SUDO apt-get install -y -qq docker-compose-plugin
 fi
 
+# uidmap (newuidmap/newgidmap) is required if the user later wants to
+# switch to rootless Docker via `dockerd-rootless-setuptool.sh install`.
+# Tiny package, harmless to have, saves a confusing second-step detour.
+if ! command -v newuidmap >/dev/null 2>&1; then
+  echo "    Installing uidmap (needed for rootless Docker)..."
+  $SUDO apt-get update -qq
+  $SUDO apt-get install -y -qq uidmap
+fi
+
 # ---- 2. Docker group ----
 echo ""
 echo "==[2/5]== Adding $USER to the docker group"
@@ -110,11 +119,21 @@ echo "==[4/5]== Fetching docker-compose.yml from $BRANCH"
 curl -fsSL "$COMPOSE_URL" -o "$INSTALL_DIR/docker-compose.yml"
 
 # ---- 5. Pull + start ----
+# Run docker as the invoking user, not via sudo. If they were just added
+# to the docker group in step 2, their current shell hasn't picked it up
+# yet — `sg docker -c ...` executes under the new primary group without
+# requiring a re-login.
+if [ "$(id -u)" -eq 0 ] || id -nG "$USER" 2>/dev/null | grep -qw docker; then
+  run_docker() { docker "$@"; }
+else
+  run_docker() { sg docker -c "docker $*"; }
+fi
+
 echo ""
 echo "==[5/5]== Pulling image + starting container"
 cd "$INSTALL_DIR"
-$SUDO docker compose pull
-$SUDO docker compose up -d
+run_docker compose pull
+run_docker compose up -d
 
 # ---- Summary ----
 HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# forty-two-watts one-shot installer.
+#
+# Designed for a freshly-installed Raspberry Pi OS (arm64) but works on
+# any Debian/Ubuntu-flavoured Linux with curl + sudo.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install.sh | bash
+#
+# What this does:
+#   1. Installs Docker Engine + the `docker compose` plugin via
+#      get.docker.com (skipped if Docker is already present).
+#   2. Adds your user to the `docker` group.
+#   3. Creates ~/forty-two-watts/ with data/ subdir owned by the
+#      in-container ftw user (uid 100 / gid 101).
+#   4. Fetches docker-compose.yml from the repo.
+#   5. Pulls the multi-arch image from GHCR and starts the container.
+#
+# Safe to re-run — every step is idempotent, and `docker compose up -d`
+# picks up config changes without destroying the state volume.
+#
+# Override via env vars (optional):
+#   FTW_DIR=/srv/ftw       # install location (default: ~/forty-two-watts)
+#   FTW_IMAGE=...          # custom image (default: ghcr.io/frahlg/forty-two-watts:latest)
+#   FTW_BRANCH=some-branch # pull docker-compose.yml from a non-master branch
+
+set -euo pipefail
+
+# ---- Config (override via env) ----
+REPO="frahlg/forty-two-watts"
+BRANCH="${FTW_BRANCH:-master}"
+IMAGE="${FTW_IMAGE:-ghcr.io/${REPO}:latest}"
+INSTALL_DIR="${FTW_DIR:-$HOME/forty-two-watts}"
+COMPOSE_URL="${FTW_COMPOSE_URL:-https://raw.githubusercontent.com/${REPO}/${BRANCH}/docker-compose.yml}"
+
+# Banner
+cat <<'BANNER'
+
+  ┌─────────────────────────────────────────────────┐
+  │     forty-two-watts installer                   │
+  │     Home Energy Management System               │
+  └─────────────────────────────────────────────────┘
+
+BANNER
+
+# ---- Prerequisites ----
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: 'curl' is required. Install with:" >&2
+  echo "       sudo apt-get update && sudo apt-get install -y curl" >&2
+  exit 1
+fi
+
+# Docker install + chown need root. Prime sudo up-front so we don't
+# interrupt the flow mid-way with a password prompt that the user
+# might miss when the script is piped from curl.
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "ERROR: 'sudo' is required when not running as root." >&2
+    exit 1
+  fi
+  SUDO="sudo"
+  echo "This installer needs sudo to install Docker. You may be prompted for your password."
+  echo ""
+  sudo -v
+fi
+
+# ---- 1. Docker ----
+echo "==[1/5]== Installing Docker Engine + compose plugin"
+if command -v docker >/dev/null 2>&1; then
+  echo "    Docker is already installed — skipping."
+else
+  curl -fsSL https://get.docker.com | $SUDO sh
+fi
+
+# get.docker.com ships the compose plugin on current Debian/Raspbian,
+# but older systems may need it installed separately.
+if ! $SUDO docker compose version >/dev/null 2>&1; then
+  echo "    Installing docker-compose-plugin separately..."
+  $SUDO apt-get update -qq
+  $SUDO apt-get install -y -qq docker-compose-plugin
+fi
+
+# ---- 2. Docker group ----
+echo ""
+echo "==[2/5]== Adding $USER to the docker group"
+if id -nG "$USER" 2>/dev/null | grep -qw docker; then
+  echo "    $USER is already in the docker group — skipping."
+  NEED_RELOGIN=0
+else
+  $SUDO usermod -aG docker "$USER"
+  echo "    Done. You'll need to run 'newgrp docker' or log out + back in"
+  echo "    before 'docker' works without sudo in your shell."
+  NEED_RELOGIN=1
+fi
+
+# ---- 3. Install directory ----
+echo ""
+echo "==[3/5]== Preparing install directory: $INSTALL_DIR"
+mkdir -p "$INSTALL_DIR/data"
+# The image runs as uid 100 / gid 101 (the `ftw` user created in the
+# alpine runtime stage — see Dockerfile). A bind-mounted host dir must
+# match those IDs so SQLite can create state.db inside it.
+$SUDO chown -R 100:101 "$INSTALL_DIR/data"
+
+# ---- 4. docker-compose.yml ----
+echo ""
+echo "==[4/5]== Fetching docker-compose.yml from $BRANCH"
+curl -fsSL "$COMPOSE_URL" -o "$INSTALL_DIR/docker-compose.yml"
+
+# ---- 5. Pull + start ----
+echo ""
+echo "==[5/5]== Pulling image + starting container"
+cd "$INSTALL_DIR"
+$SUDO docker compose pull
+$SUDO docker compose up -d
+
+# ---- Summary ----
+HOST_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+[ -z "$HOST_IP" ] && HOST_IP="localhost"
+
+cat <<EOF
+
+──────────────────────────────────────────────────────────────────
+  ✓ forty-two-watts is running.
+
+  Open the dashboard:
+     http://${HOST_IP}:8080/         (from another device on the LAN)
+     http://localhost:8080/          (from this machine)
+
+  First-time setup wizard:
+     http://${HOST_IP}:8080/setup
+
+  Install directory:    ${INSTALL_DIR}
+  Persistent data:      ${INSTALL_DIR}/data/
+    └── config.yaml, state.db, battery models, cold/ rolloff
+
+  Manage the container (from ${INSTALL_DIR}):
+     docker compose logs -f                      # tail logs
+     docker compose pull && docker compose up -d # upgrade
+     docker compose down                         # stop
+
+EOF
+
+if [ "$NEED_RELOGIN" = "1" ]; then
+  cat <<'EOF'
+  NOTE: your current shell isn't in the docker group yet. Until you log
+        out + back in (or run 'newgrp docker'), prefix docker commands
+        with sudo, e.g.  `sudo docker compose logs -f`.
+
+EOF
+fi
+
+echo "──────────────────────────────────────────────────────────────────"

--- a/web/app.js
+++ b/web/app.js
@@ -1448,13 +1448,22 @@
 
   var evRefreshTimer = null;
   if (cardEv && evModal) {
-    cardEv.addEventListener("click", function () {
+    function openEvModal() {
       evModal.classList.remove("hidden");
       refreshEvModal();
       // Guard against stacked timers if the card is clicked while the
       // modal is still open (e.g. background click that didn't close).
       if (evRefreshTimer) { clearInterval(evRefreshTimer); }
       evRefreshTimer = setInterval(refreshEvModal, 5000);
+    }
+    cardEv.addEventListener("click", openEvModal);
+    // The card has role="button" + tabindex="0" so it's keyboard-focusable;
+    // WAI-ARIA requires Enter + Space to activate a role="button" element.
+    cardEv.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openEvModal();
+      }
     });
     function closeEvModal() {
       evModal.classList.add("hidden");

--- a/web/app.js
+++ b/web/app.js
@@ -1304,16 +1304,21 @@
       });
   }
 
+  // Fire-and-forget wrappers around postJson. postJson itself rethrows
+  // so callers that chain .then/.finally (evCommand) behave correctly;
+  // here we explicitly mark the rejection handled so the browser
+  // doesn't log "Uncaught (in promise)" on every network hiccup.
+  // postJson has already console.warn'd the failure.
   function setTarget(w) {
-    postJson("/api/target", { grid_target_w: w });
+    postJson("/api/target", { grid_target_w: w }).catch(function () {});
   }
 
   function setPeakLimit(w) {
-    postJson("/api/peak_limit", { peak_limit_w: w });
+    postJson("/api/peak_limit", { peak_limit_w: w }).catch(function () {});
   }
 
   function setEvCharging(w) {
-    postJson("/api/ev_charging", { power_w: w, active: w > 0 });
+    postJson("/api/ev_charging", { power_w: w, active: w > 0 }).catch(function () {});
   }
 
   function postJson(url, body) {

--- a/web/app.js
+++ b/web/app.js
@@ -1317,7 +1317,7 @@
   }
 
   function postJson(url, body) {
-    fetch(url, {
+    return fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -1325,11 +1325,13 @@
       .then(function (res) {
         if (!res.ok) throw new Error("HTTP " + res.status);
         fetchStatus();
+        return res;
       })
       .catch(function (e) {
         console.warn("POST failed:", url, e);
         // Don't flip connection state on POST failures —
         // connection state reflects read polling, not write commands
+        throw e;
       });
   }
 
@@ -1448,14 +1450,37 @@
 
   var evRefreshTimer = null;
   if (cardEv && evModal) {
+    var evBtnStart = document.getElementById("ev-btn-start");
+    var evBtnPause = document.getElementById("ev-btn-pause");
+    var evBtnResume = document.getElementById("ev-btn-resume");
+    var evActionBtns = [evBtnStart, evBtnPause, evBtnResume];
+    // Focus-trap bounds — first and last focusable controls in the modal.
+    // Tab from the last wraps to the first and vice versa.
+    var evFocusable = [evModalClose, evBtnStart, evBtnPause, evBtnResume];
+    var evLastFocused = null;
+
     function openEvModal() {
+      evLastFocused = document.activeElement;
       evModal.classList.remove("hidden");
+      evModal.setAttribute("aria-hidden", "false");
       refreshEvModal();
       // Guard against stacked timers if the card is clicked while the
       // modal is still open (e.g. background click that didn't close).
       if (evRefreshTimer) { clearInterval(evRefreshTimer); }
       evRefreshTimer = setInterval(refreshEvModal, 5000);
+      // Focus lands on the close button so ESC/Enter work immediately.
+      setTimeout(function () { evModalClose.focus(); }, 0);
     }
+    function closeEvModal() {
+      evModal.classList.add("hidden");
+      evModal.setAttribute("aria-hidden", "true");
+      if (evRefreshTimer) { clearInterval(evRefreshTimer); evRefreshTimer = null; }
+      if (evLastFocused && typeof evLastFocused.focus === "function") {
+        evLastFocused.focus();
+      }
+    }
+    function isEvModalOpen() { return !evModal.classList.contains("hidden"); }
+
     cardEv.addEventListener("click", openEvModal);
     // The card has role="button" + tabindex="0" so it's keyboard-focusable;
     // WAI-ARIA requires Enter + Space to activate a role="button" element.
@@ -1465,26 +1490,48 @@
         openEvModal();
       }
     });
-    function closeEvModal() {
-      evModal.classList.add("hidden");
-      if (evRefreshTimer) { clearInterval(evRefreshTimer); evRefreshTimer = null; }
-    }
     evModalClose.addEventListener("click", closeEvModal);
     evModal.addEventListener("click", function (e) {
       if (e.target === evModal) closeEvModal();
     });
+    // ESC-to-close + Tab focus trap. Attached to the modal itself so the
+    // listener is only live while one of its descendants has focus.
+    evModal.addEventListener("keydown", function (e) {
+      if (!isEvModalOpen()) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeEvModal();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      var enabled = evFocusable.filter(function (b) { return b && !b.disabled; });
+      if (enabled.length === 0) return;
+      var first = enabled[0];
+      var last = enabled[enabled.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
 
-    function evCommand(action, btn) {
-      btn.disabled = true;
-      postJson("/api/ev/command", { action: action });
-      setTimeout(function () { refreshEvModal(); btn.disabled = false; }, 3000);
+    function evCommand(action) {
+      // Disable all three action buttons while any command is inflight so
+      // a Pause→Resume double-click can't send both. The close button
+      // stays enabled so the user can always dismiss the modal.
+      evActionBtns.forEach(function (b) { b.disabled = true; });
+      postJson("/api/ev/command", { action: action })
+        .catch(function () { /* postJson already logs */ })
+        .finally(function () {
+          refreshEvModal();
+          evActionBtns.forEach(function (b) { b.disabled = false; });
+        });
     }
-    var evBtnStart = document.getElementById("ev-btn-start");
-    var evBtnPause = document.getElementById("ev-btn-pause");
-    var evBtnResume = document.getElementById("ev-btn-resume");
-    evBtnStart.addEventListener("click", function () { evCommand("ev_start", evBtnStart); });
-    evBtnPause.addEventListener("click", function () { evCommand("ev_pause", evBtnPause); });
-    evBtnResume.addEventListener("click", function () { evCommand("ev_resume", evBtnResume); });
+    evBtnStart.addEventListener("click", function () { evCommand("ev_start"); });
+    evBtnPause.addEventListener("click", function () { evCommand("ev_pause"); });
+    evBtnResume.addEventListener("click", function () { evCommand("ev_resume"); });
   }
 
   // Click-to-toggle legend items. Each item has data-toggle with a

--- a/web/app.js
+++ b/web/app.js
@@ -1385,8 +1385,98 @@
     setPeakLimit(Number(peakLimitSlider.value));
   });
 
-  // EV slider removed — ev_charging_w now comes from the Easee driver.
-  // Manual override still available via /api/ev_charging (debug only).
+  // EV detail modal
+  var evModal = document.getElementById("ev-modal");
+  var evModalBody = document.getElementById("ev-modal-body");
+  var evModalClose = document.getElementById("ev-modal-close");
+  var cardEv = document.getElementById("card-ev");
+
+  // Render the EV modal by building DOM nodes (textContent) rather than
+  // concatenating strings into innerHTML — d.driver comes from driver
+  // config and would otherwise be an XSS vector if the config is edited
+  // by a lower-trust user.
+  function renderEvStatusTable(d) {
+    var status = d.charging ? "Charging" : (d.connected ? "Connected" : "Idle");
+    var rows = [
+      ["Status", status],
+      ["Power", formatW(d.w || 0)],
+    ];
+    if (d.session_wh != null) rows.push(["Session", (d.session_wh / 1000).toFixed(1) + " kWh"]);
+    if (d.driver) rows.push(["Driver", String(d.driver)]);
+
+    var table = document.createElement("table");
+    table.style.width = "100%";
+    table.style.borderCollapse = "collapse";
+    rows.forEach(function (r) {
+      var tr = document.createElement("tr");
+      var tdLabel = document.createElement("td");
+      tdLabel.style.padding = "0.3rem 0";
+      tdLabel.style.color = "var(--text-dim)";
+      tdLabel.textContent = r[0];
+      var tdVal = document.createElement("td");
+      tdVal.style.padding = "0.3rem 0";
+      tdVal.style.textAlign = "right";
+      tdVal.style.fontWeight = "600";
+      tdVal.textContent = r[1];
+      tr.appendChild(tdLabel);
+      tr.appendChild(tdVal);
+      table.appendChild(tr);
+    });
+    return table;
+  }
+
+  function setEvModalMessage(text) {
+    evModalBody.textContent = "";
+    var p = document.createElement("p");
+    p.style.color = "var(--text-dim)";
+    p.textContent = text;
+    evModalBody.appendChild(p);
+  }
+
+  function refreshEvModal() {
+    fetch("/api/ev/status").then(function (r) { return r.json(); }).then(function (d) {
+      if (!d || d.connected === false) {
+        setEvModalMessage("No EV charger connected");
+        return;
+      }
+      evModalBody.textContent = "";
+      evModalBody.appendChild(renderEvStatusTable(d));
+    }).catch(function () {
+      setEvModalMessage("Failed to load EV status");
+    });
+  }
+
+  var evRefreshTimer = null;
+  if (cardEv && evModal) {
+    cardEv.addEventListener("click", function () {
+      evModal.classList.remove("hidden");
+      refreshEvModal();
+      // Guard against stacked timers if the card is clicked while the
+      // modal is still open (e.g. background click that didn't close).
+      if (evRefreshTimer) { clearInterval(evRefreshTimer); }
+      evRefreshTimer = setInterval(refreshEvModal, 5000);
+    });
+    function closeEvModal() {
+      evModal.classList.add("hidden");
+      if (evRefreshTimer) { clearInterval(evRefreshTimer); evRefreshTimer = null; }
+    }
+    evModalClose.addEventListener("click", closeEvModal);
+    evModal.addEventListener("click", function (e) {
+      if (e.target === evModal) closeEvModal();
+    });
+
+    function evCommand(action, btn) {
+      btn.disabled = true;
+      postJson("/api/ev/command", { action: action });
+      setTimeout(function () { refreshEvModal(); btn.disabled = false; }, 3000);
+    }
+    var evBtnStart = document.getElementById("ev-btn-start");
+    var evBtnPause = document.getElementById("ev-btn-pause");
+    var evBtnResume = document.getElementById("ev-btn-resume");
+    evBtnStart.addEventListener("click", function () { evCommand("ev_start", evBtnStart); });
+    evBtnPause.addEventListener("click", function () { evCommand("ev_pause", evBtnPause); });
+    evBtnResume.addEventListener("click", function () { evCommand("ev_resume", evBtnResume); });
+  }
 
   // Click-to-toggle legend items. Each item has data-toggle with a
   // key; clicking toggles visibility of the matching series and

--- a/web/index.html
+++ b/web/index.html
@@ -276,11 +276,11 @@
   </footer>
 
   <!-- EV detail popup -->
-  <div id="ev-modal" class="modal hidden">
+  <div id="ev-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="ev-modal-title" aria-hidden="true">
     <div class="modal-content" style="max-width:380px">
       <div class="modal-header">
-        <h2>EV Charger</h2>
-        <button id="ev-modal-close" class="modal-close">&times;</button>
+        <h2 id="ev-modal-title">EV Charger</h2>
+        <button id="ev-modal-close" class="modal-close" aria-label="Close">&times;</button>
       </div>
       <div class="modal-body" id="ev-modal-body" style="padding:1rem">
         <p style="color:var(--text-dim)">Loading...</p>

--- a/web/index.html
+++ b/web/index.html
@@ -86,7 +86,8 @@
         <div class="fuse-bar" id="fuse-bar-fallback"><div class="fuse-fill" id="fuse-fill"></div></div>
         <div class="card-value fuse-fallback-value" id="fuse-use">-- A</div>
       </div>
-      <div class="card summary-card" id="card-ev" style="cursor:pointer">
+      <div class="card summary-card" id="card-ev" style="cursor:pointer"
+           role="button" tabindex="0" aria-label="Open EV charger details">
         <div class="card-label">EV</div>
         <div class="card-value" id="ev-w">-- W</div>
         <div class="card-sub" id="ev-status">--</div>

--- a/web/index.html
+++ b/web/index.html
@@ -86,7 +86,7 @@
         <div class="fuse-bar" id="fuse-bar-fallback"><div class="fuse-fill" id="fuse-fill"></div></div>
         <div class="card-value fuse-fallback-value" id="fuse-use">-- A</div>
       </div>
-      <div class="card summary-card" id="card-ev">
+      <div class="card summary-card" id="card-ev" style="cursor:pointer">
         <div class="card-label">EV</div>
         <div class="card-value" id="ev-w">-- W</div>
         <div class="card-sub" id="ev-status">--</div>
@@ -274,6 +274,24 @@
     <span class="footer-tagline">Don't Panic 🐬</span>
   </footer>
 
+  <!-- EV detail popup -->
+  <div id="ev-modal" class="modal hidden">
+    <div class="modal-content" style="max-width:380px">
+      <div class="modal-header">
+        <h2>EV Charger</h2>
+        <button id="ev-modal-close" class="modal-close">&times;</button>
+      </div>
+      <div class="modal-body" id="ev-modal-body" style="padding:1rem">
+        <p style="color:var(--text-dim)">Loading...</p>
+      </div>
+      <div style="display:flex;gap:0.5rem;padding:0 1rem 1rem">
+        <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
+        <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
+        <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
+      </div>
+    </div>
+  </div>
+
   <script src="/app.js?v=de88f43m"></script>
   <script src="/settings.js?v=de88f43m"></script>
   <script src="/models.js?v=de88f43m"></script>
@@ -307,5 +325,7 @@
       });
     })();
   </script>
+
+
 </body>
 </html>

--- a/web/plan.js
+++ b/web/plan.js
@@ -94,7 +94,12 @@
     // glance without reading per-slot tooltips.
     const modeBandY0 = priceY0 + priceH + 2;
 
-    // Power band in middle — covers battery + grid
+    // Power band in middle — covers battery + grid.
+    // Several later sections ("Plan battery bars", "Load forecast",
+    // predicted-zone shade, etc.) reference `plan` directly. Keep this
+    // alias — removing it leaves those `plan` references undefined and
+    // the whole render throws, wiping the chart.
+    const plan = state.plan;
     const powerY0 = modeBandY0 + modeBandH + 4;
     const powerH = plotH * 0.42;
     // Scale off the fuse (what the site can *physically* deliver) plus a

--- a/web/plan.js
+++ b/web/plan.js
@@ -11,19 +11,22 @@
     prices: null,
     forecast: null,
     plan: null,
+    fuse: null,         // { max_amps, phases, voltage } — drives the power y-axis
     lastUpdate: null,
   };
 
   async function fetchAll() {
-    const [p, f, m] = await Promise.all([
+    const [p, f, m, c] = await Promise.all([
       fetch('/api/prices').then(r => r.json()).catch(() => ({})),
       fetch('/api/forecast').then(r => r.json()).catch(() => ({})),
       fetch('/api/mpc/plan').then(r => r.json()).catch(() => ({})),
+      fetch('/api/config').then(r => r.json()).catch(() => ({})),
     ]);
     state.prices = (p && p.items) || [];
     state.forecast = (f && f.items) || [];
     state.plan = (m && m.plan) || null;
     state.planMeta = (m && m.meta) || null;
+    state.fuse = (c && c.fuse) || null;
     state.enabled = {
       prices: p && p.enabled,
       forecast: f && f.enabled,
@@ -94,18 +97,14 @@
     // Power band in middle — covers battery + grid
     const powerY0 = modeBandY0 + modeBandH + 4;
     const powerH = plotH * 0.42;
-    // Scale based on plan battery + PV magnitudes
-    const plan = state.plan;
-    let pMagMax = 1000;
-    if (plan && plan.actions) {
-      for (const a of plan.actions) {
-        pMagMax = Math.max(pMagMax, Math.abs(a.battery_w), Math.abs(a.grid_w), Math.abs(a.pv_w));
-      }
-    } else {
-      for (const f of state.forecast || []) {
-        if (f.pv_w_estimated) pMagMax = Math.max(pMagMax, f.pv_w_estimated);
-      }
-    }
+    // Scale off the fuse (what the site can *physically* deliver) plus a
+    // 15% headroom so peak transients don't clip. e.g. 16 A × 3 φ × 230 V
+    // ≈ 11 kW → y-axis spans ±12.7 kW. A fixed scale makes it easier to
+    // eyeball plan magnitudes across runs instead of re-interpreting the
+    // axis every time the max sample changes.
+    const fuse = state.fuse || {};
+    const fuseMaxW = (fuse.max_amps || 16) * (fuse.phases || 3) * (fuse.voltage || 230);
+    let pMagMax = fuseMaxW * 1.15;
     const powerYCenter = powerY0 + powerH / 2;
     const powerY = w => powerYCenter - (w / pMagMax) * (powerH / 2);
 

--- a/web/plan.js
+++ b/web/plan.js
@@ -237,17 +237,34 @@
     ctx.textAlign = 'left';
     ctx.fillText('Price', pad.l + 4, priceY0 + 12);
 
-    // ---- Forecast PV line (negative = generation, site sign) ----
+    // ---- PV line (negative = generation, site sign) ----
+    // Prefer the plan's own per-slot pv_w when the optimiser is running
+    // — that's the number that drove the charge/idle/discharge
+    // decisions, and it's what you want to compare against reality when
+    // the battery behaves unexpectedly (e.g. plan says 0.8 kW PV,
+    // reality is 4.6 kW, so the battery absorbs the unforecast surplus).
+    // Fall back to the raw weather forecast when there's no plan.
     ctx.strokeStyle = 'rgba(34,197,94,0.9)';
     ctx.lineWidth = 2;
     ctx.beginPath();
     let first = true;
-    for (const f of state.forecast || []) {
-      if (f.slot_ts_ms > tMax || !f.pv_w_estimated) continue;
-      const x = xScale(f.slot_ts_ms);
-      const y = powerY(-f.pv_w_estimated); // site sign
-      if (first) { ctx.moveTo(x, y); first = false; }
-      else ctx.lineTo(x, y);
+    if (plan && plan.actions && plan.actions.length) {
+      for (const a of plan.actions) {
+        if (a.slot_start_ms > tMax) break;
+        if (a.pv_w == null) continue;
+        const x = xScale(a.slot_start_ms);
+        const y = powerY(a.pv_w); // plan.pv_w is already site-signed
+        if (first) { ctx.moveTo(x, y); first = false; }
+        else ctx.lineTo(x, y);
+      }
+    } else {
+      for (const f of state.forecast || []) {
+        if (f.slot_ts_ms > tMax || !f.pv_w_estimated) continue;
+        const x = xScale(f.slot_ts_ms);
+        const y = powerY(-f.pv_w_estimated); // flip forecast → site sign
+        if (first) { ctx.moveTo(x, y); first = false; }
+        else ctx.lineTo(x, y);
+      }
     }
     ctx.stroke();
 

--- a/web/settings.js
+++ b/web/settings.js
@@ -255,10 +255,27 @@
               if (!email) { if (statusEl) statusEl.textContent = "Enter email first"; return; }
               if (statusEl) statusEl.textContent = "Connecting...";
               btn.disabled = true;
+              // Derive the provider name from the driver's lua path so a new
+              // cloud driver can slot in without touching this button — e.g.
+              // "drivers/easee_cloud.lua" → "easee". Strip any directory
+              // prefix, the trailing "_cloud" tag, and the ".lua" extension;
+              // fall back to "easee" when nothing matches (preserves current
+              // behavior for oddly-named files and for the case where the
+              // driver config itself is missing a lua path).
+              var dCfg = currentConfig && currentConfig.drivers
+                ? currentConfig.drivers[dIdx] : null;
+              var provider = "easee";
+              if (dCfg && typeof dCfg.lua === "string" && dCfg.lua !== "") {
+                provider = dCfg.lua
+                  .replace(/^.*[\\/]/, "")   // strip dirs
+                  .replace(/\.lua$/i, "")
+                  .replace(/_cloud$/i, "");
+                if (!provider) provider = "easee";
+              }
               fetch("/api/ev/chargers", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ provider: "easee", email: email, password: pw })
+                body: JSON.stringify({ provider: provider, email: email, password: pw })
               }).then(function (r) {
                 if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || "HTTP " + r.status); });
                 return r.json();

--- a/web/settings.js
+++ b/web/settings.js
@@ -241,6 +241,61 @@
             currentConfig.drivers.push(driver);
             renderTab("devices");
           });
+
+          // Wire up Connect buttons for cloud drivers
+          bodyEl.querySelectorAll(".ev-connect-btn").forEach(function (btn) {
+            btn.addEventListener("click", function () {
+              var dIdx = btn.dataset.driverIdx;
+              var statusEl = document.getElementById("ev-connect-status-" + dIdx);
+              var sel = document.getElementById("ev-charger-select-" + dIdx);
+              var emailInput = bodyEl.querySelector('[data-path="drivers.' + dIdx + '.config.email"]');
+              var pwInput = bodyEl.querySelector('[data-path="drivers.' + dIdx + '.config.password"]');
+              var email = emailInput ? emailInput.value : "";
+              var pw = pwInput ? pwInput.value : "";
+              if (!email) { if (statusEl) statusEl.textContent = "Enter email first"; return; }
+              if (statusEl) statusEl.textContent = "Connecting...";
+              btn.disabled = true;
+              fetch("/api/ev/chargers", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ provider: "easee", email: email, password: pw })
+              }).then(function (r) {
+                if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || "HTTP " + r.status); });
+                return r.json();
+              }).then(function (chargers) {
+                if (!sel || !Array.isArray(chargers) || chargers.length === 0) {
+                  if (statusEl) statusEl.textContent = "No chargers found";
+                  return;
+                }
+                var d = currentConfig.drivers[dIdx];
+                var current = (d && d.config && d.config.serial) || "";
+                sel.innerHTML = "";
+                chargers.forEach(function (ch) {
+                  var opt = document.createElement("option");
+                  opt.value = ch.id;
+                  opt.textContent = ch.id + (ch.name ? "  —  " + ch.name : "");
+                  if (ch.id === current) opt.selected = true;
+                  sel.appendChild(opt);
+                });
+                // Update config immediately so save picks up the selected charger.
+                // Assign via onchange (not addEventListener) so repeated Connect
+                // clicks replace the handler instead of stacking duplicates that
+                // each write to config.
+                var selected = sel.value;
+                if (d && d.config) d.config.serial = selected;
+                if (currentConfig.ev_charger) currentConfig.ev_charger.serial = selected;
+                sel.onchange = function () {
+                  if (d && d.config) d.config.serial = sel.value;
+                  if (currentConfig.ev_charger) currentConfig.ev_charger.serial = sel.value;
+                };
+                if (statusEl) statusEl.textContent = chargers.length + " charger(s) found";
+              }).catch(function (e) {
+                if (statusEl) statusEl.textContent = "Error: " + e.message;
+              }).finally(function () {
+                btn.disabled = false;
+              });
+            });
+          });
         }, 0);
         html += '<div class="devices-list">';
         currentConfig.drivers.forEach(function (d, idx) {
@@ -322,15 +377,24 @@
               : '<span class="creds-badge creds-missing">⚠ Not saved</span>';
             html += '<fieldset><legend>Cloud credentials</legend>' +
               '<div class="field-row"><div>' +
-              '<label>Email / phone ' + help('Account email or phone number (with country code, e.g. +46...) for the cloud service.') + '</label>' +
+              '<label>Email ' + help('Account email for the cloud service.') + '</label>' +
               '<input type="text" data-path="drivers.' + idx + '.config.email" value="' + escHtml(cfg.email || '') + '">' +
               '</div><div>' +
               '<label>Password ' + pwBadge + '</label>' +
               '<input type="password" data-path="drivers.' + idx + '.config.password" value="" ' +
                 'placeholder="' + (hasPw ? '•••••••• (leave empty to keep)' : 'enter password') + '">' +
               '</div></div>' +
-              '<label>Device serial ' + help('Serial number of the charger. Leave empty to auto-detect.') + '</label>' +
-              '<input type="text" data-path="drivers.' + idx + '.config.serial" value="' + escHtml(cfg.serial || '') + '">' +
+              '<div class="field-row" style="align-items:flex-end"><div style="flex:1">' +
+              '<label>Charger ' + help('Click Connect to load chargers from your account.') + '</label>' +
+              '<select id="ev-charger-select-' + idx + '" data-path="drivers.' + idx + '.config.serial">' +
+              (cfg.serial
+                ? '<option value="' + escHtml(cfg.serial) + '" selected>' + escHtml(cfg.serial) + '</option>'
+                : '<option value="">(not connected)</option>') +
+              '</select>' +
+              '</div><div>' +
+              '<button class="btn-add ev-connect-btn" type="button" data-driver-idx="' + idx + '">Connect</button>' +
+              '</div></div>' +
+              '<span id="ev-connect-status-' + idx + '" style="font-size:0.8rem;color:var(--text-dim)"></span>' +
               '</fieldset>';
           }
           html += '</div>';

--- a/web/settings.js
+++ b/web/settings.js
@@ -316,22 +316,20 @@
         }, 0);
         html += '<div class="devices-list">';
         currentConfig.drivers.forEach(function (d, idx) {
-          // Go-port config: d.wasm (or legacy d.lua), capabilities.mqtt/modbus
           var cap = d.capabilities || {};
           var mqtt = cap.mqtt || d.mqtt; // legacy fallback
           var modbus = cap.modbus || d.modbus;
           var protocol = mqtt ? "mqtt" : (modbus ? "modbus" : (cap.http ? "http" : "?"));
-          var driverFile = d.wasm || d.lua || "(none)";
-          var fmtKind = d.wasm ? "wasm" : (d.lua ? "lua" : "?");
+          var driverFile = d.lua || "(none)";
           html += '<div class="device-item">' +
             '<div class="device-item-header">' +
             '<strong>' + escHtml(d.name) + '</strong>' +
-            '<span style="color:var(--text-dim);font-size:0.75rem">' + fmtKind + ' · ' + protocol + ' · ' + escHtml(driverFile) + '</span>' +
+            '<span style="color:var(--text-dim);font-size:0.75rem">lua · ' + protocol + ' · ' + escHtml(driverFile) + '</span>' +
             '<button class="btn-remove" data-remove-idx="' + idx + '">Remove</button>' +
             '</div>' +
             '<div class="field-row"><div>' +
-            '<label>Driver file ' + help('Path to the .wasm (or legacy .lua) driver. Absolute or relative to the config file directory.') + '</label>' +
-            '<input type="text" data-path="drivers.' + idx + '.' + fmtKind + '" value="' + escHtml(driverFile) + '">' +
+            '<label>Driver file ' + help('Path to the .lua driver. Absolute or relative to the config file directory.') + '</label>' +
+            '<input type="text" data-path="drivers.' + idx + '.lua" value="' + escHtml(driverFile) + '">' +
             '</div><div>' +
             '<label>Battery capacity (kWh) ' + help('Nameplate storage capacity in kilowatt-hours. Stored internally as Wh.') + '</label>' +
             '<input type="number" step="0.1" data-path="drivers.' + idx + '.battery_capacity_wh" data-unit-scale="1000" value="' + ((d.battery_capacity_wh || 0) / 1000) + '">' +

--- a/web/style.css
+++ b/web/style.css
@@ -658,7 +658,7 @@ footer {
 
 .controls-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
   margin-top: 12px;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1086,17 +1086,13 @@ footer {
   align-items: baseline;
 }
 
-/* Stack live + plan vertically by default — both charts read better
-   full-width. Only split on very wide screens (desktops) to save
-   vertical scrolling; most users get the stacked layout. */
+/* Always stack live + plan vertically — both charts are easier to read
+   full-width than squeezed into 50% even on wide desktops. */
 .live-plan-row {
   display: grid;
   grid-template-columns: 1fr;
   gap: 16px;
   margin-top: 14px;
-}
-@media (min-width: 1800px) {
-  .live-plan-row { grid-template-columns: 1fr 1fr; }
 }
 .live-plan-row > section { min-width: 0; }
 .live-plan-row .chart-container canvas { width: 100%; display: block; }


### PR DESCRIPTION
…rn, dashboard modal

Easee driver:
- Switch from deprecated /chargers/{id}/state to /state/{id}/observations endpoint with specific observation IDs (power, mode, session energy)
- Parse wrapped {observations: [...]} response format
- Fix charger auto-detect field (use .id from chargers list)

EV cloud provider pattern:
- New evcloud package with Provider interface (ListChargers)
- Easee implementation self-registers via init()
- API dispatches by provider name, defaults to "easee"

Driver path fixes:
- Strip leading "../" from driver paths on config load
- GET /api/config returns config-relative paths (no ../ in UI)
- Consolidated ResolveDriverPaths/UnresolveDriverPaths methods
- InjectEVChargerDriver paths now properly resolved

Settings UI:
- Connect button on cloud driver cards loads chargers into dropdown
- Selected charger syncs to both driver config and ev_charger config
- Grid tariff label clarified as "excl. VAT"

Dashboard:
- Clickable EV card opens detail modal with live status and power
- Start/Pause/Resume buttons dispatch commands to the EV driver
- Modal auto-refreshes every 5s while open
- New /api/ev/status, /api/ev/command endpoints
- Driver registry wired into API deps for command dispatch