### PR TITLE
feat: EV driver UI + lifecycle controls + creds visibility

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -128,6 +128,55 @@ end
 --   5 = error
 --   6 = ready to charge
 
+local OP_MODE_LABELS = {
+    [0] = "offline",
+    [1] = "disconnected",
+    [2] = "awaiting start",
+    [3] = "charging",
+    [4] = "completed",
+    [5] = "error",
+    [6] = "ready",
+}
+
+-- Easee ReasonForNoCurrent. 0 = charger OK (no reason to surface).
+-- Source: developer.easee.com/docs/enumerations
+local REASON_LABELS = {
+    [0]   = nil, -- no reason
+    [1]   = "max circuit current too low",
+    [2]   = "dynamic circuit current too low",
+    [3]   = "offline fallback circuit current too low",
+    [4]   = "circuit fuse too low",
+    [5]   = "waiting in queue",
+    [6]   = "waiting (other cars fully charged)",
+    [7]   = "illegal grid type",
+    [8]   = "no current request from primary",
+    [9]   = "max dynamic charger current too low",
+    [10]  = "phase imbalance",
+    [11]  = "equalizer communication lost",
+    [25]  = "equalizer dynamic limit too low",
+    [26]  = "equalizer static limit too low",
+    [27]  = "offline fallback equalizer too low",
+    [28]  = "fuse limit reached",
+    [29]  = "current limited by equalizer",
+    [30]  = "current limited by offline equalizer",
+    [50]  = "secondary unit not requesting current",
+    [51]  = "max charger current too low",
+    [52]  = "max dynamic charger current too low",
+    [53]  = "charger disabled",
+    [54]  = "pending scheduled charging",
+    [55]  = "pending authorization",
+    [56]  = "charger in error state",
+    [57]  = "erratic EV",
+    [75]  = "limited by cable rating",
+    [76]  = "limited by schedule",
+    [77]  = "limited by charger current",
+    [78]  = "limited by dynamic charger current",
+    [79]  = "car not drawing current",
+    [80]  = "current ramping",
+    [81]  = "limited by car",
+    [100] = "undefined error",
+}
+
 local email, password
 
 function driver_init(config)
@@ -184,17 +233,20 @@ function driver_poll()
     local connected = (op_mode >= 2 and op_mode <= 6)
     local charging = (op_mode == 3)
 
+    local reason_code = state.reasonForNoCurrent
     host.emit("ev", {
-        w                 = power_w,
-        connected         = connected,
-        charging          = charging,
-        session_wh        = session_wh,
-        op_mode           = op_mode,                     -- 1=disc,2=awaiting,3=charging,4=completed,5=error,6=ready
-        reason_no_current = state.reasonForNoCurrent,    -- int: 0=ok; why NOT drawing current
-        is_online         = state.isOnline,              -- Easee cloud considers charger online
-        cable_locked      = state.cableLocked,
-        max_a             = state.dynamicChargerCurrent, -- current dynamic limit (A)
-        phases            = 3,                           -- Easee defaults 3-phase
+        w                       = power_w,
+        connected               = connected,
+        charging                = charging,
+        session_wh              = session_wh,
+        op_mode                 = op_mode,                     -- 1=disc,2=awaiting,3=charging,4=completed,5=error,6=ready
+        state_label             = OP_MODE_LABELS[op_mode] or "unknown",
+        reason_no_current       = reason_code,                 -- int: 0=ok; why NOT drawing current
+        reason_no_current_label = reason_code and REASON_LABELS[reason_code], -- nil if 0/ok, string otherwise
+        is_online               = state.isOnline,              -- Easee cloud considers charger online
+        cable_locked            = state.cableLocked,
+        max_a                   = state.dynamicChargerCurrent, -- current dynamic limit (A)
+        phases                  = 3,                           -- Easee defaults 3-phase
     })
 
     -- Diagnostic metrics

--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -185,10 +185,16 @@ function driver_poll()
     local charging = (op_mode == 3)
 
     host.emit("ev", {
-        w          = power_w,
-        connected  = connected,
-        charging   = charging,
-        session_wh = session_wh,
+        w                 = power_w,
+        connected         = connected,
+        charging          = charging,
+        session_wh        = session_wh,
+        op_mode           = op_mode,                     -- 1=disc,2=awaiting,3=charging,4=completed,5=error,6=ready
+        reason_no_current = state.reasonForNoCurrent,    -- int: 0=ok; why NOT drawing current
+        is_online         = state.isOnline,              -- Easee cloud considers charger online
+        cable_locked      = state.cableLocked,
+        max_a             = state.dynamicChargerCurrent, -- current dynamic limit (A)
+        phases            = 3,                           -- Easee defaults 3-phase
     })
 
     -- Diagnostic metrics
@@ -200,6 +206,12 @@ function driver_poll()
     end
     if state.lifetimeEnergy then
         host.emit_metric("ev_lifetime_kwh", state.lifetimeEnergy)
+    end
+    if state.dynamicChargerCurrent then
+        host.emit_metric("ev_dynamic_current_a", state.dynamicChargerCurrent)
+    end
+    if state.temperature then
+        host.emit_metric("ev_temp_c", state.temperature)
     end
 
     return 5000

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -153,6 +153,10 @@ func main() {
 	reg.ARPLookup = arp.Lookup
 	// Spawn initial drivers
 	for _, d := range cfg.Drivers {
+		if d.Disabled {
+			slog.Info("driver skipped (disabled)", "name", d.Name)
+			continue
+		}
 		// Resolve relative WASM paths against config dir
 		if d.WASM != "" && !filepath.IsAbs(d.WASM) {
 			d.WASM = filepath.Join(filepath.Dir(*configPath), d.WASM)
@@ -394,6 +398,7 @@ func main() {
 		PVModel:    pvSvc,
 		LoadModel:  loadSvc,
 		HA:         haBridge,
+		Registry:   reg,
 		Version:    Version,
 	}
 	srv := api.New(deps)

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -295,27 +295,34 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			d["ev_w"] = r.SmoothedW
 			// Surface the structured fields the driver put in Data so the
 			// UI can render a proper EV card (plug state, reason, limits).
+			// All labels are rendered by the driver itself — the UI
+			// just displays strings verbatim. Codes are also surfaced
+			// for anyone who wants to filter/route on them.
 			var ev struct {
-				Connected       *bool    `json:"connected"`
-				Charging        *bool    `json:"charging"`
-				SessionWh       *float64 `json:"session_wh"`
-				OpMode          *int     `json:"op_mode"`
-				ReasonNoCurrent *int     `json:"reason_no_current"`
-				IsOnline        *bool    `json:"is_online"`
-				CableLocked     *bool    `json:"cable_locked"`
-				MaxA            *float64 `json:"max_a"`
-				Phases          *int     `json:"phases"`
+				Connected            *bool    `json:"connected"`
+				Charging             *bool    `json:"charging"`
+				SessionWh            *float64 `json:"session_wh"`
+				OpMode               *int     `json:"op_mode"`
+				StateLabel           *string  `json:"state_label"`
+				ReasonNoCurrent      *int     `json:"reason_no_current"`
+				ReasonNoCurrentLabel *string  `json:"reason_no_current_label"`
+				IsOnline             *bool    `json:"is_online"`
+				CableLocked          *bool    `json:"cable_locked"`
+				MaxA                 *float64 `json:"max_a"`
+				Phases               *int     `json:"phases"`
 			}
 			if r.Data != nil && json.Unmarshal(r.Data, &ev) == nil {
-				if ev.Connected != nil       { d["ev_connected"] = *ev.Connected }
-				if ev.Charging != nil        { d["ev_charging"] = *ev.Charging }
-				if ev.SessionWh != nil       { d["ev_session_wh"] = *ev.SessionWh }
-				if ev.OpMode != nil          { d["ev_op_mode"] = *ev.OpMode }
-				if ev.ReasonNoCurrent != nil { d["ev_reason_no_current"] = *ev.ReasonNoCurrent }
-				if ev.IsOnline != nil        { d["ev_is_online"] = *ev.IsOnline }
-				if ev.CableLocked != nil     { d["ev_cable_locked"] = *ev.CableLocked }
-				if ev.MaxA != nil            { d["ev_max_a"] = *ev.MaxA }
-				if ev.Phases != nil          { d["ev_phases"] = *ev.Phases }
+				if ev.Connected != nil            { d["ev_connected"] = *ev.Connected }
+				if ev.Charging != nil             { d["ev_charging"] = *ev.Charging }
+				if ev.SessionWh != nil            { d["ev_session_wh"] = *ev.SessionWh }
+				if ev.OpMode != nil               { d["ev_op_mode"] = *ev.OpMode }
+				if ev.StateLabel != nil           { d["ev_state_label"] = *ev.StateLabel }
+				if ev.ReasonNoCurrent != nil      { d["ev_reason_no_current"] = *ev.ReasonNoCurrent }
+				if ev.ReasonNoCurrentLabel != nil { d["ev_reason_no_current_label"] = *ev.ReasonNoCurrentLabel }
+				if ev.IsOnline != nil             { d["ev_is_online"] = *ev.IsOnline }
+				if ev.CableLocked != nil          { d["ev_cable_locked"] = *ev.CableLocked }
+				if ev.MaxA != nil                 { d["ev_max_a"] = *ev.MaxA }
+				if ev.Phases != nil               { d["ev_phases"] = *ev.Phases }
 			}
 		}
 		drivers[name] = d

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -80,6 +80,10 @@ type Deps struct {
 	// Optional: HA MQTT bridge (nil if disabled).
 	HA *ha.Bridge
 
+	// Driver registry — used by lifecycle endpoints (restart/disable/enable).
+	// Nil disables those endpoints (returns 503).
+	Registry *drivers.Registry
+
 	Version string
 }
 
@@ -119,6 +123,9 @@ func (s *Server) routes() {
 	s.handle("POST /api/ev_charging", s.handleSetEVCharging)
 	s.handle("GET  /api/drivers", s.handleDrivers)
 	s.handle("GET  /api/drivers/catalog", s.handleDriversCatalog)
+	s.handle("POST /api/drivers/{name}/restart", s.handleDriverRestart)
+	s.handle("POST /api/drivers/{name}/disable", s.handleDriverDisable)
+	s.handle("POST /api/drivers/{name}/enable", s.handleDriverEnable)
 	s.handle("GET  /api/ha/status", s.handleHAStatus)
 	s.handle("GET  /api/battery_models", s.handleGetModels)
 	s.handle("POST /api/battery_models/reset", s.handleResetModel)
@@ -284,8 +291,60 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 				d["bat_soc"] = *r.SoC
 			}
 		}
+		if r := s.deps.Tel.Get(name, telemetry.DerEV); r != nil {
+			d["ev_w"] = r.SmoothedW
+			// Surface the structured fields the driver put in Data so the
+			// UI can render a proper EV card (plug state, reason, limits).
+			var ev struct {
+				Connected       *bool    `json:"connected"`
+				Charging        *bool    `json:"charging"`
+				SessionWh       *float64 `json:"session_wh"`
+				OpMode          *int     `json:"op_mode"`
+				ReasonNoCurrent *int     `json:"reason_no_current"`
+				IsOnline        *bool    `json:"is_online"`
+				CableLocked     *bool    `json:"cable_locked"`
+				MaxA            *float64 `json:"max_a"`
+				Phases          *int     `json:"phases"`
+			}
+			if r.Data != nil && json.Unmarshal(r.Data, &ev) == nil {
+				if ev.Connected != nil       { d["ev_connected"] = *ev.Connected }
+				if ev.Charging != nil        { d["ev_charging"] = *ev.Charging }
+				if ev.SessionWh != nil       { d["ev_session_wh"] = *ev.SessionWh }
+				if ev.OpMode != nil          { d["ev_op_mode"] = *ev.OpMode }
+				if ev.ReasonNoCurrent != nil { d["ev_reason_no_current"] = *ev.ReasonNoCurrent }
+				if ev.IsOnline != nil        { d["ev_is_online"] = *ev.IsOnline }
+				if ev.CableLocked != nil     { d["ev_cable_locked"] = *ev.CableLocked }
+				if ev.MaxA != nil            { d["ev_max_a"] = *ev.MaxA }
+				if ev.Phases != nil          { d["ev_phases"] = *ev.Phases }
+			}
+		}
 		drivers[name] = d
 	}
+	// Merge config drivers that aren't in the registry so the UI can
+	// render them with a Restart or Enable button. A driver can be absent
+	// from the registry because (a) it's disabled in yaml, or (b) the
+	// initial Add failed (e.g. cloud auth error). Running drivers already
+	// populated above take precedence.
+	s.deps.CfgMu.RLock()
+	for _, dc := range s.deps.Cfg.Drivers {
+		if _, ok := drivers[dc.Name]; ok {
+			continue
+		}
+		if dc.Disabled {
+			drivers[dc.Name] = map[string]any{
+				"status":   "disabled",
+				"disabled": true,
+			}
+		} else {
+			// Configured but not running — spawn probably failed. Show
+			// as offline so the user sees it and can Restart.
+			drivers[dc.Name] = map[string]any{
+				"status":      "offline",
+				"not_running": true,
+			}
+		}
+	}
+	s.deps.CfgMu.RUnlock()
 
 	// Dispatch targets
 	dispatch := make([]map[string]any, 0, len(lastTargets))
@@ -369,6 +428,16 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"grid_target_w":    ctrl.GridTargetW,
 		"peak_limit_w":     ctrl.PeakLimitW,
 		"ev_charging_w":    ctrl.EVChargingW,
+		// True when an EV charger password is persisted in state.db. The
+		// Settings UI uses this to show a "credentials saved" badge so the
+		// operator can tell apart "never entered" from "saved but masked".
+		"ev_credentials_saved": func() bool {
+			if s.deps.State == nil {
+				return false
+			}
+			pw, ok := s.deps.State.LoadConfig(evPasswordKey)
+			return ok && pw != ""
+		}(),
 		"fuse":             fuseCfg,
 		"phase_amps":       phaseAmps,
 		"drivers":          drivers,
@@ -601,6 +670,104 @@ func (s *Server) handleDriversCatalog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, 200, map[string]any{"path": dir, "entries": entries})
+}
+
+// POST /api/drivers/{name}/restart — stop + re-add the driver so it
+// re-runs driver_init. Useful to force a cloud driver to re-authenticate
+// after you've updated credentials without restarting the whole process.
+func (s *Server) handleDriverRestart(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Registry == nil {
+		writeJSON(w, 503, map[string]string{"error": "registry unavailable"})
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSON(w, 400, map[string]string{"error": "missing driver name"})
+		return
+	}
+	// Look up the latest config from the in-memory cfg so the restart
+	// picks up anything the UI just changed (e.g. a new EV password
+	// injected from state.db on config POST).
+	s.deps.CfgMu.RLock()
+	var cfg *config.Driver
+	for i := range s.deps.Cfg.Drivers {
+		if s.deps.Cfg.Drivers[i].Name == name {
+			c := s.deps.Cfg.Drivers[i]
+			cfg = &c
+			break
+		}
+	}
+	s.deps.CfgMu.RUnlock()
+	if cfg == nil {
+		// Fall back to whatever the registry has — still lets you restart
+		// a driver that isn't in cfg.yaml (e.g. injected EV charger).
+		if err := s.deps.Registry.RestartByName(r.Context(), name); err != nil {
+			writeJSON(w, 404, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, 200, map[string]string{"status": "restarted", "source": "registry"})
+		return
+	}
+	if err := s.deps.Registry.Restart(r.Context(), *cfg); err != nil {
+		writeJSON(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 200, map[string]string{"status": "restarted", "source": "config"})
+}
+
+// POST /api/drivers/{name}/disable — set the Disabled flag in the
+// config and persist, stopping the running driver. Survives restarts.
+func (s *Server) handleDriverDisable(w http.ResponseWriter, r *http.Request) {
+	s.setDriverDisabled(w, r, true)
+}
+
+// POST /api/drivers/{name}/enable — clear the Disabled flag and spawn
+// the driver (if it's not already running).
+func (s *Server) handleDriverEnable(w http.ResponseWriter, r *http.Request) {
+	s.setDriverDisabled(w, r, false)
+}
+
+func (s *Server) setDriverDisabled(w http.ResponseWriter, r *http.Request, disabled bool) {
+	if s.deps.Registry == nil {
+		writeJSON(w, 503, map[string]string{"error": "registry unavailable"})
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		writeJSON(w, 400, map[string]string{"error": "missing driver name"})
+		return
+	}
+	s.deps.CfgMu.Lock()
+	found := false
+	for i := range s.deps.Cfg.Drivers {
+		if s.deps.Cfg.Drivers[i].Name == name {
+			s.deps.Cfg.Drivers[i].Disabled = disabled
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.deps.CfgMu.Unlock()
+		writeJSON(w, 404, map[string]string{"error": "driver not found in config"})
+		return
+	}
+	cfgCopy := *s.deps.Cfg
+	s.deps.CfgMu.Unlock()
+
+	// Persist to disk so the change survives restart.
+	if err := s.deps.SaveConfig(s.deps.ConfigPath, &cfgCopy); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "save failed: " + err.Error()})
+		return
+	}
+	// Apply immediately via Reload — it filters disabled drivers and
+	// stops running ones, or re-adds the newly-enabled one.
+	s.deps.Registry.Reload(r.Context(), cfgCopy.Drivers)
+
+	action := "disabled"
+	if !disabled {
+		action = "enabled"
+	}
+	writeJSON(w, 200, map[string]string{"status": action, "driver": name})
 }
 
 // GET /api/ha/status — is the HA MQTT bridge connected?

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -107,6 +107,14 @@ type Driver struct {
 	Lua                string  `yaml:"lua,omitempty" json:"lua,omitempty"`  // legacy, path to .lua file
 	IsSiteMeter        bool    `yaml:"is_site_meter,omitempty" json:"is_site_meter,omitempty"`
 	BatteryCapacityWh  float64 `yaml:"battery_capacity_wh,omitempty" json:"battery_capacity_wh,omitempty"`
+	// Disabled skips this driver at startup / reload. Set via the UI when
+	// you want to temporarily take a driver out without editing yaml.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	// HasPassword is a JSON-only signal to the UI that Config["password"]
+	// holds a non-empty value on disk. Populated by MaskSecrets after the
+	// real password is blanked out so the operator can still tell apart
+	// "never entered" from "saved but masked". Never written to yaml.
+	HasPassword bool `yaml:"-" json:"has_password,omitempty"`
 
 	// Capabilities: the resources this driver is allowed to use.
 	// Unset capabilities are explicitly denied.
@@ -284,7 +292,11 @@ func (c Config) MaskSecrets() Config {
 				for k, v := range drivers[i].Config {
 					cp[k] = v
 				}
-				if _, has := cp["password"]; has {
+				if pw, has := cp["password"]; has {
+					// Signal "stored" to the UI before we blank it out.
+					if s, ok := pw.(string); ok && s != "" {
+						drivers[i].HasPassword = true
+					}
 					cp["password"] = ""
 				}
 				drivers[i].Config = cp

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -281,7 +281,19 @@ func (r *Registry) ShutdownAll() {
 
 // Reload diffs a new driver list against running state and applies add/
 // remove/restart. Drivers with changed wasm path / capabilities are restarted.
+// Drivers marked Disabled are treated as "not in the new list" — running
+// ones get stopped, missing ones are not added.
 func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
+	// Filter out disabled drivers — they behave like removed from the
+	// registry's perspective but remain in config.yaml for re-enable.
+	active := make([]config.Driver, 0, len(newDrivers))
+	for _, d := range newDrivers {
+		if d.Disabled {
+			continue
+		}
+		active = append(active, d)
+	}
+
 	r.mu.Lock()
 	oldNames := make(map[string]bool, len(r.rec))
 	oldCfgs := make(map[string]config.Driver, len(r.rec))
@@ -291,12 +303,12 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 	}
 	r.mu.Unlock()
 
-	newNames := make(map[string]bool, len(newDrivers))
-	for _, d := range newDrivers { newNames[d.Name] = true }
+	newNames := make(map[string]bool, len(active))
+	for _, d := range active { newNames[d.Name] = true }
 
 	// Remove or restart
 	for n, old := range oldCfgs {
-		newCfg, stillThere := findDriver(newDrivers, n)
+		newCfg, stillThere := findDriver(active, n)
 		if !stillThere {
 			r.Remove(n)
 		} else if !sameDriverConfig(old, newCfg) {
@@ -305,7 +317,7 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 		}
 	}
 	// Add new
-	for _, d := range newDrivers {
+	for _, d := range active {
 		r.mu.Lock()
 		_, exists := r.rec[d.Name]
 		r.mu.Unlock()
@@ -316,6 +328,31 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 	}
 }
 
+// Restart stops a driver (if running) and re-adds it with the provided cfg.
+// If cfg.Disabled is true, this is a no-op after the stop. Used by the API
+// restart endpoint so the driver picks up fresh credentials / re-auths.
+func (r *Registry) Restart(ctx context.Context, cfg config.Driver) error {
+	r.Remove(cfg.Name)
+	if cfg.Disabled {
+		return nil
+	}
+	return r.Add(ctx, cfg)
+}
+
+// Restart a driver by name using whatever cfg it was last started with.
+// Returns an error if the driver isn't running (use Restart with a cfg
+// to spawn from scratch).
+func (r *Registry) RestartByName(ctx context.Context, name string) error {
+	r.mu.Lock()
+	rd, ok := r.rec[name]
+	r.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("driver %q not running", name)
+	}
+	cfg := rd.cfg
+	return r.Restart(ctx, cfg)
+}
+
 func findDriver(list []config.Driver, name string) (config.Driver, bool) {
 	for _, d := range list {
 		if d.Name == name { return d, true }
@@ -324,8 +361,10 @@ func findDriver(list []config.Driver, name string) (config.Driver, bool) {
 }
 
 func sameDriverConfig(a, b config.Driver) bool {
-	if a.WASM != b.WASM || a.IsSiteMeter != b.IsSiteMeter ||
-		a.BatteryCapacityWh != b.BatteryCapacityWh {
+	if a.WASM != b.WASM || a.Lua != b.Lua ||
+		a.IsSiteMeter != b.IsSiteMeter ||
+		a.BatteryCapacityWh != b.BatteryCapacityWh ||
+		a.Disabled != b.Disabled {
 		return false
 	}
 	aMq, bMq := a.EffectiveMQTT(), b.EffectiveMQTT()
@@ -339,5 +378,24 @@ func sameDriverConfig(a, b config.Driver) bool {
 	if aMb != nil && (aMb.Host != bMb.Host || aMb.Port != bMb.Port || aMb.UnitID != bMb.UnitID) {
 		return false
 	}
+	// Compare the free-form Config map. Previously omitted, so a changed
+	// cloud-driver password in drivers[i].config.password was silently
+	// ignored by the hot-reload diff — the driver kept running with the
+	// stale credentials. Deep-equal via JSON is coarse but correct for the
+	// stringly-typed config map we actually use.
+	if !sameConfigMap(a.Config, b.Config) {
+		return false
+	}
 	return true
+}
+
+// sameConfigMap compares two driver Config maps. Nil and empty are
+// treated as equal. Uses JSON marshal so order of keys doesn't matter.
+func sameConfigMap(a, b map[string]any) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	ja, _ := json.Marshal(a)
+	jb, _ := json.Marshal(b)
+	return string(ja) == string(jb)
 }

--- a/web/app.js
+++ b/web/app.js
@@ -1042,6 +1042,110 @@
     }
   }
 
+  // Easee chargerOpMode → human label
+  function evOpModeLabel(m) {
+    switch (m) {
+      case 1: return "disconnected";
+      case 2: return "awaiting start";
+      case 3: return "charging";
+      case 4: return "completed";
+      case 5: return "error";
+      case 6: return "ready";
+      default: return "unknown";
+    }
+  }
+
+  // Easee reasonForNoCurrent → human label. 0 = no limit (charging ok).
+  // Source: developer.easee.com/docs/enumerations (ReasonForNoCurrent 96).
+  // Returns null for "no reason / charging is fine" so the UI can skip the row.
+  function evReasonLabel(r) {
+    switch (r) {
+      case 0:   return null; // charger OK
+      // 1–6: load balancing / queue
+      case 1:   return "max circuit current too low";
+      case 2:   return "dynamic circuit current too low";
+      case 3:   return "offline fallback circuit current too low";
+      case 4:   return "circuit fuse too low";
+      case 5:   return "waiting in queue";
+      case 6:   return "waiting (other cars fully charged)";
+      // 7–11: grid / phase / equalizer
+      case 7:   return "illegal grid type";
+      case 8:   return "no current request from primary";
+      case 9:   return "max dynamic charger current too low";
+      case 10:  return "phase imbalance";
+      case 11:  return "equalizer communication lost";
+      // 25–30: equalizer / fuse limits
+      case 25:  return "equalizer dynamic limit too low";
+      case 26:  return "equalizer static limit too low";
+      case 27:  return "offline fallback equalizer too low";
+      case 28:  return "fuse limit reached";
+      case 29:  return "current limited by equalizer";
+      case 30:  return "current limited by offline equalizer";
+      // 50–57: secondary unit / charger state
+      case 50:  return "secondary unit not requesting current";
+      case 51:  return "max charger current too low";
+      case 52:  return "max dynamic charger current too low";
+      case 53:  return "charger disabled";
+      case 54:  return "pending scheduled charging";
+      case 55:  return "pending authorization";
+      case 56:  return "charger in error state";
+      case 57:  return "erratic EV";
+      // 75–81: cable / schedule / car
+      case 75:  return "limited by cable rating";
+      case 76:  return "limited by schedule";
+      case 77:  return "limited by charger current";
+      case 78:  return "limited by dynamic charger current";
+      case 79:  return "car not drawing current";
+      case 80:  return "current ramping";
+      case 81:  return "limited by car";
+      case 100: return "undefined error";
+      default:  return "reason " + r;
+    }
+  }
+
+  function driverLifecycleCall(name, action) {
+    return fetch("/api/drivers/" + encodeURIComponent(name) + "/" + action, { method: "POST" })
+      .then(function (res) {
+        if (!res.ok) return res.text().then(function (t) { throw new Error(t || ("HTTP " + res.status)); });
+        return res.json();
+      });
+  }
+
+  function renderDriverActions(name, d) {
+    // Buttons per driver: Restart (if running), Disable (if running),
+    // Enable (if disabled). Small, unobtrusive; rely on the existing
+    // .btn-send style from index.html.
+    var isDisabled = d.disabled === true || d.status === "disabled";
+    var actions = '<div class="driver-actions" style="margin-top:6px;display:flex;gap:6px;flex-wrap:wrap">';
+    if (isDisabled) {
+      actions += '<button class="btn-send" data-drv-action="enable" data-drv="' + escHtml(name) + '">Enable</button>';
+    } else {
+      actions += '<button class="btn-send" data-drv-action="restart" data-drv="' + escHtml(name) + '">Restart</button>';
+      actions += '<button class="btn-send" data-drv-action="disable" data-drv="' + escHtml(name) + '" style="opacity:0.75">Disable</button>';
+    }
+    actions += "</div>";
+    return actions;
+  }
+
+  // Event delegation — one listener for all driver-action buttons. Saves
+  // re-binding on every re-render.
+  if (driversGrid) {
+    driversGrid.addEventListener("click", function (ev) {
+      var btn = ev.target.closest("[data-drv-action]");
+      if (!btn) return;
+      var name = btn.getAttribute("data-drv");
+      var action = btn.getAttribute("data-drv-action");
+      if (!name || !action) return;
+      if (action === "disable" && !window.confirm("Disable driver \"" + name + "\"? It will be stopped and won't auto-start until re-enabled.")) return;
+      btn.disabled = true;
+      btn.textContent = action + "ing…";
+      driverLifecycleCall(name, action)
+        .then(function () { fetchStatus(); })
+        .catch(function (err) { alert("Driver " + action + " failed: " + err.message); })
+        .finally(function () { btn.disabled = false; });
+    });
+  }
+
   function renderDrivers(drivers, dispatchByDriver) {
     driversGrid.innerHTML = "";
     var names = Object.keys(drivers).sort();
@@ -1049,27 +1153,94 @@
       var d = drivers[name];
       var card = document.createElement("div");
       card.className = "driver-card";
+      if (d.disabled === true || d.status === "disabled") card.className += " driver-card-disabled";
+      if (d.not_running === true) card.className += " driver-card-warn";
 
-      var meterW = d.meter_w != null ? d.meter_w : 0;
-      var pvWVal = d.pv_w != null ? d.pv_w : 0;
-      var batWVal = d.bat_w != null ? d.bat_w : 0;
-      var batSocVal = d.bat_soc != null ? d.bat_soc : 0;
       var ticks = d.tick_count != null ? d.tick_count : 0;
       var errors = d.consecutive_errors != null ? d.consecutive_errors : 0;
 
-      // Battery target + tracking deviation. Skip if no dispatch (planner
-      // hasn't run) OR this driver has no battery (target meaningless).
-      var batteryRow =
-        '  <span class="stat-label">Battery</span><span class="stat-value">' + formatW(batWVal) + "</span>";
-      var disp = (dispatchByDriver || {})[name];
-      if (disp && d.bat_w != null) {
-        var dev = batWVal - disp.target_w;
-        var devClass = Math.abs(dev) > 200 ? "stat-warn" : "stat-dim";
-        batteryRow =
-          '  <span class="stat-label">Battery</span><span class="stat-value">' + formatW(batWVal) +
-          '    <span class="stat-target">→ ' + formatW(disp.target_w) + '</span>' +
-          '    <span class="' + devClass + '">Δ ' + formatW(dev) + '</span>' +
-          "</span>";
+      // Detect EV driver by presence of any ev_* field. Render a distinct
+      // card body — PV/battery/meter rows are always 0 for EV chargers.
+      var isEV = (d.ev_w != null || d.ev_connected != null || d.ev_charging != null);
+
+      var body;
+      if (isEV) {
+        var evWVal = d.ev_w != null ? d.ev_w : 0;
+        var opLabel = d.ev_op_mode != null ? evOpModeLabel(d.ev_op_mode)
+                     : (d.ev_charging ? "charging"
+                     : (d.ev_connected ? "connected" : "idle"));
+        var stateClass =
+          (d.ev_charging ? "stat-ok"
+          : (d.ev_connected ? "stat-warn" : "stat-dim"));
+        var sessionKwh = d.ev_session_wh != null ? (d.ev_session_wh / 1000).toFixed(2) + " kWh" : "—";
+        var maxA = d.ev_max_a != null ? d.ev_max_a.toFixed(0) + " A" : "—";
+        var reason = d.ev_reason_no_current != null ? evReasonLabel(d.ev_reason_no_current) : null;
+
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">State</span><span class="stat-value ' + stateClass + '">' + escHtml(opLabel) + '</span>' +
+          '  <span class="stat-label">Power</span><span class="stat-value">' + formatW(evWVal) + '</span>' +
+          '  <span class="stat-label">Session</span><span class="stat-value">' + sessionKwh + '</span>' +
+          '  <span class="stat-label">Max current</span><span class="stat-value">' + maxA + '</span>' +
+          (reason
+            ? '  <span class="stat-label">Reason</span><span class="stat-value stat-warn">' + escHtml(reason) + '</span>'
+            : '') +
+          (d.ev_cable_locked === false && d.ev_connected
+            ? '  <span class="stat-label">Cable</span><span class="stat-value stat-warn">unlocked</span>'
+            : '') +
+          (d.ev_is_online === false
+            ? '  <span class="stat-label">Cloud</span><span class="stat-value stat-warn">offline</span>'
+            : '') +
+          '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + '</span>' +
+          '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + '</span>' +
+          '</div>';
+      } else {
+        var meterW = d.meter_w != null ? d.meter_w : 0;
+        var pvWVal = d.pv_w != null ? d.pv_w : 0;
+        var batWVal = d.bat_w != null ? d.bat_w : 0;
+        var batSocVal = d.bat_soc != null ? d.bat_soc : 0;
+
+        // Battery target + tracking deviation. Skip if no dispatch (planner
+        // hasn't run) OR this driver has no battery (target meaningless).
+        var batteryRow =
+          '  <span class="stat-label">Battery</span><span class="stat-value">' + formatW(batWVal) + "</span>";
+        var disp = (dispatchByDriver || {})[name];
+        if (disp && d.bat_w != null) {
+          var dev = batWVal - disp.target_w;
+          var devClass = Math.abs(dev) > 200 ? "stat-warn" : "stat-dim";
+          batteryRow =
+            '  <span class="stat-label">Battery</span><span class="stat-value">' + formatW(batWVal) +
+            '    <span class="stat-target">→ ' + formatW(disp.target_w) + '</span>' +
+            '    <span class="' + devClass + '">Δ ' + formatW(dev) + '</span>' +
+            "</span>";
+        }
+
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">Meter</span><span class="stat-value">' + formatW(meterW) + "</span>" +
+          '  <span class="stat-label">PV</span><span class="stat-value">' + formatW(pvWVal) + "</span>" +
+          batteryRow +
+          '  <span class="stat-label">SoC</span><span class="stat-value">' + formatSoc(batSocVal) + "</span>" +
+          '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + "</span>" +
+          '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
+          "</div>" +
+          '<div class="driver-soc-bar"><div class="driver-soc-fill" style="width:' + Math.round(batSocVal * 100) + '%"></div></div>';
+      }
+
+      // For disabled drivers the body is minimal — just show the label.
+      if (d.disabled === true || d.status === "disabled") {
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">State</span><span class="stat-value stat-dim">disabled</span>' +
+          '</div>';
+      } else if (d.not_running === true || (d.status === "offline" && d.tick_count == null)) {
+        // Configured in yaml but never successfully spawned — most often
+        // a cloud auth failure. Offer Restart to retry with fresh creds.
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">State</span><span class="stat-value stat-warn">not running (spawn failed)</span>' +
+          '  <span class="stat-label">Hint</span><span class="stat-value stat-dim">check credentials, then restart</span>' +
+          '</div>';
       }
 
       card.innerHTML =
@@ -1077,19 +1248,12 @@
         '  <span class="driver-name">' + escHtml(name) + "</span>" +
         '  <span class="status-dot ' + statusClass(d.status) + '" title="' + escHtml(d.status || "unknown") + '"></span>' +
         "</div>" +
-        '<div class="driver-stats">' +
-        '  <span class="stat-label">Meter</span><span class="stat-value">' + formatW(meterW) + "</span>" +
-        '  <span class="stat-label">PV</span><span class="stat-value">' + formatW(pvWVal) + "</span>" +
-        batteryRow +
-        '  <span class="stat-label">SoC</span><span class="stat-value">' + formatSoc(batSocVal) + "</span>" +
-        '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + "</span>" +
-        '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
-        "</div>" +
-        '<div class="driver-soc-bar"><div class="driver-soc-fill" style="width:' + Math.round(batSocVal * 100) + '%"></div></div>' +
+        body +
+        renderDriverActions(name, d) +
         // Inline battery model — rendered from models.js's cached payload.
         // Drawing it here in the same pass as the driver card avoids the
         // earlier race where two independent polls fought over the slot.
-        (window.renderInlineBatteryModel ? window.renderInlineBatteryModel(name) : "");
+        (!isEV && !(d.disabled === true || d.status === "disabled") && window.renderInlineBatteryModel ? window.renderInlineBatteryModel(name) : "");
 
       driversGrid.appendChild(card);
     });

--- a/web/app.js
+++ b/web/app.js
@@ -1042,67 +1042,6 @@
     }
   }
 
-  // Easee chargerOpMode → human label
-  function evOpModeLabel(m) {
-    switch (m) {
-      case 1: return "disconnected";
-      case 2: return "awaiting start";
-      case 3: return "charging";
-      case 4: return "completed";
-      case 5: return "error";
-      case 6: return "ready";
-      default: return "unknown";
-    }
-  }
-
-  // Easee reasonForNoCurrent → human label. 0 = no limit (charging ok).
-  // Source: developer.easee.com/docs/enumerations (ReasonForNoCurrent 96).
-  // Returns null for "no reason / charging is fine" so the UI can skip the row.
-  function evReasonLabel(r) {
-    switch (r) {
-      case 0:   return null; // charger OK
-      // 1–6: load balancing / queue
-      case 1:   return "max circuit current too low";
-      case 2:   return "dynamic circuit current too low";
-      case 3:   return "offline fallback circuit current too low";
-      case 4:   return "circuit fuse too low";
-      case 5:   return "waiting in queue";
-      case 6:   return "waiting (other cars fully charged)";
-      // 7–11: grid / phase / equalizer
-      case 7:   return "illegal grid type";
-      case 8:   return "no current request from primary";
-      case 9:   return "max dynamic charger current too low";
-      case 10:  return "phase imbalance";
-      case 11:  return "equalizer communication lost";
-      // 25–30: equalizer / fuse limits
-      case 25:  return "equalizer dynamic limit too low";
-      case 26:  return "equalizer static limit too low";
-      case 27:  return "offline fallback equalizer too low";
-      case 28:  return "fuse limit reached";
-      case 29:  return "current limited by equalizer";
-      case 30:  return "current limited by offline equalizer";
-      // 50–57: secondary unit / charger state
-      case 50:  return "secondary unit not requesting current";
-      case 51:  return "max charger current too low";
-      case 52:  return "max dynamic charger current too low";
-      case 53:  return "charger disabled";
-      case 54:  return "pending scheduled charging";
-      case 55:  return "pending authorization";
-      case 56:  return "charger in error state";
-      case 57:  return "erratic EV";
-      // 75–81: cable / schedule / car
-      case 75:  return "limited by cable rating";
-      case 76:  return "limited by schedule";
-      case 77:  return "limited by charger current";
-      case 78:  return "limited by dynamic charger current";
-      case 79:  return "car not drawing current";
-      case 80:  return "current ramping";
-      case 81:  return "limited by car";
-      case 100: return "undefined error";
-      default:  return "reason " + r;
-    }
-  }
-
   function driverLifecycleCall(name, action) {
     return fetch("/api/drivers/" + encodeURIComponent(name) + "/" + action, { method: "POST" })
       .then(function (res) {
@@ -1166,15 +1105,16 @@
       var body;
       if (isEV) {
         var evWVal = d.ev_w != null ? d.ev_w : 0;
-        var opLabel = d.ev_op_mode != null ? evOpModeLabel(d.ev_op_mode)
-                     : (d.ev_charging ? "charging"
-                     : (d.ev_connected ? "connected" : "idle"));
+        // state_label + reason_no_current_label come from the driver —
+        // UI renders them verbatim. Protocol knowledge stays in Lua.
+        var opLabel = d.ev_state_label
+          || (d.ev_charging ? "charging" : (d.ev_connected ? "connected" : "idle"));
         var stateClass =
           (d.ev_charging ? "stat-ok"
           : (d.ev_connected ? "stat-warn" : "stat-dim"));
         var sessionKwh = d.ev_session_wh != null ? (d.ev_session_wh / 1000).toFixed(2) + " kWh" : "—";
         var maxA = d.ev_max_a != null ? d.ev_max_a.toFixed(0) + " A" : "—";
-        var reason = d.ev_reason_no_current != null ? evReasonLabel(d.ev_reason_no_current) : null;
+        var reason = d.ev_reason_no_current_label || null;
 
         body =
           '<div class="driver-stats">' +

--- a/web/models.js
+++ b/web/models.js
@@ -195,6 +195,25 @@
       } else {
         localStorage.setItem(key, "1");
       }
+      // Re-render this panel in place using cached data so the click is
+      // instant. Previously we waited for fetchModels → /api/battery_models
+      // → next /api/status poll (app.js renderDrivers), which added up to
+      // a 3s lag before the section visibly unfolded.
+      var m = lastModels[name];
+      if (m) {
+        var panel = hdr.closest(".driver-model-panel");
+        if (panel) {
+          // renderInlineModel returns the full panel wrapper; strip it so
+          // we replace panel's inner HTML, preserving the outer element
+          // and any click-state the browser has on it.
+          var html = renderInlineModel(name, m);
+          var tmp = document.createElement("div");
+          tmp.innerHTML = html;
+          var newPanel = tmp.firstChild;
+          if (newPanel) panel.innerHTML = newPanel.innerHTML;
+        }
+      }
+      // Still kick off a background refresh so we see the latest numbers.
       fetchModels();
       return;
     }

--- a/web/settings.js
+++ b/web/settings.js
@@ -230,7 +230,7 @@
           var cap = d.capabilities || {};
           var mqtt = cap.mqtt || d.mqtt; // legacy fallback
           var modbus = cap.modbus || d.modbus;
-          var protocol = mqtt ? "mqtt" : (modbus ? "modbus" : "?");
+          var protocol = mqtt ? "mqtt" : (modbus ? "modbus" : (cap.http ? "http" : "?"));
           var driverFile = d.wasm || d.lua || "(none)";
           var fmtKind = d.wasm ? "wasm" : (d.lua ? "lua" : "?");
           html += '<div class="device-item">' +
@@ -277,13 +277,21 @@
           var isCloudDriver = (driverFile || '').indexOf('easee_cloud') >= 0 || (cap.http != null);
           if (isCloudDriver) {
             var cfg = d.config || {};
+            // Server sets has_password=true via MaskSecrets when a password
+            // is on disk — lets us show a "saved" badge even though the
+            // value itself is blanked out of the response.
+            var hasPw = d.has_password === true;
+            var pwBadge = hasPw
+              ? '<span class="creds-badge creds-saved">✓ Saved</span>'
+              : '<span class="creds-badge creds-missing">⚠ Not saved</span>';
             html += '<fieldset><legend>Cloud credentials</legend>' +
               '<div class="field-row"><div>' +
               '<label>Email / phone ' + help('Account email or phone number (with country code, e.g. +46...) for the cloud service.') + '</label>' +
               '<input type="text" data-path="drivers.' + idx + '.config.email" value="' + escHtml(cfg.email || '') + '">' +
               '</div><div>' +
-              '<label>Password</label>' +
-              '<input type="password" data-path="drivers.' + idx + '.config.password" value="' + escHtml(cfg.password || '') + '">' +
+              '<label>Password ' + pwBadge + '</label>' +
+              '<input type="password" data-path="drivers.' + idx + '.config.password" value="" ' +
+                'placeholder="' + (hasPw ? '•••••••• (leave empty to keep)' : 'enter password') + '">' +
               '</div></div>' +
               '<label>Device serial ' + help('Serial number of the charger. Leave empty to auto-detect.') + '</label>' +
               '<input type="text" data-path="drivers.' + idx + '.config.serial" value="' + escHtml(cfg.serial || '') + '">' +
@@ -499,6 +507,12 @@
           }
         }
         var evHasPassword = !!getByPath(currentConfig, "ev_charger.password", "");
+        // Authoritative source for credentials-saved is /api/status; the
+        // cfg may show the placeholder but not the actual state.db entry.
+        // We fill this in once the indicator-refresh fetch completes.
+        var credsBadge = evHasPassword
+          ? '<span id="ev-creds-badge" class="creds-badge creds-saved">✓ Credentials saved</span>'
+          : '<span id="ev-creds-badge" class="creds-badge creds-missing">⚠ No credentials saved</span>';
         html = '<div id="ev-status-indicator" class="ha-status-indicator">checking…</div>' +
           '<fieldset><legend>EV Charger</legend>' +
           selectField("Provider", "ev_charger.provider", ["easee"], "easee",
@@ -507,6 +521,7 @@
             "Account email for the charger cloud service.") +
           '<label>Password ' + help("Account password for the charger cloud service.") + '</label>' +
           '<input type="password" data-path="ev_charger.password" value="" placeholder="' + (evHasPassword ? '••••••••' : '') + '">' +
+          '<div style="margin-top:4px">' + credsBadge + '</div>' +
           field("Charger serial", "ev_charger.serial", "text", "",
             "Serial number of the charger. Leave empty to auto-detect the first charger on the account.") +
           '</fieldset>' +
@@ -531,6 +546,18 @@
           if (!el) return;
           function refresh() {
             fetch("/api/status").then(function(r){return r.json();}).then(function(d) {
+              // Update the credentials-saved badge from the authoritative
+              // server flag (based on state.db, not the masked cfg value).
+              var badge = document.getElementById("ev-creds-badge");
+              if (badge) {
+                if (d.ev_credentials_saved) {
+                  badge.textContent = "✓ Credentials saved";
+                  badge.className = "creds-badge creds-saved";
+                } else {
+                  badge.textContent = "⚠ No credentials saved";
+                  badge.className = "creds-badge creds-missing";
+                }
+              }
               // drivers may be an object keyed by name or an array — normalize.
               var rawDrivers = d.drivers || {};
               var drivers = [];

--- a/web/style.css
+++ b/web/style.css
@@ -1184,6 +1184,42 @@ footer {
   color: #94a3b8;
 }
 
+/* EV credentials-saved badge — shown next to the password field in
+   Settings so the operator can tell "stored in state.db" apart from
+   "empty because never entered". */
+.creds-badge {
+  display: inline-block;
+  font-size: 0.78rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+}
+.creds-badge.creds-saved {
+  color: #86efac;
+  background: rgba(34,197,94,0.08);
+  border-color: rgba(34,197,94,0.3);
+}
+.creds-badge.creds-missing {
+  color: #fbbf24;
+  background: rgba(251,191,36,0.08);
+  border-color: rgba(251,191,36,0.3);
+}
+
+/* Disabled driver card — faded out so it's obvious at a glance that
+   the driver is not running, and the Enable button is the only
+   actionable thing on the card. */
+.driver-card-disabled {
+  opacity: 0.55;
+  background: rgba(148,163,184,0.04);
+}
+
+/* Configured but not running — spawn failed (typically cloud auth).
+   Warmer colour than disabled to draw attention. */
+.driver-card-warn {
+  border-color: rgba(251,191,36,0.4);
+  background: rgba(251,191,36,0.04);
+}
+
 /* Help "?" badges with hover bubble. Uses native `title` attr too for
    a fallback; the nicer custom tooltip appears on hover via CSS. */
 .help {


### PR DESCRIPTION
## Summary

- First-class EV driver rendering in the dashboard (Easee surfaces plug state, charging, session energy, reason for no current, cable lock, cloud status)
- Per-driver **Restart / Disable / Enable** buttons + new `/api/drivers/{name}/{restart,disable,enable}` endpoints
- Fix the silent password-reload bug: `sameDriverConfig` now compares the `Config` map, so credential changes actually restart the driver instead of being diffed away
- "Credentials saved" visibility: badges in Settings + Devices tab, driven by `ev_credentials_saved` + per-driver `has_password` (populated by `MaskSecrets`)
- Instant model panel expand — no longer waits up to 3 s for the next poll
- Protocol knowledge moved into the Easee driver (op_mode + reason_no_current code→label tables in lua, not JS)

## Test plan

- [x] `go test ./internal/{api,drivers,config}/...` passes
- [x] Deployed to homelab-rpi, easee driver auths after password fix, EV fields visible in API
- [x] Restart endpoint verified (`POST /api/drivers/ferroamp/restart` → `{"source":"config","status":"restarted"}`)
- [x] Config-map diff confirmed in logs: `driver config changed, restarting` fires after password edit
- [ ] Disable/Enable flow via UI (endpoints exercised, UI buttons not yet clicked by user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)