### PR TITLE
fix: restore PR #71 HTTP capability support (erased by force-push)

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -28,6 +28,7 @@ DRIVER = {
   capabilities = { "ev" },
   description  = "Easee Home/Charge via Cloud REST API. No local protocol needed.",
   homepage     = "https://easee.com",
+  http_hosts   = { "api.easee.com" },
   authors      = { "forty-two-watts contributors" },
   tested_models = { "Home", "Charge" },
 }

--- a/go/internal/drivers/catalog.go
+++ b/go/internal/drivers/catalog.go
@@ -22,6 +22,7 @@ type CatalogEntry struct {
 	Version            string         `json:"version,omitempty"`
 	Protocols          []string       `json:"protocols,omitempty"`            // mqtt / modbus / http
 	Capabilities       []string       `json:"capabilities,omitempty"`         // meter / pv / battery
+	HTTPHosts          []string       `json:"http_hosts,omitempty"`
 	Description        string         `json:"description,omitempty"`
 	Homepage           string         `json:"homepage,omitempty"`
 	ConnectionDefaults map[string]any `json:"connection_defaults,omitempty"`
@@ -91,6 +92,7 @@ func parseCatalogEntry(path string) (CatalogEntry, error) {
 	e.Homepage = pickString(block, "homepage")
 	e.Protocols = pickList(block, "protocols")
 	e.Capabilities = pickList(block, "capabilities")
+	e.HTTPHosts = pickList(block, "http_hosts")
 	e.ConnectionDefaults = pickKVBlock(block, "connection_defaults")
 	return e, nil
 }

--- a/web/settings.js
+++ b/web/settings.js
@@ -202,6 +202,7 @@
               opt.textContent = (e.name || e.filename) + "  —  " + (e.manufacturer || "?") + "  [" + protoLabel + "]" + (e.version ? "  v" + e.version : "");
               opt.dataset.protocols = protoLabel;
               opt.dataset.id = e.id || "";
+              opt.dataset.httpHosts = (e.http_hosts || []).join(",");
               sel.appendChild(opt);
             });
           });
@@ -217,9 +218,11 @@
             driver.capabilities = {};
             if (protocols.indexOf("mqtt") >= 0) driver.capabilities.mqtt = { host: "", port: 1883 };
             if (protocols.indexOf("modbus") >= 0) driver.capabilities.modbus = { host: "", port: 502, unit_id: 1 };
-            if (protocols.indexOf("http") >= 0) driver.capabilities.http = { allowed_hosts: ["api.easee.com"] };
-            // Cloud drivers need a config block for credentials
-            if (protocols.indexOf("http") >= 0) driver.config = { email: "", password: "", serial: "" };
+            if (protocols.indexOf("http") >= 0) {
+              var hosts = (chosen.dataset.httpHosts || "").split(",").filter(Boolean);
+              driver.capabilities.http = { allowed_hosts: hosts };
+              driver.config = { email: "", password: "", serial: "" };
+            }
             currentConfig.drivers.push(driver);
             renderTab("devices");
           });
@@ -312,7 +315,8 @@
           selectField("Zone", "price.zone", ["SE1","SE2","SE3","SE4","NO1","NO2","NO3","NO4","DK1","DK2","FI","DE"], "SE3") +
           selectField("Currency", "price.currency", ["SEK", "NOK", "DKK", "EUR"], "SEK") +
           '<div class="field-row"><div>' +
-          field("Grid tariff (öre/kWh)", "price.grid_tariff_ore_kwh", "number", 60) +
+          field("Grid tariff excl. VAT (öre/kWh)", "price.grid_tariff_ore_kwh", "number", 60,
+            "Per-kWh network/distribution fee from your DSO (elnätsavgift), excluding VAT. This is the cost of moving electricity over the wire, independent of the spot price.") +
           '</div><div>' +
           field("VAT (%)", "price.vat_percent", "number", 25) +
           '</div></div>' +


### PR DESCRIPTION
## Summary
Restores the changes from PR #71 (by @erikarenhill), which were erased from `origin/master` when a concurrent session force-pushed `48e0d28` on top of `7cd2d9f`, bypassing the PR #71 merge commit (`e83945e`). The `v0.5.3` tag on origin still points to the now-orphaned `fb3ded2`, but none of the code changes remained reachable from master.

Cherry-picks `02a3001` onto current `master` (0.6.0) with conflict resolution in `web/settings.js`:
- Keeps PR #71's dynamic `http_hosts` catalog metadata approach (replaces the hardcoded `["api.easee.com"]` that was added as a workaround).
- Preserves the `driver.config = { email, password, serial }` block that PR #73 added for cloud-driver credentials.

## Changes
- `drivers/easee_cloud.lua` — adds `http_hosts = { "api.easee.com" }` to DRIVER metadata.
- `go/internal/drivers/catalog.go` — adds `HTTPHosts` field to `CatalogEntry` + parses `http_hosts` from Lua metadata.
- `web/settings.js` — catalog-add flow reads `http_hosts` from selected driver's metadata.

## Test plan
- [ ] Add Easee from catalog in UI, confirm `capabilities.http.allowed_hosts` = `["api.easee.com"]` (from metadata, not hardcode).
- [ ] Confirm existing cloud-driver credential config block still initializes.
- [ ] Confirm no regression for mqtt/modbus catalog drivers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>