### PR TITLE
feat(drivers): add Sourceful Zap meter driver

### DIFF
--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -1,0 +1,227 @@
+-- zap.lua
+-- Sourceful Zap — multi-device energy gateway with P1 meter, Modbus TCP
+-- inverters/batteries and local JSON API. This driver reads the P1 grid
+-- meter exposed over /api/devices/<p1-sn>/data/json and emits it as the
+-- site meter.
+-- Emits: Meter (read-only)
+-- Protocol: HTTP (local JSON API on the Zap gateway)
+--
+-- Discovery:
+--   The Zap advertises itself via mDNS as `zap.local`. On Linux the OS
+--   resolver handles that transparently as long as nss-mdns / avahi is
+--   installed (it is on RPi OS). If zap.local doesn't resolve on the
+--   operator's network — router blocks mDNS, DNS rebinding filter, or
+--   the EMS is on a different VLAN — set `host` to the device's LAN IP.
+--
+--   The P1 meter's serial number is auto-discovered on the first poll by
+--   walking GET /api/devices and picking the entry with type=="p1_uart".
+--   Override by setting `serial` in config if you have more than one P1
+--   device on the same Zap and want to pin a specific one.
+--
+-- Config example (config.yaml):
+--   drivers:
+--     - name: zap
+--       lua: drivers/zap.lua
+--       is_site_meter: true
+--       capabilities:
+--         http:
+--           allowed_hosts: ["zap.local"]  # or the LAN IP
+--       config:
+--         host: "zap.local"          # default; override with IP if mDNS fails
+--         # serial: "p1m-xxxxxxxx"   # optional; auto-detected when omitted
+--
+-- Sign convention (SITE = positive W flows INTO the site):
+--   meter.w: positive = importing from grid, negative = exporting
+-- The Zap P1 meter already reports import-positive, so no sign flip.
+
+DRIVER = {
+  id           = "sourceful-zap",
+  name         = "Sourceful Zap",
+  manufacturer = "Sourceful",
+  version      = "1.0.0",
+  protocols    = { "http" },
+  capabilities = { "meter" },
+  description  = "Sourceful Zap local-JSON gateway reading the P1 grid meter (zap.local or LAN IP).",
+  homepage     = "https://sourceful.energy",
+  authors      = { "forty-two-watts contributors" },
+  http_hosts   = { "zap.local" },
+  connection_defaults = {
+    host = "zap.local",
+  },
+}
+
+PROTOCOL = "http"
+
+local zap_host = "zap.local"
+local p1_serial = nil
+
+-- Backoff state for discovery failures: no point hammering /api/devices
+-- every second when the gateway is unreachable.
+local discovery_last_attempt = 0
+local discovery_backoff_ms   = 0
+local DISCOVERY_BACKOFF_MIN  = 2000
+local DISCOVERY_BACKOFF_MAX  = 60000
+
+local function base_url()
+    -- Accept both "zap.local" and "http://zap.local" styles.
+    if string.sub(zap_host, 1, 7) == "http://" or string.sub(zap_host, 1, 8) == "https://" then
+        return zap_host
+    end
+    return "http://" .. zap_host
+end
+
+-- Walk GET /api/devices and pick the first `p1_uart` entry's serial.
+-- Returns (serial, err). Logs at info on success, warn on any failure.
+local function discover_p1_serial()
+    local url = base_url() .. "/api/devices"
+    local body, err = host.http_get(url)
+    if err then
+        return nil, err
+    end
+    local data = host.json_decode(body)
+    if not data or not data.devices then
+        return nil, "unexpected payload (no `devices` array)"
+    end
+    for _, dev in ipairs(data.devices) do
+        if dev.type == "p1_uart" and dev.sn then
+            return dev.sn, nil
+        end
+    end
+    return nil, "no p1_uart device found"
+end
+
+-- Bump the discovery backoff exponentially (cap at MAX). Called whenever
+-- discovery or a data poll fails so we don't spam the network.
+local function bump_backoff()
+    if discovery_backoff_ms == 0 then
+        discovery_backoff_ms = DISCOVERY_BACKOFF_MIN
+    else
+        discovery_backoff_ms = math.min(discovery_backoff_ms * 2, DISCOVERY_BACKOFF_MAX)
+    end
+    discovery_last_attempt = host.millis()
+end
+
+local function clear_backoff()
+    discovery_backoff_ms = 0
+    discovery_last_attempt = 0
+end
+
+local function in_backoff()
+    if discovery_backoff_ms == 0 then return false end
+    return (host.millis() - discovery_last_attempt) < discovery_backoff_ms
+end
+
+----------------------------------------------------------------------------
+-- Driver interface
+----------------------------------------------------------------------------
+
+function driver_init(config)
+    host.set_make("Sourceful")
+
+    if config and type(config.host) == "string" and config.host ~= "" then
+        zap_host = config.host
+    end
+    if config and type(config.serial) == "string" and config.serial ~= "" then
+        p1_serial = config.serial
+        host.set_sn(p1_serial)
+        host.log("info", "Zap: using pinned P1 serial " .. p1_serial)
+    end
+
+    host.log("info", "Zap: driver initialized (host=" .. zap_host .. ")")
+end
+
+function driver_poll()
+    -- Phase 1: discover the P1 serial if we don't know it yet.
+    if not p1_serial then
+        if in_backoff() then
+            return 1000
+        end
+        local sn, err = discover_p1_serial()
+        if err or not sn then
+            bump_backoff()
+            host.log("warn", "Zap: P1 discovery failed: " .. tostring(err)
+                .. " (retry in " .. discovery_backoff_ms .. "ms)")
+            return 1000
+        end
+        p1_serial = sn
+        host.set_sn(p1_serial)
+        clear_backoff()
+        host.log("info", "Zap: discovered P1 meter " .. p1_serial)
+    end
+
+    -- Phase 2: poll meter data.
+    local url = base_url() .. "/api/devices/" .. p1_serial .. "/data/json"
+    local body, err = host.http_get(url)
+    if err then
+        bump_backoff()
+        host.log("warn", "Zap: data fetch failed: " .. tostring(err)
+            .. " (retry in " .. discovery_backoff_ms .. "ms)")
+        -- If the Zap was rebooted the serial may have rotated (unlikely
+        -- on real hardware but possible on dev gateways). Force re-discovery
+        -- on persistent failure.
+        if discovery_backoff_ms >= DISCOVERY_BACKOFF_MAX then
+            host.log("warn", "Zap: repeated failures — will re-discover P1 serial")
+            p1_serial = nil
+        end
+        return 1000
+    end
+
+    local data = host.json_decode(body)
+    if not data or not data.meter then
+        bump_backoff()
+        host.log("warn", "Zap: payload missing `meter` block")
+        return 1000
+    end
+    clear_backoff()
+
+    local m = data.meter
+    local meter = {
+        w         = tonumber(m.W)    or 0,
+        l1_w      = tonumber(m.L1_W) or 0,
+        l2_w      = tonumber(m.L2_W) or 0,
+        l3_w      = tonumber(m.L3_W) or 0,
+        l1_v      = tonumber(m.L1_V) or 0,
+        l2_v      = tonumber(m.L2_V) or 0,
+        l3_v      = tonumber(m.L3_V) or 0,
+        l1_a      = tonumber(m.L1_A) or 0,
+        l2_a      = tonumber(m.L2_A) or 0,
+        l3_a      = tonumber(m.L3_A) or 0,
+        import_wh = tonumber(m.total_import_Wh) or 0,
+        export_wh = tonumber(m.total_export_Wh) or 0,
+    }
+
+    host.emit("meter", meter)
+    -- Diagnostics: long-format TS DB
+    host.emit_metric("meter_l1_w", meter.l1_w)
+    host.emit_metric("meter_l2_w", meter.l2_w)
+    host.emit_metric("meter_l3_w", meter.l3_w)
+    host.emit_metric("meter_l1_v", meter.l1_v)
+    host.emit_metric("meter_l2_v", meter.l2_v)
+    host.emit_metric("meter_l3_v", meter.l3_v)
+    host.emit_metric("meter_l1_a", meter.l1_a)
+    host.emit_metric("meter_l2_a", meter.l2_a)
+    host.emit_metric("meter_l3_a", meter.l3_a)
+
+    return 1000
+end
+
+----------------------------------------------------------------------------
+-- Control (READ-ONLY — P1 meter exposes no writable endpoint)
+----------------------------------------------------------------------------
+
+function driver_command(action, power_w, cmd)
+    if action == "init" or action == "deinit" then
+        return true
+    end
+    host.log("warn", "Zap: read-only driver, ignoring action=" .. tostring(action))
+    return false
+end
+
+function driver_default_mode()
+    -- Read-only: nothing to revert.
+end
+
+function driver_cleanup()
+    p1_serial = nil
+    clear_backoff()
+end

--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -71,7 +71,8 @@ local function base_url()
 end
 
 -- Walk GET /api/devices and pick the first `p1_uart` entry's serial.
--- Returns (serial, err). Logs at info on success, warn on any failure.
+-- Returns (serial, err). Does not log — the caller owns that so success
+-- and failure messages stay co-located with the backoff / retry logic.
 local function discover_p1_serial()
     local url = base_url() .. "/api/devices"
     local body, err = host.http_get(url)

--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -2,8 +2,9 @@
 -- Sourceful Zap — multi-device energy gateway with P1 meter, Modbus TCP
 -- inverters/batteries and local JSON API. This driver reads the P1 grid
 -- meter exposed over /api/devices/<p1-sn>/data/json and emits it as the
--- site meter.
--- Emits: Meter (read-only)
+-- site meter, and aggregates PV generation from any inverter the Zap is
+-- talking to (device_type=="inverter" with an enabled pv DER).
+-- Emits: Meter, PV (read-only)
 -- Protocol: HTTP (local JSON API on the Zap gateway)
 --
 -- Discovery:
@@ -13,10 +14,12 @@
 --   operator's network — router blocks mDNS, DNS rebinding filter, or
 --   the EMS is on a different VLAN — set `host` to the device's LAN IP.
 --
---   The P1 meter's serial number is auto-discovered on the first poll by
---   walking GET /api/devices and picking the entry with type=="p1_uart".
---   Override by setting `serial` in config if you have more than one P1
---   device on the same Zap and want to pin a specific one.
+--   On the first poll the driver walks GET /api/devices once and picks:
+--     - the first `p1_uart` entry as the P1 meter (site meter)
+--     - every `device_type=="inverter"` entry with an enabled `pv` DER
+--       as a PV source; W values across them are summed.
+--   Override the P1 via config.serial if you have several; the PV set is
+--   always auto-detected (add/remove an inverter → restart the driver).
 --
 -- Config example (config.yaml):
 --   drivers:
@@ -32,16 +35,18 @@
 --
 -- Sign convention (SITE = positive W flows INTO the site):
 --   meter.w: positive = importing from grid, negative = exporting
--- The Zap P1 meter already reports import-positive, so no sign flip.
+--   pv.w   : negative = generating (source).  Zap reports generation as
+--            positive W, so the driver negates at the boundary.
+-- The Zap P1 meter already reports import-positive, so no meter flip.
 
 DRIVER = {
   id           = "sourceful-zap",
   name         = "Sourceful Zap",
   manufacturer = "Sourceful",
-  version      = "1.0.0",
+  version      = "1.1.0",
   protocols    = { "http" },
-  capabilities = { "meter" },
-  description  = "Sourceful Zap local-JSON gateway reading the P1 grid meter (zap.local or LAN IP).",
+  capabilities = { "meter", "pv" },
+  description  = "Sourceful Zap local-JSON gateway: P1 grid meter + PV from any attached inverter.",
   homepage     = "https://sourceful.energy",
   authors      = { "forty-two-watts contributors" },
   http_hosts   = { "zap.local" },
@@ -54,9 +59,10 @@ PROTOCOL = "http"
 
 local zap_host = "zap.local"
 local p1_serial = nil
+local pv_serials = {}   -- list of inverter serials that carry an enabled pv DER
 
--- Backoff state for discovery failures: no point hammering /api/devices
--- every second when the gateway is unreachable.
+-- Backoff state for discovery / data failures: no point hammering the
+-- gateway when it's unreachable.
 local discovery_last_attempt = 0
 local discovery_backoff_ms   = 0
 local DISCOVERY_BACKOFF_MIN  = 2000
@@ -70,29 +76,57 @@ local function base_url()
     return "http://" .. zap_host
 end
 
--- Walk GET /api/devices and pick the first `p1_uart` entry's serial.
--- Returns (serial, err). Does not log — the caller owns that so success
--- and failure messages stay co-located with the backoff / retry logic.
-local function discover_p1_serial()
+-- Clamp obviously-bogus readings. The Zap passes through raw overflow
+-- sentinels when a downstream device is offline (u16=65535, i16=32768/
+-- -32768, u32=4294967295, and a couple of *100-scaled lookalikes for
+-- currents). Treat any |v| above `max_abs` as "not available" → nil.
+local function sane(v, max_abs)
+    local n = tonumber(v)
+    if n == nil then return nil end
+    if max_abs and math.abs(n) > max_abs then return nil end
+    return n
+end
+
+-- Walk GET /api/devices and return:
+--   (p1_serial, pv_serials[], err)
+-- p1_serial is the first `p1_uart` device; pv_serials is every inverter
+-- with at least one enabled `pv` DER, in the order the Zap returns them.
+-- Does not log — the caller owns that so success and failure messages
+-- stay co-located with the backoff / retry logic.
+local function discover_devices()
     local url = base_url() .. "/api/devices"
     local body, err = host.http_get(url)
     if err then
-        return nil, err
+        return nil, nil, err
     end
     local data = host.json_decode(body)
     if not data or not data.devices then
-        return nil, "unexpected payload (no `devices` array)"
+        return nil, nil, "unexpected payload (no `devices` array)"
     end
+    local p1 = nil
+    local pvs = {}
     for _, dev in ipairs(data.devices) do
-        if dev.type == "p1_uart" and dev.sn then
-            return dev.sn, nil
+        if not dev.sn then
+            -- nothing to key on; skip
+        elseif dev.type == "p1_uart" and not p1 then
+            p1 = dev.sn
+        elseif dev.device_type == "inverter" and type(dev.ders) == "table" then
+            for _, der in ipairs(dev.ders) do
+                if der.type == "pv" and der.enabled then
+                    pvs[#pvs + 1] = dev.sn
+                    break
+                end
+            end
         end
     end
-    return nil, "no p1_uart device found"
+    if not p1 then
+        return nil, nil, "no p1_uart device found"
+    end
+    return p1, pvs, nil
 end
 
 -- Bump the discovery backoff exponentially (cap at MAX). Called whenever
--- discovery or a data poll fails so we don't spam the network.
+-- discovery or the site-meter data poll fails so we don't spam the network.
 local function bump_backoff()
     if discovery_backoff_ms == 0 then
         discovery_backoff_ms = DISCOVERY_BACKOFF_MIN
@@ -110,6 +144,16 @@ end
 local function in_backoff()
     if discovery_backoff_ms == 0 then return false end
     return (host.millis() - discovery_last_attempt) < discovery_backoff_ms
+end
+
+-- Fetch /api/devices/<sn>/data/json, return the decoded table or (nil, err).
+local function fetch_device(sn)
+    local url = base_url() .. "/api/devices/" .. sn .. "/data/json"
+    local body, err = host.http_get(url)
+    if err then return nil, err end
+    local data = host.json_decode(body)
+    if not data then return nil, "json decode failed" end
+    return data, nil
 end
 
 ----------------------------------------------------------------------------
@@ -132,45 +176,58 @@ function driver_init(config)
 end
 
 function driver_poll()
-    -- Phase 1: discover the P1 serial if we don't know it yet.
-    if not p1_serial then
-        if in_backoff() then
-            return 1000
+    -- Phase 1: discover P1 + PV inverters if we don't know them yet.
+    if not p1_serial or #pv_serials == 0 then
+        -- Skip if the user pinned config.serial and we already have it;
+        -- otherwise run discovery whenever p1 is missing OR we haven't
+        -- enumerated inverters yet.
+        local need_discovery = (not p1_serial) or (p1_serial and #pv_serials == 0)
+        if need_discovery then
+            if in_backoff() then
+                return 1000
+            end
+            local p1, pvs, err = discover_devices()
+            if err then
+                bump_backoff()
+                host.log("warn", "Zap: discovery failed: " .. tostring(err)
+                    .. " (retry in " .. discovery_backoff_ms .. "ms)")
+                return 1000
+            end
+            if not p1_serial then
+                p1_serial = p1
+                host.set_sn(p1_serial)
+                host.log("info", "Zap: discovered P1 meter " .. p1_serial)
+            end
+            pv_serials = pvs
+            if #pv_serials > 0 then
+                host.log("info", "Zap: discovered " .. #pv_serials
+                    .. " PV inverter(s): " .. table.concat(pv_serials, ","))
+            else
+                host.log("info", "Zap: no PV inverters found")
+            end
+            clear_backoff()
         end
-        local sn, err = discover_p1_serial()
-        if err or not sn then
-            bump_backoff()
-            host.log("warn", "Zap: P1 discovery failed: " .. tostring(err)
-                .. " (retry in " .. discovery_backoff_ms .. "ms)")
-            return 1000
-        end
-        p1_serial = sn
-        host.set_sn(p1_serial)
-        clear_backoff()
-        host.log("info", "Zap: discovered P1 meter " .. p1_serial)
     end
 
-    -- Phase 2: poll meter data.
-    local url = base_url() .. "/api/devices/" .. p1_serial .. "/data/json"
-    local body, err = host.http_get(url)
+    -- Phase 2: poll the P1 meter.
+    local data, err = fetch_device(p1_serial)
     if err then
         bump_backoff()
-        host.log("warn", "Zap: data fetch failed: " .. tostring(err)
+        host.log("warn", "Zap: P1 data fetch failed: " .. tostring(err)
             .. " (retry in " .. discovery_backoff_ms .. "ms)")
         -- If the Zap was rebooted the serial may have rotated (unlikely
         -- on real hardware but possible on dev gateways). Force re-discovery
         -- on persistent failure.
         if discovery_backoff_ms >= DISCOVERY_BACKOFF_MAX then
-            host.log("warn", "Zap: repeated failures — will re-discover P1 serial")
+            host.log("warn", "Zap: repeated failures — will re-discover devices")
             p1_serial = nil
+            pv_serials = {}
         end
         return 1000
     end
-
-    local data = host.json_decode(body)
-    if not data or not data.meter then
+    if not data.meter then
         bump_backoff()
-        host.log("warn", "Zap: payload missing `meter` block")
+        host.log("warn", "Zap: P1 payload missing `meter` block")
         return 1000
     end
     clear_backoff()
@@ -192,7 +249,6 @@ function driver_poll()
     }
 
     host.emit("meter", meter)
-    -- Diagnostics: long-format TS DB
     host.emit_metric("meter_l1_w", meter.l1_w)
     host.emit_metric("meter_l2_w", meter.l2_w)
     host.emit_metric("meter_l3_w", meter.l3_w)
@@ -203,11 +259,68 @@ function driver_poll()
     host.emit_metric("meter_l2_a", meter.l2_a)
     host.emit_metric("meter_l3_a", meter.l3_a)
 
+    -- Phase 3: aggregate PV across every inverter the Zap exposes.
+    -- Each inverter has an independent data endpoint; we sum W and
+    -- generation energy, and emit diagnostics per inverter (the structured
+    -- `pv` reading on the telemetry store is a single slot, so combining
+    -- them is the only way both inverters show up). PV fetch failures
+    -- don't reset the meter's backoff — the site meter is load-bearing,
+    -- PV is nice-to-have; we just log debug and skip that inverter.
+    if #pv_serials > 0 then
+        local total_w = 0
+        local total_gen_wh = 0
+        local any = false
+        for _, sn in ipairs(pv_serials) do
+            local pvdata, perr = fetch_device(sn)
+            if perr or not pvdata or not pvdata.pv then
+                host.log("debug", "Zap: PV fetch failed for "
+                    .. sn .. ": " .. tostring(perr or "missing pv block"))
+            else
+                any = true
+                local pv = pvdata.pv
+                -- Rated cap gives us a sanity bound for the W reading.
+                -- The Zap emits overflow sentinels when the inverter is
+                -- offline (i16 32768, u32 huge values); anything above
+                -- 10× rated or otherwise clearly bogus → treat as 0.
+                local rated = tonumber(pv.rated_power_W) or 0
+                local cap = rated > 0 and (rated * 10) or 1e6
+                local w = sane(pv.W, cap) or 0
+                total_w = total_w + w
+                local gen = sane(pv.total_generation_Wh, 1e12) or 0
+                total_gen_wh = total_gen_wh + gen
+
+                -- Per-inverter diagnostics into the TS DB. For multi-inverter
+                -- setups tag the serial onto each metric name so they don't
+                -- collide; for single-inverter sites the outer aggregate
+                -- emission below covers `pv_w` and we only need the extra
+                -- MPPT / heatsink detail here.
+                local multi = (#pv_serials > 1)
+                local tag = multi and ("_" .. sn) or ""
+                if multi then host.emit_metric("pv_w" .. tag, w) end
+                local hs = sane(pv.heatsink_C, 150)
+                if hs then host.emit_metric("pv_heatsink_c" .. tag, hs) end
+                local m1v = sane(pv.mppt1_V, 1500)
+                if m1v then host.emit_metric("pv_mppt1_v" .. tag, m1v) end
+                local m1a = sane(pv.mppt1_A, 50)
+                if m1a then host.emit_metric("pv_mppt1_a" .. tag, m1a) end
+                local m2v = sane(pv.mppt2_V, 1500)
+                if m2v then host.emit_metric("pv_mppt2_v" .. tag, m2v) end
+                local m2a = sane(pv.mppt2_A, 50)
+                if m2a then host.emit_metric("pv_mppt2_a" .. tag, m2a) end
+            end
+        end
+        if any then
+            -- Site convention: PV generation is a source → negative W.
+            host.emit("pv", { w = -total_w, lifetime_wh = total_gen_wh })
+            host.emit_metric("pv_w", -total_w)
+        end
+    end
+
     return 1000
 end
 
 ----------------------------------------------------------------------------
--- Control (READ-ONLY — P1 meter exposes no writable endpoint)
+-- Control (READ-ONLY — Zap exposes no writable endpoint)
 ----------------------------------------------------------------------------
 
 function driver_command(action, power_w, cmd)
@@ -224,5 +337,6 @@ end
 
 function driver_cleanup()
     p1_serial = nil
+    pv_serials = {}
     clear_backoff()
 end

--- a/web/settings.js
+++ b/web/settings.js
@@ -221,7 +221,15 @@
             if (protocols.indexOf("http") >= 0) {
               var hosts = (chosen.dataset.httpHosts || "").split(",").filter(Boolean);
               driver.capabilities.http = { allowed_hosts: hosts };
-              driver.config = { email: "", password: "", serial: "" };
+              // A driver that declares http_hosts in its catalog block is
+              // reaching a known local device at a fixed hostname — seed a
+              // config.host field. Anything else is a cloud driver whose
+              // vendor endpoint is hardcoded and instead needs auth creds.
+              if (hosts.length > 0) {
+                driver.config = { host: hosts[0] };
+              } else {
+                driver.config = { email: "", password: "", serial: "" };
+              }
             }
             currentConfig.drivers.push(driver);
             renderTab("devices");
@@ -276,8 +284,26 @@
               '<input type="number" data-path="drivers.' + idx + '.capabilities.modbus.unit_id" value="' + (modbus.unit_id || 1) + '">' +
               '</fieldset>';
           }
-          // Cloud API drivers (e.g. Easee) — show auth fields inline
-          var isCloudDriver = (driverFile || '').indexOf('easee_cloud') >= 0 || (cap.http != null);
+          // Distinguish "local HTTP driver that needs an IP" (e.g. Sourceful
+          // Zap) from "cloud API driver that needs creds" (e.g. Easee) by
+          // the config shape the driver declared: config.host → local,
+          // config.email/password → cloud. Name-based matching rots the
+          // moment a new driver lands. If only an http capability is set
+          // and the config is empty, fall back to cloud so a hand-edited
+          // yaml still surfaces the auth form.
+          var dcfg = d.config || {};
+          var hasHostField = Object.prototype.hasOwnProperty.call(dcfg, 'host');
+          var hasAuthField = Object.prototype.hasOwnProperty.call(dcfg, 'email') ||
+                             Object.prototype.hasOwnProperty.call(dcfg, 'password');
+          var isLocalHTTP = cap.http != null && hasHostField;
+          var isCloudDriver = cap.http != null && !hasHostField && (hasAuthField || Object.keys(dcfg).length === 0);
+          if (isLocalHTTP) {
+            var lcfg = d.config || {};
+            html += '<fieldset><legend>HTTP</legend>' +
+              '<label>Host / IP ' + help('Hostname (e.g. zap.local) or IP address of the device. mDNS names work when your OS resolver supports them; otherwise use the LAN IP.') + '</label>' +
+              '<input type="text" data-path="drivers.' + idx + '.config.host" value="' + escHtml(lcfg.host || '') + '" placeholder="zap.local">' +
+              '</fieldset>';
+          }
           if (isCloudDriver) {
             var cfg = d.config || {};
             // Server sets has_password=true via MaskSecrets when a password

--- a/web/settings.js
+++ b/web/settings.js
@@ -203,6 +203,10 @@
               opt.dataset.protocols = protoLabel;
               opt.dataset.id = e.id || "";
               opt.dataset.httpHosts = (e.http_hosts || []).join(",");
+              // connection_defaults.host is the local-HTTP discriminator —
+              // http_hosts is declared by cloud drivers too (Easee uses it
+              // for allowed-hosts), so it can't be used on its own.
+              opt.dataset.connectionHost = (e.connection_defaults && e.connection_defaults.host) || "";
               sel.appendChild(opt);
             });
           });
@@ -221,12 +225,15 @@
             if (protocols.indexOf("http") >= 0) {
               var hosts = (chosen.dataset.httpHosts || "").split(",").filter(Boolean);
               driver.capabilities.http = { allowed_hosts: hosts };
-              // A driver that declares http_hosts in its catalog block is
-              // reaching a known local device at a fixed hostname — seed a
-              // config.host field. Anything else is a cloud driver whose
-              // vendor endpoint is hardcoded and instead needs auth creds.
-              if (hosts.length > 0) {
-                driver.config = { host: hosts[0] };
+              // connection_defaults.host is declared only by drivers that
+              // take a user-configurable local endpoint (e.g. Sourceful
+              // Zap → "zap.local"). Cloud drivers like Easee declare
+              // http_hosts for allowed-hosts but have no connection_defaults
+              // — their endpoint is hardcoded and they need email/password
+              // in config instead.
+              var connHost = chosen.dataset.connectionHost || "";
+              if (connHost) {
+                driver.config = { host: connHost };
               } else {
                 driver.config = { email: "", password: "", serial: "" };
               }

--- a/web/setup.js
+++ b/web/setup.js
@@ -273,6 +273,16 @@
       driver.capabilities.mqtt = { host: ip, port: port };
     } else if (protocol === 'http') {
       driver.capabilities.http = { allowed_hosts: [ip] };
+      // A catalog entry that declares http_hosts is a local-HTTP driver
+      // reaching a device at a known hostname — seed config.host from the
+      // IP the user just entered. Catalog entries without http_hosts are
+      // cloud drivers (Easee etc.) whose endpoint is hardcoded; those
+      // drivers key off config.email/password and shouldn't carry a host.
+      var declared = (selectedCatalog && selectedCatalog.http_hosts) || [];
+      if (declared.length > 0) {
+        driver.config = driver.config || {};
+        driver.config.host = ip;
+      }
     }
 
     // If this is the site meter, uncheck others
@@ -297,6 +307,8 @@
       detail = d.capabilities.modbus.host + ':' + d.capabilities.modbus.port;
     } else if (d.capabilities.mqtt) {
       detail = d.capabilities.mqtt.host + ':' + d.capabilities.mqtt.port;
+    } else if (d.capabilities.http) {
+      detail = (d.config && d.config.host) || (d.capabilities.http.allowed_hosts || [])[0] || '';
     }
     var tags = [];
     if (d.is_site_meter) tags.push('site meter');

--- a/web/setup.js
+++ b/web/setup.js
@@ -273,13 +273,15 @@
       driver.capabilities.mqtt = { host: ip, port: port };
     } else if (protocol === 'http') {
       driver.capabilities.http = { allowed_hosts: [ip] };
-      // A catalog entry that declares http_hosts is a local-HTTP driver
-      // reaching a device at a known hostname — seed config.host from the
-      // IP the user just entered. Catalog entries without http_hosts are
-      // cloud drivers (Easee etc.) whose endpoint is hardcoded; those
-      // drivers key off config.email/password and shouldn't carry a host.
-      var declared = (selectedCatalog && selectedCatalog.http_hosts) || [];
-      if (declared.length > 0) {
+      // connection_defaults.host is declared only by drivers that take a
+      // user-configurable local endpoint — seed config.host from the IP the
+      // user just entered. Cloud drivers (Easee etc.) declare http_hosts
+      // for allowed-hosts handling but have no connection_defaults.host;
+      // their vendor endpoint is hardcoded and they key off
+      // config.email/password instead, so leave config untouched here.
+      var connHost = (selectedCatalog && selectedCatalog.connection_defaults &&
+                      selectedCatalog.connection_defaults.host) || '';
+      if (connHost) {
         driver.config = driver.config || {};
         driver.config.host = ip;
       }


### PR DESCRIPTION
Adds drivers/zap.lua, a read-only driver for the Sourceful Zap energy gateway. The Zap exposes a local JSON API; this driver walks /api/devices to discover the P1 (grid) meter serial, then polls /api/devices/<sn>/data/json and emits meter telemetry in site convention (positive = import).

Host/IP is configurable via config.host (defaults to the mDNS name zap.local). Serial auto-discovers on first poll; can be pinned via config.serial. Failed calls back off exponentially (2s → 60s) and force re-discovery if they persist, so a rebooted gateway with a rotated serial recovers on its own.

Also fixes a UI bug where every HTTP-capable driver was rendered with the cloud-credentials form. settings.js and setup.js now distinguish local HTTP (seed config.host from the catalog's http_hosts) from cloud HTTP (seed config.email/password/serial) by the shape the driver declares, not by filename — so future local HTTP drivers pick up the right form automatically.