### PR TITLE
ci: build + attach linux/windows release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,89 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  binaries:
+    name: build + upload release binaries
+    runs-on: ubuntu-latest
+    needs: release
+    # Skip when semantic-release didn't cut a new version — nothing to
+    # attach to. Parallel with the docker job (both gated on the same
+    # output) so a failing binary build doesn't block the image push.
+    if: needs.release.outputs.new_release_published == 'true'
+    permissions:
+      contents: write  # upload assets to the release
+    strategy:
+      # fail-fast off: if one platform breaks, still get assets for the
+      # others uploaded so users aren't blocked by a single bad target.
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+            archive: tar.gz
+          - goos: linux
+            goarch: arm64
+            ext: ""
+            archive: tar.gz
+          - goos: windows
+            goarch: amd64
+            ext: ".exe"
+            archive: zip
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v5
+        with:
+          # semantic-release pushed v${version} (tag) + a changelog commit.
+          # Check out the tag so -X main.Version matches what users install.
+          ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: go/go.sum
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+          VERSION: v${{ needs.release.outputs.new_release_version }}
+        working-directory: go
+        run: |
+          mkdir -p ../bin
+          go build -trimpath -ldflags "-s -w -X main.Version=${VERSION}" \
+            -o "../bin/forty-two-watts-${GOOS}-${GOARCH}${{ matrix.ext }}" \
+            ./cmd/forty-two-watts
+          ls -la "../bin/forty-two-watts-${GOOS}-${GOARCH}${{ matrix.ext }}"
+
+      - name: Package
+        env:
+          PLATFORM: ${{ matrix.goos }}-${{ matrix.goarch }}
+          BINARY: forty-two-watts-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          if [[ "${ARCHIVE}" == "zip" ]]; then
+            (cd bin && zip -q "../release/forty-two-watts-${PLATFORM}.zip" "${BINARY}")
+            zip -qr "release/forty-two-watts-${PLATFORM}.zip" drivers web config.example.yaml
+          else
+            tar czf "release/forty-two-watts-${PLATFORM}.tar.gz" \
+              -C bin "${BINARY}" \
+              -C .. drivers web config.example.yaml
+          fi
+          ls -la release/
+
+      - name: Upload to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.release.outputs.new_release_version }}
+          ASSET: release/forty-two-watts-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive }}
+        # --clobber lets a workflow re-run replace a prior upload without
+        # failing — useful when semantic-release is re-triggered manually.
+        run: gh release upload "${TAG}" "${ASSET}" --clobber
+
   docker:
     name: docker build + push
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 # Top-level build for forty-two-watts (pure Go + Lua drivers).
 #
 # Common targets:
-#   make test         — full test suite
-#   make build        — native binaries for this machine
-#   make build-arm64  — cross-compile for linux/arm64 (RPi)
-#   make release      — arm64 + amd64 tarballs in release/
-#   make run-sim      — start both simulators locally
-#   make dev          — start sims + main app (hot-reload workflow)
-#   make clean        — remove all build artifacts
+#   make test                 — full test suite
+#   make build                — native binaries for this machine
+#   make build-arm64          — cross-compile for linux/arm64 (RPi)
+#   make build-amd64          — cross-compile for linux/amd64 (x86_64 server)
+#   make build-windows-amd64  — cross-compile for windows/amd64 (.exe)
+#   make release              — linux arm64/amd64 tarballs + windows zip
+#   make run-sim              — start both simulators locally
+#   make dev                  — start sims + main app (hot-reload workflow)
+#   make clean                — remove all build artifacts
 
-.PHONY: help test build build-arm64 build-amd64 release \
+.PHONY: help test build build-arm64 build-amd64 build-windows-amd64 release \
         run-sim dev fmt vet clean e2e docs
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -19,15 +21,17 @@ help:
 	@echo "forty-two-watts — Go + Lua EMS"
 	@echo ""
 	@echo "Targets:"
-	@echo "  test         run full test suite"
-	@echo "  build        native binaries into bin/"
-	@echo "  build-arm64  cross-compile for linux/arm64"
-	@echo "  release      arm64 + amd64 tarballs"
-	@echo "  run-sim      start Ferroamp + Sungrow simulators"
-	@echo "  dev          start sims + main app against config.local.yaml"
-	@echo "  e2e          run the full-stack e2e test"
-	@echo "  fmt vet      Go format + static checks"
-	@echo "  clean        nuke build artifacts"
+	@echo "  test                 run full test suite"
+	@echo "  build                native binaries into bin/"
+	@echo "  build-arm64          cross-compile for linux/arm64"
+	@echo "  build-amd64          cross-compile for linux/amd64"
+	@echo "  build-windows-amd64  cross-compile for windows/amd64 (.exe)"
+	@echo "  release              linux tarballs + windows zip in release/"
+	@echo "  run-sim              start Ferroamp + Sungrow simulators"
+	@echo "  dev                  start sims + main app against config.local.yaml"
+	@echo "  e2e                  run the full-stack e2e test"
+	@echo "  fmt vet              Go format + static checks"
+	@echo "  clean                nuke build artifacts"
 
 # ---- Testing ----
 
@@ -58,9 +62,15 @@ build-amd64:
 		go build -ldflags="$(LDFLAGS)" -o ../bin/forty-two-watts-linux-amd64 ./cmd/forty-two-watts
 	@ls -la bin/forty-two-watts-linux-amd64
 
-# ---- Release tarballs ----
+build-windows-amd64:
+	@mkdir -p bin
+	cd go && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
+		go build -ldflags="$(LDFLAGS)" -o ../bin/forty-two-watts-windows-amd64.exe ./cmd/forty-two-watts
+	@ls -la bin/forty-two-watts-windows-amd64.exe
 
-release: build-arm64 build-amd64
+# ---- Release archives ----
+
+release: build-arm64 build-amd64 build-windows-amd64
 	@mkdir -p release
 	@for arch in arm64 amd64; do \
 		tar czf release/forty-two-watts-linux-$$arch.tar.gz \
@@ -69,6 +79,14 @@ release: build-arm64 build-amd64
 		printf "built release/forty-two-watts-linux-%s.tar.gz (%s bytes)\n" "$$arch" \
 			"$$(wc -c <release/forty-two-watts-linux-$$arch.tar.gz)"; \
 	done
+	@# Windows: .zip (native format on the platform) — binary from bin/ plus
+	@# bundled drivers/web/config.example.yaml from repo root. Delete first
+	@# so rerunning release doesn't keep appending to a stale archive.
+	@rm -f release/forty-two-watts-windows-amd64.zip
+	@cd bin && zip -q ../release/forty-two-watts-windows-amd64.zip forty-two-watts-windows-amd64.exe
+	@zip -qr release/forty-two-watts-windows-amd64.zip drivers web config.example.yaml
+	@printf "built release/forty-two-watts-windows-amd64.zip (%s bytes)\n" \
+		"$$(wc -c <release/forty-two-watts-windows-amd64.zip)"
 
 # ---- Dev workflow ----
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,35 +1,39 @@
 #!/bin/bash
-# Build static binaries and create a GitHub release
+# Build release archives and create (or attach to) a GitHub release.
 # Usage: ./scripts/release.sh v0.2.0
+#
+# Produces linux arm64/amd64 tarballs + windows amd64 zip via the
+# Makefile's `release` target, then uploads them to the GitHub release
+# for the given tag. If the release doesn't exist yet it's created with
+# auto-generated notes; if it does exist the assets are added with
+# --clobber so a re-run safely replaces a broken archive.
 
 set -euo pipefail
 
 VERSION=${1:?Usage: $0 <version>}
 REPO="frahlg/forty-two-watts"
 
-echo "Building forty-two-watts ${VERSION}..."
-mkdir -p release
+echo "Building forty-two-watts ${VERSION} (linux arm64/amd64, windows amd64)…"
+make release
 
-# Build static binaries for both architectures
-for PLATFORM in linux/arm64 linux/amd64; do
-    ARCH=$(echo $PLATFORM | cut -d/ -f2)
-    echo "  Building ${ARCH}..."
-    docker build --platform ${PLATFORM} -t forty-two-watts:${ARCH} .
-    docker create --name ems-extract forty-two-watts:${ARCH}
-    docker cp ems-extract:/app/forty-two-watts release/forty-two-watts-linux-${ARCH}
-    docker rm ems-extract
-    chmod +x release/forty-two-watts-linux-${ARCH}
-    tar czf release/forty-two-watts-linux-${ARCH}.tar.gz \
-        -C release forty-two-watts-linux-${ARCH} \
-        -C .. drivers/ web/ config.example.yaml
+ASSETS=(
+    release/forty-two-watts-linux-arm64.tar.gz
+    release/forty-two-watts-linux-amd64.tar.gz
+    release/forty-two-watts-windows-amd64.zip
+)
+
+for f in "${ASSETS[@]}"; do
+    [ -f "$f" ] || { echo "missing: $f"; exit 1; }
 done
 
-echo "Creating GitHub release ${VERSION}..."
-gh release create ${VERSION} \
-    release/forty-two-watts-linux-arm64.tar.gz \
-    release/forty-two-watts-linux-amd64.tar.gz \
-    --repo ${REPO} \
-    --title "${VERSION}" \
-    --generate-notes
+if gh release view "${VERSION}" --repo "${REPO}" >/dev/null 2>&1; then
+    echo "Release ${VERSION} exists — uploading assets (clobbering duplicates)…"
+    gh release upload "${VERSION}" --repo "${REPO}" --clobber "${ASSETS[@]}"
+else
+    echo "Creating GitHub release ${VERSION}…"
+    gh release create "${VERSION}" --repo "${REPO}" \
+        --title "${VERSION}" --generate-notes \
+        "${ASSETS[@]}"
+fi
 
 echo "Done! Release: https://github.com/${REPO}/releases/tag/${VERSION}"


### PR DESCRIPTION
## Summary
Release pipeline currently only runs semantic-release + Docker push — GitHub releases (v0.7.0 / v0.8.0) have no binary assets attached. `scripts/deploy-go.sh` breaks against empty asset lists. This wires up multi-platform binary builds into the release workflow.

## What changes
- `.github/workflows/release.yml`: new `binaries` job parallel to `docker`, both gated on `new_release_published == true`. Matrix over `linux/amd64`, `linux/arm64`, `windows/amd64`. Cross-compiles with `CGO_ENABLED=0`, packages (tar.gz / zip) with bundled `drivers/`, `web/`, `config.example.yaml`, and uploads via `gh release upload --clobber`.
- `Makefile`: adds `build-windows-amd64`; extends `release` target to include the Windows zip alongside the existing Linux tarballs. Local output mirrors CI.
- `scripts/release.sh`: simplified to `make release` + `gh release upload/create` — Docker build path retired since modernc.org/sqlite is pure Go, no container needed for static binaries.

## Why windows/amd64 only (no 386 or arm64)
- 32-bit x86 is vanishingly rare on Windows hosts that would run this.
- Windows-on-ARM could be added later as another matrix entry if needed.

## Test plan
- [x] `make clean && make release` builds all three archives locally (verified: linux-arm64.tar.gz 7.2 MB, linux-amd64.tar.gz 7.8 MB, windows-amd64.zip 8.0 MB).
- [x] Archive contents verified: binary + drivers/ + web/ + config.example.yaml.
- [ ] Next merge to master that produces a semantic-release version should attach all three assets to the new tag. If that works, retroactively `scripts/release.sh v0.8.0` locally to backfill missing v0.7.0 / v0.8.0 assets.
- [ ] One-time Windows smoke test by a Windows user (binary runs, static web loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)