### PR TITLE
feat: plan allocates energy, EMS converts to power (opt-in)

### DIFF
--- a/docs/plan-ems-contract.md
+++ b/docs/plan-ems-contract.md
@@ -1,0 +1,223 @@
+# Plan / EMS contract
+
+Design note for the dispatch-layer rework. Three principles, the mode
+taxonomy they imply, the wire contract between the planner and the EMS,
+and the migration plan. Status: proposal — not yet implemented.
+
+## Motivating incident
+
+Operator report (2026-04-17): plan said `grid_target_w = -51`, actual
+grid was `-18`, battery charging ~3.9 kW during a high-price window.
+Forecast had PV = 700 W; reality was 4.8 kW. Instead of exporting the
+surplus at peak price, the battery absorbed it.
+
+Root cause: the plan's per-slot output is a **grid target**, and the PI
+loop chases it. When PV surprises on the upside, the PI sees excess
+export and pulls the battery into charging to restore the grid target.
+The plan's intent was "charge ~800 W from the forecasted PV" — but the
+way that intent reaches the EMS is "drive grid to −51 W", which under
+4.8 kW of PV means "absorb the surplus in the battery".
+
+The plan would also need to re-decide whether to export once it sees
+the real PV. Reactive replan exists but fires on integrated energy
+error (500 Wh default), which at 4.1 kW surplus takes ~7 minutes —
+well past the peak-price minute.
+
+Two distinct failures. Fixing either without the other doesn't help.
+
+## Three principles
+
+### 1. The plan allocates *energy* per slot, not power
+
+The DP already integrates `action_w × slot_duration` internally — that
+product is what gets priced. Exposing power hides the conserved
+quantity. Change the contract: per-slot output is
+`battery_energy_wh` (signed — positive = charge, negative =
+discharge), not `battery_w`.
+
+Consequence: how fast the energy flows within a slot becomes a
+tactical decision for the EMS, not a strategic decision for the plan.
+
+### 2. The EMS converts energy to power in real time
+
+Each tick:
+
+```
+remaining_wh  = slot.target_wh - delivered_wh_this_slot
+remaining_s   = slot_end - now
+battery_w     = remaining_wh * 3600 / remaining_s
+```
+
+Clamp against per-driver max charge/discharge power, SoC floor/ceiling,
+and the site fuse. Split across multiple batteries by the active
+mode's distribution rule (priority / weighted — unchanged).
+
+Consequence: if reality runs ahead of plan (e.g. PV surprise fills the
+energy target in 2 minutes), the EMS idles the battery for the rest of
+the slot. If reality runs behind, the EMS accelerates.
+
+### 3. The grid is the residual
+
+Nothing in the control loop tracks a grid target. Grid flow is
+whatever results from `load - pv - battery`. The PI loop on grid is
+deleted from the plan-driven path.
+
+Consequence: PV surprises flow to grid naturally. No feedforward
+hack needed. The plan's intent is respected (the battery does what
+it was told) and the grid sees whatever physics dictates.
+
+This is the architectural flip. The PI still exists, but only for
+**SoC tracking** against the plan's SoC trajectory — a slow inner
+loop that corrects for model error, not a fast outer loop fighting
+grid flow.
+
+## What the plan still decides strategically
+
+- How much energy each battery should absorb/release per slot
+- Which slots to charge vs discharge (price arbitrage, SoC trajectory)
+- When to trigger a full replan (passive divergence detector)
+
+What the plan no longer commands directly:
+- Instantaneous grid flow
+- Instantaneous battery power
+
+## Mode taxonomy
+
+Today's `Mode` is a soup of strategies, dispatch rules, and execution
+states. Split into two orthogonal axes.
+
+### Planner strategy (what the DP optimizes)
+
+| Strategy | Objective |
+|---|---|
+| `self_consumption` | Minimize grid flow. Store PV for own use. Export only when battery is full. |
+| `arbitrage` | Maximize price spread. Cycle the battery when `export_price - import_price × 1/roundtrip_eff > threshold`. |
+| `cheap_charge` | Charge from grid during cheap hours; discharge whenever. For low-PV, high-base-load sites. |
+
+Exactly one selected at any time. Stored in `state.db` under `mode`,
+exposed via `/api/mode`.
+
+### EMS state (how the EMS acts on plan output)
+
+| State | Behavior |
+|---|---|
+| `follow_plan` | Normal. Battery setpoint derived from `plan.battery_energy_wh` per §2. |
+| `manual` | Operator sets `battery_w` directly via API. Timeout back to `follow_plan` after N minutes (so a forgotten manual command self-heals). |
+| `idle` | No dispatch. Safety / maintenance. Explicit operator action. |
+| `auto_fallback` | Plan is stale (> `MaxPlanAge`) or absent. Falls back to a local self-consumption rule. Not operator-selectable — entered automatically when the plan hook returns `(_, false)`. |
+
+### Not modes — always on
+
+- **Peak shaving** — hard constraint: grid import ≤ `fuse.max_amps × voltage × phases`. Fuse guard in `dispatch.go` already enforces this for any strategy.
+- **SoC floor / ceiling** — per-battery parameters (`soc_min_pct`, `soc_max_pct`). DP respects them; dispatch clamps enforce them.
+- **Backup reserve** — a parameter (`soc_reserve_pct`) that becomes a hard SoC floor when the operator wants outage resilience. Not a mode.
+- **Multi-battery split** — internal dispatch rule (`priority` / `weighted`), not operator-facing.
+
+## Wire contract
+
+```go
+// planner → EMS
+type SlotDirective struct {
+    SlotStart    time.Time
+    SlotEnd      time.Time
+    BatteryWh    float64  // signed: + = charge, - = discharge, total for slot
+    SoCTargetPct float64  // plan's SoC trajectory at slot end (for inner PI)
+    Strategy     Strategy // operator's selected strategy (echoed for logging)
+}
+
+// Service.SlotDirectiveAt(now) (SlotDirective, bool)
+```
+
+EMS holds the current directive, accumulates `delivered_wh` per slot,
+resets when slot rolls over. On divergence the plan triggers a replan
+with updated forecasts; the new plan may emit a different directive
+for the remainder of the current slot (EMS resets accumulation to the
+new directive's start).
+
+### Divergence detector (replan trigger)
+
+Replan remains reactive but with a clarified role: **detect strategic
+drift, not tactical mismatch**. Triggers:
+
+- `|integrated_pv_error_wh|` > threshold (existing, keep)
+- `|integrated_load_error_wh|` > threshold (existing, keep)
+- `|actual_soc_pct - plan_soc_target_pct|` > threshold (new — catches when the plan's SoC trajectory no longer matches reality)
+
+Thresholds can be more lenient than today because the EMS is no longer
+fighting reality between replans. Flapping risk drops.
+
+## What changes in code
+
+Required:
+
+- `mpc.Service.SlotDirectiveAt(now)` replaces `GridTargetAt(now)`.
+- `mpc.Plan.Actions[i]` exposes `BatteryEnergyWh` (derived from existing
+  `BatteryW × slot_duration`) and `SoCTargetPct`.
+- `control/dispatch.go`: plan-driven branch reads the directive,
+  maintains `delivered_wh` state, computes `battery_w` per tick, drops
+  the grid-target PI for this path.
+- `control.State` gains `EMSState Enum` (`follow_plan` | `manual` |
+  `idle` | `auto_fallback`).
+- `/api/mode` responds with `{strategy, ems_state}` instead of a flat
+  string. Existing flat-string mode field deprecated with one release
+  of overlap.
+
+Unchanged:
+
+- DP internals (`mpc.go` Optimize / Bellman recursion).
+- Per-battery split rules (`priority` / `weighted`).
+- Fuse guard, SoC clamps, slew limiter in `dispatch.go`.
+- Watchdog, stale-meter short-circuit.
+- Forecast / price / twin services feeding DP inputs.
+
+## Migration
+
+Single PR. Small enough to review in one sitting and touches one layer
+boundary cleanly.
+
+1. Introduce `SlotDirective` alongside `GridTargetAt`. Both return for
+   one release.
+2. Switch `dispatch.go` plan branch to the new directive.
+3. Remove `GridTargetAt` once no caller remains.
+4. Update `docs/mpc-planner.md` + `docs/architecture.md` to reflect.
+5. E2E test: reproduce the xorath scenario (forecast PV = 700 W,
+   simulator PV = 4.8 kW, arbitrage mode, verify export > 3 kW within
+   one control interval of the PV step).
+
+No config schema changes. Mode persistence key (`mode` in `state.db`)
+gets a companion key (`ems_state`) — both migrate in place.
+
+## Open questions
+
+1. **Inner SoC PI:** does the plan's SoC trajectory need to be a PI
+   setpoint, or is the energy-accumulation bookkeeping enough? Probably
+   enough on its own; the PI is a safety net for modeling error. Start
+   without it; add later if divergence detector fires too often.
+
+2. **Slot duration vs tick cadence:** today's 15-min slots + 5-s ticks
+   give 180 ticks/slot. For a 200 Wh slot target, first-tick power is
+   ~4 kW → typical batteries can do it. For tiny slot targets (say 20
+   Wh), first-tick power falls below the battery's control resolution.
+   Solution: clamp EMS minimum-effective-power and carry the residual
+   to the next tick. Degenerate case only — flag as follow-up.
+
+3. **Manual state timeout default:** 30 min? Operator preference. Start
+   at 30, make configurable.
+
+4. **`/api/mpc/diagnose` endpoint:** for ops to introspect plan
+   decisions post-hoc. Returns for any historical slot: forecasts used,
+   directive emitted, actual telemetry, replan reason if any. Separate
+   PR, not blocking.
+
+## Success criteria
+
+- Xorath's scenario reproduced in an e2e test: forecast PV 700 W,
+  actual 4800 W, arbitrage mode, expected export > 3 kW within the
+  first tick after the step.
+- `TestE2E_FullStack` keeps passing (the current failure on Erik's
+  branch is orthogonal — Lua-driver warmup timing — and should be
+  fixed separately).
+- No regression in self-consumption mode (PV surplus still absorbed
+  into battery until full, as today).
+- Reactive replan frequency measurably lower in production telemetry
+  after deploy (fewer spurious flips, tighter strategic fit).

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -375,8 +375,26 @@ func main() {
 		}
 		mpcSvc.Start(ctx)
 		defer mpcSvc.Stop()
-		// Inject plan → control.State so planner modes can override grid_target.
+		// Inject plan → control.State. Both callbacks are wired:
+		//   PlanTarget — legacy grid-target path (grid_target_w, mode str)
+		//   SlotDirective — new energy-allocation path (Wh per slot)
+		// State.UseEnergyDispatch picks which one is actually used when a
+		// planner mode is active; see docs/plan-ems-contract.md.
 		ctrl.PlanTarget = mpcSvc.SlotAt
+		ctrl.SlotDirective = func(now time.Time) (control.SlotDirective, bool) {
+			d, ok := mpcSvc.SlotDirectiveAt(now)
+			if !ok {
+				return control.SlotDirective{}, false
+			}
+			return control.SlotDirective{
+				SlotStart:       d.SlotStart,
+				SlotEnd:         d.SlotEnd,
+				BatteryEnergyWh: d.BatteryEnergyWh,
+				SoCTargetPct:    d.SoCTargetPct,
+				Strategy:        string(d.Strategy),
+			}, true
+		}
+		ctrl.UseEnergyDispatch = cfg.Planner != nil && cfg.Planner.UseEnergyDispatch
 		// If the restored control mode is a planner variant, push the
 		// corresponding mpc.Mode so the plan is built with the strategy
 		// the user actually picked — not whatever cfg.planner.mode says.

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -73,6 +73,12 @@ type Planner struct {
 	ChargeEfficiency    float64 `yaml:"charge_efficiency,omitempty" json:"charge_efficiency,omitempty"`
 	DischargeEfficiency float64 `yaml:"discharge_efficiency,omitempty" json:"discharge_efficiency,omitempty"`
 	ExportOrePerKWh     float64 `yaml:"export_ore_per_kwh,omitempty" json:"export_ore_per_kwh,omitempty"` // 0 = use mean spot
+	// UseEnergyDispatch switches the control loop from the legacy
+	// PI-on-grid-target path to the energy-allocation path where the
+	// plan directs total battery Wh per slot and the EMS converts to
+	// power in real time. See docs/plan-ems-contract.md. Defaults off
+	// until validated in production.
+	UseEnergyDispatch bool `yaml:"use_energy_dispatch,omitempty" json:"use_energy_dispatch,omitempty"`
 }
 
 // Site is the top-level control loop config.

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -474,3 +474,159 @@ func TestSlewRespectsRateWhenTracking(t *testing.T) {
 		t.Errorf("expected slewed target = -1500 W (anchor -1000 + step -500), got %f W", got)
 	}
 }
+
+// ---- Energy-allocation dispatch path (UseEnergyDispatch) ----
+
+// newStateWithEnergyDispatch sets up a fresh State in planner_arbitrage mode
+// with the energy-allocation path enabled. Slew + holdoff are relaxed so the
+// test exercises the formula, not the rate limiter.
+func newStateWithEnergyDispatch(dir SlotDirective, siteMeter string) *State {
+	st := NewState(0, 0, siteMeter) // tolerance=0 so no deadband noise
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100000 // effectively unbounded for the formula test
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+	return st
+}
+
+// Core conversion: 200 Wh allocated, whole 15-min slot remaining,
+// no energy delivered yet → target = 200 × 3600 / 900 = 800 W.
+func TestEnergyDispatchConvertsWhToW(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(0, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	// 200 Wh × 3600 s/h / 900 s ≈ 800 W. Small tolerance for time drift.
+	if got := targets[0].TargetW; math.Abs(got-800) > 5 {
+		t.Errorf("TargetW = %f, want ≈800 (200 Wh / 15 min)", got)
+	}
+}
+
+// The motivating scenario (operator report 2026-04-17): forecast PV 700 W,
+// actual 4800 W, plan wants to charge 200 Wh this slot. Under the legacy
+// path the PI drives battery to ~3.9 kW charge (absorb everything) to hit
+// grid_target. Under energy dispatch the battery stays at ~800 W and the
+// 4 kW surplus flows to the grid.
+func TestEnergyDispatchDoesNotAbsorbPVSurprise(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200, // plan: charge 200 Wh
+		Strategy:        "arbitrage",
+	}
+	// Grid exporting 4 kW (because PV 4.8 kW, load 0.8 kW, battery 0 W).
+	// Under legacy PI with grid_target=−51 the controller would pull the
+	// battery into aggressive charging to pin grid to −51.
+	store := seedStore(-4000, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	// PV telemetry so applyFuseGuard has something to count.
+	store.Update("pv-1", telemetry.DerPV, -4800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	// Expect ~800 W charge, NOT multi-kW absorption. Flag anything beyond
+	// 1.5 kW — that's 7× the plan's intent and signals the old bug.
+	got := targets[0].TargetW
+	if got > 1500 {
+		t.Errorf("TargetW = %f W — battery is absorbing the PV surprise (regression). plan wanted ~800 W charge.", got)
+	}
+	if got < 100 {
+		t.Errorf("TargetW = %f W — battery should still be charging per plan intent.", got)
+	}
+}
+
+// Slot rollover: when SlotDirective returns a new SlotStart, the delivered
+// accumulator must reset so the next slot starts from zero.
+func TestEnergyDispatchResetsOnSlotRollover(t *testing.T) {
+	now := time.Now()
+	// First slot: mid-slot, accumulator should build up.
+	dir1 := SlotDirective{
+		SlotStart:       now.Add(-10 * time.Minute),
+		SlotEnd:         now.Add(5 * time.Minute),
+		BatteryEnergyWh: 200,
+	}
+	store := seedStore(0, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 800, 0.5}, // battery already charging 800 W
+	})
+	st := newStateWithEnergyDispatch(dir1, "ferroamp")
+
+	// First call establishes the slot.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	// New slot — different SlotStart. Should reset slotDelivered.
+	dir2 := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 300,
+	}
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir2, true }
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	if st.slotDelivered != 0 {
+		t.Errorf("slotDelivered = %f after slot rollover, want 0", st.slotDelivered)
+	}
+	if !st.currentDirective.SlotStart.Equal(dir2.SlotStart) {
+		t.Errorf("currentDirective.SlotStart = %v, want %v", st.currentDirective.SlotStart, dir2.SlotStart)
+	}
+}
+
+// When the energy path is enabled but the plan is stale, the legacy path
+// runs (PI on grid_target=0, self_consumption distribution). Verifies the
+// fallback doesn't leave the path flag mis-set.
+func TestEnergyDispatchFallsBackToLegacyWhenDirectiveUnavailable(t *testing.T) {
+	store := seedStore(1000, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	// Directive returns ok=false — plan stale.
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return SlotDirective{}, false }
+	// Legacy fallback hook: return ok=false too, should route to the
+	// "plan stale" self-consumption-with-grid-target=0 branch.
+	st.PlanTarget = func(time.Time) (string, float64, bool) { return "", 0, false }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if !st.PlanStale {
+		t.Error("expected PlanStale=true when both energy + legacy paths lack a plan")
+	}
+	// With grid = +1000 and target = 0, PI should command some charge-absorption
+	// (negative correction if batteries > 0, toward discharge). Just assert the
+	// path dispatched something.
+	if len(targets) == 0 {
+		t.Error("expected some dispatch under legacy fallback, got nothing")
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -45,7 +45,28 @@ func (m Mode) IsPlannerMode() bool {
 // Returns (mode_string, grid_target_w, ok). mode_string maps to a Mode
 // constant; the dispatch uses its existing mode logic for HOW batteries
 // respond. The plan is a scheduler, not a regulator.
+//
+// Legacy — the new contract (energy-allocation per slot, EMS converts to
+// power) uses SlotDirectiveFunc. See docs/plan-ems-contract.md.
 type PlanTargetFunc func(now time.Time) (string, float64, bool)
+
+// SlotDirective mirrors mpc.SlotDirective — we redefine here to keep the
+// control package import-cycle free. Populated by main.go's injected
+// SlotDirectiveFunc adapter.
+type SlotDirective struct {
+	SlotStart       time.Time
+	SlotEnd         time.Time
+	BatteryEnergyWh float64 // site-signed: + = charge, − = discharge
+	SoCTargetPct    float64
+	Strategy        string // echoed for logging / API; mirrors mpc.Mode
+}
+
+// SlotDirectiveFunc returns the plan's energy-allocation directive for
+// the slot containing `now`. When ok=false the plan is stale or missing
+// and the control loop falls back to auto_fallback (local self-consumption
+// rule with no forward-planning) — same behavior as PlanTargetFunc's
+// stale-plan branch.
+type SlotDirectiveFunc func(now time.Time) (SlotDirective, bool)
 
 // MaxCommandW is the hard per-command power cap (±5 kW). Used by both
 // clampWithSoC (distribution) and the post-slew re-clamp.
@@ -96,7 +117,28 @@ type State struct {
 	// PlanTarget is consulted at the top of each control cycle when
 	// Mode is a planner mode. Nil outside planner modes. Injected from
 	// main.go — the control package doesn't need to know about mpc.
+	//
+	// Legacy (grid-target driven). The new path uses SlotDirective.
 	PlanTarget PlanTargetFunc
+
+	// SlotDirective is the new plan→EMS callback (energy-allocation
+	// contract). When set AND UseEnergyDispatch is true, ComputeDispatch
+	// uses the energy-driven code path instead of the PI-on-grid-target
+	// path. Injected from main.go like PlanTarget. See
+	// docs/plan-ems-contract.md.
+	SlotDirective SlotDirectiveFunc
+
+	// UseEnergyDispatch toggles between the legacy PI-on-grid path and
+	// the new energy-allocation path. False until validated in production
+	// and flipped via config. Default off preserves today's behavior.
+	UseEnergyDispatch bool
+
+	// currentDirective + slotDelivered track the active slot's energy
+	// accounting. Reset when the slot rolls over (by SlotStart equality).
+	// Zero-valued until UseEnergyDispatch fires its first cycle.
+	currentDirective SlotDirective
+	slotDelivered    float64   // Wh delivered to batteries since slot start
+	lastTickTs       time.Time // for ∫ battery_w dt
 
 	// PlanStale tracks whether the last cycle fell back to self_consumption
 	// because the plan was missing. Surfaced via the API for the UI.
@@ -157,29 +199,58 @@ func ComputeDispatch(
 	// charge at 02:00, export at 17:00). The EMS's existing mode logic
 	// decides HOW batteries respond every 5 s based on the live meter.
 	//
-	// The planner's PlanSlot.Mode replaces the effective mode for this
-	// cycle. PlanSlot.GridW overrides the grid target when the slot's
-	// mode needs it (e.g. charge → target = +max_charge). For self-
-	// consumption slots, grid_target is always 0.
+	// Two dispatch paths are supported during the rollout:
+	//
+	//   1. Legacy (UseEnergyDispatch=false): plan returns grid_target_w,
+	//      PI chases it, batteries absorb anything that differs — the
+	//      behavior this package has shipped since the port.
+	//
+	//   2. Energy-allocation (UseEnergyDispatch=true, SlotDirective set):
+	//      plan returns battery energy for the slot; EMS converts to
+	//      instantaneous power from (remaining_wh / remaining_s); grid
+	//      flow is the residual. See docs/plan-ems-contract.md.
+	//
+	// The two paths share all of gather-batteries → distribute → slew →
+	// fuse. They differ only in how `totalCorrection` is computed below.
 	effectiveMode := state.Mode
+	useEnergyPath := false
+	var currentDirective SlotDirective
 	if state.Mode.IsPlannerMode() {
-		var modeStr string
-		var gridW float64
-		ok := false
-		if state.PlanTarget != nil {
-			modeStr, gridW, ok = state.PlanTarget(time.Now())
-		}
-		if ok {
-			effectiveMode = Mode(modeStr)
-			state.SetGridTarget(gridW)
-			state.PlanStale = false
-		} else {
-			if !state.PlanStale {
-				slog.Warn("mpc plan stale — falling back to self_consumption")
+		// Try the energy-allocation path first when enabled.
+		if state.UseEnergyDispatch && state.SlotDirective != nil {
+			if dir, ok := state.SlotDirective(time.Now()); ok {
+				currentDirective = dir
+				useEnergyPath = true
+				// Distribution mode is decoupled from planner strategy in
+				// the energy path — the operator-selected strategy drives
+				// the plan's DP, distribution is always proportional across
+				// online batteries. If the operator wants priority or
+				// weighted, they use the manual modes, not a planner mode.
+				effectiveMode = ModeSelfConsumption
+				state.PlanStale = false
 			}
-			effectiveMode = ModeSelfConsumption
-			state.SetGridTarget(0)
-			state.PlanStale = true
+		}
+		// Fall through to legacy path if energy path is off or its plan
+		// is stale.
+		if !useEnergyPath {
+			var modeStr string
+			var gridW float64
+			ok := false
+			if state.PlanTarget != nil {
+				modeStr, gridW, ok = state.PlanTarget(time.Now())
+			}
+			if ok {
+				effectiveMode = Mode(modeStr)
+				state.SetGridTarget(gridW)
+				state.PlanStale = false
+			} else {
+				if !state.PlanStale {
+					slog.Warn("mpc plan stale — falling back to self_consumption")
+				}
+				effectiveMode = ModeSelfConsumption
+				state.SetGridTarget(0)
+				state.PlanStale = true
+			}
 		}
 	}
 
@@ -260,44 +331,88 @@ func ComputeDispatch(
 		return nil
 	}
 
-	// ---- Compute error based on mode ----
-	var errW float64
-	switch effectiveMode {
-	case ModePeakShaving:
-		// Only act when grid import exceeds peak_limit. Allow any amount of
-		// export, allow import up to peak_limit.
-		if gridW > state.PeakLimitW {
-			errW = gridW - state.PeakLimitW
-		} else if gridW < 0 {
-			errW = gridW // exporting → charge with surplus
+	// ---- Sum of battery current power (site-signed) ----
+	// Used by both paths: legacy distributors take (currentTotal + correction);
+	// energy path computes correction as (desired_total - currentTotal).
+	var currentTotal float64
+	for _, b := range onlineBats {
+		currentTotal += b.currentW
+	}
+
+	// ---- Compute totalCorrection — two paths diverge here ----
+	var totalCorrection float64
+	if useEnergyPath {
+		// Energy-allocation path: plan's slot directive says "this many Wh
+		// over this slot". Derive the instantaneous power needed to hit the
+		// remaining energy in the remaining time, then pass (target - currentTotal)
+		// as the correction the existing distributors expect.
+		now := time.Now()
+		// Slot rollover: new slot → reset the delivered accumulator.
+		if !currentDirective.SlotStart.Equal(state.currentDirective.SlotStart) {
+			state.currentDirective = currentDirective
+			state.slotDelivered = 0
+			state.lastTickTs = now
 		} else {
-			errW = 0
+			// Accumulate energy delivered since the last tick, using live
+			// battery telemetry (the truth about what the fleet is doing
+			// right now). This lets the formula course-correct when the
+			// commanded setpoint couldn't be met.
+			dt := now.Sub(state.lastTickTs).Seconds()
+			if dt > 0 && dt < 300 { // cap dt at 5min so a long pause doesn't poison accumulator
+				state.slotDelivered += currentTotal * dt / 3600.0
+			}
+			state.lastTickTs = now
 		}
-	default:
-		errW = gridW - state.GridTargetW
-	}
-
-	// ---- Deadband ----
-	if math.Abs(errW) < state.GridToleranceW {
-		return nil
-	}
-
-	// ---- Outer PI — drives total correction we want across all batteries ----
-	// Site convention: gridW positive = too much import → we want to discharge
-	// batteries (site-signed correction should be negative).
-	// PI setpoint = GridTargetW, measurement = gridW. error = setpoint - measurement.
-	// When gridW > target, error < 0, PI output < 0 → total_correction < 0 → bat targets shift
-	// toward more discharge (more negative). That's exactly what we want.
-	//
-	// For PeakShaving we feed a slightly different measurement so the same PI works.
-	var piMeasurement float64
-	if effectiveMode == ModePeakShaving {
-		piMeasurement = state.GridTargetW + errW // puts the bias into the setpoint-error
+		remainingWh := currentDirective.BatteryEnergyWh - state.slotDelivered
+		remainingS := currentDirective.SlotEnd.Sub(now).Seconds()
+		var targetTotalW float64
+		if remainingS > 0.5 {
+			targetTotalW = remainingWh * 3600.0 / remainingS
+		}
+		// Grid target is a pure observation on this path — useful for UI
+		// + legacy API, not driving PI. Reset PI so switching back to the
+		// legacy path doesn't carry stale integral state.
+		state.GridTargetW = 0
+		state.PI.Reset()
+		totalCorrection = targetTotalW - currentTotal
 	} else {
-		piMeasurement = gridW
+		// Legacy path: PI on grid target.
+		var errW float64
+		switch effectiveMode {
+		case ModePeakShaving:
+			// Only act when grid import exceeds peak_limit. Allow any amount of
+			// export, allow import up to peak_limit.
+			if gridW > state.PeakLimitW {
+				errW = gridW - state.PeakLimitW
+			} else if gridW < 0 {
+				errW = gridW // exporting → charge with surplus
+			} else {
+				errW = 0
+			}
+		default:
+			errW = gridW - state.GridTargetW
+		}
+
+		// Deadband only applies to the legacy path — the energy formula
+		// produces small corrections naturally when close to target.
+		if math.Abs(errW) < state.GridToleranceW {
+			return nil
+		}
+
+		// Outer PI — drives total correction we want across all batteries.
+		// Site convention: gridW positive = too much import → we want to discharge
+		// batteries (site-signed correction should be negative).
+		// PI setpoint = GridTargetW, measurement = gridW.
+		// For PeakShaving we feed a slightly different measurement so the same PI works.
+		var piMeasurement float64
+		if effectiveMode == ModePeakShaving {
+			piMeasurement = state.GridTargetW + errW
+		} else {
+			piMeasurement = gridW
+		}
+		out := state.PI.Update(piMeasurement)
+		totalCorrection = out.Output
 	}
-	out := state.PI.Update(piMeasurement)
-	totalCorrection := out.Output
 
 	// ---- Distribute across batteries ----
 	var raw []DispatchTarget

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -124,10 +124,66 @@ func (s *Service) Latest() *Plan {
 // single missed replan doesn't flip us into fallback.
 const MaxPlanAge = 30 * time.Minute
 
+// SlotDirective is the plan's per-slot instruction to the EMS under the
+// energy-allocation contract (see docs/plan-ems-contract.md). The plan
+// allocates total battery energy (Wh, site-signed) for the slot; the
+// EMS converts to instantaneous power each tick from remaining energy
+// and remaining time. Grid flow is the residual — no PI target on it.
+//
+// Signed convention matches Action.BatteryW: positive = charge, negative
+// = discharge. Magnitude is the total energy expected to move into (or
+// out of) the battery fleet across the slot.
+type SlotDirective struct {
+	SlotStart       time.Time
+	SlotEnd         time.Time
+	BatteryEnergyWh float64 // total energy for the slot (site-signed)
+	SoCTargetPct    float64 // plan's SoC at SlotEnd — used by divergence detector
+	Strategy        Mode    // echoed for logging + API
+}
+
+// SlotDirectiveAt returns the energy-allocation directive for the slot
+// containing `now`. Non-breaking companion to SlotAt — the control loop
+// switches to this when the new dispatch path is enabled; SlotAt stays
+// for the legacy grid-target path until that's retired.
+func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
+	if s == nil {
+		return SlotDirective{}, false
+	}
+	s.mu.RLock()
+	p := s.last
+	s.mu.RUnlock()
+	if p == nil {
+		return SlotDirective{}, false
+	}
+	if time.Since(time.UnixMilli(p.GeneratedAtMs)) > MaxPlanAge {
+		return SlotDirective{}, false
+	}
+	nowMs := now.UnixMilli()
+	for _, a := range p.Actions {
+		slotLenMs := int64(a.SlotLenMin) * 60 * 1000
+		endMs := a.SlotStartMs + slotLenMs
+		if nowMs < a.SlotStartMs || nowMs >= endMs {
+			continue
+		}
+		// energy_wh = power_w * hours. a.SlotLenMin/60 gives hours.
+		energyWh := a.BatteryW * float64(a.SlotLenMin) / 60.0
+		return SlotDirective{
+			SlotStart:       time.UnixMilli(a.SlotStartMs),
+			SlotEnd:         time.UnixMilli(endMs),
+			BatteryEnergyWh: energyWh,
+			SoCTargetPct:    a.SoCPct,
+			Strategy:        s.Defaults.Mode,
+		}, true
+	}
+	return SlotDirective{}, false
+}
+
 // SlotAt returns the plan's directive for the slot containing `now`.
 // Returns (mode, grid_target_w, ok). Dispatch uses `mode` to select
 // the EMS strategy and `grid_target_w` as the PI setpoint. The plan is
 // a scheduler (decides WHEN); the EMS is the regulator (decides HOW).
+//
+// Legacy — the new path uses SlotDirectiveAt. See docs/plan-ems-contract.md.
 func (s *Service) SlotAt(now time.Time) (string, float64, bool) {
 	if s == nil {
 		return "", 0, false

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -196,3 +196,114 @@ func TestOptimizeSelfConsumptionDoesNotDischargeWithOldTerminalPrice(t *testing.
 		}
 	}
 }
+
+// SlotDirectiveAt returns energy-allocation directive for the slot
+// containing now. Verifies that power is converted to energy via the
+// slot length, that stale plans return ok=false, and that out-of-window
+// queries return ok=false.
+func TestSlotDirectiveAt(t *testing.T) {
+	now := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	slotStart := now.Add(-3 * time.Minute) // we're 3 min into a 15-min slot
+	slotLenMin := 15
+
+	s := &Service{
+		Defaults: Params{Mode: ModeArbitrage},
+		last: &Plan{
+			GeneratedAtMs: now.Add(-time.Minute).UnixMilli(),
+			Actions: []Action{{
+				SlotStartMs: slotStart.UnixMilli(),
+				SlotLenMin:  slotLenMin,
+				BatteryW:    800, // 800 W × 15/60 h = 200 Wh for the slot
+				SoCPct:      45.5,
+			}},
+		},
+	}
+
+	d, ok := s.SlotDirectiveAt(now)
+	if !ok {
+		t.Fatal("SlotDirectiveAt returned ok=false, want true")
+	}
+	if want := 200.0; math.Abs(d.BatteryEnergyWh-want) > 0.01 {
+		t.Errorf("BatteryEnergyWh = %f, want %f", d.BatteryEnergyWh, want)
+	}
+	if !d.SlotStart.Equal(slotStart) {
+		t.Errorf("SlotStart = %v, want %v", d.SlotStart, slotStart)
+	}
+	if want := slotStart.Add(15 * time.Minute); !d.SlotEnd.Equal(want) {
+		t.Errorf("SlotEnd = %v, want %v", d.SlotEnd, want)
+	}
+	if d.SoCTargetPct != 45.5 {
+		t.Errorf("SoCTargetPct = %f, want 45.5", d.SoCTargetPct)
+	}
+	if d.Strategy != ModeArbitrage {
+		t.Errorf("Strategy = %v, want arbitrage", d.Strategy)
+	}
+}
+
+// Discharge intent (negative BatteryW) surfaces as negative energy.
+func TestSlotDirectiveAtDischarge(t *testing.T) {
+	now := time.Date(2026, 4, 17, 17, 0, 0, 0, time.UTC)
+	s := &Service{
+		last: &Plan{
+			GeneratedAtMs: now.UnixMilli(),
+			Actions: []Action{{
+				SlotStartMs: now.UnixMilli(),
+				SlotLenMin:  15,
+				BatteryW:    -2400, // discharge 600 Wh over 15 min
+			}},
+		},
+	}
+	d, ok := s.SlotDirectiveAt(now)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if want := -600.0; math.Abs(d.BatteryEnergyWh-want) > 0.01 {
+		t.Errorf("BatteryEnergyWh = %f, want %f", d.BatteryEnergyWh, want)
+	}
+}
+
+// A plan older than MaxPlanAge should not surface any directive — the
+// control loop falls back to auto_fallback.
+func TestSlotDirectiveAtStalePlan(t *testing.T) {
+	now := time.Now()
+	s := &Service{
+		last: &Plan{
+			GeneratedAtMs: now.Add(-MaxPlanAge - time.Minute).UnixMilli(),
+			Actions: []Action{{
+				SlotStartMs: now.UnixMilli(),
+				SlotLenMin:  15,
+				BatteryW:    800,
+			}},
+		},
+	}
+	if _, ok := s.SlotDirectiveAt(now); ok {
+		t.Error("SlotDirectiveAt returned ok=true for stale plan, want false")
+	}
+}
+
+// A query outside any slot's time window should return ok=false.
+func TestSlotDirectiveAtOutOfWindow(t *testing.T) {
+	slotStart := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC)
+	s := &Service{
+		last: &Plan{
+			GeneratedAtMs: slotStart.UnixMilli(),
+			Actions: []Action{{
+				SlotStartMs: slotStart.UnixMilli(),
+				SlotLenMin:  15,
+				BatteryW:    800,
+			}},
+		},
+	}
+	future := slotStart.Add(30 * time.Minute) // 15 min past slot end
+	if _, ok := s.SlotDirectiveAt(future); ok {
+		t.Error("SlotDirectiveAt returned ok=true for out-of-window time")
+	}
+}
+
+// Nil service must not panic.
+func TestSlotDirectiveAtNilService(t *testing.T) {
+	var s *Service
+	if _, ok := s.SlotDirectiveAt(time.Now()); ok {
+		t.Error("nil Service returned ok=true")
+	}
+}


### PR DESCRIPTION
## Summary

Implements the three-principle dispatch rework described in `docs/plan-ems-contract.md`:

1. **Planner allocates energy per slot** (Wh), not instantaneous power.
2. **EMS converts energy to power in real time** per tick from remaining Wh / remaining seconds.
3. **Grid flow is the residual** — no PI loop chasing a grid target on the plan-driven path.

Opt-in via `planner.use_energy_dispatch: true` in config. Default off — zero behavior change for anyone not flipping the flag. Legacy PI-on-grid path untouched.

## Why

Operator report (2026-04-17): plan said `grid_target_w = −51`, actual grid was `−18`, battery charging ~3.9 kW during a high-price window. Forecast PV = 700 W; reality = 4.8 kW. Instead of exporting the 4 kW surplus at peak price, the PI drove the battery to absorb it — because the plan's intent reached the EMS as "drive grid to −51 W", not as "charge ~800 W from the available PV".

Under the new path: plan emits `BatteryEnergyWh = 200` for the slot. EMS computes `battery_w = (200 − delivered_wh) × 3600 / remaining_s ≈ 800 W`. Grid absorbs the 4 kW surplus naturally. Plan's intent respected. No PI fighting reality.

## What changes

- `mpc.SlotDirectiveAt(now) (SlotDirective, bool)` — non-breaking addition alongside `SlotAt`. Returns `{SlotStart, SlotEnd, BatteryEnergyWh, SoCTargetPct, Strategy}`.
- `control.State`:
  - New fields `SlotDirective`, `UseEnergyDispatch`, internal `currentDirective`, `slotDelivered`, `lastTickTs`.
  - `ComputeDispatch` gains a second code path gated on `UseEnergyDispatch + SlotDirective set`. Falls back to legacy when the directive is unavailable.
- `config.Planner.UseEnergyDispatch` (YAML: `use_energy_dispatch`).
- `main.go` wires `mpcSvc.SlotDirectiveAt` into control via a thin adapter.

## Tests

Four new tests in `control_test.go`:
- `TestEnergyDispatchConvertsWhToW` — core formula: 200 Wh, 15 min → 800 W.
- `TestEnergyDispatchDoesNotAbsorbPVSurprise` — the motivating scenario: 4.8 kW actual PV vs 700 W forecast, plan allocates 200 Wh charge → battery stays at ~800 W instead of ~3.9 kW absorption.
- `TestEnergyDispatchResetsOnSlotRollover` — delivered accumulator resets at slot boundary.
- `TestEnergyDispatchFallsBackToLegacyWhenDirectiveUnavailable` — stale plan routes through the existing plan-stale branch.

Plus five new `SlotDirectiveAt` tests in `mpc/service_test.go` (happy path, discharge, stale plan, out-of-window, nil service).

## Rollout

1. Merge this PR — nothing changes in production since the flag defaults off.
2. Flip `planner.use_energy_dispatch: true` on a single site (homelab-rpi) and observe for a day or two.
3. If clean, flip for other sites; eventually retire the legacy path and drop the flag.

## Design note

Full rationale + mode taxonomy + migration notes + open questions in `docs/plan-ems-contract.md` (223 lines). Read that first if you want the thinking behind the change.

## Not addressed here (follow-ups)

- Divergence detector reads SoC target (currently plan-pv / plan-load only).
- New mode taxonomy (strategy × ems_state) — the doc covers it; implementation is a separate PR.
- `/api/mpc/diagnose` for ops introspection — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)