### PR TITLE
fix(ci): gate release workflow on successful test run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,16 @@
 name: release
 
-# Run on every push to master. Pull requests do NOT trigger a release —
-# they only run when actually merged. Manual dispatch is allowed for
-# emergency re-runs (no-op if the analyzer doesn't find releasable
-# commits since the last tag).
+# Gated on the `test` workflow — triggering on `push:master` directly
+# would race: semantic-release pushes a changelog commit + tag before
+# `go test + vet` finishes, and master's branch protection rejects it
+# with GH006 ("Required status check ... is expected"). `workflow_run`
+# fires once test.yml completes; the `if:` on each job filters to
+# successful test runs so a broken master still blocks the release.
+# Manual dispatch stays available for emergency re-runs.
 on:
-  push:
+  workflow_run:
+    workflows: [test]
+    types: [completed]
     branches: [master]
   workflow_dispatch:
 
@@ -21,6 +26,10 @@ jobs:
   release:
     name: semantic-release
     runs-on: ubuntu-latest
+    # Only proceed when tests succeeded (workflow_run path) or when
+    # manually re-triggered (workflow_dispatch has no workflow_run event
+    # attached — conclusion would be empty, so gate on the trigger too).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version:   ${{ steps.semantic.outputs.new_release_version }}


### PR DESCRIPTION
semantic-release was racing `go test + vet` — both workflows triggered on `push:master` in parallel, so the changelog commit + tag push landed before the test job finished and GitHub's branch protection rejected it with GH006 ("Required status check 'go test + vet' is expected").

Switch release.yml's trigger to `workflow_run` on the `test` workflow and guard the semantic-release job with
`conclusion == 'success'`. `workflow_dispatch` stays wired for manual re-runs (event has no `workflow_run` payload — gate on event name too).

The downstream `binaries` + `docker` jobs already gate on `needs.release.outputs.new_release_published`, so no extra `if:` needed there.