### PR TITLE
fix(ci): drop @semantic-release/git — push hits branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,11 @@ jobs:
           # semantic-release walks every commit since the last tag, so
           # it needs the full history. fetch-depth: 0 is the standard.
           fetch-depth: 0
-          # Use the default GITHUB_TOKEN; persist-credentials lets the
-          # @semantic-release/git plugin push the changelog commit.
+          # @semantic-release/github now creates the tag + release via
+          # the API — no local branch push happens anymore. The @…/git
+          # plugin was removed because its changelog-commit push was
+          # rejected by master's branch protection (the fresh commit
+          # had no status check attached).
           persist-credentials: true
 
       - name: Setup Node
@@ -64,8 +67,6 @@ jobs:
           # never import it directly).
           semantic_version: 24
           extra_plugins: |
-            @semantic-release/changelog@6
-            @semantic-release/git@10
             conventional-changelog-conventionalcommits@8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -69,17 +69,6 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      { "changelogFile": "CHANGELOG.md" }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "successComment": false,


### PR DESCRIPTION
semantic-release kept failing with GH006 "Required status check 'go test + vet' is expected" even after gating the release workflow on a successful test run. Root cause: `@semantic-release/git` creates a brand-new commit (`chore(release): X.Y.Z` with the CHANGELOG update) and pushes it to master. That new commit has never had any workflow run against it, so the required status check is absent on its SHA and branch protection rejects the push.

Remove `@semantic-release/git` and the paired `@semantic-release/ changelog` from both .releaserc.json and release.yml's extra_plugins. Release notes continue to be published by `@semantic-release/github`, which creates the tag + GitHub Release via the REST API — that path doesn't go through branch protection. CHANGELOG.md in the repo becomes a historical snapshot; new entries live on the Releases page.