### PR TITLE
fix(control): sync PI.Setpoint when energy-dispatch zeros GridTargetW

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -600,6 +600,39 @@ func TestEnergyDispatchResetsOnSlotRollover(t *testing.T) {
 	}
 }
 
+// Energy-dispatch must keep GridTargetW and PI.Setpoint in lockstep so
+// the legacy path doesn't inherit a stale PI setpoint when the operator
+// later switches out of a planner mode. Regression test for a P1
+// raised on PR #79 (Codex).
+func TestEnergyDispatchSyncsPISetpointWithGridTarget(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200,
+	}
+	store := seedStore(0, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	// Pre-poison the setpoint as if a manual mode had set it earlier —
+	// this is what SetGridTarget needs to overwrite atomically.
+	st.PI.Setpoint = 3000
+	st.GridTargetW = 3000
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	if st.PI.Setpoint != 0 {
+		t.Errorf("PI.Setpoint = %f, want 0 after energy-dispatch cycle (stale setpoint would produce wrong corrections after mode switch)", st.PI.Setpoint)
+	}
+	if st.GridTargetW != 0 {
+		t.Errorf("GridTargetW = %f, want 0", st.GridTargetW)
+	}
+}
+
 // When the energy path is enabled but the plan is stale, the legacy path
 // runs (PI on grid_target=0, self_consumption distribution). Verifies the
 // fallback doesn't leave the path flag mis-set.

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -370,9 +370,13 @@ func ComputeDispatch(
 			targetTotalW = remainingWh * 3600.0 / remainingS
 		}
 		// Grid target is a pure observation on this path — useful for UI
-		// + legacy API, not driving PI. Reset PI so switching back to the
-		// legacy path doesn't carry stale integral state.
-		state.GridTargetW = 0
+		// + legacy API, not driving PI. Use SetGridTarget so both
+		// GridTargetW *and* PI.Setpoint move to 0 in lockstep: if the
+		// operator later switches out of a planner mode, the legacy
+		// path's PI.Update would otherwise compute error against a
+		// stale setpoint while deadband/error checks use the synced
+		// GridTargetW, producing wrong corrections.
+		state.SetGridTarget(0)
 		state.PI.Reset()
 		totalCorrection = targetTotalW - currentTotal
 	} else {


### PR DESCRIPTION
Addresses the P1 Codex raised on #79 — https://github.com/frahlg/forty-two-watts/pull/79#discussion_r...

## What was wrong
The energy-dispatch branch in `ComputeDispatch` zeroed `GridTargetW` with a direct assignment and called `PI.Reset()` (which only clears the integral, not the setpoint). If the operator later left a planner mode, the legacy PI path would compute `error = PI.Setpoint - gridW` against a stale setpoint while deadband / error checks used the synced `GridTargetW=0`. Result: the controller could issue no correction when one was needed, or the wrong correction, until another explicit `SetGridTarget` call happened.

## Fix
One-liner: `state.GridTargetW = 0` → `state.SetGridTarget(0)`. The helper updates both fields in lockstep, same pattern as every other caller in the package.

## Test
Pre-poisons `PI.Setpoint + GridTargetW = 3000`, runs one energy-dispatch cycle, asserts both are 0 afterward. Fails cleanly before the fix, passes after.

## Test plan
- [x] Go unit tests green (`go test ./...`).
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)