### PR TITLE
feat(pvmodel): hot-reload rated PV + lat/lon without restart

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -206,6 +206,14 @@ func main() {
 	cfgMu := &sync.RWMutex{}
 	modelsMu := &sync.Mutex{}
 
+	// Pre-declare services that the hot-reload Applier needs to touch.
+	// The Applier closure captures these by reference; they're assigned
+	// further down when their packages are wired, and the Applier only
+	// ever fires after `watcher.Start()` — by which point everything is
+	// in place.
+	var pvSvc *pvmodel.Service
+	var forecastSvc *forecast.Service
+
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
@@ -228,6 +236,40 @@ func main() {
 				capacities[k] = v
 			}
 			capMu.Unlock()
+
+			// Weather diff → push live into the PV twin + forecast
+			// fetcher without a process restart. Users adjust rated PV
+			// + lat/lon from Settings and expect the change to take
+			// effect right away.
+			if newCfg.Weather != nil {
+				oldLat, oldLon, oldRated := 0.0, 0.0, 0.0
+				if oldCfg.Weather != nil {
+					oldLat = oldCfg.Weather.Latitude
+					oldLon = oldCfg.Weather.Longitude
+					oldRated = oldCfg.Weather.PVRatedW
+				}
+				newRated := newCfg.Weather.PVRatedW
+				if newRated > 0 && newRated != oldRated {
+					if pvSvc != nil {
+						pvSvc.SetRated(newRated)
+					}
+					if forecastSvc != nil {
+						forecastSvc.RatedPVW = newRated
+					}
+				}
+				newLat := newCfg.Weather.Latitude
+				newLon := newCfg.Weather.Longitude
+				if newLat != oldLat || newLon != oldLon {
+					if pvSvc != nil {
+						pvSvc.ClearSky = func(t time.Time) float64 { return forecast.ClearSkyW(newLat, newLon, t) }
+					}
+					if forecastSvc != nil {
+						forecastSvc.Lat = newLat
+						forecastSvc.Lon = newLon
+					}
+					slog.Info("weather location updated", "lat", newLat, "lon", newLon)
+				}
+			}
 		})
 	if err != nil {
 		slog.Warn("could not start config watcher", "err", err)
@@ -284,7 +326,7 @@ func main() {
 			ratedPVW = 10000
 		}
 	}
-	forecastSvc := forecast.FromConfig(cfg.Weather, ratedPVW, st,
+	forecastSvc = forecast.FromConfig(cfg.Weather, ratedPVW, st,
 		"forty-two-watts/"+Version+" github.com/frahlg/forty-two-watts")
 	if forecastSvc != nil {
 		forecastSvc.Start(ctx)
@@ -294,7 +336,7 @@ func main() {
 	}
 
 	// ---- Start PV digital twin (optional, requires weather config) ----
-	var pvSvc *pvmodel.Service
+	// pvSvc is pre-declared above so the reload Applier can update it.
 	if cfg.Weather != nil && cfg.Weather.Provider != "" && cfg.Weather.Provider != "none" {
 		lat, lon := cfg.Weather.Latitude, cfg.Weather.Longitude
 		clearSkyFn := func(t time.Time) float64 { return forecast.ClearSkyW(lat, lon, t) }

--- a/go/internal/pvmodel/service.go
+++ b/go/internal/pvmodel/service.go
@@ -80,6 +80,25 @@ func (s *Service) Model() Model {
 	return *s.model
 }
 
+// SetRated updates the array nameplate (W) used by the model's output
+// envelope, input outlier guards, and cold-start prior. Learned RLS
+// coefficients are NOT reset — the twin has already adapted to reality
+// so the learned fit stays more accurate than a fresh prior. Call
+// `POST /api/pvmodel/reset` separately if the array itself changed
+// and you want the model to re-seed.
+func (s *Service) SetRated(w float64) {
+	if s == nil || w <= 0 {
+		return
+	}
+	s.mu.Lock()
+	prev := s.model.RatedW
+	s.model.RatedW = w
+	s.mu.Unlock()
+	if prev != w {
+		slog.Info("pvmodel rated updated", "old_w", prev, "new_w", w)
+	}
+}
+
 // Predict is the main integration point: MPC + UI call this to get the
 // twin's prediction for any future instant.
 func (s *Service) Predict(t time.Time, cloudPct float64) float64 {


### PR DESCRIPTION
Changing weather.pv_rated_w or weather.latitude/longitude in Settings didn't propagate to the running PV twin — the values were read once in NewService and captured inside the ClearSky closure, so the user had to restart the process to see any effect.

- Add (*pvmodel.Service).SetRated(w) that updates Model.RatedW under the service's write lock. Learned RLS coefficients stay (the twin has already adapted to reality so a fresh prior would regress); POST /api/pvmodel/reset remains the escape hatch for real array changes.
- Promote pvSvc + forecastSvc declarations above the reload Applier so the closure captures them by reference and sees the assignments further down.
- In the Applier, diff cfg.Weather and push changes live: rated W into pvSvc.SetRated + forecastSvc.RatedPVW; lat/lon into a fresh ClearSky closure + forecastSvc.Lat/Lon (next forecast fetch uses the new coordinates).