### PR TITLE
feat(forecast): Open-Meteo + Forecast.Solar weather providers

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -229,7 +229,7 @@ type Price struct {
 
 // Weather is the weather-forecast source config.
 type Weather struct {
-	Provider  string  `yaml:"provider" json:"provider"` // met_no | openweather | none
+	Provider  string  `yaml:"provider" json:"provider"` // met_no | openweather | open_meteo | forecast_solar | none
 	Latitude  float64 `yaml:"latitude" json:"latitude"`
 	Longitude float64 `yaml:"longitude" json:"longitude"`
 	APIKey    string  `yaml:"api_key,omitempty" json:"api_key,omitempty"`
@@ -240,6 +240,14 @@ type Weather struct {
 	// which is only roughly right for homes where PV and storage were
 	// sized together. Set explicitly for accurate day-1 forecasts.
 	PVRatedW float64 `yaml:"pv_rated_w,omitempty" json:"pv_rated_w,omitempty"`
+
+	// PVTiltDeg / PVAzimuthDeg describe the physical orientation of the
+	// panels. Only used by providers that need site geometry
+	// (forecast_solar). Tilt is angle from horizontal (0 = flat, 90 =
+	// wall). Azimuth is compass heading (180 = south). Safe to omit
+	// when using met_no / open_meteo.
+	PVTiltDeg    float64 `yaml:"pv_tilt_deg,omitempty" json:"pv_tilt_deg,omitempty"`
+	PVAzimuthDeg float64 `yaml:"pv_azimuth_deg,omitempty" json:"pv_azimuth_deg,omitempty"`
 
 	// HeatingWPerDegC adds load proportional to max(18°C − outdoor_temp, 0).
 	// A rough-but-useful way to teach the planner that cold nights cost

--- a/go/internal/forecast/forecast.go
+++ b/go/internal/forecast/forecast.go
@@ -38,12 +38,16 @@ type Provider interface {
 }
 
 // RawForecast is one hour's parsed forecast. Fields may be nil if the
-// provider didn't return them.
+// provider didn't return them. Providers populate whichever fields they
+// natively expose — the downstream fetchAndStore selects the most
+// direct PV-power signal available (PVWEstimated > SolarWm2 → derived
+// > CloudCoverPct → derived).
 type RawForecast struct {
-	HourStart      time.Time
-	CloudCoverPct  *float64 // 0..100
-	TempC          *float64
-	SolarWm2       *float64 // direct shortwave radiation W/m² (if provider gives it)
+	HourStart     time.Time
+	CloudCoverPct *float64 // 0..100
+	TempC         *float64
+	SolarWm2      *float64 // direct shortwave radiation W/m² (if provider gives it)
+	PVWEstimated  *float64 // provider-native site PV output (if provider gives it, e.g. Forecast.Solar)
 }
 
 // ---- met.no provider ----
@@ -260,6 +264,11 @@ func FromConfig(cfg *config.Weather, ratedPVW float64, st *state.Store, userAgen
 		p = NewMetNo(userAgent)
 	case "openweather":
 		p = NewOpenWeather(cfg.APIKey)
+	case "open_meteo":
+		p = NewOpenMeteo()
+	case "forecast_solar":
+		kWp := ratedPVW / 1000.0
+		p = NewForecastSolar(cfg.PVTiltDeg, cfg.PVAzimuthDeg, kWp)
 	default:
 		return nil
 	}
@@ -310,7 +319,19 @@ func (s *Service) fetchAndStore(ctx context.Context) {
 	nowMs := time.Now().UnixMilli()
 	points := make([]state.ForecastPoint, 0, len(rows))
 	for _, r := range rows {
-		pvW := EstimatePVW(s.Lat, s.Lon, r.HourStart, r.CloudCoverPct, s.RatedPVW)
+		// Pick the most direct PV signal the provider gave us. Forecast.Solar
+		// returns site-calibrated watts directly; Open-Meteo returns shortwave
+		// radiation we turn into watts via rated × W/m²/1000; met.no only has
+		// cloud fraction, so we fall through to the naive cloud-derated prior.
+		var pvW float64
+		switch {
+		case r.PVWEstimated != nil:
+			pvW = *r.PVWEstimated
+		case r.SolarWm2 != nil && s.RatedPVW > 0:
+			pvW = s.RatedPVW * (*r.SolarWm2) / 1000.0
+		default:
+			pvW = EstimatePVW(s.Lat, s.Lon, r.HourStart, r.CloudCoverPct, s.RatedPVW)
+		}
 		pvPtr := &pvW
 		points = append(points, state.ForecastPoint{
 			SlotTsMs:      r.HourStart.UnixMilli(),

--- a/go/internal/forecast/forecast_solar.go
+++ b/go/internal/forecast/forecast_solar.go
@@ -1,0 +1,146 @@
+package forecast
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ForecastSolarProvider uses the free tier of api.forecast.solar, which
+// combines the EU PVGIS clear-sky model with a weather forecast and
+// returns site-specific PV output (watts) per timestamp for the next
+// few days. No authentication required. Free-tier rate limit is
+// 12 calls/hour over a rolling window; forecast.Service's 3-hour
+// refresh loop uses a tiny fraction of that.
+//
+// Why it's better than cloud-fraction-only providers: the response is
+// already calibrated for our site (lat/lon/tilt/azimuth/kWp are part
+// of the URL), so the cloud_area_fraction → PV conversion that we
+// approximate with (1 - cloud)^1.5 is done for us using their model.
+// The RLS twin becomes a thin correction on top of an already-good
+// prediction, not the sole calibration mechanism.
+//
+// Limitations:
+//   - Doesn't return cloud cover or temperature; we set both nil so
+//     downstream code falls back to whatever it uses when these are
+//     absent (pvmodel: neutral 50%, fuse/thermal: no-op).
+//   - The response is per-timestamp at irregular intervals (typically
+//     minutely around dawn/dusk, larger during the flat part of the
+//     day). We bucket to UTC hours by picking the sample closest to
+//     each hour's start.
+type ForecastSolarProvider struct {
+	Client  *http.Client
+	BaseURL string
+
+	// Site geometry. Tilt is the panels' angle from horizontal (0 = flat
+	// roof, 90 = wall). Azimuth is compass heading the panels face in
+	// degrees (180 = south). kWp is nameplate DC capacity.
+	TiltDeg    float64
+	AzimuthDeg float64
+	KWp        float64
+}
+
+// NewForecastSolar returns a configured provider. Pass the site's
+// roof geometry + total installed capacity. Free tier requires no key.
+func NewForecastSolar(tiltDeg, azimuthDeg, kWp float64) *ForecastSolarProvider {
+	return &ForecastSolarProvider{
+		Client:     &http.Client{Timeout: 15 * time.Second},
+		BaseURL:    "https://api.forecast.solar",
+		TiltDeg:    tiltDeg,
+		AzimuthDeg: azimuthDeg,
+		KWp:        kWp,
+	}
+}
+
+// Name implements Provider.
+func (f *ForecastSolarProvider) Name() string { return "forecast_solar" }
+
+// Fetch implements Provider. Returns one RawForecast per UTC hour with
+// PVWEstimated populated; cloud/temperature stay nil.
+func (f *ForecastSolarProvider) Fetch(ctx context.Context, lat, lon float64) ([]RawForecast, error) {
+	if f.KWp <= 0 {
+		return nil, fmt.Errorf("forecast.solar: kWp must be > 0 (got %f)", f.KWp)
+	}
+	// /estimate/lat/lon/tilt/azimuth/kwp. ?time=utc forces UTC timestamps
+	// in the response so we don't have to guess the server's locale.
+	url := fmt.Sprintf(
+		"%s/estimate/%.4f/%.4f/%.1f/%.1f/%.2f?time=utc",
+		f.BaseURL, lat, lon, f.TiltDeg, f.AzimuthDeg, f.KWp,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := f.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 429 {
+		return nil, fmt.Errorf("forecast.solar: rate limited (429); reset at %s",
+			resp.Header.Get("X-Ratelimit-Reset"))
+	}
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("forecast.solar: status %d: %s", resp.StatusCode, string(body))
+	}
+	var doc struct {
+		Result struct {
+			Watts map[string]float64 `json:"watts"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("forecast.solar: decode: %w", err)
+	}
+
+	// Bucket to UTC hours. The API returns timestamps like
+	// "2026-04-17 12:00:00" (UTC when time=utc); we pick the first
+	// sample whose timestamp falls inside each hour-aligned bucket and
+	// use its watts value for the whole hour. Fine-grained dawn/dusk
+	// transitions get smoothed to the hour, which is what the downstream
+	// schema (SlotLenMin=60) expects anyway.
+	buckets := make(map[int64]float64, len(doc.Result.Watts))
+	for tsStr, w := range doc.Result.Watts {
+		t, err := time.Parse("2006-01-02 15:04:05", tsStr)
+		if err != nil {
+			continue
+		}
+		// The API documents "local time unless ?time=utc"; we sent
+		// ?time=utc so treat the string as UTC.
+		t = t.UTC()
+		hour := t.Truncate(time.Hour)
+		hourMs := hour.UnixMilli()
+		// Keep the MAX within the hour so a brief peak (e.g. sunrise
+		// crossing the first minute) isn't washed out by the zero
+		// timestamps the API emits right before dawn.
+		if cur, ok := buckets[hourMs]; !ok || w > cur {
+			buckets[hourMs] = w
+		}
+	}
+	out := make([]RawForecast, 0, len(buckets))
+	for hourMs, watts := range buckets {
+		w := watts
+		out = append(out, RawForecast{
+			HourStart:    time.UnixMilli(hourMs).UTC(),
+			PVWEstimated: &w,
+		})
+	}
+	// Sort by HourStart so consumers (state.SaveForecasts, the MPC
+	// lookup) see monotone timestamps.
+	sortByHour(out)
+	return out, nil
+}
+
+func sortByHour(rows []RawForecast) {
+	// Insertion sort — the list is ~200 rows for 8 days at hourly
+	// resolution, not worth importing sort.Slice.
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0 && rows[j-1].HourStart.After(rows[j].HourStart); j-- {
+			rows[j-1], rows[j] = rows[j], rows[j-1]
+		}
+	}
+}

--- a/go/internal/forecast/forecast_solar_test.go
+++ b/go/internal/forecast/forecast_solar_test.go
@@ -1,0 +1,123 @@
+package forecast
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Stub server returns a canned Forecast.Solar response. Verifies that
+// per-timestamp watts get bucketed to UTC hours and materialised on
+// PVWEstimated. We don't assert exact hour-count because the API's
+// dawn/dusk sampling is irregular; we assert the peak-hour value is
+// preserved and cloud/temp are not fabricated.
+func TestForecastSolar_BucketsToHours(t *testing.T) {
+	body := `{
+		"result": {
+			"watts": {
+				"2026-04-17 06:53:38": 0.0,
+				"2026-04-17 07:00:00": 150.0,
+				"2026-04-17 07:30:00": 450.0,
+				"2026-04-17 12:00:00": 8200.0,
+				"2026-04-17 12:30:00": 8450.0,
+				"2026-04-17 13:00:00": 8100.0
+			}
+		},
+		"message": {"code": 0, "type": "success"}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify geometry lands in the URL.
+		if !strings.Contains(r.URL.Path, "/estimate/56.7") {
+			t.Errorf("missing lat in path: %s", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.RawQuery, "time=utc") {
+			t.Errorf("expected time=utc, got %q", r.URL.RawQuery)
+		}
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	fs := &ForecastSolarProvider{
+		Client: srv.Client(), BaseURL: srv.URL,
+		TiltDeg: 35, AzimuthDeg: 180, KWp: 10,
+	}
+	rows, err := fs.Fetch(context.Background(), 56.7, 16.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Buckets: 06:53:38 → 06; 07:00 + 07:30 → 07; 12:00 + 12:30 → 12; 13:00 → 13.
+	if len(rows) != 4 {
+		t.Errorf("want 4 hour buckets (06/07/12/13), got %d", len(rows))
+	}
+	// Find the 12:00 UTC bucket — its max in-hour sample is 8450.
+	var noonPV *float64
+	for _, r := range rows {
+		if r.HourStart.Hour() == 12 {
+			noonPV = r.PVWEstimated
+		}
+	}
+	if noonPV == nil || *noonPV != 8450.0 {
+		t.Errorf("12:00 bucket PV = %v, want 8450 (max-in-hour)", noonPV)
+	}
+	// No fabrication of cloud/temp.
+	for _, r := range rows {
+		if r.CloudCoverPct != nil {
+			t.Error("forecast.solar shouldn't emit CloudCoverPct")
+		}
+		if r.TempC != nil {
+			t.Error("forecast.solar shouldn't emit TempC")
+		}
+	}
+	// Sorted by time.
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].HourStart.After(rows[i].HourStart) {
+			t.Errorf("rows not sorted: %s > %s", rows[i-1].HourStart, rows[i].HourStart)
+		}
+	}
+}
+
+// 429 rate-limit surfaces with a clear error — not a silent zero-row
+// response that would look like "no sun ever".
+func TestForecastSolar_RateLimitedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Ratelimit-Reset", "3600")
+		w.WriteHeader(429)
+		fmt.Fprint(w, `{"message":{"code":429,"type":"error","text":"rate limit"}}`)
+	}))
+	defer srv.Close()
+	fs := &ForecastSolarProvider{Client: srv.Client(), BaseURL: srv.URL, KWp: 10}
+	_, err := fs.Fetch(context.Background(), 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "rate") {
+		t.Errorf("want rate-limit error, got %v", err)
+	}
+}
+
+// Zero or negative kWp is a config mistake — fail fast instead of
+// emitting a nonsense URL.
+func TestForecastSolar_RejectsZeroKWp(t *testing.T) {
+	fs := NewForecastSolar(35, 180, 0)
+	if _, err := fs.Fetch(context.Background(), 0, 0); err == nil {
+		t.Error("expected error for kWp=0, got nil")
+	}
+}
+
+// Verifies sortByHour stays stable even with already-sorted input.
+func TestForecastSolarSortByHour(t *testing.T) {
+	base := time.Date(2026, 4, 17, 10, 0, 0, 0, time.UTC)
+	rows := []RawForecast{
+		{HourStart: base.Add(2 * time.Hour)},
+		{HourStart: base},
+		{HourStart: base.Add(time.Hour)},
+	}
+	sortByHour(rows)
+	if !rows[0].HourStart.Equal(base) {
+		t.Errorf("first row = %v, want %v", rows[0].HourStart, base)
+	}
+	if !rows[2].HourStart.Equal(base.Add(2*time.Hour)) {
+		t.Errorf("last row = %v, want %v", rows[2].HourStart, base.Add(2*time.Hour))
+	}
+}

--- a/go/internal/forecast/open_meteo.go
+++ b/go/internal/forecast/open_meteo.go
@@ -1,0 +1,96 @@
+package forecast
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// OpenMeteoProvider uses Open-Meteo's forecast API to fetch hourly
+// shortwave solar irradiance alongside cloud cover and air temperature.
+// Free, no key required, ECMWF-driven; covers 16 days ahead.
+//
+// The radiation signal is materially better input for PV prediction
+// than cloud_area_fraction alone because "49% cloud in the sky" can
+// mean anything from full sun to overcast depending on which part of
+// the sky the Sun is behind — radiation measures what actually reaches
+// a horizontal surface. The downstream PV derivation simplifies to
+// `rated × (W/m² / 1000)` with a single calibration coefficient per
+// site (orientation + soiling), not the brittle `(1 - cloud)^1.5`
+// curve used when only cloud fraction is available.
+type OpenMeteoProvider struct {
+	Client  *http.Client
+	BaseURL string
+}
+
+// NewOpenMeteo returns a configured provider. No API key — Open-Meteo
+// is free under a fair-use policy; the existing 3-hour refresh loop in
+// forecast.Service.loop is well inside the limits.
+func NewOpenMeteo() *OpenMeteoProvider {
+	return &OpenMeteoProvider{
+		Client:  &http.Client{Timeout: 15 * time.Second},
+		BaseURL: "https://api.open-meteo.com/v1/forecast",
+	}
+}
+
+// Name implements Provider.
+func (o *OpenMeteoProvider) Name() string { return "open_meteo" }
+
+// Fetch implements Provider. Returns one RawForecast per UTC hour for
+// the next ~16 days with SolarWm2 + CloudCoverPct + TempC populated.
+func (o *OpenMeteoProvider) Fetch(ctx context.Context, lat, lon float64) ([]RawForecast, error) {
+	url := fmt.Sprintf(
+		"%s?latitude=%.4f&longitude=%.4f&hourly=shortwave_radiation,cloud_cover,temperature_2m&timezone=UTC&forecast_days=16",
+		o.BaseURL, lat, lon,
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := o.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("open-meteo: status %d: %s", resp.StatusCode, string(body))
+	}
+	var doc struct {
+		Hourly struct {
+			Time               []string   `json:"time"`
+			ShortwaveRadiation []*float64 `json:"shortwave_radiation"` // W/m²
+			CloudCover         []*float64 `json:"cloud_cover"`         // %
+			Temperature2m      []*float64 `json:"temperature_2m"`      // °C
+		} `json:"hourly"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("open-meteo: decode: %w", err)
+	}
+	n := len(doc.Hourly.Time)
+	out := make([]RawForecast, 0, n)
+	for i := 0; i < n; i++ {
+		// Open-Meteo returns naive local times per the &timezone= param;
+		// with &timezone=UTC they're UTC-zoned ISO8601 without offset.
+		t, err := time.Parse("2006-01-02T15:04", doc.Hourly.Time[i])
+		if err != nil {
+			continue
+		}
+		t = t.UTC()
+		row := RawForecast{HourStart: t}
+		if i < len(doc.Hourly.CloudCover) {
+			row.CloudCoverPct = doc.Hourly.CloudCover[i]
+		}
+		if i < len(doc.Hourly.Temperature2m) {
+			row.TempC = doc.Hourly.Temperature2m[i]
+		}
+		if i < len(doc.Hourly.ShortwaveRadiation) {
+			row.SolarWm2 = doc.Hourly.ShortwaveRadiation[i]
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}

--- a/go/internal/forecast/open_meteo_test.go
+++ b/go/internal/forecast/open_meteo_test.go
@@ -1,0 +1,102 @@
+package forecast
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Stub server returns a canned Open-Meteo response. Verifies that
+// shortwave_radiation, cloud_cover, temperature_2m all land on the
+// right RawForecast fields and that timestamps are parsed as UTC.
+func TestOpenMeteo_ParsesRadiationAndCloud(t *testing.T) {
+	body := `{
+		"hourly": {
+			"time": ["2026-04-17T12:00","2026-04-17T13:00","2026-04-17T14:00"],
+			"shortwave_radiation": [712.5, 685.1, 420.0],
+			"cloud_cover": [10.0, 20.0, 45.5],
+			"temperature_2m": [18.2, 17.8, 15.9]
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.RawQuery, "shortwave_radiation") {
+			t.Errorf("expected query param shortwave_radiation, got %q", r.URL.RawQuery)
+		}
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	om := &OpenMeteoProvider{Client: srv.Client(), BaseURL: srv.URL}
+	rows, err := om.Fetch(context.Background(), 56.7, 16.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	if rows[0].SolarWm2 == nil || *rows[0].SolarWm2 != 712.5 {
+		t.Errorf("SolarWm2 at 12:00 = %v, want 712.5", rows[0].SolarWm2)
+	}
+	if rows[0].CloudCoverPct == nil || *rows[0].CloudCoverPct != 10.0 {
+		t.Errorf("CloudCoverPct = %v, want 10", rows[0].CloudCoverPct)
+	}
+	if rows[2].TempC == nil || *rows[2].TempC != 15.9 {
+		t.Errorf("TempC[2] = %v, want 15.9", rows[2].TempC)
+	}
+	// PVWEstimated must be nil — this provider only emits radiation;
+	// fetchAndStore derives PV from that.
+	if rows[0].PVWEstimated != nil {
+		t.Errorf("PVWEstimated should be nil for open-meteo, got %v", rows[0].PVWEstimated)
+	}
+	// Timestamps parsed as UTC.
+	if rows[0].HourStart.Location().String() != "UTC" {
+		t.Errorf("HourStart.Location = %s, want UTC", rows[0].HourStart.Location())
+	}
+}
+
+// A row with a missing shortwave_radiation entry (null in the JSON)
+// should be surfaced as a nil *float64, not silently zero.
+func TestOpenMeteo_HandlesNullFields(t *testing.T) {
+	body := `{
+		"hourly": {
+			"time": ["2026-04-17T12:00"],
+			"shortwave_radiation": [null],
+			"cloud_cover": [50.0],
+			"temperature_2m": [10.0]
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+	om := &OpenMeteoProvider{Client: srv.Client(), BaseURL: srv.URL}
+	rows, err := om.Fetch(context.Background(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d", len(rows))
+	}
+	if rows[0].SolarWm2 != nil {
+		t.Errorf("null shortwave should be nil, got %v", *rows[0].SolarWm2)
+	}
+	if rows[0].CloudCoverPct == nil || *rows[0].CloudCoverPct != 50 {
+		t.Errorf("CloudCoverPct = %v, want 50", rows[0].CloudCoverPct)
+	}
+}
+
+// Non-200 responses are surfaced as errors — no silent fallback to empty
+// rows that would starve downstream consumers without logging.
+func TestOpenMeteo_NonOKError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "blocked", http.StatusForbidden)
+	}))
+	defer srv.Close()
+	om := &OpenMeteoProvider{Client: srv.Client(), BaseURL: srv.URL}
+	if _, err := om.Fetch(context.Background(), 0, 0); err == nil {
+		t.Error("expected error on 403, got nil")
+	}
+}


### PR DESCRIPTION
Direct fix for the operator report on homelab-rpi today: met.no says 49 % cloud, naive PV formula predicts 2.1 kW, reality is 8 kW. The RLS twin needs ~50 samples of matching features to self-correct — meanwhile the MPC undercommits. Using a forecaster that returns radiation or site-calibrated PV output sidesteps the cloud-fraction conversion entirely.

## What's new

- **open_meteo** — free, no key, ECMWF-driven. Returns hourly `shortwave_radiation` (W/m²), `cloud_cover`, `temperature_2m`. 16-day horizon. Radiation is a far better PV proxy than cloud fraction.
- **forecast_solar** — purpose-built for residential PV. Free tier, 12 req/hour. Takes site geometry (lat/lon/tilt/azimuth/kWp) and returns site-calibrated watts per timestamp via EU PVGIS + weather. fetchAndStore uses the provider's PVWEstimated directly when present.

Signal precedence in `fetchAndStore`:
```
PVWEstimated (Forecast.Solar) > SolarWm2 × rated/1000 (Open-Meteo) > cloud-derated (met.no, openweather)
```

No default changed — sites stay on met.no until explicitly migrated via config.

## Config

```yaml
weather:
  provider: forecast_solar      # new option, or: open_meteo
  latitude: 56.7045
  longitude: 16.3353
  pv_rated_w: 10000
  pv_tilt_deg: 35               # forecast_solar needs geometry; open_meteo ignores
  pv_azimuth_deg: 180
```

## Tests

- Open-Meteo: happy-path parsing, null-field handling, non-200 error surfacing.
- Forecast.Solar: bucket-to-hour aggregation with max-in-hour, URL geometry check, 429 rate-limit surfacing, zero-kWp rejection, sortByHour stability.
- Existing forecast / e2e suite still green.

## Test plan
- [x] `go test ./...` green (unit + e2e).
- [ ] Deploy to homelab-rpi after merge, switch `weather.provider: forecast_solar`, observe `pv_w_predicted` track reality across multi-hour slots.

## Follow-ups (not in this PR)
- `pvmodel` should drop the (1 - cloud)^1.5 prior when radiation or direct-PV signal is present — the RLS is then a thin calibration on top.
- Delete `EstimatePVW` once no sites use cloud-only providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)