### PR TITLE
chore: bump Go from 1.25 → 1.26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache-dependency-path: go/go.sum
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache-dependency-path: go/go.sum
 
       - name: Go vet

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # host and only `go build` is cross-compiled.
 
 # --- Builder ---------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 # git is needed by `go build` to resolve VCS info baked into the binary
 # via -X main.Version. Everything else is in the base image.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/frahlg/forty-two-watts/go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/eclipse/paho.mqtt.golang v1.5.1


### PR DESCRIPTION
Four-file bump — `go.mod`, Dockerfile builder image, test workflow, release workflow. Local + CI toolchains follow automatically via Go's toolchain resolution.

## What 1.26 brings that matters here
- **Green Tea GC** enabled by default — lower latency, useful on the Pi where every ms helps the dispatch loop stay ahead of watchdog windows.
- **More slices allocated on the stack** instead of the heap — less GC pressure in telemetry/dispatch hot paths.
- **Security fixes** up to 1.26.2 in the `go` command, compiler, and several stdlib packages.

## Not used (mentioned for completeness)
- cgo call overhead −30 % — we build with `CGO_ENABLED=0` everywhere. Zero impact.

## Verified locally
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` green incl e2e (26 s)
- [x] Binary shape unchanged (~18.9 MB arm64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)