### PR TITLE
fix(mpc): treat non-positive battery-limit overrides as config error

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -794,16 +794,27 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 			continue
 		}
 		totalCap += cap
-		// Default max (de)charge = 0.5C unless overridden
+		// Default max (de)charge = 0.5C unless overridden. Only honor
+		// a strictly-positive override — zero or negative overrides
+		// would leave the planner with no actions to explore and
+		// every slot would plan battery_w=0. That looks like "MPC
+		// disabled" in the UI even though the service is running.
+		// Much more likely to be a config mistake than intent.
 		defaultP := cap / 2
 		chg := defaultP
 		dis := defaultP
 		if b, ok := cfg.Batteries[d.Name]; ok {
-			if b.MaxChargeW != nil {
+			if b.MaxChargeW != nil && *b.MaxChargeW > 0 {
 				chg = *b.MaxChargeW
+			} else if b.MaxChargeW != nil {
+				slog.Warn("mpc: ignoring non-positive batteries.max_charge_w; using default 0.5C",
+					"driver", d.Name, "value", *b.MaxChargeW, "default_w", defaultP)
 			}
-			if b.MaxDischargeW != nil {
+			if b.MaxDischargeW != nil && *b.MaxDischargeW > 0 {
 				dis = *b.MaxDischargeW
+			} else if b.MaxDischargeW != nil {
+				slog.Warn("mpc: ignoring non-positive batteries.max_discharge_w; using default 0.5C",
+					"driver", d.Name, "value", *b.MaxDischargeW, "default_w", defaultP)
 			}
 		}
 		maxChg += chg


### PR DESCRIPTION
Operator report: `mpc: optimize params ... max_charge_w=0 max_discharge_w=0 capacity_wh=20000`. Planner was alive but all slot decisions were `battery_w=0` — UI looked "disabled" even though the service was running.

Root: `buildMPC` honored any explicit `batteries.*.max_charge_w` override, including `0`. Zero kills the planner's action space silently.

Fix: only accept strictly-positive overrides; non-positive falls back to 0.5C default with a `slog.Warn` pointing at the config mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)