### PR TITLE
fix(mpc): DST/timezone audit — coerce planner time indexing to UTC

### DIFF
--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -218,3 +218,33 @@ Signal to read from the table:
 
 Total annual savings depend heavily on market volatility; a stable
 market year narrows the gap between the three modes.
+
+---
+
+## Time-zone convention — UTC everywhere
+
+All time-of-day and day-of-week indexing inside the planner and its
+digital twins is done in **UTC**. The price-forecast's hour-of-week
+buckets, the load-model's hour-of-week buckets, the PV-twin's
+time-of-day harmonic features, and every `time.UnixMilli(...)`
+conversion that feeds a predictor all coerce to UTC before the
+`.Hour()` / `.Weekday()` / `.Month()` access.
+
+Why: a wall-clock 19:00 in Stockholm lands on a *different* UTC hour
+in summer (CEST, UTC+2) than in winter (CET, UTC+1). Indexing buckets
+by local-zone hour silently slides the learned EMA by one bucket
+twice a year, and a single `Predict` call could resolve a different
+bucket for the same instant depending on which `time.Location` the
+`time.Time` carried. Both bugs produce "planner chose to charge from
+an expensive hour" symptoms around DST transitions.
+
+Source-of-truth timestamps in the state store are unix-milli (absolute,
+timezone-agnostic); the UTC coercion is only at the leaf points where
+we access calendar fields. Operator-facing UI formatting still uses
+the site's local zone — that's a display concern, not a model
+concern.
+
+If you add a new predictor or new time-field access inside the
+planner, coerce `t` with `t.UTC()` first. Tests
+(`TestPredictStableAcrossDST`, `TestHourOfWeekStableAcrossDST`,
+`TestFeaturesStableAcrossDST`) enforce the invariant per package.

--- a/go/internal/loadmodel/model.go
+++ b/go/internal/loadmodel/model.go
@@ -97,12 +97,14 @@ func NewModel(peakW float64) *Model {
 }
 
 // HourOfWeek computes 0..167 for a time. Monday = 0 through Sunday.
-// Works in UTC to keep results deterministic — callers pass t in
-// local time when they want local-time behaviour.
+// Coerces to UTC so the bucket index stays stable across DST
+// transitions (wall-clock 19:00 maps to a different bucket in summer
+// vs. winter otherwise, silently misaligning the EMA).
 func HourOfWeek(t time.Time) int {
+	u := t.UTC()
 	// time.Weekday: Sunday=0, Saturday=6. We shift so Monday=0.
-	wd := (int(t.Weekday()) + 6) % 7
-	return wd*24 + t.Hour()
+	wd := (int(u.Weekday()) + 6) % 7
+	return wd*24 + u.Hour()
 }
 
 // Predict returns the expected load (W, non-negative) at time t with

--- a/go/internal/loadmodel/model_test.go
+++ b/go/internal/loadmodel/model_test.go
@@ -7,6 +7,29 @@ import (
 	"time"
 )
 
+// TestHourOfWeekStableAcrossDST — the bucket index must not shift when
+// the same absolute instant is represented in a different timezone.
+// Before the UTC coercion, evening-hour Predict calls around DST
+// boundaries silently drew from the wrong bucket.
+func TestHourOfWeekStableAcrossDST(t *testing.T) {
+	stockholm, err := time.LoadLocation("Europe/Stockholm")
+	if err != nil {
+		t.Skipf("Europe/Stockholm tzdata unavailable: %v", err)
+	}
+	instants := []time.Time{
+		time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC),
+		time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 15, 17, 0, 0, 0, time.UTC),
+		time.Date(2026, 12, 15, 20, 0, 0, 0, time.UTC),
+	}
+	for _, inst := range instants {
+		if HourOfWeek(inst) != HourOfWeek(inst.In(stockholm)) {
+			t.Errorf("HourOfWeek differs: utc=%d local=%d (inst=%v)",
+				HourOfWeek(inst), HourOfWeek(inst.In(stockholm)), inst)
+		}
+	}
+}
+
 // synthetic household: 300W baseline, morning peak 2500W around 07:30,
 // evening peak 3500W around 19:00.
 func synthetic(t time.Time) float64 {

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -561,7 +561,7 @@ func extendPricesWithForecast(prices []state.PricePoint, zone string, pricer Pri
 	mod := start % (int64(slotLen) * 60 * 1000)
 	start -= mod
 	for ts := start; ts < untilMs; ts += int64(slotLen) * 60 * 1000 {
-		t := time.UnixMilli(ts)
+		t := time.UnixMilli(ts).UTC()
 		spot := pricer(zone, t)
 		total := (spot + gridTariff) * (1 + vatPct/100.0)
 		prices = append(prices, state.PricePoint{
@@ -597,7 +597,7 @@ func buildSlots(prices []state.PricePoint, forecasts []state.ForecastPoint, base
 		if slotEnd <= nowMs {
 			continue // past slot
 		}
-		slotT := time.UnixMilli(pr.SlotTsMs)
+		slotT := time.UnixMilli(pr.SlotTsMs).UTC()
 		var pvW float64
 		forecastPVW := lookupPV(forecasts, pr.SlotTsMs)
 		if pv != nil {

--- a/go/internal/priceforecast/forecast.go
+++ b/go/internal/priceforecast/forecast.go
@@ -134,9 +134,14 @@ func NewZoneModel(zone string) *ZoneModel {
 // Predict returns the expected spot öre/kWh at t for zone. The bucket
 // value is already prior-blended via FitFromHistory, so we just apply
 // the monthly seasonality.
+//
+// Coerces t to UTC so hour-of-week + month indexing is stable across
+// DST transitions. FitFromHistory does the same (see line 183), so Fit
+// and Predict agree on bucket addressing.
 func (m ZoneModel) Predict(t time.Time) float64 {
-	idx := hourOfWeek(t)
-	return m.Bucket[idx] * m.Month[int(t.Month())-1]
+	u := t.UTC()
+	idx := hourOfWeek(u)
+	return m.Bucket[idx] * m.Month[int(u.Month())-1]
 }
 
 // overallMean across buckets weighted by counts.
@@ -232,10 +237,14 @@ func (m *ZoneModel) FitFromHistory(pts []state.PricePoint) {
 	m.FittedAt = time.Now().UnixMilli()
 }
 
-// hourOfWeek: Mon=0..Sun=6 × 24. Works in UTC for determinism.
+// hourOfWeek: Mon=0..Sun=6 × 24. Coerces to UTC so the bucket index is
+// deterministic across DST transitions — without this, a wall-clock
+// 19:00 call returns a different bucket in summer than in winter,
+// silently misaligning the learned EMA against Fit's UTC-indexed data.
 func hourOfWeek(t time.Time) int {
-	wd := (int(t.Weekday()) + 6) % 7
-	return wd*24 + t.Hour()
+	u := t.UTC()
+	wd := (int(u.Weekday()) + 6) % 7
+	return wd*24 + u.Hour()
 }
 
 // ---- Service ----

--- a/go/internal/priceforecast/forecast_test.go
+++ b/go/internal/priceforecast/forecast_test.go
@@ -148,6 +148,80 @@ SE4,1735689600000,60,90.0
 	}
 }
 
+// TestPredictStableAcrossDST ensures Predict returns the same value for
+// the same absolute instant regardless of the timezone the caller has
+// attached to the time.Time struct. Before the UTC coercion in
+// hourOfWeek + Predict, passing a local-zone time around DST boundaries
+// produced a different bucket (and thus price) than passing the UTC
+// equivalent — Erik's 21:00 bug was on this exact code path.
+func TestPredictStableAcrossDST(t *testing.T) {
+	stockholm, err := time.LoadLocation("Europe/Stockholm")
+	if err != nil {
+		t.Skipf("Europe/Stockholm tzdata unavailable: %v", err)
+	}
+	m := NewZoneModel("SE3")
+	// Several points over the year — including both DST transitions.
+	cases := []struct {
+		name string
+		inst time.Time
+	}{
+		// Winter (CET = UTC+1): 19:00 local = 18:00 UTC
+		{"winter evening", time.Date(2026, 1, 15, 18, 0, 0, 0, time.UTC)},
+		// Spring-forward day: 2026-03-29 01:00 UTC = 03:00 CEST (02:00 local skipped)
+		{"spring forward 01UTC", time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC)},
+		{"spring forward 10UTC", time.Date(2026, 3, 29, 10, 0, 0, 0, time.UTC)},
+		// Summer (CEST = UTC+2): 19:00 local = 17:00 UTC
+		{"summer evening", time.Date(2026, 7, 15, 17, 0, 0, 0, time.UTC)},
+		// Fall-back day: 2026-10-25 00:00 UTC = 02:00 CEST; 01:00 UTC = 02:00 CET (second time)
+		{"fall back 00UTC", time.Date(2026, 10, 25, 0, 0, 0, 0, time.UTC)},
+		{"fall back 01UTC", time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC)},
+		// Erik's scenario: ~21:00 local (19:00-20:00 UTC depending on season)
+		{"winter 21 local", time.Date(2026, 12, 10, 20, 0, 0, 0, time.UTC)},
+		{"summer 21 local", time.Date(2026, 7, 10, 19, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			utc := tc.inst
+			local := utc.In(stockholm)
+			if !utc.Equal(local) {
+				t.Fatalf("instants must be equal — test bug")
+			}
+			pUTC := m.Predict(utc)
+			pLocal := m.Predict(local)
+			if pUTC != pLocal {
+				t.Errorf("Predict diverged across timezones for same instant: "+
+					"utc=%v -> %.4f, local=%v -> %.4f",
+					utc, pUTC, local, pLocal)
+			}
+		})
+	}
+}
+
+// TestHourOfWeekStableAcrossDST is the lower-level regression: the
+// bucket index itself must not change when the same instant is
+// represented in a different timezone.
+func TestHourOfWeekStableAcrossDST(t *testing.T) {
+	stockholm, err := time.LoadLocation("Europe/Stockholm")
+	if err != nil {
+		t.Skipf("Europe/Stockholm tzdata unavailable: %v", err)
+	}
+	// Pick a few instants across DST boundaries.
+	instants := []time.Time{
+		time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC), // spring forward
+		time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC), // fall back
+		time.Date(2026, 7, 15, 17, 0, 0, 0, time.UTC), // summer
+		time.Date(2026, 12, 15, 20, 0, 0, 0, time.UTC), // winter
+	}
+	for _, inst := range instants {
+		utc := inst
+		local := inst.In(stockholm)
+		if hourOfWeek(utc) != hourOfWeek(local) {
+			t.Errorf("hourOfWeek differs: utc=%d local=%d (inst=%v)",
+				hourOfWeek(utc), hourOfWeek(local), inst)
+		}
+	}
+}
+
 func TestSeedFromCSVRejectsMissingColumns(t *testing.T) {
 	st, _ := state.Open(filepath.Join(t.TempDir(), "t.db"))
 	defer st.Close()

--- a/go/internal/pvmodel/model.go
+++ b/go/internal/pvmodel/model.go
@@ -72,6 +72,9 @@ func NewModel(ratedW float64) *Model {
 }
 
 // Features returns the feature vector for a given forecast sample.
+//
+// Hour-of-day uses UTC so the harmonic phase is stable across DST
+// transitions and matches sunpos's UTC convention (see sunpos.go).
 func Features(clearSkyW, cloudPct float64, t time.Time) [NFeat]float64 {
 	cloudFrac := cloudPct / 100.0
 	if cloudFrac < 0 {
@@ -81,7 +84,8 @@ func Features(clearSkyW, cloudPct float64, t time.Time) [NFeat]float64 {
 		cloudFrac = 1
 	}
 	cf := math.Pow(1-cloudFrac, 1.5)
-	hour := float64(t.Hour()) + float64(t.Minute())/60.0
+	u := t.UTC()
+	hour := float64(u.Hour()) + float64(u.Minute())/60.0
 	h := 2 * math.Pi * hour / 24.0
 	return [NFeat]float64{
 		1.0,

--- a/go/internal/pvmodel/model_test.go
+++ b/go/internal/pvmodel/model_test.go
@@ -7,6 +7,31 @@ import (
 	"time"
 )
 
+// TestFeaturesStableAcrossDST — the time-of-day harmonic phase must
+// not shift when the same instant is passed in a different timezone.
+// Otherwise DST transitions silently re-score the learned β coefficients.
+func TestFeaturesStableAcrossDST(t *testing.T) {
+	stockholm, err := time.LoadLocation("Europe/Stockholm")
+	if err != nil {
+		t.Skipf("Europe/Stockholm tzdata unavailable: %v", err)
+	}
+	instants := []time.Time{
+		time.Date(2026, 3, 29, 1, 0, 0, 0, time.UTC),
+		time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 15, 10, 30, 0, 0, time.UTC),
+	}
+	for _, inst := range instants {
+		fUTC := Features(500, 30, inst)
+		fLocal := Features(500, 30, inst.In(stockholm))
+		for i := range fUTC {
+			if fUTC[i] != fLocal[i] {
+				t.Errorf("Features[%d] diverges: utc=%.4f local=%.4f (inst=%v)",
+					i, fUTC[i], fLocal[i], inst)
+			}
+		}
+	}
+}
+
 // synthetic simulates a real rooftop: rated 10 kW south-facing with a
 // morning shading lobe (soft -30% around 08:00, tapering to 1.0 by 11:00),
 // a 92% of rated peak (module aging), and a slightly stronger cloud


### PR DESCRIPTION
## Summary

Phase 1 of 4 in the planner overhaul roadmap.

Fixes a silent DST bug in the MPC planner's predictors. Every time-of-day / day-of-week bucket lookup (price forecast, load model) and every harmonic feature (PV twin) was indexed from whatever `time.Location` the caller attached to the `time.Time` — but `FitFromHistory` already indexed in UTC. Summer vs winter, Predict and Fit ended up addressing different bucket coordinate spaces, shifting the learned EMA by one bucket twice a year.

Matches the pattern in Erik's (xorath) report of the planner charging from expensive grid around 21:00 near DST boundaries.

## Fix

Coerce `t.UTC()` at every leaf that accesses `.Hour` / `.Weekday` / `.Month`:

- `priceforecast/forecast.go` — `hourOfWeek` + `Predict`
- `loadmodel/model.go` — `HourOfWeek`
- `pvmodel/model.go` — `Features` (harmonic phase)
- `mpc/service.go` — `UnixMilli` conversions feeding predictors

Source-of-truth timestamps stay unix-milli (timezone-agnostic). UI / operator-facing formatting still uses the site's local zone — that's display, not model.

## Tests

Added cross-DST regression test per package that asserts **the same absolute instant gives identical model output regardless of which `time.Location` the `time.Time` carries**:

- `priceforecast.TestPredictStableAcrossDST` + `TestHourOfWeekStableAcrossDST`
- `loadmodel.TestHourOfWeekStableAcrossDST`
- `pvmodel.TestFeaturesStableAcrossDST`

Tests cover:
- Spring-forward boundary (2026-03-29 01:00 UTC)
- Fall-back boundary (2026-10-25 01:00 UTC)
- Summer vs winter evening peaks
- Erik's ~21:00-local scenario

## Test plan

- [x] `go test ./...` — all green (including e2e, 27s)
- [x] `go test ./internal/priceforecast/...` — cross-DST tests pass
- [x] `go test ./internal/loadmodel/...` — cross-DST test passes
- [x] `go test ./internal/pvmodel/...` — cross-DST test passes
- [x] `go test ./internal/mpc/...` — no regressions
- [ ] Erik tests deploy on affected system once merged

## Roadmap context

Part of the unified-planner overhaul (plan in this session). Subsequent PRs:
- **Phase 2** — `/api/mpc/diagnose` endpoint for per-slot explainability
- **Phase 3** — `PowerLimits` (time-varying grid limits) + `Loadpoint` observable skeleton
- **Phase 4** — EV in DP + dispatch + charger capabilities (ONE system: battery + PV + EV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)