### PR TITLE
feat(mpc): /api/mpc/diagnose endpoint for per-slot audit

### DIFF
--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -138,6 +138,7 @@ when the operator has chosen one.
 
 - `GET  /api/mpc/plan` — latest cached plan (mode, horizon, per-slot actions with reasons)
 - `POST /api/mpc/replan` — force an immediate replan
+- `GET  /api/mpc/diagnose` — per-slot audit view: what the DP saw (price, spot, confidence, PV, load) joined with what it decided (battery, grid, SoC, cost, reason) plus the full `Params` the optimize was parameterized with. Meant for debugging "why did the planner decide X at this slot?" without shelling into the host
 - `POST /api/mode {"mode":"planner_arbitrage"}` — activates a strategy AND forces an MPC replan so targets take effect within one control cycle
 
 ---

--- a/go/internal/api/CLAUDE.md
+++ b/go/internal/api/CLAUDE.md
@@ -32,7 +32,7 @@ Endpoint groups (route table is `api.go:95-130`):
 | self_tune | `POST /api/self_tune/start`, `GET /api/self_tune/status`, `POST /api/self_tune/cancel` |
 | history / series | `GET /api/history`, `GET /api/series`, `GET /api/series/catalog` |
 | prices / forecast | `GET /api/prices`, `GET /api/forecast` |
-| mpc | `GET /api/mpc/plan`, `POST /api/mpc/replan` |
+| mpc | `GET /api/mpc/plan`, `POST /api/mpc/replan`, `GET /api/mpc/diagnose` |
 | twins | `GET /api/pvmodel`, `POST /api/pvmodel/reset`, `GET /api/loadmodel`, `POST /api/loadmodel/reset` |
 | ha | `GET /api/ha/status` |
 | static | `/` falls through to `Deps.WebDir` |

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -139,6 +139,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/forecast", s.handleForecast)
 	s.handle("GET  /api/mpc/plan", s.handleMPCPlan)
 	s.handle("POST /api/mpc/replan", s.handleMPCReplan)
+	s.handle("GET  /api/mpc/diagnose", s.handleMPCDiagnose)
 	s.handle("GET  /api/pvmodel", s.handlePVModel)
 	s.handle("POST /api/pvmodel/reset", s.handlePVModelReset)
 	s.handle("GET  /api/loadmodel", s.handleLoadModel)
@@ -1073,6 +1074,24 @@ func (s *Server) handleMPCReplan(w http.ResponseWriter, r *http.Request) {
 	}
 	plan := s.deps.MPC.Replan(r.Context())
 	writeJSON(w, 200, map[string]any{"enabled": true, "plan": plan})
+}
+
+// handleMPCDiagnose exposes the full per-slot context of the most
+// recent Optimize call: inputs (price, PV, load, confidence) joined
+// with outputs (battery, grid, SoC, cost, reason) plus the Params the
+// DP was parameterized with. Lets operators answer "why did the
+// planner decide X at 21:00?" without shelling into the host.
+func (s *Server) handleMPCDiagnose(w http.ResponseWriter, r *http.Request) {
+	if s.deps.MPC == nil {
+		writeJSON(w, 200, map[string]any{"enabled": false})
+		return
+	}
+	diag := s.deps.MPC.Diagnose()
+	if diag == nil {
+		writeJSON(w, 200, map[string]any{"enabled": true, "diagnostic": nil})
+		return
+	}
+	writeJSON(w, 200, map[string]any{"enabled": true, "diagnostic": diag})
 }
 
 // ---- Long-format time-series ----

--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -1,0 +1,137 @@
+package mpc
+
+// DiagnosticSlot joins the per-slot inputs the DP saw with the action
+// it chose. One row per horizon slot, indexed from 0 at the slot
+// containing "now". The UI renders this as the per-slot explainability
+// table so operators can answer "why did the planner charge at 21:00?".
+type DiagnosticSlot struct {
+	Idx         int     `json:"idx"`
+	SlotStartMs int64   `json:"slot_start_ms"`
+	SlotEndMs   int64   `json:"slot_end_ms"`
+	LenMin      int     `json:"len_min"`
+
+	// Inputs
+	PriceOre   float64 `json:"price_ore"`   // consumer total (spot + tariff + VAT)
+	SpotOre    float64 `json:"spot_ore"`    // raw spot — used for export revenue
+	Confidence float64 `json:"confidence"`  // 1.0 = day-ahead, 0.6 = forecast
+	PVW        float64 `json:"pv_w"`        // site-signed (≤ 0 when producing)
+	LoadW      float64 `json:"load_w"`
+
+	// Outputs
+	BatteryW float64 `json:"battery_w"`
+	GridW    float64 `json:"grid_w"`
+	SoCPct   float64 `json:"soc_pct"`       // SoC at END of slot
+	CostOre  float64 `json:"cost_ore"`      // raw (un-blended) slot cost
+	Reason   string  `json:"reason"`
+	EMSMode  string  `json:"ems_mode"`
+	PVLimitW float64 `json:"pv_limit_w,omitempty"`
+}
+
+// DiagnosticParams is a JSON-friendly subset of the Params struct —
+// enough for operators to verify the DP was parameterized correctly
+// without pulling the whole internal struct.
+type DiagnosticParams struct {
+	Mode                Mode    `json:"mode"`
+	InitialSoCPct       float64 `json:"initial_soc_pct"`
+	SoCMinPct           float64 `json:"soc_min_pct"`
+	SoCMaxPct           float64 `json:"soc_max_pct"`
+	SoCLevels           int     `json:"soc_levels"`
+	ActionLevels        int     `json:"action_levels"`
+	MaxChargeW          float64 `json:"max_charge_w"`
+	MaxDischargeW       float64 `json:"max_discharge_w"`
+	ChargeEfficiency    float64 `json:"charge_efficiency"`
+	DischargeEfficiency float64 `json:"discharge_efficiency"`
+	CapacityWh          float64 `json:"capacity_wh"`
+	TerminalSoCPrice    float64 `json:"terminal_soc_price_ore_kwh"`
+	ExportBonusOreKwh   float64 `json:"export_bonus_ore_kwh"`
+	ExportFeeOreKwh     float64 `json:"export_fee_ore_kwh"`
+}
+
+// Diagnostic is the full post-mortem of the most recent Optimize call.
+// Returned by Service.Diagnose for the /api/mpc/diagnose endpoint.
+type Diagnostic struct {
+	ComputedAtMs   int64            `json:"computed_at_ms"`
+	Zone           string           `json:"zone"`
+	Horizon        int              `json:"horizon_slots"`
+	TotalCostOre   float64          `json:"total_cost_ore"`
+	Params         DiagnosticParams `json:"params"`
+	Slots          []DiagnosticSlot `json:"slots"`
+	LastReplanAtMs int64            `json:"last_replan_at_ms"`
+	LastReason     string           `json:"last_reason"`
+}
+
+// Diagnose returns the inputs + outputs of the most recent Optimize
+// call, joined per slot. Returns nil until the first successful replan.
+//
+// The shape matches what the UI renders in the planner inspector so
+// operators can audit each slot: "what did the DP see, what did it
+// decide, and why". The per-slot `Reason` string already explains the
+// decision class; the adjacent inputs show whether the decision was
+// grounded in a real day-ahead price (`confidence == 1.0`) or a
+// forecasted one (`confidence == 0.6`).
+func (s *Service) Diagnose() *Diagnostic {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.last == nil || len(s.lastSlots) == 0 {
+		return nil
+	}
+	// Slots and Actions are generated in the same order by Optimize:
+	// action[i] corresponds to slot[i]. Guard against a mismatch
+	// anyway — better one-off wrong row than a panic in production.
+	n := len(s.lastSlots)
+	if len(s.last.Actions) < n {
+		n = len(s.last.Actions)
+	}
+	out := make([]DiagnosticSlot, n)
+	for i := 0; i < n; i++ {
+		slot := s.lastSlots[i]
+		action := s.last.Actions[i]
+		out[i] = DiagnosticSlot{
+			Idx:         i,
+			SlotStartMs: slot.StartMs,
+			SlotEndMs:   slot.StartMs + int64(slot.LenMin)*60*1000,
+			LenMin:      slot.LenMin,
+			PriceOre:    slot.PriceOre,
+			SpotOre:     slot.SpotOre,
+			Confidence:  slot.Confidence,
+			PVW:         slot.PVW,
+			LoadW:       slot.LoadW,
+			BatteryW:    action.BatteryW,
+			GridW:       action.GridW,
+			SoCPct:      action.SoCPct,
+			CostOre:     action.CostOre,
+			Reason:      action.Reason,
+			EMSMode:     action.EMSMode,
+			PVLimitW:    action.PVLimitW,
+		}
+	}
+	p := s.lastParams
+	return &Diagnostic{
+		ComputedAtMs: s.last.GeneratedAtMs,
+		Zone:         s.Zone,
+		Horizon:      s.last.HorizonSlots,
+		TotalCostOre: s.last.TotalCostOre,
+		Params: DiagnosticParams{
+			Mode:                p.Mode,
+			InitialSoCPct:       p.InitialSoCPct,
+			SoCMinPct:           p.SoCMinPct,
+			SoCMaxPct:           p.SoCMaxPct,
+			SoCLevels:           p.SoCLevels,
+			ActionLevels:        p.ActionLevels,
+			MaxChargeW:          p.MaxChargeW,
+			MaxDischargeW:       p.MaxDischargeW,
+			ChargeEfficiency:    p.ChargeEfficiency,
+			DischargeEfficiency: p.DischargeEfficiency,
+			CapacityWh:          p.CapacityWh,
+			TerminalSoCPrice:    p.TerminalSoCPrice,
+			ExportBonusOreKwh:   p.ExportBonusOreKwh,
+			ExportFeeOreKwh:     p.ExportFeeOreKwh,
+		},
+		Slots:          out,
+		LastReplanAtMs: s.lastReplanAt.UnixMilli(),
+		LastReason:     s.lastReason,
+	}
+}

--- a/go/internal/mpc/diagnose_test.go
+++ b/go/internal/mpc/diagnose_test.go
@@ -1,0 +1,135 @@
+package mpc
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDiagnoseNilBeforeReplan asserts we return nil (not a garbage
+// struct or panic) when Diagnose is called before any replan has
+// completed. The UI handles nil as "no plan yet".
+func TestDiagnoseNilBeforeReplan(t *testing.T) {
+	s := &Service{Zone: "SE3"}
+	if d := s.Diagnose(); d != nil {
+		t.Errorf("Diagnose before first replan must be nil, got %+v", d)
+	}
+}
+
+// TestDiagnoseJoinsSlotsAndActions is the core contract: the per-slot
+// output row must carry BOTH the input context the DP saw (price, PV,
+// load, confidence) and the decision it made (battery, grid, SoC,
+// reason). Without the join, operators can't audit decisions.
+func TestDiagnoseJoinsSlotsAndActions(t *testing.T) {
+	start := time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC).UnixMilli()
+	// Two 15-min slots, both have positive price so the DP will opt to
+	// idle (self-consumption mode). Exact decision doesn't matter —
+	// we're testing the join shape.
+	slots := []Slot{
+		{StartMs: start, LenMin: 15, PriceOre: 100, SpotOre: 50,
+			PVW: -200, LoadW: 400, Confidence: 1.0},
+		{StartMs: start + 15*60*1000, LenMin: 15, PriceOre: 150,
+			SpotOre: 80, PVW: -100, LoadW: 500, Confidence: 0.6},
+	}
+	p := Params{
+		Mode:                ModeSelfConsumption,
+		SoCLevels:           11,
+		CapacityWh:          10000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        7,
+		MaxChargeW:          5000,
+		MaxDischargeW:       5000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    100,
+	}
+	plan := Optimize(slots, p)
+
+	svc := &Service{
+		Zone:         "SE3",
+		last:         &plan,
+		lastSlots:    slots,
+		lastParams:   p,
+		lastReplanAt: time.UnixMilli(plan.GeneratedAtMs),
+		lastReason:   "unit-test",
+	}
+	d := svc.Diagnose()
+	if d == nil {
+		t.Fatal("Diagnose returned nil after a successful optimize")
+	}
+	if d.Zone != "SE3" {
+		t.Errorf("Zone: got %q want SE3", d.Zone)
+	}
+	if d.Params.Mode != ModeSelfConsumption {
+		t.Errorf("Params.Mode: got %q want self_consumption", d.Params.Mode)
+	}
+	if d.Params.InitialSoCPct != 50 {
+		t.Errorf("Params.InitialSoCPct: got %.2f want 50", d.Params.InitialSoCPct)
+	}
+	if d.LastReason != "unit-test" {
+		t.Errorf("LastReason: got %q want unit-test", d.LastReason)
+	}
+	if got := len(d.Slots); got != len(slots) {
+		t.Fatalf("Slots length: got %d want %d", got, len(slots))
+	}
+	// Verify row 0 joined correctly: inputs match slots[0], outputs
+	// match plan.Actions[0].
+	row := d.Slots[0]
+	if row.PriceOre != 100 {
+		t.Errorf("row0 PriceOre: got %.1f want 100", row.PriceOre)
+	}
+	if row.SpotOre != 50 {
+		t.Errorf("row0 SpotOre: got %.1f want 50", row.SpotOre)
+	}
+	if row.Confidence != 1.0 {
+		t.Errorf("row0 Confidence: got %.2f want 1.0", row.Confidence)
+	}
+	if row.PVW != -200 {
+		t.Errorf("row0 PVW: got %.1f want -200", row.PVW)
+	}
+	if row.LoadW != 400 {
+		t.Errorf("row0 LoadW: got %.1f want 400", row.LoadW)
+	}
+	// Outputs come from the plan's action — we don't assert exact
+	// values (that's what the mpc_test suite covers), just that they
+	// were populated.
+	if row.Reason == "" {
+		t.Error("row0 Reason should be populated by the DP")
+	}
+	// Row 1 should carry the forecast confidence.
+	if d.Slots[1].Confidence != 0.6 {
+		t.Errorf("row1 Confidence: got %.2f want 0.6", d.Slots[1].Confidence)
+	}
+	if d.Slots[1].SlotStartMs != start+15*60*1000 {
+		t.Errorf("row1 SlotStartMs: got %d want %d",
+			d.Slots[1].SlotStartMs, start+15*60*1000)
+	}
+}
+
+// TestDiagnoseHandlesLengthMismatch guards against a panic if slots
+// and actions ever get out of sync (shouldn't happen in practice —
+// Optimize returns len(actions) == len(slots) — but we round-trip
+// into lastSlots in service code paths that could diverge).
+func TestDiagnoseHandlesLengthMismatch(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 1000, LenMin: 15, PriceOre: 100, Confidence: 1.0},
+		{StartMs: 2000, LenMin: 15, PriceOre: 110, Confidence: 1.0},
+	}
+	plan := Plan{
+		GeneratedAtMs: 123,
+		Actions:       []Action{{SlotStartMs: 1000, SlotLenMin: 15}},
+	}
+	svc := &Service{
+		Zone:      "SE3",
+		last:      &plan,
+		lastSlots: slots,
+	}
+	d := svc.Diagnose()
+	if d == nil {
+		t.Fatal("Diagnose should not be nil on mismatch — should truncate")
+	}
+	if len(d.Slots) != 1 {
+		t.Errorf("should truncate to shorter side; got %d rows", len(d.Slots))
+	}
+}

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -83,8 +83,10 @@ type Service struct {
 
 	Defaults Params
 
-	mu   sync.RWMutex
-	last *Plan
+	mu         sync.RWMutex
+	last       *Plan
+	lastSlots  []Slot  // inputs that went into the most recent Optimize call
+	lastParams Params  // params that went into the most recent Optimize call
 
 	stop chan struct{}
 	done chan struct{}
@@ -501,6 +503,8 @@ func (s *Service) replan(_ context.Context) *Plan {
 
 	s.mu.Lock()
 	s.last = &plan
+	s.lastSlots = slots
+	s.lastParams = p
 	s.lastReplanAt = time.Now()
 	reason := s.lastReason
 	if reason == "" {


### PR DESCRIPTION
## Summary

Phase 2 of 4 in the planner overhaul roadmap. Builds on the observability gap that blocked root-causing Erik's 21:00 charging bug.

Adds `GET /api/mpc/diagnose` — returns the full input/output context of the most recent `Optimize` call, joined per slot:

**Per-slot inputs** the DP saw: `price_ore` (consumer total), `spot_ore` (raw), `confidence` (1.0 day-ahead vs 0.6 forecast), `pv_w`, `load_w`, slot window

**Per-slot outputs** the DP produced: `battery_w`, `grid_w`, `soc_pct`, `cost_ore` (raw un-blended), `reason`, `ems_mode`, `pv_limit_w`

**Params** the DP was parameterized with: mode, SoC bounds, efficiency, terminal valuation, export bonus/fee

Lets operators answer "why did the planner decide X at 21:00?" without correlating multiple endpoints or shelling into the host.

## Implementation

- `Service.lastSlots []Slot` + `Service.lastParams Params` fields populated alongside `Service.last *Plan` in `replan()`
- `Service.Diagnose() *Diagnostic` joins by slot index
- New `go/internal/mpc/diagnose.go` holds the `Diagnostic` / `DiagnosticSlot` / `DiagnosticParams` types (JSON-friendly, subset of internal `Params`)
- `handleMPCDiagnose` in `api.go` + new route

Safe-by-construction: Diagnose returns nil before first replan, truncates on Slots/Actions length mismatch rather than panicking.

## Example

```bash
curl localhost:8080/api/mpc/diagnose | jq '.diagnostic.slots[] | {idx, slot_start_ms, price_ore, confidence, pv_w, battery_w, soc_pct, reason}'
```

Returns one row per horizon slot so you can spot "forecast slot got a confidence 0.6 weight that pulled the effective price toward horizon mean, hence the charge decision despite apparent 145 öre price".

## Test plan

- [x] `go test ./internal/mpc/...` — new `diagnose_test.go` covers nil-before-replan, join shape, length-mismatch safety
- [x] `go test ./...` — full suite incl. e2e (27s) green
- [ ] Deploy to Pi, `curl localhost:8080/api/mpc/diagnose | jq` — inspect Erik's 21:00 decision
- [ ] Follow-up PR: wire a diagnose inspector into the web UI

## Roadmap context

Part of the unified-planner overhaul.

- **Phase 1** — DST/timezone audit (PR #97)
- **Phase 2** — this PR
- **Phase 3** — PowerLimits (time-varying grid limits) + Loadpoint observable skeleton
- **Phase 4** — EV in DP + dispatch + charger capabilities (ONE system: battery + PV + EV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)