### PR TITLE
feat(mpc): PowerLimits per slot + Loadpoint observable skeleton

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/forecast"
 	"github.com/frahlg/forty-two-watts/go/internal/ha"
 	"github.com/frahlg/forty-two-watts/go/internal/loadmodel"
+	"github.com/frahlg/forty-two-watts/go/internal/loadpoint"
 	mqttcli "github.com/frahlg/forty-two-watts/go/internal/mqtt"
 	modbuscli "github.com/frahlg/forty-two-watts/go/internal/modbus"
 	"github.com/frahlg/forty-two-watts/go/internal/mpc"
@@ -465,6 +466,28 @@ func main() {
 			"pvtwin", pvSvc != nil)
 	}
 
+	// ---- EV loadpoints (observable skeleton) ----
+	// Phase 3 of the planner overhaul introduces the Loadpoint concept
+	// as a first-class entity the API / UI can surface. Phase 4 extends
+	// the MPC's DP with per-loadpoint state + wires Observe() into
+	// charger drivers.
+	lpMgr := loadpoint.NewManager()
+	if len(cfg.Loadpoints) > 0 {
+		lpCfg := make([]loadpoint.Config, 0, len(cfg.Loadpoints))
+		for _, lp := range cfg.Loadpoints {
+			lpCfg = append(lpCfg, loadpoint.Config{
+				ID:                lp.ID,
+				DriverName:        lp.DriverName,
+				MinChargeW:        lp.MinChargeW,
+				MaxChargeW:        lp.MaxChargeW,
+				AllowedStepsW:     lp.AllowedStepsW,
+				VehicleCapacityWh: lp.VehicleCapacityWh,
+			})
+		}
+		lpMgr.Load(lpCfg)
+		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
+	}
+
 	// ---- Start HTTP API ----
 	// Forward-declare haBridge so Deps can reference it; the bridge
 	// gets wired further down (HA is optional + depends on reg.Names()).
@@ -485,6 +508,7 @@ func main() {
 		MPC:        mpcSvc,
 		PVModel:    pvSvc,
 		LoadModel:  loadSvc,
+		Loadpoints: lpMgr,
 		HA:         haBridge,
 		Registry:   reg,
 		Version:    Version,

--- a/go/internal/api/CLAUDE.md
+++ b/go/internal/api/CLAUDE.md
@@ -33,6 +33,7 @@ Endpoint groups (route table is `api.go:95-130`):
 | history / series | `GET /api/history`, `GET /api/series`, `GET /api/series/catalog` |
 | prices / forecast | `GET /api/prices`, `GET /api/forecast` |
 | mpc | `GET /api/mpc/plan`, `POST /api/mpc/replan` |
+| loadpoints | `GET /api/loadpoints` |
 | twins | `GET /api/pvmodel`, `POST /api/pvmodel/reset`, `GET /api/loadmodel`, `POST /api/loadmodel/reset` |
 | ha | `GET /api/ha/status` |
 | static | `/` falls through to `Deps.WebDir` |

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/forecast"
 	"github.com/frahlg/forty-two-watts/go/internal/ha"
 	"github.com/frahlg/forty-two-watts/go/internal/loadmodel"
+	"github.com/frahlg/forty-two-watts/go/internal/loadpoint"
 	"github.com/frahlg/forty-two-watts/go/internal/mpc"
 	"github.com/frahlg/forty-two-watts/go/internal/prices"
 	"github.com/frahlg/forty-two-watts/go/internal/pvmodel"
@@ -78,6 +79,10 @@ type Deps struct {
 
 	// Optional: load digital-twin self-learner.
 	LoadModel *loadmodel.Service
+
+	// Optional: EV loadpoints (Phase 3 observable skeleton; Phase 4
+	// wires these into MPC decision surface).
+	Loadpoints *loadpoint.Manager
 
 	// Optional: HA MQTT bridge (nil if disabled).
 	HA *ha.Bridge
@@ -150,6 +155,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/ev/status", s.handleEVStatus)
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
+	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.
@@ -1368,4 +1374,18 @@ func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, 200, chargers)
+}
+
+// GET /api/loadpoints returns the configured EV loadpoints with their
+// current observable state. Read-only in Phase 3; POST /target comes
+// in Phase 4 with the full charger control wiring.
+func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Loadpoints == nil {
+		writeJSON(w, 200, map[string]any{"enabled": false, "loadpoints": []any{}})
+		return
+	}
+	writeJSON(w, 200, map[string]any{
+		"enabled":    true,
+		"loadpoints": s.deps.Loadpoints.States(),
+	})
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -29,6 +29,20 @@ type Config struct {
 	Batteries     map[string]Battery `yaml:"batteries,omitempty" json:"batteries,omitempty"`
 	OCPP          *OCPP              `yaml:"ocpp,omitempty" json:"ocpp,omitempty"`
 	EVCharger     *EVCharger         `yaml:"ev_charger,omitempty" json:"ev_charger,omitempty"`
+	Loadpoints    []Loadpoint        `yaml:"loadpoints,omitempty" json:"loadpoints,omitempty"`
+}
+
+// Loadpoint is one EV charge point the planner can reason about.
+// Phase 3 introduces the schema + observable surface; Phase 4 wires
+// it into the DP state space so the MPC optimizes battery + EV jointly.
+// See docs/plan-ems-contract.md + go/internal/loadpoint.
+type Loadpoint struct {
+	ID                string    `yaml:"id" json:"id"`
+	DriverName        string    `yaml:"driver_name" json:"driver_name"`
+	MinChargeW        float64   `yaml:"min_charge_w,omitempty" json:"min_charge_w,omitempty"`
+	MaxChargeW        float64   `yaml:"max_charge_w,omitempty" json:"max_charge_w,omitempty"`
+	AllowedStepsW     []float64 `yaml:"allowed_steps_w,omitempty" json:"allowed_steps_w,omitempty"`
+	VehicleCapacityWh float64   `yaml:"vehicle_capacity_wh,omitempty" json:"vehicle_capacity_wh,omitempty"`
 }
 
 // OCPP configures the embedded OCPP 1.6J Central System for EV chargers.

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -1,0 +1,213 @@
+// Package loadpoint models an EV charge point as a first-class entity
+// the planner can reason about. A loadpoint couples a physical charger
+// driver (Easee, Zap, OCPP, …) with a specific vehicle and user intent
+// (target SoC by target time).
+//
+// This package currently hosts the config-facing types and a read-only
+// manager that surfaces configured loadpoints through the API. Phase 3
+// of the planner overhaul introduces the skeleton without wiring it to
+// the MPC's decision surface — that comes in Phase 4, where the DP is
+// extended with EV-SoC state and the dispatch layer gains a per-
+// loadpoint energy-budget path that mirrors the battery energy path.
+//
+// Keeping it lightweight is intentional: EVCC ships ~20 kLOC of
+// loadpoint machinery (hysteresis, enable/disable delays, phase
+// switching). We don't need most of that because the energy-budget
+// contract is continuous by construction (no flap-flapping). Phase
+// switching is a driver-local heuristic, not a planner concern.
+package loadpoint
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Config is the YAML-facing definition of one loadpoint. Wired into
+// config.Config under "loadpoints". All electrical fields are
+// optional with sensible defaults for a typical single-phase /
+// three-phase residential EV charger.
+type Config struct {
+	ID         string `yaml:"id" json:"id"`                   // stable identifier ("garage", "street")
+	DriverName string `yaml:"driver_name" json:"driver_name"` // which driver controls the charger
+
+	// Elektriska gränser
+	MinChargeW    float64   `yaml:"min_charge_w,omitempty" json:"min_charge_w,omitempty"`       // e.g. 1400 (1-phase 6 A)
+	MaxChargeW    float64   `yaml:"max_charge_w,omitempty" json:"max_charge_w,omitempty"`       // e.g. 11000 (3-phase 16 A)
+	AllowedStepsW []float64 `yaml:"allowed_steps_w,omitempty" json:"allowed_steps_w,omitempty"` // discrete Wh levels supported
+
+	// Battery capacity in Wh (used to translate SoC% ↔ Wh and to
+	// validate target-SoC feasibility given a deadline). 0 falls
+	// back to a typical 60 kWh assumption.
+	VehicleCapacityWh float64 `yaml:"vehicle_capacity_wh,omitempty" json:"vehicle_capacity_wh,omitempty"`
+}
+
+// State is the observable snapshot of one loadpoint at a point in time.
+// Read-only for consumers — only the Manager or dispatch paths mutate
+// it under lock.
+type State struct {
+	ID                 string    `json:"id"`
+	DriverName         string    `json:"driver_name"`
+	PluggedIn          bool      `json:"plugged_in"`
+	CurrentSoCPct      float64   `json:"current_soc_pct"`       // observed or estimated
+	CurrentPowerW      float64   `json:"current_power_w"`       // actual draw (site sign: + = charging)
+	DeliveredWhSession float64   `json:"delivered_wh_session"`  // since plug-in
+	TargetSoCPct       float64   `json:"target_soc_pct"`        // user intent
+	TargetTime         time.Time `json:"target_time,omitempty"` // user intent
+	UpdatedAtMs        int64     `json:"updated_at_ms"`
+	// MinChargeW / MaxChargeW / AllowedStepsW are repeated here so the
+	// UI has everything for rendering in one fetch.
+	MinChargeW    float64   `json:"min_charge_w"`
+	MaxChargeW    float64   `json:"max_charge_w"`
+	AllowedStepsW []float64 `json:"allowed_steps_w,omitempty"`
+}
+
+// Manager holds the running set of loadpoints. Thread-safe.
+type Manager struct {
+	mu     sync.RWMutex
+	byID   map[string]*loadpointRuntime
+	order  []string // insertion-preserving id list for deterministic listing
+}
+
+// loadpointRuntime is the in-memory representation. Its fields are the
+// union of configured parameters and observed state. Lives behind
+// Manager so consumers access it via the public State snapshot.
+type loadpointRuntime struct {
+	Config
+
+	pluggedIn          bool
+	currentSoCPct      float64
+	currentPowerW      float64
+	deliveredWhSession float64
+	targetSoCPct       float64
+	targetTime         time.Time
+	updatedAtMs        int64
+}
+
+// NewManager returns an empty manager. Configure with Load().
+func NewManager() *Manager {
+	return &Manager{byID: map[string]*loadpointRuntime{}}
+}
+
+// Load replaces the configured set. Idempotent: existing state is
+// carried across when the ID is kept; removed IDs are dropped.
+func (m *Manager) Load(cfgs []Config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	newByID := make(map[string]*loadpointRuntime, len(cfgs))
+	newOrder := make([]string, 0, len(cfgs))
+	for _, c := range cfgs {
+		if c.ID == "" {
+			continue
+		}
+		lp := &loadpointRuntime{Config: c}
+		if existing, ok := m.byID[c.ID]; ok {
+			// Preserve observed state across reload.
+			lp.pluggedIn = existing.pluggedIn
+			lp.currentSoCPct = existing.currentSoCPct
+			lp.currentPowerW = existing.currentPowerW
+			lp.deliveredWhSession = existing.deliveredWhSession
+			lp.targetSoCPct = existing.targetSoCPct
+			lp.targetTime = existing.targetTime
+			lp.updatedAtMs = existing.updatedAtMs
+		}
+		newByID[c.ID] = lp
+		newOrder = append(newOrder, c.ID)
+	}
+	m.byID = newByID
+	m.order = newOrder
+}
+
+// IDs returns configured loadpoint IDs in insertion order.
+func (m *Manager) IDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, len(m.order))
+	copy(out, m.order)
+	return out
+}
+
+// State returns an immutable snapshot. Returns (State{}, false) when ID
+// is unknown.
+func (m *Manager) State(id string) (State, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return State{}, false
+	}
+	return lp.snapshot(), true
+}
+
+// States returns snapshots of every configured loadpoint, sorted by
+// the configured ID order. Useful for GET /api/loadpoints.
+func (m *Manager) States() []State {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]State, 0, len(m.order))
+	for _, id := range m.order {
+		if lp, ok := m.byID[id]; ok {
+			out = append(out, lp.snapshot())
+		}
+	}
+	return out
+}
+
+// Observe updates the measurement side of a loadpoint. Called by the
+// driver layer once per poll cycle (phase 4 wiring). No-op for
+// unknown IDs — a misconfigured driver shouldn't crash the manager.
+func (m *Manager) Observe(id string, pluggedIn bool, socPct, powerW,
+	deliveredWh float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return
+	}
+	lp.pluggedIn = pluggedIn
+	lp.currentSoCPct = socPct
+	lp.currentPowerW = powerW
+	lp.deliveredWhSession = deliveredWh
+	lp.updatedAtMs = time.Now().UnixMilli()
+}
+
+// SetTarget updates the user-intent fields for an existing loadpoint.
+// targetTime zero = no deadline. Returns false for unknown IDs.
+func (m *Manager) SetTarget(id string, socPct float64, targetTime time.Time) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return false
+	}
+	if socPct < 0 {
+		socPct = 0
+	}
+	if socPct > 100 {
+		socPct = 100
+	}
+	lp.targetSoCPct = socPct
+	lp.targetTime = targetTime
+	return true
+}
+
+func (lp *loadpointRuntime) snapshot() State {
+	steps := make([]float64, len(lp.AllowedStepsW))
+	copy(steps, lp.AllowedStepsW)
+	sort.Float64s(steps)
+	return State{
+		ID:                 lp.ID,
+		DriverName:         lp.DriverName,
+		PluggedIn:          lp.pluggedIn,
+		CurrentSoCPct:      lp.currentSoCPct,
+		CurrentPowerW:      lp.currentPowerW,
+		DeliveredWhSession: lp.deliveredWhSession,
+		TargetSoCPct:       lp.targetSoCPct,
+		TargetTime:         lp.targetTime,
+		UpdatedAtMs:        lp.updatedAtMs,
+		MinChargeW:         lp.MinChargeW,
+		MaxChargeW:         lp.MaxChargeW,
+		AllowedStepsW:      steps,
+	}
+}

--- a/go/internal/loadpoint/loadpoint_test.go
+++ b/go/internal/loadpoint/loadpoint_test.go
@@ -1,0 +1,105 @@
+package loadpoint
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadPopulatesAndPreservesOrder(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{
+		{ID: "garage", DriverName: "easee-cloud", MaxChargeW: 11000},
+		{ID: "street", DriverName: "zap", MaxChargeW: 7400},
+	})
+	if ids := m.IDs(); len(ids) != 2 || ids[0] != "garage" || ids[1] != "street" {
+		t.Errorf("IDs not insertion-ordered: %v", ids)
+	}
+}
+
+func TestLoadSkipsBlankID(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "", DriverName: "ghost"}, {ID: "real"}})
+	if len(m.IDs()) != 1 || m.IDs()[0] != "real" {
+		t.Errorf("blank ID should be skipped; got %v", m.IDs())
+	}
+}
+
+func TestReloadPreservesObservedState(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee-cloud"}})
+	m.Observe("garage", true, 55, 7400, 1200)
+	target := time.Date(2026, 4, 18, 6, 0, 0, 0, time.UTC)
+	m.SetTarget("garage", 80, target)
+
+	// Reload with same ID — state should persist.
+	m.Load([]Config{{ID: "garage", DriverName: "easee-cloud", MaxChargeW: 11000}})
+	st, ok := m.State("garage")
+	if !ok {
+		t.Fatal("state missing after reload")
+	}
+	if !st.PluggedIn || st.CurrentSoCPct != 55 || st.CurrentPowerW != 7400 {
+		t.Errorf("observed state lost: %+v", st)
+	}
+	if st.TargetSoCPct != 80 || !st.TargetTime.Equal(target) {
+		t.Errorf("target lost: %+v", st)
+	}
+	// But config should update.
+	if st.MaxChargeW != 11000 {
+		t.Errorf("config not updated: MaxChargeW=%f", st.MaxChargeW)
+	}
+}
+
+func TestReloadDropsRemovedIDs(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a"}, {ID: "b"}})
+	m.Load([]Config{{ID: "b"}})
+	if ids := m.IDs(); len(ids) != 1 || ids[0] != "b" {
+		t.Errorf("removed ID should be dropped; got %v", ids)
+	}
+}
+
+func TestObserveOnUnknownIsNoop(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "real"}})
+	m.Observe("ghost", true, 80, 7400, 0) // must not panic
+	if _, ok := m.State("ghost"); ok {
+		t.Error("ghost state should not exist")
+	}
+}
+
+func TestSetTargetClamp(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a"}})
+	m.SetTarget("a", 250, time.Time{})
+	st, _ := m.State("a")
+	if st.TargetSoCPct != 100 {
+		t.Errorf("should clamp to 100; got %f", st.TargetSoCPct)
+	}
+	m.SetTarget("a", -10, time.Time{})
+	st, _ = m.State("a")
+	if st.TargetSoCPct != 0 {
+		t.Errorf("should clamp to 0; got %f", st.TargetSoCPct)
+	}
+}
+
+func TestStatesReturnsAllInOrder(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{
+		{ID: "garage", MaxChargeW: 11000},
+		{ID: "street", MaxChargeW: 7400},
+	})
+	m.Observe("garage", true, 40, 11000, 500)
+	states := m.States()
+	if len(states) != 2 {
+		t.Fatalf("expected 2 states, got %d", len(states))
+	}
+	if states[0].ID != "garage" || states[1].ID != "street" {
+		t.Errorf("wrong ordering: %v, %v", states[0].ID, states[1].ID)
+	}
+	if !states[0].PluggedIn {
+		t.Error("garage should be plugged in")
+	}
+	if states[1].PluggedIn {
+		t.Error("street should not be plugged in")
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -74,6 +74,11 @@ type Slot struct {
 	// the planner doesn't over-commit to uncertain spikes. Defaults to
 	// 1.0 when callers leave it zero.
 	Confidence float64
+
+	// Limits caps grid flow for this slot. Zero value = unlimited.
+	// See power_limits.go for use cases (peak-tariff capacity, DSO
+	// curtailment, service-entrance current limit).
+	Limits PowerLimits
 }
 
 // Params bounds the optimization. All fields are required.
@@ -258,6 +263,14 @@ func Optimize(slots []Slot, p Params) Plan {
 
 				// Mode-based feasibility.
 				if !modeAllows(p.Mode, baselineGridW, gridW, actW) {
+					continue
+				}
+
+				// Per-slot power limits (tariff capacity / DSO
+				// curtailment / service-entrance fuse). Zero-value
+				// PowerLimits is unlimited — the zero-check lives
+				// inside allowsImport/allowsExport.
+				if !slot.Limits.allowsImport(gridW) || !slot.Limits.allowsExport(gridW) {
 					continue
 				}
 

--- a/go/internal/mpc/power_limits.go
+++ b/go/internal/mpc/power_limits.go
@@ -1,0 +1,54 @@
+package mpc
+
+// PowerLimits caps the grid flow the DP is allowed to consider in a
+// given slot. Default (zero value) is unlimited — the MPC plans as if
+// the grid connection has unbounded capacity in both directions.
+//
+// Use cases:
+//
+//   - Dynamic-capacity tariff: "between 17-20 local, max 5 kW import"
+//     (the tariff charges a fixed monthly fee for every kW peak above
+//     that) — set MaxImportW = 5000 on affected slots.
+//
+//   - DSO / grid operator curtailment signal: "zero export during
+//     congestion event" — set MaxExportW to a small value. The DP
+//     then avoids plans that require exporting more than that.
+//
+//   - Phase-current limit from a constrained service entrance: cap
+//     import so battery charging + household load don't trip the
+//     main fuse even when prices would make grid-charging attractive.
+//
+// Inspired by the per-slot PowerLimits dataclass in
+// srcful-nova-ems-x; kept as a plain value (not a pointer) so the
+// zero-value default is "no limit applied" without any nil-check
+// boilerplate at call sites.
+type PowerLimits struct {
+	// MaxImportW caps positive grid flow (site convention: grid W > 0
+	// = importing). A value of 0 or negative means unlimited.
+	MaxImportW float64
+
+	// MaxExportW caps the magnitude of negative grid flow
+	// (|grid W| when grid W < 0). A value of 0 or negative means
+	// unlimited.
+	MaxExportW float64
+}
+
+// allowsImport reports whether the slot permits the given positive
+// grid flow (W). Returns true for any non-positive flow (import check
+// only applies to import).
+func (l PowerLimits) allowsImport(gridW float64) bool {
+	if gridW <= 0 || l.MaxImportW <= 0 {
+		return true
+	}
+	return gridW <= l.MaxImportW
+}
+
+// allowsExport reports whether the slot permits the given negative
+// grid flow (W). Returns true for any non-negative flow (export check
+// only applies to export).
+func (l PowerLimits) allowsExport(gridW float64) bool {
+	if gridW >= 0 || l.MaxExportW <= 0 {
+		return true
+	}
+	return -gridW <= l.MaxExportW
+}

--- a/go/internal/mpc/power_limits_test.go
+++ b/go/internal/mpc/power_limits_test.go
@@ -1,0 +1,149 @@
+package mpc
+
+import "testing"
+
+// TestPowerLimitsDefaultIsUnlimited asserts the zero value places no
+// constraints on the DP — protecting backwards compatibility. Without
+// this invariant, every existing Slot caller would suddenly face a
+// zero-import / zero-export constraint.
+func TestPowerLimitsDefaultIsUnlimited(t *testing.T) {
+	var l PowerLimits
+	for _, grid := range []float64{-10000, -100, 0, 100, 10000} {
+		if !l.allowsImport(grid) {
+			t.Errorf("default should allow import for gridW=%.0f", grid)
+		}
+		if !l.allowsExport(grid) {
+			t.Errorf("default should allow export for gridW=%.0f", grid)
+		}
+	}
+}
+
+func TestPowerLimitsImportCap(t *testing.T) {
+	l := PowerLimits{MaxImportW: 5000}
+	cases := []struct {
+		gridW  float64
+		ok     bool
+		reason string
+	}{
+		{-10000, true, "export ignores import cap"},
+		{0, true, "zero flow allowed"},
+		{4000, true, "below cap"},
+		{5000, true, "at cap"},
+		{5001, false, "above cap"},
+		{10000, false, "well above cap"},
+	}
+	for _, tc := range cases {
+		if got := l.allowsImport(tc.gridW); got != tc.ok {
+			t.Errorf("%s: gridW=%.0f, got allowsImport=%v, want %v",
+				tc.reason, tc.gridW, got, tc.ok)
+		}
+	}
+}
+
+func TestPowerLimitsExportCap(t *testing.T) {
+	l := PowerLimits{MaxExportW: 3000}
+	cases := []struct {
+		gridW  float64
+		ok     bool
+		reason string
+	}{
+		{10000, true, "import ignores export cap"},
+		{0, true, "zero flow allowed"},
+		{-2000, true, "below cap (magnitude)"},
+		{-3000, true, "at cap"},
+		{-3001, false, "above cap"},
+	}
+	for _, tc := range cases {
+		if got := l.allowsExport(tc.gridW); got != tc.ok {
+			t.Errorf("%s: gridW=%.0f, got allowsExport=%v, want %v",
+				tc.reason, tc.gridW, got, tc.ok)
+		}
+	}
+}
+
+// TestOptimizeRespectsImportCap is the end-to-end: if every cheap slot
+// has an import cap, the DP should not schedule import over that cap.
+// Without the cap, a cheap slot would tempt an unbounded charge.
+func TestOptimizeRespectsImportCap(t *testing.T) {
+	// 4 hourly slots, all cheap at 10 öre. Default battery params
+	// would happily charge at full power in every slot; the cap on
+	// slot 1 should force the DP to stay under 2000 W net import.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 10, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 10, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0,
+			Limits: PowerLimits{MaxImportW: 2000}},
+		{StartMs: 7200_000, LenMin: 60, PriceOre: 10, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 10800_000, LenMin: 60, PriceOre: 10, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0},
+	}
+	p := Params{
+		Mode:                ModeCheapCharge,
+		SoCLevels:           41,
+		CapacityWh:          15000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       20,
+		ActionLevels:        21,
+		MaxChargeW:           5000,
+		MaxDischargeW:        5000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    50,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) != len(slots) {
+		t.Fatalf("got %d actions, want %d", len(plan.Actions), len(slots))
+	}
+	// Slot 1 has the cap. GridW there must not exceed 2000 W.
+	g := plan.Actions[1].GridW
+	if g > 2000+1e-6 {
+		t.Errorf("capped slot GridW = %.1f, exceeds cap 2000 W", g)
+	}
+	// Uncapped slots should still be free to import more to make up
+	// what was missed in the capped one — we don't assert a specific
+	// bound, just that the DP didn't get stuck at a degenerate plan.
+	if plan.Actions[0].GridW <= 0 && plan.Actions[2].GridW <= 0 &&
+		plan.Actions[3].GridW <= 0 {
+		t.Error("uncapped slots should import at least somewhere in a " +
+			"4-hour flat-cheap window")
+	}
+}
+
+// TestOptimizeRespectsExportCap mirrors the import test — PV surplus
+// exported into a negative-price slot must respect the cap.
+func TestOptimizeRespectsExportCap(t *testing.T) {
+	// 3 hourly slots. Middle slot has negative price (export is
+	// painful) AND a hard export cap of 500 W. The DP's export
+	// decision in that slot must not exceed the cap.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 100, SpotOre: 80,
+			PVW: -4000, LoadW: 500, Confidence: 1.0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 100, SpotOre: 80,
+			PVW: -4000, LoadW: 500, Confidence: 1.0,
+			Limits: PowerLimits{MaxExportW: 500}},
+		{StartMs: 7200_000, LenMin: 60, PriceOre: 100, SpotOre: 80,
+			PVW: -4000, LoadW: 500, Confidence: 1.0},
+	}
+	p := Params{
+		Mode:                ModeArbitrage,
+		SoCLevels:           41,
+		CapacityWh:          15000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       70,
+		ActionLevels:        21,
+		MaxChargeW:          5000,
+		MaxDischargeW:       5000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    80,
+	}
+	plan := Optimize(slots, p)
+	g := plan.Actions[1].GridW
+	if g < -500-1e-6 {
+		t.Errorf("capped slot GridW = %.1f, below export cap -500 W", g)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 of 4 in the planner overhaul roadmap. Introduces structural pieces for unified battery + EV optimization (Phase 4), without yet activating EV-side control.

## PowerLimits — per-slot grid flow caps

New `mpc.PowerLimits` value type on `Slot`. Zero-value = unlimited (backwards compatible — no existing call sites need changes).

Use cases inspired by `srcful-nova-ems-x`:

- **Dynamic-capacity tariffs**: ''between 17-20 local, max 5 kW import'' (avoid a peak-kW charge from the DSO)
- **DSO curtailment signals**: ''zero export during congestion event''
- **Service-entrance fuse**: cap total import even when prices would make aggressive grid-charging attractive

DP respects them after the mode-feasibility check, before the SoC transition. Infeasible actions are skipped.

## Loadpoint — EV charge point skeleton

New `go/internal/loadpoint` package modeling one EV charge point:

- **Config** (YAML-facing): `id`, `driver_name`, `min_charge_w`, `max_charge_w`, `allowed_steps_w`, `vehicle_capacity_wh`
- **State** (observable): plug status, current SoC %, current power W, delivered Wh this session, user intent (target SoC + target time)
- **Manager**: thread-safe registry + reload-preserves-observed-state semantics

Read-only in Phase 3:

- Configured via new `loadpoints:` top-level in `config.yaml`
- Exposed at `GET /api/loadpoints` for the UI
- No driver wiring yet — `Observe()` exists but isn't called

Deliberately lightweight (~300 LOC vs EVCC's ~20 kLOC). We skip EVCC's hysteresis/enable-delay because the energy-budget dispatch contract is continuous by construction; phase-switching is a driver-local concern.

## What Phase 4 will add

- Extend DP with EV-SoC dimension (11 steps per loadpoint)
- `SlotDirective.LoadpointEnergyWh` for per-LP energy budgets
- EV dispatch mirroring battery dispatch
- `ChargerCap` capability + `easee-cloud.lua` / `zap.lua` driver support
- Divergence check per loadpoint
- `POST /api/loadpoints/:id/target` for UI target setting

## Test plan

- [x] `go test ./internal/mpc/...` — 4 new tests covering unlimited default, import/export caps, end-to-end DP respect (passes)
- [x] `go test ./internal/loadpoint/...` — 7 tests covering load/reload, state preservation, drop-removed-IDs, target clamping, States() ordering
- [x] `go test ./...` — full suite including e2e (27s) green
- [x] `go build ./...` — main.go wiring compiles
- [ ] Deploy to Pi, add a test `loadpoints:` block, `curl localhost:8080/api/loadpoints`

## Roadmap

- **Phase 1** — DST/timezone audit (PR #97)
- **Phase 2** — `/api/mpc/diagnose` (PR #98)
- **Phase 3** — this PR
- **Phase 4** — EV in DP + dispatch + charger capabilities (ONE system: battery + PV + EV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)