### PR TITLE
feat(mpc): unified battery + EV MPC (Phase 4 — ONE system)

### DIFF
--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -139,6 +139,8 @@ when the operator has chosen one.
 - `GET  /api/mpc/plan` — latest cached plan (mode, horizon, per-slot actions with reasons)
 - `POST /api/mpc/replan` — force an immediate replan
 - `POST /api/mode {"mode":"planner_arbitrage"}` — activates a strategy AND forces an MPC replan so targets take effect within one control cycle
+- `GET  /api/loadpoints` — list configured EV loadpoints + observable state (plug, SoC, power, session Wh)
+- `POST /api/loadpoints/{id}/target` — set user intent `{soc_pct: 80, target_time_ms: …}`; triggers an MPC replan
 
 ---
 
@@ -218,3 +220,49 @@ Signal to read from the table:
 
 Total annual savings depend heavily on market volatility; a stable
 market year narrows the gap between the three modes.
+
+---
+
+## Unified EV charging (Phase 4)
+
+When one or more loadpoints are configured and the MPC's `LoadpointProbe`
+sees a plugged-in EV, the DP extends its state space with a per-vehicle
+SoC dimension. The optimization then schedules **battery AND EV actions
+jointly** rather than treating the EV as uncontrolled load — avoiding
+the "two planners fighting" problem that happens when an external EVCC-
+style scheduler runs alongside our MPC.
+
+Per-slot decision space expands from `(battery_soc, battery_action)` to
+`(battery_soc, ev_soc, battery_action, ev_action)`. The EV action set is
+discrete (the charger's allowed W levels), which lets us handle the
+disjunctive 1-phase↔3-phase gap without MILP.
+
+### Target + deadline
+
+User intent (`POST /api/loadpoints/{id}/target`) sets `target_soc_pct` +
+`target_time_ms`. The planner maps the time to a horizon slot index
+and adds a shortfall penalty at that slot: missing the target costs
+`missed_kwh × horizon_mean_price × 4`. Factor 4 is tuned so meeting the
+target dominates any single-slot charging cost, with lexicographic
+degradation when infeasible — if the vehicle can't reach target by
+deadline, the DP maximizes delivered energy instead of returning no plan.
+
+### No deadline
+
+`target_soc_pct == 0` or `target_time_ms == 0` means "charge
+opportunistically". No penalty, no push — the DP will only charge when
+a slot is cheap enough to be worth it relative to battery alternatives
+and terminal credit.
+
+### Output
+
+`Action.LoadpointW` per slot (W, positive = charging) and
+`Action.LoadpointSoCPct` (post-slot EV SoC). The SlotDirective the EMS
+consumes carries `LoadpointEnergyWh[id]` and `LoadpointSoCTargetPct[id]`
+for the dispatch layer.
+
+### What's not yet wired
+
+- Driver-side charger capability (`ChargerCap`) — coming in Phase 4.1
+- Per-loadpoint divergence check for reactive replan
+- UI for setting target + target-time (API is ready; web-form follows)

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -406,6 +406,28 @@ func main() {
 	defer loadSvc.Stop()
 	slog.Info("loadmodel started", "peak_w", loadPeakW, "quality", loadSvc.Model().Quality())
 
+	// ---- EV loadpoints (observable + MPC-input) ----
+	// Phase 3 introduced the Loadpoint concept as a first-class
+	// entity the API / UI surfaces. Phase 4 wires the MPC's DP with
+	// the first plugged-in loadpoint's state so battery + EV are
+	// co-optimized in one DP instead of two separate schedulers.
+	lpMgr := loadpoint.NewManager()
+	if len(cfg.Loadpoints) > 0 {
+		lpCfg := make([]loadpoint.Config, 0, len(cfg.Loadpoints))
+		for _, lp := range cfg.Loadpoints {
+			lpCfg = append(lpCfg, loadpoint.Config{
+				ID:                lp.ID,
+				DriverName:        lp.DriverName,
+				MinChargeW:        lp.MinChargeW,
+				MaxChargeW:        lp.MaxChargeW,
+				AllowedStepsW:     lp.AllowedStepsW,
+				VehicleCapacityWh: lp.VehicleCapacityWh,
+			})
+		}
+		lpMgr.Load(lpCfg)
+		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
+	}
+
 	// ---- Start MPC planner (optional) ----
 	mpcSvc := buildMPC(cfg, st, tel, capacities)
 	if mpcSvc != nil {
@@ -415,6 +437,50 @@ func main() {
 		mpcSvc.Load = loadSvc.Predict
 		mpcSvc.Price = priceFc.Predict
 		mpcSvc.SiteMeter = cfg.SiteMeterDriver()
+		// Wire the loadpoint probe so the DP extends its state space
+		// when an EV is plugged in. Single-loadpoint for now: picks
+		// the first plugged-in one.
+		mpcSvc.Loadpoint = func() *mpc.LoadpointSpec {
+			for _, st := range lpMgr.States() {
+				if !st.PluggedIn {
+					continue
+				}
+				// Pull capacity off the configured loadpoint.
+				var capWh float64 = 60000 // 60 kWh fallback
+				for _, c := range cfg.Loadpoints {
+					if c.ID == st.ID && c.VehicleCapacityWh > 0 {
+						capWh = c.VehicleCapacityWh
+						break
+					}
+				}
+				// Map target time → slot index. The replan loop
+				// decides slot boundaries, so a "target by X" maps
+				// to "hours from now" → slot index. Anything past
+				// horizon maps to horizon end.
+				targetSlot := -1
+				if !st.TargetTime.IsZero() {
+					delta := time.Until(st.TargetTime)
+					if delta > 0 {
+						targetSlot = int(delta / (15 * time.Minute))
+					}
+				}
+				return &mpc.LoadpointSpec{
+					ID:              st.ID,
+					CapacityWh:      capWh,
+					Levels:          11,
+					MinPct:          0,
+					MaxPct:          100,
+					InitialSoCPct:   st.CurrentSoCPct,
+					PluggedIn:       true,
+					TargetSoCPct:    st.TargetSoCPct,
+					TargetSlotIdx:   targetSlot,
+					MaxChargeW:      st.MaxChargeW,
+					AllowedStepsW:   st.AllowedStepsW,
+					ChargeEfficiency: 0.9,
+				}
+			}
+			return nil
+		}
 		if cfg.Price != nil {
 			mpcSvc.ExportBonusOreKwh = cfg.Price.ExportBonusOreKwh
 			mpcSvc.ExportFeeOreKwh = cfg.Price.ExportFeeOreKwh
@@ -464,28 +530,6 @@ func main() {
 			"horizon", mpcSvc.Horizon,
 			"interval", mpcSvc.Interval,
 			"pvtwin", pvSvc != nil)
-	}
-
-	// ---- EV loadpoints (observable skeleton) ----
-	// Phase 3 of the planner overhaul introduces the Loadpoint concept
-	// as a first-class entity the API / UI can surface. Phase 4 extends
-	// the MPC's DP with per-loadpoint state + wires Observe() into
-	// charger drivers.
-	lpMgr := loadpoint.NewManager()
-	if len(cfg.Loadpoints) > 0 {
-		lpCfg := make([]loadpoint.Config, 0, len(cfg.Loadpoints))
-		for _, lp := range cfg.Loadpoints {
-			lpCfg = append(lpCfg, loadpoint.Config{
-				ID:                lp.ID,
-				DriverName:        lp.DriverName,
-				MinChargeW:        lp.MinChargeW,
-				MaxChargeW:        lp.MaxChargeW,
-				AllowedStepsW:     lp.AllowedStepsW,
-				VehicleCapacityWh: lp.VehicleCapacityWh,
-			})
-		}
-		lpMgr.Load(lpCfg)
-		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
 	}
 
 	// ---- Start HTTP API ----

--- a/go/internal/api/CLAUDE.md
+++ b/go/internal/api/CLAUDE.md
@@ -33,7 +33,7 @@ Endpoint groups (route table is `api.go:95-130`):
 | history / series | `GET /api/history`, `GET /api/series`, `GET /api/series/catalog` |
 | prices / forecast | `GET /api/prices`, `GET /api/forecast` |
 | mpc | `GET /api/mpc/plan`, `POST /api/mpc/replan` |
-| loadpoints | `GET /api/loadpoints` |
+| loadpoints | `GET /api/loadpoints`, `POST /api/loadpoints/{id}/target` |
 | twins | `GET /api/pvmodel`, `POST /api/pvmodel/reset`, `GET /api/loadmodel`, `POST /api/loadmodel/reset` |
 | ha | `GET /api/ha/status` |
 | static | `/` falls through to `Deps.WebDir` |

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -156,6 +156,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
+	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.
@@ -1377,8 +1378,7 @@ func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
 }
 
 // GET /api/loadpoints returns the configured EV loadpoints with their
-// current observable state. Read-only in Phase 3; POST /target comes
-// in Phase 4 with the full charger control wiring.
+// current observable state.
 func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
 	if s.deps.Loadpoints == nil {
 		writeJSON(w, 200, map[string]any{"enabled": false, "loadpoints": []any{}})
@@ -1388,4 +1388,45 @@ func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
 		"enabled":    true,
 		"loadpoints": s.deps.Loadpoints.States(),
 	})
+}
+
+// POST /api/loadpoints/{id}/target sets user intent for an EV
+// loadpoint: the SoC % the vehicle should reach by the target time.
+// Triggers an MPC replan so the new target takes effect within one
+// control cycle.
+//
+// Body: {"soc_pct": 80, "target_time_ms": 1745000000000}
+//
+// target_time_ms == 0 → no deadline (charge opportunistically).
+func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Loadpoints == nil {
+		writeJSON(w, 404, map[string]string{"error": "loadpoints not configured"})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, 400, map[string]string{"error": "id required"})
+		return
+	}
+	var req struct {
+		SoCPct       float64 `json:"soc_pct"`
+		TargetTimeMs int64   `json:"target_time_ms"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	var deadline time.Time
+	if req.TargetTimeMs > 0 {
+		deadline = time.UnixMilli(req.TargetTimeMs).UTC()
+	}
+	if !s.deps.Loadpoints.SetTarget(id, req.SoCPct, deadline) {
+		writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
+		return
+	}
+	// Trigger replan so the new target lands in the schedule fast.
+	if s.deps.MPC != nil {
+		go s.deps.MPC.Replan(r.Context())
+	}
+	writeJSON(w, 200, map[string]any{"ok": true})
 }

--- a/go/internal/mpc/loadpoint_service_test.go
+++ b/go/internal/mpc/loadpoint_service_test.go
@@ -1,0 +1,123 @@
+package mpc
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSlotDirectiveCarriesLoadpointEnergyWh asserts that when the DP
+// decided an EV should charge in a slot, SlotDirectiveAt surfaces the
+// planned Wh under the correct loadpoint ID. This is the contract the
+// dispatch layer consumes to drive the charger.
+func TestSlotDirectiveCarriesLoadpointEnergyWh(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	start := now.Truncate(15 * time.Minute)
+	// 4 hourly slots with cheap nighttime + expensive daytime. A
+	// target of 40 % on a 20-% start forces the DP to schedule EV
+	// charging across multiple slots — we don't assert WHICH ones;
+	// only that at least one gets a loadpoint entry.
+	slots := make([]Slot, 4)
+	for i := range slots {
+		slots[i] = Slot{
+			StartMs:    start.Add(time.Duration(i) * time.Hour).UnixMilli(),
+			LenMin:     60,
+			PriceOre:   40,
+			SpotOre:    20,
+			LoadW:      400,
+			Confidence: 1.0,
+		}
+	}
+	p := Params{
+		Mode:                ModeCheapCharge,
+		SoCLevels:           11,
+		CapacityWh:          5000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        5,
+		MaxChargeW:          2000,
+		MaxDischargeW:       2000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    40,
+		Loadpoint: &LoadpointSpec{
+			ID:               "garage",
+			CapacityWh:       60000,
+			Levels:           11,
+			InitialSoCPct:    20,
+			PluggedIn:        true,
+			TargetSoCPct:     40,
+			TargetSlotIdx:    3,
+			MaxChargeW:       11000,
+			AllowedStepsW:    []float64{0, 11000},
+			ChargeEfficiency: 0.9,
+		},
+	}
+	plan := Optimize(slots, p)
+
+	// Find a slot where DP scheduled charging — assert the Service
+	// routes its Wh under the loadpoint ID.
+	var chargedSlotIdx int = -1
+	for i, a := range plan.Actions {
+		if a.LoadpointW > 0 {
+			chargedSlotIdx = i
+			break
+		}
+	}
+	if chargedSlotIdx < 0 {
+		t.Fatalf("DP never scheduled EV charging; actions: %+v", plan.Actions)
+	}
+
+	svc := &Service{
+		Zone:            "SE3",
+		Defaults:        Params{Mode: ModeCheapCharge},
+		last:            &plan,
+		lastLoadpointID: "garage",
+	}
+	// Query inside the charged slot.
+	queryAt := time.UnixMilli(plan.Actions[chargedSlotIdx].SlotStartMs).Add(1 * time.Minute)
+	d, ok := svc.SlotDirectiveAt(queryAt)
+	if !ok {
+		t.Fatal("SlotDirectiveAt returned ok=false")
+	}
+	if d.LoadpointEnergyWh == nil {
+		t.Fatalf("LoadpointEnergyWh nil on slot %d where DP set LoadpointW=%f",
+			chargedSlotIdx, plan.Actions[chargedSlotIdx].LoadpointW)
+	}
+	wh, exists := d.LoadpointEnergyWh["garage"]
+	if !exists {
+		t.Fatalf("garage missing: %+v", d.LoadpointEnergyWh)
+	}
+	if wh <= 0 {
+		t.Errorf("LoadpointEnergyWh[garage] = %.1f, want > 0", wh)
+	}
+	if _, ok := d.LoadpointSoCTargetPct["garage"]; !ok {
+		t.Errorf("LoadpointSoCTargetPct missing garage entry")
+	}
+}
+
+// TestSlotDirectiveEmptyWhenNoLoadpoint asserts the legacy path:
+// when no loadpoint was active, SlotDirective's LP fields stay nil
+// so older dispatch code paths see no change.
+func TestSlotDirectiveEmptyWhenNoLoadpoint(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	start := now.Truncate(15 * time.Minute)
+	slots := []Slot{
+		{StartMs: start.UnixMilli(), LenMin: 15, PriceOre: 50,
+			LoadW: 500, Confidence: 1.0},
+	}
+	plan := Optimize(slots, Params{
+		Mode: ModeSelfConsumption, SoCLevels: 11, CapacityWh: 10000,
+		SoCMinPct: 10, SoCMaxPct: 95, InitialSoCPct: 50,
+		ActionLevels: 5, MaxChargeW: 2000, MaxDischargeW: 2000,
+		ChargeEfficiency: 0.95, DischargeEfficiency: 0.95,
+	})
+	svc := &Service{last: &plan, lastLoadpointID: ""}
+	d, ok := svc.SlotDirectiveAt(start.Add(1 * time.Minute))
+	if !ok {
+		t.Fatal("SlotDirectiveAt ok=false")
+	}
+	if d.LoadpointEnergyWh != nil {
+		t.Errorf("expected nil LoadpointEnergyWh, got %+v", d.LoadpointEnergyWh)
+	}
+}

--- a/go/internal/mpc/loadpoint_spec.go
+++ b/go/internal/mpc/loadpoint_spec.go
@@ -1,0 +1,98 @@
+package mpc
+
+// LoadpointSpec tells the DP how to extend its state space with an EV
+// loadpoint. Set `Params.Loadpoint` to a non-nil spec to have the
+// optimizer treat charging the EV as a decision variable alongside
+// battery action. Leave nil to preserve the legacy battery-only DP.
+//
+// Design choices:
+//
+//   - The action set is DISCRETE (AllowedStepsW) rather than continuous.
+//     EVs have real disjunctive constraints — a 1-phase charger jumps
+//     {0, 1.4, 2.3} kW but not 3.5 kW; a 3-phase jumps to 4.1+ only.
+//     LP/MILP would need binary variables; DP just enumerates the
+//     allowed levels and the infeasible gap between 1-phase and
+//     3-phase minima is handled for free.
+//
+//   - Only charging is modeled — no V2G. Our current chargers
+//     (Easee, Zap) don't discharge to the grid, and including V2G
+//     would double the action dimension.
+//
+//   - Target SoC + deadline are honored via a linearly decaying
+//     terminal penalty in the DP (see optimize.go). This is a
+//     "lexicographic fallback" analogue: prefer meeting target, but
+//     when infeasible, maximize delivered energy instead of
+//     returning no plan.
+type LoadpointSpec struct {
+	ID string // matches loadpoint.Config.ID for dispatch routing
+
+	// Vehicle battery capacity (Wh). Drives SoC% ↔ Wh conversion.
+	CapacityWh float64
+
+	// SoC grid. Coarser than battery (11 is typical — EV loads are
+	// lumpy anyway).
+	Levels  int
+	MinPct  float64 // usually 0
+	MaxPct  float64 // usually 100
+
+	// Plan-start conditions.
+	InitialSoCPct float64 // EV SoC at the first slot
+	PluggedIn     bool    // when false, Optimize treats the loadpoint as absent
+
+	// User intent. Zero target (< 1%) = no deadline — charge
+	// opportunistically based on price/PV surplus only.
+	TargetSoCPct    float64
+	TargetSlotIdx   int // slot index by which target must be met; 0 or negative = no deadline
+
+	// Electrical constraints. AllowedStepsW MUST include 0 (off) and
+	// should enumerate the discrete charger power levels. If empty,
+	// defaults to {0, MaxChargeW}.
+	MaxChargeW      float64
+	AllowedStepsW   []float64
+
+	// Charge-side efficiency (AC → battery). Typical 0.90 for a
+	// modern 3-phase EV charger. 0 defaults to 0.90.
+	ChargeEfficiency float64
+}
+
+// normalizedSteps returns a non-nil, 0-included, dedup'd + sorted
+// action set. Used internally by the DP.
+func (l *LoadpointSpec) normalizedSteps() []float64 {
+	if l == nil {
+		return nil
+	}
+	if len(l.AllowedStepsW) == 0 {
+		if l.MaxChargeW <= 0 {
+			return []float64{0}
+		}
+		return []float64{0, l.MaxChargeW}
+	}
+	seen := map[float64]struct{}{0: {}}
+	out := []float64{0}
+	for _, s := range l.AllowedStepsW {
+		if s < 0 {
+			continue
+		}
+		if l.MaxChargeW > 0 && s > l.MaxChargeW {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	// Bubble-insertion sort (few elements, clarity > performance).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// active reports whether the DP should include EV dimensions for
+// this spec. Nil or un-plugged = inactive; treat as pure battery.
+func (l *LoadpointSpec) active() bool {
+	return l != nil && l.PluggedIn && l.CapacityWh > 0 && l.Levels >= 2
+}

--- a/go/internal/mpc/loadpoint_spec_test.go
+++ b/go/internal/mpc/loadpoint_spec_test.go
@@ -1,0 +1,177 @@
+package mpc
+
+import "testing"
+
+func TestNormalizedStepsDefaults(t *testing.T) {
+	cases := []struct {
+		name string
+		lp   *LoadpointSpec
+		want []float64
+	}{
+		{"nil spec", nil, nil},
+		{"empty steps, no max", &LoadpointSpec{}, []float64{0}},
+		{"empty steps, max only", &LoadpointSpec{MaxChargeW: 11000}, []float64{0, 11000}},
+		{"explicit steps preserved", &LoadpointSpec{
+			MaxChargeW:    11000,
+			AllowedStepsW: []float64{1400, 4100, 7400},
+		}, []float64{0, 1400, 4100, 7400}},
+		{"dedup + zero always included", &LoadpointSpec{
+			AllowedStepsW: []float64{0, 0, 1400, 1400, 4100},
+		}, []float64{0, 1400, 4100}},
+		{"above max clamped out", &LoadpointSpec{
+			MaxChargeW:    5000,
+			AllowedStepsW: []float64{1400, 4100, 7400, 11000},
+		}, []float64{0, 1400, 4100}},
+		{"negative filtered", &LoadpointSpec{
+			AllowedStepsW: []float64{-100, 1400},
+		}, []float64{0, 1400}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.lp.normalizedSteps()
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d]=%f, want %f", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestActiveGate(t *testing.T) {
+	cases := []struct {
+		name string
+		lp   *LoadpointSpec
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unplugged", &LoadpointSpec{CapacityWh: 60000, Levels: 11}, false},
+		{"zero capacity", &LoadpointSpec{PluggedIn: true, Levels: 11}, false},
+		{"too-coarse levels", &LoadpointSpec{PluggedIn: true, CapacityWh: 60000, Levels: 1}, false},
+		{"active", &LoadpointSpec{PluggedIn: true, CapacityWh: 60000, Levels: 11}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.lp.active(); got != tc.want {
+				t.Errorf("active() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOptimizePrefersCheapSlotsForEV is the core contract of Phase 4:
+// MPC should schedule EV charging in cheap slots and skip expensive
+// ones, given the EV can wait until cheaper prices arrive before its
+// deadline.
+func TestOptimizePrefersCheapSlotsForEV(t *testing.T) {
+	// 4 hourly slots. Slot 0 expensive (150), slot 1 cheap (20),
+	// slot 2 expensive (180), slot 3 cheap (30). Target: charge EV
+	// by end of slot 3 (50 %). No PV, flat 500 W load. Battery
+	// inactive-ish (small capacity).
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 150, SpotOre: 100,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 20, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 7200_000, LenMin: 60, PriceOre: 180, SpotOre: 140,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 10800_000, LenMin: 60, PriceOre: 30, SpotOre: 20,
+			LoadW: 500, Confidence: 1.0},
+	}
+	p := Params{
+		Mode:                ModeCheapCharge,
+		SoCLevels:           11,
+		CapacityWh:          5000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        5,
+		MaxChargeW:          2000,
+		MaxDischargeW:       2000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    70,
+		Loadpoint: &LoadpointSpec{
+			ID:              "garage",
+			CapacityWh:      60000, // 60 kWh
+			Levels:          11,
+			InitialSoCPct:   20,
+			PluggedIn:       true,
+			TargetSoCPct:    30,   // need 10 % → 6 kWh
+			TargetSlotIdx:   3,    // deadline at end of horizon
+			MaxChargeW:      11000,
+			AllowedStepsW:   []float64{0, 11000},
+			ChargeEfficiency: 0.9,
+		},
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) != 4 {
+		t.Fatalf("got %d actions, want 4", len(plan.Actions))
+	}
+	// Charging in slot 1 (cheap) or slot 3 (cheap) is acceptable.
+	// Charging in slot 0 (150) or slot 2 (180) when cheaper
+	// alternatives exist should not happen.
+	if plan.Actions[0].LoadpointW > 0 {
+		t.Errorf("charged EV in slot 0 (expensive) — DP should have waited")
+	}
+	if plan.Actions[2].LoadpointW > 0 {
+		t.Errorf("charged EV in slot 2 (expensive) — DP should have waited")
+	}
+	// At least one cheap slot should have EV charging.
+	cheapCharged := plan.Actions[1].LoadpointW > 0 || plan.Actions[3].LoadpointW > 0
+	if !cheapCharged {
+		t.Errorf("DP did not charge EV in any cheap slot; actions: %+v", plan.Actions)
+	}
+	// Final EV SoC should be at or above target (hard deadline).
+	finalEV := plan.Actions[3].LoadpointSoCPct
+	if finalEV < p.Loadpoint.TargetSoCPct-1 {
+		t.Errorf("final EV SoC %.1f below target %.1f — deadline missed",
+			finalEV, p.Loadpoint.TargetSoCPct)
+	}
+}
+
+// TestOptimizeNilLoadpointUnchanged asserts the legacy battery-only
+// path produces identical decisions when Loadpoint is nil vs. a
+// non-plugged spec. Guards the refactor from regressing.
+func TestOptimizeNilLoadpointUnchanged(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 150, SpotOre: 100,
+			LoadW: 500, Confidence: 1.0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 20, SpotOre: 10,
+			LoadW: 500, Confidence: 1.0},
+	}
+	p := Params{
+		Mode:                ModeCheapCharge,
+		SoCLevels:           21,
+		CapacityWh:          10000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        11,
+		MaxChargeW:          3000,
+		MaxDischargeW:       3000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    70,
+	}
+	planNil := Optimize(slots, p)
+	p.Loadpoint = &LoadpointSpec{ID: "none", PluggedIn: false}
+	planUnplugged := Optimize(slots, p)
+	if len(planNil.Actions) != len(planUnplugged.Actions) {
+		t.Fatalf("length mismatch: %d vs %d",
+			len(planNil.Actions), len(planUnplugged.Actions))
+	}
+	for i := range planNil.Actions {
+		if planNil.Actions[i].BatteryW != planUnplugged.Actions[i].BatteryW {
+			t.Errorf("slot %d: battery action differs: nil=%.1f unplugged=%.1f",
+				i, planNil.Actions[i].BatteryW, planUnplugged.Actions[i].BatteryW)
+		}
+		if planUnplugged.Actions[i].LoadpointW != 0 {
+			t.Errorf("slot %d: unplugged LP should produce 0 W, got %.1f",
+				i, planUnplugged.Actions[i].LoadpointW)
+		}
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -117,6 +117,11 @@ type Params struct {
 	ExportOrePerKWh    float64
 	ExportBonusOreKwh  float64
 	ExportFeeOreKwh    float64
+
+	// Loadpoint extends the DP state space with one EV charge point.
+	// Nil (default) keeps the battery-only optimization path. See
+	// LoadpointSpec for the state/action shape.
+	Loadpoint *LoadpointSpec
 }
 
 // Action is one scheduled battery target.
@@ -139,6 +144,16 @@ type Action struct {
 	// cost money (negative export revenue after fees). Consumed by the
 	// control loop only when the driver advertises `supports_pv_curtail`.
 	PVLimitW float64 `json:"pv_limit_w,omitempty"`
+
+	// LoadpointW is the EV charger power (W, positive = charging) the
+	// DP picked for this slot. Zero when no loadpoint was in Params
+	// or the DP chose "don't charge" this slot. Per-loadpoint in a
+	// multi-LP future; single-value for now.
+	LoadpointW float64 `json:"loadpoint_w,omitempty"`
+
+	// LoadpointSoCPct is the EV SoC at END of slot, following the
+	// same convention as SoCPct for the home battery.
+	LoadpointSoCPct float64 `json:"loadpoint_soc_pct,omitempty"`
 }
 
 // Plan is the output.
@@ -230,95 +245,217 @@ func Optimize(slots []Slot, p Params) Plan {
 		return -p.MaxDischargeW + frac*(p.MaxChargeW+p.MaxDischargeW)
 	}
 
-	// V[t][s] = minimum expected cost from slot t onward, starting from
-	// SoC index s. V is filled backwards.
-	V := make([][]float64, N+1)
-	Policy := make([][]int, N)
+	// EV dimensions. When no loadpoint is active, EL=EA=1 and the
+	// EV loops degenerate to a single pass that adds zero power /
+	// zero SoC — functionally identical to the legacy battery-only
+	// DP. Keeps one code path.
+	lp := p.Loadpoint
+	evActive := lp.active()
+	EL := 1
+	EA := 1
+	var evSteps []float64
+	var evSocStep float64
+	var evChargeEff float64 = 0.9
+	if evActive {
+		EL = lp.Levels
+		evSteps = lp.normalizedSteps()
+		EA = len(evSteps)
+		if lp.MaxPct <= lp.MinPct {
+			lp.MaxPct = 100
+			lp.MinPct = 0
+		}
+		evSocStep = (lp.MaxPct - lp.MinPct) / float64(EL-1)
+		if lp.ChargeEfficiency > 0 {
+			evChargeEff = lp.ChargeEfficiency
+		}
+	}
+	evSocAt := func(e int) float64 {
+		if !evActive {
+			return 0
+		}
+		return lp.MinPct + float64(e)*evSocStep
+	}
+	evActionW := func(ea int) float64 {
+		if !evActive {
+			return 0
+		}
+		return evSteps[ea]
+	}
+
+	// V[t][s][e] = minimum expected cost from slot t onward, starting
+	// from battery SoC index s and EV SoC index e. Backward-filled.
+	V := make([][][]float64, N+1)
+	Policy := make([][][]int, N) // encodes (battActionIdx * EA + evActionIdx)
 	for t := 0; t <= N; t++ {
-		V[t] = make([]float64, S)
+		V[t] = make([][]float64, S)
+		for si := 0; si < S; si++ {
+			V[t][si] = make([]float64, EL)
+		}
 		if t < N {
-			Policy[t] = make([]int, S)
+			Policy[t] = make([][]int, S)
+			for si := 0; si < S; si++ {
+				Policy[t][si] = make([]int, EL)
+			}
 		}
 	}
 
-	// Terminal value: credit stored energy at TerminalSoCPrice (öre/kWh).
-	// Cost is negative (=credit), so we subtract.
-	for s := 0; s < S; s++ {
-		kwh := p.CapacityWh * socAt(s) / 100.0 / 1000.0
-		V[N][s] = -p.TerminalSoCPrice * kwh
+	// Deadline slot index for the mid-horizon EV target penalty. A
+	// target beyond horizon end gets clamped to the last slot so
+	// the DP still "sees" it (rather than silently ignoring). A
+	// target of -1 means no deadline — opportunistic charging only.
+	deadlineSlot := -1
+	if evActive && lp.TargetSoCPct > 0 {
+		deadlineSlot = lp.TargetSlotIdx
+		if deadlineSlot < 0 {
+			deadlineSlot = -1
+		} else if deadlineSlot >= N {
+			deadlineSlot = N - 1
+		}
+	}
+
+	// Terminal values. Battery SoC credits stored energy. EV SoC
+	// carries no terminal cost — the deadline-slot penalty below
+	// handles target enforcement and avoids double-counting.
+	for si := 0; si < S; si++ {
+		battKwh := p.CapacityWh * socAt(si) / 100.0 / 1000.0
+		battCredit := -p.TerminalSoCPrice * battKwh
+		for ei := 0; ei < EL; ei++ {
+			V[N][si][ei] = battCredit
+		}
 	}
 
 	// Backwards induction.
 	for t := N - 1; t >= 0; t-- {
 		slot := slots[t]
 		dtH := float64(slot.LenMin) / 60.0
-		baselineGridW := slot.LoadW + slot.PVW // grid if battery did nothing
-		for s := 0; s < S; s++ {
-			soc := socAt(s)
-			bestV := math.Inf(1)
-			bestA := 0
-			for j := 0; j < A; j++ {
-				actW := actionAt(j)
-				gridW := baselineGridW + actW
+		for si := 0; si < S; si++ {
+			soc := socAt(si)
+			for ei := 0; ei < EL; ei++ {
+				evSoc := evSocAt(ei)
+				bestV := math.Inf(1)
+				bestPolicy := 0
+				for ba := 0; ba < A; ba++ {
+					battW := actionAt(ba)
 
-				// Mode-based feasibility.
-				if !modeAllows(p.Mode, baselineGridW, gridW, actW) {
-					continue
-				}
+					// Battery SoC transition (independent of EV).
+					var dBattWh float64
+					if battW >= 0 {
+						dBattWh = +battW * dtH * p.ChargeEfficiency
+					} else {
+						dBattWh = +battW * dtH / p.DischargeEfficiency
+					}
+					battSoc2 := soc + dBattWh/p.CapacityWh*100.0
+					if battSoc2 < p.SoCMinPct-1e-9 || battSoc2 > p.SoCMaxPct+1e-9 {
+						continue
+					}
 
-				// Per-slot power limits (tariff capacity / DSO
-				// curtailment / service-entrance fuse). Zero-value
-				// PowerLimits is unlimited — the zero-check lives
-				// inside allowsImport/allowsExport.
-				if !slot.Limits.allowsImport(gridW) || !slot.Limits.allowsExport(gridW) {
-					continue
-				}
+					for ea := 0; ea < EA; ea++ {
+						evW := evActionW(ea)
+						// EV SoC transition: only charging, so non-
+						// negative by construction. Skip actions
+						// that would overshoot max (realistic
+						// chargers taper, but we approximate).
+						var evSoc2 float64
+						if evActive {
+							dEvWh := evW * dtH * evChargeEff
+							evSoc2 = evSoc + dEvWh/lp.CapacityWh*100.0
+							if evSoc2 > lp.MaxPct+1e-9 {
+								continue
+							}
+						}
+						// EV appears as a site load (+ site-signed).
+						// GridW = load + PV + battery + EV.
+						gridW := slot.LoadW + slot.PVW + battW + evW
 
-				// SoC transition with efficiency (guarded at function entry).
-				var dSoCWh float64
-				if actW >= 0 {
-					dSoCWh = +actW * dtH * p.ChargeEfficiency
-				} else {
-					dSoCWh = +actW * dtH / p.DischargeEfficiency
-				}
-				dSoCPct := dSoCWh / p.CapacityWh * 100.0
-				soc2 := soc + dSoCPct
-				if soc2 < p.SoCMinPct-1e-9 || soc2 > p.SoCMaxPct+1e-9 {
-					continue
-				}
+						// Mode-based feasibility. Baseline includes
+						// EV so the mode check asks "is the extra
+						// battery action pulling the grid further
+						// into import/export than baseline?".
+						baseGridW := slot.LoadW + slot.PVW + evW
+						if !modeAllows(p.Mode, baseGridW, gridW, battW) {
+							continue
+						}
 
-				// Per-slot cost in öre. Import cost at consumer price;
-				// export revenue at the slot's spot + bonus − fee.
-				// Both sides are confidence-blended so ML-forecasted
-				// slots nudge the DP less aggressively.
-				gridKWh := gridW * dtH / 1000.0
-				var cost float64
-				if gridKWh > 0 {
-					cost = effPrice(slot) * gridKWh
-				} else {
-					cost = -slotExportOre(slot) * (-gridKWh)
-				}
+						// Per-slot power limits.
+						if !slot.Limits.allowsImport(gridW) || !slot.Limits.allowsExport(gridW) {
+							continue
+						}
 
-				// Next SoC index: linear interpolation between floor/ceil.
-				fIdx := (soc2 - p.SoCMinPct) / socStep
-				lo := int(math.Floor(fIdx))
-				hi := lo + 1
-				if lo < 0 {
-					lo, hi = 0, 0
+						gridKWh := gridW * dtH / 1000.0
+						var cost float64
+						if gridKWh > 0 {
+							cost = effPrice(slot) * gridKWh
+						} else {
+							cost = -slotExportOre(slot) * (-gridKWh)
+						}
+
+						// Deadline slot: if this slot is the EV's
+						// deadline AND target isn't met with this
+						// action's evSoc2, add a shortfall penalty.
+						// Penalty factor 4×meanPrice makes missing
+						// the target more expensive than the
+						// aggressive-slot charge cost a DP might
+						// otherwise prefer, so it commits when
+						// feasible. Lexicographic behaviour:
+						// infeasible targets degrade gracefully —
+						// DP maximizes delivered energy since less
+						// shortfall = less penalty.
+						if deadlineSlot == t {
+							short := lp.TargetSoCPct - evSoc2
+							if short > 0 {
+								missedKwh := lp.CapacityWh * short / 100.0 / 1000.0
+								cost += missedKwh * meanPrice * 4.0
+							}
+						}
+
+						// Battery SoC interpolation indices.
+						fIdx := (battSoc2 - p.SoCMinPct) / socStep
+						lo := int(math.Floor(fIdx))
+						hi := lo + 1
+						if lo < 0 {
+							lo, hi = 0, 0
+						}
+						if hi >= S {
+							lo, hi = S-1, S-1
+						}
+						frac := fIdx - float64(lo)
+
+						// EV SoC interpolation indices. Discrete
+						// charger steps often produce fractional
+						// bucket advances (e.g. 11 kW for 15 min →
+						// 4.1 % at 10 % resolution). Rounding to
+						// nearest kills incremental progress and
+						// makes the DP blind to "almost-a-full-
+						// bucket" moves. Bilinear lookup preserves
+						// fractional progress.
+						eLo, eHi := 0, 0
+						eFrac := 0.0
+						if evActive {
+							f := (evSoc2 - lp.MinPct) / evSocStep
+							eLo = int(math.Floor(f))
+							eHi = eLo + 1
+							if eLo < 0 {
+								eLo, eHi = 0, 0
+							}
+							if eHi >= EL {
+								eLo, eHi = EL-1, EL-1
+							}
+							eFrac = f - float64(eLo)
+						}
+						vNext := (1-frac)*(1-eFrac)*V[t+1][lo][eLo] +
+							(1-frac)*eFrac*V[t+1][lo][eHi] +
+							frac*(1-eFrac)*V[t+1][hi][eLo] +
+							frac*eFrac*V[t+1][hi][eHi]
+						total := cost + vNext
+						if total < bestV {
+							bestV = total
+							bestPolicy = ba*EA + ea
+						}
+					}
 				}
-				if hi >= S {
-					lo, hi = S-1, S-1
-				}
-				frac := fIdx - float64(lo)
-				vNext := (1-frac)*V[t+1][lo] + frac*V[t+1][hi]
-				total := cost + vNext
-				if total < bestV {
-					bestV = total
-					bestA = j
-				}
+				V[t][si][ei] = bestV
+				Policy[t][si][ei] = bestPolicy
 			}
-			V[t][s] = bestV
-			Policy[t][s] = bestA
 		}
 	}
 
@@ -332,21 +469,38 @@ func Optimize(slots []Slot, p Params) Plan {
 		Actions:       make([]Action, 0, N),
 	}
 	fIdx := (p.InitialSoCPct - p.SoCMinPct) / socStep
-	s := int(math.Round(fIdx))
-	if s < 0 {
-		s = 0
+	si := int(math.Round(fIdx))
+	if si < 0 {
+		si = 0
 	}
-	if s >= S {
-		s = S - 1
+	if si >= S {
+		si = S - 1
 	}
-	soc := socAt(s)
+	soc := socAt(si)
+	// Initial EV SoC index.
+	ei := 0
+	var evSoc float64
+	if evActive {
+		f := (lp.InitialSoCPct - lp.MinPct) / evSocStep
+		ei = int(math.Round(f))
+		if ei < 0 {
+			ei = 0
+		}
+		if ei >= EL {
+			ei = EL - 1
+		}
+		evSoc = evSocAt(ei)
+	}
 	var totalCost float64
 	for t := 0; t < N; t++ {
 		slot := slots[t]
 		dtH := float64(slot.LenMin) / 60.0
-		j := Policy[t][s]
-		actW := actionAt(j)
-		// SoC transition with efficiency (guarded at function entry).
+		pol := Policy[t][si][ei]
+		ba := pol / EA
+		ea := pol % EA
+		actW := actionAt(ba)
+		evW := evActionW(ea)
+		// Battery SoC transition.
 		var dSoCWh float64
 		if actW >= 0 {
 			dSoCWh = +actW * dtH * p.ChargeEfficiency
@@ -360,7 +514,16 @@ func Optimize(slots []Slot, p Params) Plan {
 		if soc2 > p.SoCMaxPct {
 			soc2 = p.SoCMaxPct
 		}
-		gridW := slot.LoadW + slot.PVW + actW
+		// EV SoC transition (no-op when !evActive since evW = 0).
+		var evSoc2 float64
+		if evActive {
+			dEvWh := evW * dtH * evChargeEff
+			evSoc2 = evSoc + dEvWh/lp.CapacityWh*100.0
+			if evSoc2 > lp.MaxPct {
+				evSoc2 = lp.MaxPct
+			}
+		}
+		gridW := slot.LoadW + slot.PVW + actW + evW
 		gridKWh := gridW * dtH / 1000.0
 		// Report the ACTUAL expected cost using the raw (un-blended)
 		// prices so the UI summary reflects "what we'd actually pay
@@ -379,7 +542,7 @@ func Optimize(slots []Slot, p Params) Plan {
 			cost = -rawExport * (-gridKWh)
 		}
 		totalCost += cost
-		plan.Actions = append(plan.Actions, Action{
+		a := Action{
 			SlotStartMs: slot.StartMs,
 			SlotLenMin:  slot.LenMin,
 			PriceOre:    slot.PriceOre,
@@ -391,15 +554,31 @@ func Optimize(slots []Slot, p Params) Plan {
 			SoCPct:      soc2,
 			CostOre:     cost,
 			Reason:      reasonFor(slot, actW, meanPrice),
-		})
+		}
+		if evActive {
+			a.LoadpointW = evW
+			a.LoadpointSoCPct = evSoc2
+		}
+		plan.Actions = append(plan.Actions, a)
 		soc = soc2
 		fIdx = (soc - p.SoCMinPct) / socStep
-		s = int(math.Round(fIdx))
-		if s < 0 {
-			s = 0
+		si = int(math.Round(fIdx))
+		if si < 0 {
+			si = 0
 		}
-		if s >= S {
-			s = S - 1
+		if si >= S {
+			si = S - 1
+		}
+		if evActive {
+			evSoc = evSoc2
+			f := (evSoc - lp.MinPct) / evSocStep
+			ei = int(math.Round(f))
+			if ei < 0 {
+				ei = 0
+			}
+			if ei >= EL {
+				ei = EL - 1
+			}
 		}
 	}
 	plan.TotalCostOre = totalCost

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -27,6 +27,16 @@ type LoadPredictor func(t time.Time) float64
 // Leave nil to cap the plan horizon at what's been published.
 type PricePredictor func(zone string, t time.Time) float64
 
+// LoadpointProbe returns the EV loadpoint state the DP should extend
+// itself with. Called once per replan. Return nil when no loadpoint
+// should be optimized (unplugged, unconfigured, or during initial
+// rollout when operator wants to disable EV-in-DP).
+//
+// Wired in main.go against *loadpoint.Manager; kept as a plain
+// closure type to avoid the mpc package importing loadpoint (which
+// would risk a cycle if loadpoint ever needs mpc types).
+type LoadpointProbe func() *LoadpointSpec
+
 // Service wires the optimizer to the rest of the stack: pulls prices +
 // forecast from the SQLite store, reads current SoC from the telemetry
 // store, and re-plans on a ticker. The latest plan is cached.
@@ -37,9 +47,10 @@ type Service struct {
 	BaseLoad float64 // baseline household load (W). 0 disables load assumption.
 	Horizon  time.Duration
 	Interval time.Duration
-	PV       PVPredictor    // optional — overrides stored pv_w_estimated
-	Load     LoadPredictor  // optional — overrides flat BaseLoad
-	Price    PricePredictor // optional — fills in future slots when day-ahead isn't published yet
+	PV        PVPredictor    // optional — overrides stored pv_w_estimated
+	Load      LoadPredictor  // optional — overrides flat BaseLoad
+	Price     PricePredictor // optional — fills in future slots when day-ahead isn't published yet
+	Loadpoint LoadpointProbe // optional — when non-nil, the DP extends its state with EV dimensions
 
 	// Reactive replan: when the integrated energy gap between actual
 	// and the plan's current-slot prediction exceeds a threshold over
@@ -83,8 +94,9 @@ type Service struct {
 
 	Defaults Params
 
-	mu   sync.RWMutex
-	last *Plan
+	mu              sync.RWMutex
+	last            *Plan
+	lastLoadpointID string // ID of the loadpoint active in the most recent plan (empty = none)
 
 	stop chan struct{}
 	done chan struct{}
@@ -139,6 +151,18 @@ type SlotDirective struct {
 	BatteryEnergyWh float64 // total energy for the slot (site-signed)
 	SoCTargetPct    float64 // plan's SoC at SlotEnd — used by divergence detector
 	Strategy        Mode    // echoed for logging + API
+
+	// LoadpointEnergyWh carries per-loadpoint EV energy budgets for
+	// this slot. Keyed by Loadpoint.ID. Positive = charging energy
+	// the plan allocated. Empty map when no loadpoints are
+	// configured / active. The dispatch layer converts energy to
+	// instantaneous power via the same `remaining_wh × 3600 /
+	// remaining_s` formula it uses for the battery.
+	LoadpointEnergyWh map[string]float64
+
+	// LoadpointSoCTargetPct is the plan's EV SoC at SlotEnd per
+	// loadpoint. Used by per-loadpoint divergence check in Phase 4.1.
+	LoadpointSoCTargetPct map[string]float64
 }
 
 // SlotDirectiveAt returns the energy-allocation directive for the slot
@@ -167,13 +191,26 @@ func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
 		}
 		// energy_wh = power_w * hours. a.SlotLenMin/60 gives hours.
 		energyWh := a.BatteryW * float64(a.SlotLenMin) / 60.0
-		return SlotDirective{
+		d := SlotDirective{
 			SlotStart:       time.UnixMilli(a.SlotStartMs),
 			SlotEnd:         time.UnixMilli(endMs),
 			BatteryEnergyWh: energyWh,
 			SoCTargetPct:    a.SoCPct,
 			Strategy:        s.Defaults.Mode,
-		}, true
+		}
+		// EV energy budget for the slot (single-loadpoint for now —
+		// keyed under lastLoadpointID so the dispatch layer routes
+		// to the right driver).
+		if a.LoadpointW > 0 && s.lastLoadpointID != "" {
+			lpEnergyWh := a.LoadpointW * float64(a.SlotLenMin) / 60.0
+			d.LoadpointEnergyWh = map[string]float64{
+				s.lastLoadpointID: lpEnergyWh,
+			}
+			d.LoadpointSoCTargetPct = map[string]float64{
+				s.lastLoadpointID: a.LoadpointSoCPct,
+			}
+		}
+		return d, true
 	}
 	return SlotDirective{}, false
 }
@@ -480,6 +517,18 @@ func (s *Service) replan(_ context.Context) *Plan {
 		}
 	}
 
+	// Loadpoint extension: if a probe is wired AND returns an active
+	// spec, the DP adds an EV SoC dimension and produces per-slot
+	// LoadpointW decisions. One loadpoint at a time — multi-LP
+	// support is on the roadmap.
+	var loadpointID string
+	if s.Loadpoint != nil {
+		if spec := s.Loadpoint(); spec != nil && spec.PluggedIn {
+			p.Loadpoint = spec
+			loadpointID = spec.ID
+		}
+	}
+
 	slog.Info("mpc: optimize params",
 		"mode", p.Mode,
 		"terminal_ore", p.TerminalSoCPrice,
@@ -489,6 +538,8 @@ func (s *Service) replan(_ context.Context) *Plan {
 		"soc_levels", p.SoCLevels,
 		"action_levels", p.ActionLevels,
 		"soc_start", p.InitialSoCPct,
+		"loadpoint_active", p.Loadpoint != nil,
+		"loadpoint_id", loadpointID,
 	)
 	plan := Optimize(slots, p)
 
@@ -501,6 +552,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 
 	s.mu.Lock()
 	s.last = &plan
+	s.lastLoadpointID = loadpointID
 	s.lastReplanAt = time.Now()
 	reason := s.lastReason
 	if reason == "" {


### PR DESCRIPTION
## Summary

Phase 4 of 4 in the planner overhaul roadmap. Delivers on the user's explicit goal: **ETT system** that co-optimizes home battery + PV + EV in one DP instead of two planners negotiating.

This PR targets ''planner-overhaul/powerlimits-loadpoint'' (Phase 3) and assumes those types are present. Please merge #99 first.

## DP extension

State: `(t, battery_soc, ev_soc)`.
Action: `(battery_action, ev_action)`.

EV action set is **discrete** (charger's allowed W levels). This elegantly handles the 1-phase ↔ 3-phase minimum-current gap that would otherwise require MILP — a key pain-point in CVXPY-style formulations (see srcful-nova-ems-x for the Python equivalent).

**Bilinear interpolation** over both SoC dimensions preserves fractional state progress. Without this, a 15-min charge that advances EV SoC by 4.1 % on a 10 % bucket resolution would round to "no progress" and the DP would refuse to charge. Caught this bucketing edge case via `TestSlotDirectiveCarriesLoadpointEnergyWh`.

**Backwards-compatible**: when no loadpoint probe is wired or no EV is plugged in, the EV dimension collapses to size 1 — the DP runs identically to the battery-only path. `TestOptimizeNilLoadpointUnchanged` locks this in.

## Target + deadline (lexicographic-style)

User intent (`POST /api/loadpoints/{id}/target`) sets target SoC + target time. Maps to horizon slot index. Deadline slot gets `missed_kwh × mean_price × 4` penalty — tuned so meeting target dominates any single-slot charging cost, with graceful degradation (max delivered energy) when infeasible.

## Public surface

- `mpc.LoadpointSpec` — DP-side EV description
- `mpc.LoadpointProbe` — closure type wired from `loadpoint.Manager` (keeps mpc free of a loadpoint import)
- `Service.Loadpoint` optional func field
- `Action.LoadpointW` + `Action.LoadpointSoCPct`
- `SlotDirective.LoadpointEnergyWh[id]` + `LoadpointSoCTargetPct[id]`
- `POST /api/loadpoints/{id}/target` triggers a replan so new intent lands in the next schedule within one tick

## Deferred to Phase 4.1 (follow-up PR)

- `drivers.ChargerCap` interface + Lua bindings (easee-cloud.lua + zap.lua need `host.set_charge_power_w` — real-hardware verification scope)
- EV dispatch path in `control/dispatch.go` (energy → W snap-to-discrete-steps)
- Per-loadpoint divergence check in the reactive replan loop
- UI target-setting form

## Test plan

- [x] `TestOptimizePrefersCheapSlotsForEV` — DP schedules EV in cheap slots, skips expensive ones
- [x] `TestOptimizeNilLoadpointUnchanged` — legacy path identical with nil or unplugged loadpoint
- [x] `TestSlotDirectiveCarriesLoadpointEnergyWh` — service routes DP's EV decision under loadpoint ID
- [x] `TestSlotDirectiveEmptyWhenNoLoadpoint` — legacy path leaves LP fields nil
- [x] `TestNormalizedStepsDefaults` + `TestActiveGate` — spec helpers
- [x] `go test ./...` — full suite incl. e2e (27s) green
- [x] `go build ./...` — main.go wiring compiles
- [ ] Deploy to Pi, configure a test loadpoint, verify `/api/mpc/plan` shows `loadpoint_w` per slot

## Roadmap

- **Phase 1** — DST/timezone audit (#97)
- **Phase 2** — `/api/mpc/diagnose` (#98)
- **Phase 3** — PowerLimits + Loadpoint skeleton (#99)
- **Phase 4** — this PR
- **Phase 4.1** — Charger capability + dispatch wiring (next, once Erik can verify on real Easee hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)