### PR TITLE
feat(ems): EV dispatch + Easee command wiring (Phase 4.1)

### DIFF
--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -261,8 +261,31 @@ and terminal credit.
 consumes carries `LoadpointEnergyWh[id]` and `LoadpointSoCTargetPct[id]`
 for the dispatch layer.
 
-### What's not yet wired
+### Dispatch
 
-- Driver-side charger capability (`ChargerCap`) — coming in Phase 4.1
+Per control tick (5 s) the main loop:
+
+1. Reads each loadpoint's driver telemetry (`tel.Get(driver, DerEV)` →
+   `{connected, session_wh}`).
+2. Calls `lpMgr.Observe(id, connected, powerW, sessionWh)`. The
+   manager infers vehicle SoC as `plugin_soc_pct + session_wh /
+   vehicle_capacity * 100` (chargers like Easee don't expose the
+   BMS).
+3. Fetches `SlotDirectiveAt(now).LoadpointEnergyWh[id]` from the
+   MPC.
+4. Computes `remainingWh / remainingSeconds → W` (same
+   energy-allocation contract as the battery), snaps to
+   `AllowedStepsW`, and sends
+   `{"action":"ev_set_current","power_w": W}` to the loadpoint's
+   driver.
+
+The Easee driver divides `power_w` by configured phases,
+clamps to 6-32 A, and sets `dynamicChargerCurrent` via the cloud
+API. 0 W cleanly pauses the session.
+
+### What's still outstanding
+
 - Per-loadpoint divergence check for reactive replan
 - UI for setting target + target-time (API is ready; web-form follows)
+- Phase-switching heuristic inside the Easee driver for sub-3 kW
+  surplus windows

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -755,6 +755,71 @@ func main() {
 				}
 			}
 
+			// ---- EV dispatch: observe + command per loadpoint ----
+			// For each configured loadpoint we first read the
+			// charger driver's latest telemetry and feed it to the
+			// manager (plug state + session Wh → inferred SoC). Then
+			// we ask the MPC for the current slot's energy budget
+			// and translate it to an instantaneous W command. No
+			// PI — energy-allocation contract: remaining Wh /
+			// remaining s → W, snap to the charger's allowed steps.
+			if len(cfg.Loadpoints) > 0 && mpcSvc != nil {
+				for _, lpCfg := range cfg.Loadpoints {
+					evr := tel.Get(lpCfg.DriverName, telemetry.DerEV)
+					plugged := false
+					var sessionWh, powerW float64
+					if evr != nil {
+						powerW = evr.SmoothedW
+						var d struct {
+							Connected bool    `json:"connected"`
+							SessionWh float64 `json:"session_wh"`
+						}
+						if err := json.Unmarshal(evr.Data, &d); err == nil {
+							plugged = d.Connected
+							sessionWh = d.SessionWh
+						}
+					}
+					lpMgr.Observe(lpCfg.ID, plugged, powerW, sessionWh)
+					if !plugged {
+						continue
+					}
+					d, ok := mpcSvc.SlotDirectiveAt(time.Now())
+					if !ok || d.LoadpointEnergyWh == nil {
+						continue
+					}
+					budgetWh, hasBudget := d.LoadpointEnergyWh[lpCfg.ID]
+					if !hasBudget {
+						continue
+					}
+					remainingS := d.SlotEnd.Sub(time.Now()).Seconds()
+					// The budget is total energy for the slot; we
+					// subtract what's already been delivered so far
+					// so a mid-slot dispatch doesn't overshoot.
+					// Without a per-slot start-energy anchor, we
+					// approximate "delivered this slot" as the
+					// charger's current power × fraction of slot
+					// elapsed. In practice most dispatch ticks are
+					// late in the slot so the error is small.
+					elapsed := d.SlotEnd.Sub(d.SlotStart).Seconds() - remainingS
+					if elapsed < 0 {
+						elapsed = 0
+					}
+					alreadyWh := powerW * elapsed / 3600.0
+					remainingWh := budgetWh - alreadyWh
+					wantW := control.EnergyBudgetToPowerW(remainingWh, remainingS)
+					cmdW := control.SnapChargeW(wantW, lpCfg.MinChargeW,
+						lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
+					payload, _ := json.Marshal(map[string]any{
+						"action":  "ev_set_current",
+						"power_w": cmdW,
+					})
+					if err := reg.Send(ctx, lpCfg.DriverName, payload); err != nil {
+						slog.Warn("loadpoint dispatch", "lp", lpCfg.ID,
+							"driver", lpCfg.DriverName, "err", err)
+					}
+				}
+			}
+
 			// ---- Record history snapshot ----
 			recordHistory(st, tel, ctrl, nowMs)
 

--- a/go/internal/control/ev_dispatch.go
+++ b/go/internal/control/ev_dispatch.go
@@ -1,0 +1,64 @@
+package control
+
+import "math"
+
+// SnapChargeW turns an ideal charging-power request into the nearest
+// feasible level the charger can actually deliver. Used by EV
+// dispatch to convert a smooth MPC-derived power target into one of
+// the discrete levels a charger supports (e.g. Easee's 0 plus 6-32 A
+// bands).
+//
+// Rules:
+//
+//   - Clamp to [min, max] first. A zero `want` short-circuits to 0
+//     (off) without falling through to a 6 A minimum.
+//   - If `steps` is empty, return the clamped value. Callers without
+//     discrete levels get a continuous power number.
+//   - Otherwise pick the step with the smallest absolute difference
+//     from the clamped target.
+//
+// We deliberately snap to NEAREST rather than floor — a 4.1 kW want
+// on a {0, 4.1, 7.4, 11} step set should hit 4.1 exactly even when
+// floating-point math puts it at 4099 W.
+func SnapChargeW(want, min, max float64, steps []float64) float64 {
+	if want <= 0 {
+		return 0
+	}
+	if want < min {
+		want = min
+	}
+	if max > 0 && want > max {
+		want = max
+	}
+	if len(steps) == 0 {
+		return want
+	}
+	best := steps[0]
+	bestDiff := math.Abs(want - best)
+	for _, s := range steps[1:] {
+		if d := math.Abs(want - s); d < bestDiff {
+			best = s
+			bestDiff = d
+		}
+	}
+	return best
+}
+
+// EnergyBudgetToPowerW translates a remaining-Wh budget over a
+// remaining-seconds window into instantaneous W. Mirrors the battery
+// energy-allocation dispatch path (see docs/plan-ems-contract.md)
+// so EV and battery share one mental model.
+//
+// Negative remaining energy (already overshot the plan) → 0 so we
+// stop drawing. Non-positive remaining time → return `want` as if
+// the slot were just beginning; the next dispatch tick will see a
+// fresh slot anyway.
+func EnergyBudgetToPowerW(remainingWh, remainingS float64) float64 {
+	if remainingWh <= 0 {
+		return 0
+	}
+	if remainingS <= 0 {
+		return 0
+	}
+	return remainingWh * 3600.0 / remainingS
+}

--- a/go/internal/control/ev_dispatch_test.go
+++ b/go/internal/control/ev_dispatch_test.go
@@ -1,0 +1,61 @@
+package control
+
+import "testing"
+
+func TestSnapChargeWSnapsToNearest(t *testing.T) {
+	steps := []float64{0, 1400, 4100, 7400, 11000}
+	cases := []struct {
+		want     float64
+		expected float64
+		note     string
+	}{
+		{0, 0, "zero → off, short-circuits"},
+		{1000, 1400, "below min step snaps up to lowest non-zero"},
+		{1300, 1400, "near min → min"},
+		{5500, 4100, "midway rounds to closer"},
+		{6000, 7400, "midway rounds to closer (upper)"},
+		{11000, 11000, "at max step"},
+		{15000, 11000, "above max clamps to max"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.note, func(t *testing.T) {
+			got := SnapChargeW(tc.want, 1400, 11000, steps)
+			if got != tc.expected {
+				t.Errorf("SnapChargeW(%f) = %f, want %f", tc.want, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestSnapChargeWNoStepsReturnsClamped(t *testing.T) {
+	got := SnapChargeW(5000, 1400, 11000, nil)
+	if got != 5000 {
+		t.Errorf("want continuous passthrough; got %.0f", got)
+	}
+	got = SnapChargeW(500, 1400, 11000, nil)
+	if got != 1400 {
+		t.Errorf("want clamp to min; got %.0f", got)
+	}
+	got = SnapChargeW(20000, 1400, 11000, nil)
+	if got != 11000 {
+		t.Errorf("want clamp to max; got %.0f", got)
+	}
+}
+
+func TestEnergyBudgetToPowerW(t *testing.T) {
+	// 1 kWh over 1 hour = 1000 W
+	if got := EnergyBudgetToPowerW(1000, 3600); got != 1000 {
+		t.Errorf("1 kWh/h should be 1000 W, got %.0f", got)
+	}
+	// 500 Wh over 15 minutes → 2000 W
+	if got := EnergyBudgetToPowerW(500, 900); got != 2000 {
+		t.Errorf("500 Wh / 15 min should be 2000 W, got %.0f", got)
+	}
+	// Negative / zero remaining → 0
+	if got := EnergyBudgetToPowerW(-50, 600); got != 0 {
+		t.Errorf("negative remaining should stop charging, got %.0f", got)
+	}
+	if got := EnergyBudgetToPowerW(500, 0); got != 0 {
+		t.Errorf("zero remaining time should return 0 (safety), got %.0f", got)
+	}
+}

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -40,6 +40,13 @@ type Config struct {
 	// validate target-SoC feasibility given a deadline). 0 falls
 	// back to a typical 60 kWh assumption.
 	VehicleCapacityWh float64 `yaml:"vehicle_capacity_wh,omitempty" json:"vehicle_capacity_wh,omitempty"`
+
+	// Assumed EV SoC % at plug-in. Chargers like Easee don't report
+	// the vehicle's SoC directly — only cumulative session energy.
+	// Current SoC is then estimated as `PluginSoCPct + delivered / cap`.
+	// 0 defaults to 20 % (conservative). Operators who care can
+	// override per-loadpoint or pre-plug-in.
+	PluginSoCPct float64 `yaml:"plugin_soc_pct,omitempty" json:"plugin_soc_pct,omitempty"`
 }
 
 // State is the observable snapshot of one loadpoint at a point in time.
@@ -82,6 +89,13 @@ type loadpointRuntime struct {
 	targetSoCPct       float64
 	targetTime         time.Time
 	updatedAtMs        int64
+
+	// Plug-in anchor: the SoC we believe the vehicle was at when
+	// this session began. Persisted across Observe() calls so SoC
+	// inference (pluginSoC + deliveredWh/capacity) stays stable
+	// even as session_wh grows. Reset to Config.PluginSoCPct on
+	// every plug-in transition (prev !pluggedIn → now pluggedIn).
+	sessionPluginSoCPct float64
 }
 
 // NewManager returns an empty manager. Configure with Load().
@@ -154,22 +168,63 @@ func (m *Manager) States() []State {
 	return out
 }
 
-// Observe updates the measurement side of a loadpoint. Called by the
-// driver layer once per poll cycle (phase 4 wiring). No-op for
-// unknown IDs — a misconfigured driver shouldn't crash the manager.
-func (m *Manager) Observe(id string, pluggedIn bool, socPct, powerW,
-	deliveredWh float64) {
+// Observe updates the measurement side of a loadpoint from raw driver
+// telemetry. The manager derives current SoC internally from the
+// session's plug-in anchor + delivered energy (chargers like Easee
+// don't report the vehicle's actual SoC).
+//
+// Plug-in transitions (prev !pluggedIn → now pluggedIn) reset the
+// session anchor to Config.PluginSoCPct (default 20 %) so the
+// inference is stable across plug cycles even if the underlying
+// charger's session counter wraps or resets.
+//
+// No-op for unknown IDs — a misconfigured driver shouldn't crash the
+// manager.
+func (m *Manager) Observe(id string, pluggedIn bool, powerW, deliveredWh float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	lp, ok := m.byID[id]
 	if !ok {
 		return
 	}
+	if pluggedIn && !lp.pluggedIn {
+		// Plug-in transition: seed the session anchor.
+		anchor := lp.PluginSoCPct
+		if anchor <= 0 {
+			anchor = 20 // conservative default
+		}
+		lp.sessionPluginSoCPct = anchor
+	}
 	lp.pluggedIn = pluggedIn
-	lp.currentSoCPct = socPct
 	lp.currentPowerW = powerW
 	lp.deliveredWhSession = deliveredWh
+	if pluggedIn {
+		lp.currentSoCPct = estimateSoCPct(lp.sessionPluginSoCPct,
+			deliveredWh, lp.VehicleCapacityWh)
+	} else {
+		lp.currentSoCPct = 0
+	}
 	lp.updatedAtMs = time.Now().UnixMilli()
+}
+
+// estimateSoCPct returns the vehicle SoC % inferred from the session
+// anchor + energy delivered. Chargers like Easee don't expose the
+// car's BMS; this is the best-effort estimate the MPC uses.
+//
+// Clamps to [0, 100]. Falls back to the anchor when capacity is
+// unknown (can't translate Wh → %).
+func estimateSoCPct(pluginSoCPct, deliveredWh, capacityWh float64) float64 {
+	if capacityWh <= 0 {
+		return pluginSoCPct
+	}
+	soc := pluginSoCPct + deliveredWh/capacityWh*100.0
+	if soc < 0 {
+		return 0
+	}
+	if soc > 100 {
+		return 100
+	}
+	return soc
 }
 
 // SetTarget updates the user-intent fields for an existing loadpoint.

--- a/go/internal/loadpoint/loadpoint_test.go
+++ b/go/internal/loadpoint/loadpoint_test.go
@@ -26,19 +26,29 @@ func TestLoadSkipsBlankID(t *testing.T) {
 
 func TestReloadPreservesObservedState(t *testing.T) {
 	m := NewManager()
-	m.Load([]Config{{ID: "garage", DriverName: "easee-cloud"}})
-	m.Observe("garage", true, 55, 7400, 1200)
+	m.Load([]Config{{
+		ID: "garage", DriverName: "easee-cloud",
+		VehicleCapacityWh: 60000, PluginSoCPct: 40,
+	}})
+	m.Observe("garage", true, 7400, 1200) // 1.2 kWh into session
 	target := time.Date(2026, 4, 18, 6, 0, 0, 0, time.UTC)
 	m.SetTarget("garage", 80, target)
 
 	// Reload with same ID — state should persist.
-	m.Load([]Config{{ID: "garage", DriverName: "easee-cloud", MaxChargeW: 11000}})
+	m.Load([]Config{{
+		ID: "garage", DriverName: "easee-cloud", MaxChargeW: 11000,
+		VehicleCapacityWh: 60000, PluginSoCPct: 40,
+	}})
 	st, ok := m.State("garage")
 	if !ok {
 		t.Fatal("state missing after reload")
 	}
-	if !st.PluggedIn || st.CurrentSoCPct != 55 || st.CurrentPowerW != 7400 {
+	// SoC = 40 + 1200/60000*100 = 42
+	if !st.PluggedIn || st.CurrentPowerW != 7400 {
 		t.Errorf("observed state lost: %+v", st)
+	}
+	if got := st.CurrentSoCPct; got < 41.5 || got > 42.5 {
+		t.Errorf("SoC estimate: got %.2f, want ~42", got)
 	}
 	if st.TargetSoCPct != 80 || !st.TargetTime.Equal(target) {
 		t.Errorf("target lost: %+v", st)
@@ -61,7 +71,7 @@ func TestReloadDropsRemovedIDs(t *testing.T) {
 func TestObserveOnUnknownIsNoop(t *testing.T) {
 	m := NewManager()
 	m.Load([]Config{{ID: "real"}})
-	m.Observe("ghost", true, 80, 7400, 0) // must not panic
+	m.Observe("ghost", true, 7400, 0) // must not panic
 	if _, ok := m.State("ghost"); ok {
 		t.Error("ghost state should not exist")
 	}
@@ -82,13 +92,49 @@ func TestSetTargetClamp(t *testing.T) {
 	}
 }
 
+// TestObserveUnpluggedClearsSoCEstimate — when the car is disconnected
+// we can't meaningfully estimate its SoC, so the manager clears it.
+// Otherwise a stale 42% would hang on the display after the car drove
+// away.
+func TestObserveUnpluggedClearsSoCEstimate(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000, PluginSoCPct: 30}})
+	m.Observe("a", true, 7400, 1800) // charging → SoC = 30 + 3 = 33
+	if st, _ := m.State("a"); st.CurrentSoCPct < 32.5 || st.CurrentSoCPct > 33.5 {
+		t.Fatalf("expected ~33 %% while plugged in, got %.2f", st.CurrentSoCPct)
+	}
+	m.Observe("a", false, 0, 0)
+	if st, _ := m.State("a"); st.CurrentSoCPct != 0 || st.PluggedIn {
+		t.Errorf("expected cleared state when unplugged, got %+v", st)
+	}
+}
+
+// TestObserveNewSessionAnchor — on plug-in the anchor resets to
+// Config.PluginSoCPct. This prevents residual session_wh from a
+// previous session leaking into the new one.
+func TestObserveNewSessionAnchor(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000, PluginSoCPct: 50}})
+	m.Observe("a", true, 0, 0)
+	if st, _ := m.State("a"); st.CurrentSoCPct < 49 || st.CurrentSoCPct > 51 {
+		t.Errorf("fresh plug-in should show 50 %%, got %.2f", st.CurrentSoCPct)
+	}
+	// Disconnect.
+	m.Observe("a", false, 0, 0)
+	// Re-plug — session delivered counter starts fresh.
+	m.Observe("a", true, 0, 0)
+	if st, _ := m.State("a"); st.CurrentSoCPct < 49 || st.CurrentSoCPct > 51 {
+		t.Errorf("re-plug should re-anchor at 50 %%, got %.2f", st.CurrentSoCPct)
+	}
+}
+
 func TestStatesReturnsAllInOrder(t *testing.T) {
 	m := NewManager()
 	m.Load([]Config{
-		{ID: "garage", MaxChargeW: 11000},
-		{ID: "street", MaxChargeW: 7400},
+		{ID: "garage", MaxChargeW: 11000, VehicleCapacityWh: 60000},
+		{ID: "street", MaxChargeW: 7400, VehicleCapacityWh: 60000},
 	})
-	m.Observe("garage", true, 40, 11000, 500)
+	m.Observe("garage", true, 11000, 500)
 	states := m.States()
 	if len(states) != 2 {
 		t.Fatalf("expected 2 states, got %d", len(states))


### PR DESCRIPTION
## Summary

Phase 4.1 follows #100 and wires the MPC output to the actual Easee charger. Targets `planner-overhaul/ev-in-dp` — merge #100 first.

Every control tick (5 s default) the main loop now:

1. Reads each loadpoint's driver telemetry — EV power + session Wh + plug state.
2. Calls `loadpoint.Manager.Observe`; the manager infers vehicle SoC as `plugin_soc + session_wh / vehicle_capacity`. Anchor defaults to 20 %, overridable via the new `plugin_soc_pct` config field.
3. Asks the MPC for the current slot's energy budget via `SlotDirective.LoadpointEnergyWh[id]`.
4. Translates remaining Wh / remaining s → instantaneous W (same energy-allocation contract as battery dispatch), snaps to the charger's allowed steps, and sends `{"action":"ev_set_current","power_w": W}` to the loadpoint's driver.

The existing `easee_cloud.lua` already understands that command — it divides by phases, clamps to 6–32 A, and writes `dynamicChargerCurrent` via the Easee cloud API. 0 W pauses the session cleanly.

## New helpers

- `control.SnapChargeW(want, min, max, steps)` — nearest-step snap with clamp
- `control.EnergyBudgetToPowerW(remainingWh, remainingS)` — the same formula battery dispatch uses

## Loadpoint changes

- `Config.PluginSoCPct` added (per-loadpoint anchor)
- `Manager.Observe` signature simplified — no more external SoC param (the charger can't tell us; manager derives it)
- `Manager` resets the session anchor on every plug-in transition so re-plugs don't leak stale delivered-Wh into the new session

## Test plan

- [x] `control.TestSnapChargeWSnapsToNearest` — step-snap is correct across edges
- [x] `control.TestSnapChargeWNoStepsReturnsClamped` — no-step fallback works
- [x] `control.TestEnergyBudgetToPowerW` — the Wh→W formula incl. edge cases
- [x] `loadpoint.TestObserveUnpluggedClearsSoCEstimate` — no stale SoC after unplug
- [x] `loadpoint.TestObserveNewSessionAnchor` — re-plug re-anchors correctly
- [x] All existing tests pass after `Observe` signature change
- [x] `go test ./...` — full suite incl. e2e (27s) green
- [ ] **Erik deploys to Pi, configures a loadpoint for his Easee, verifies MPC schedules EV charging through cheap hours and the charger actually responds.**

## Config example

```yaml
loadpoints:
  - id: garage
    driver_name: easee-cloud            # existing Easee driver
    min_charge_w: 1400                  # 1-phase 6 A (~230 V)
    max_charge_w: 11000                 # 3-phase 16 A
    allowed_steps_w: [0, 1400, 4100, 7400, 11000]
    vehicle_capacity_wh: 75000          # 75 kWh
    plugin_soc_pct: 25                  # conservative anchor
```

After setting a target:

```bash
curl -XPOST localhost:8080/api/loadpoints/garage/target \
  -d '{"soc_pct": 80, "target_time_ms": 1745030400000}'
```

## Roadmap

- **Phase 1** — DST/timezone audit (#97)
- **Phase 2** — `/api/mpc/diagnose` (#98)
- **Phase 3** — PowerLimits + Loadpoint skeleton (#99)
- **Phase 4** — EV in DP (#100)
- **Phase 4.1** — this PR (EV dispatch)
- **Phase 4.2** — UI form for target + divergence check + 1/3-phase switching (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)