### PR TITLE
fix(planner): Codex review follow-ups from overhaul chain (P1+P2)

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -215,6 +215,17 @@ func main() {
 	var pvSvc *pvmodel.Service
 	var forecastSvc *forecast.Service
 
+	// ---- EV loadpoints ----
+	// Manager is created early so the config hot-reload closure can
+	// reference it; actual Load() runs against initial cfg below.
+	// Phase 4 wires the first plugged-in loadpoint's state into the
+	// MPC's DP so battery + EV are co-optimized in one DP.
+	lpMgr := loadpoint.NewManager()
+	if len(cfg.Loadpoints) > 0 {
+		lpMgr.Load(buildLoadpointConfigs(cfg.Loadpoints))
+		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
+	}
+
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
@@ -237,6 +248,12 @@ func main() {
 				capacities[k] = v
 			}
 			capMu.Unlock()
+
+			// Hot-reload EV loadpoints so operators can add / remove /
+			// retune them without restarting. Manager preserves
+			// observed state across reloads (plug status, session
+			// anchor, current SoC estimate) — see loadpoint.Manager.Load.
+			lpMgr.Load(buildLoadpointConfigs(newCfg.Loadpoints))
 
 			// Weather diff → push live into the PV twin + forecast
 			// fetcher without a process restart. Users adjust rated PV
@@ -406,28 +423,6 @@ func main() {
 	defer loadSvc.Stop()
 	slog.Info("loadmodel started", "peak_w", loadPeakW, "quality", loadSvc.Model().Quality())
 
-	// ---- EV loadpoints (observable + MPC-input) ----
-	// Phase 3 introduced the Loadpoint concept as a first-class
-	// entity the API / UI surfaces. Phase 4 wires the MPC's DP with
-	// the first plugged-in loadpoint's state so battery + EV are
-	// co-optimized in one DP instead of two separate schedulers.
-	lpMgr := loadpoint.NewManager()
-	if len(cfg.Loadpoints) > 0 {
-		lpCfg := make([]loadpoint.Config, 0, len(cfg.Loadpoints))
-		for _, lp := range cfg.Loadpoints {
-			lpCfg = append(lpCfg, loadpoint.Config{
-				ID:                lp.ID,
-				DriverName:        lp.DriverName,
-				MinChargeW:        lp.MinChargeW,
-				MaxChargeW:        lp.MaxChargeW,
-				AllowedStepsW:     lp.AllowedStepsW,
-				VehicleCapacityWh: lp.VehicleCapacityWh,
-			})
-		}
-		lpMgr.Load(lpCfg)
-		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
-	}
-
 	// ---- Start MPC planner (optional) ----
 	mpcSvc := buildMPC(cfg, st, tel, capacities)
 	if mpcSvc != nil {
@@ -440,7 +435,7 @@ func main() {
 		// Wire the loadpoint probe so the DP extends its state space
 		// when an EV is plugged in. Single-loadpoint for now: picks
 		// the first plugged-in one.
-		mpcSvc.Loadpoint = func() *mpc.LoadpointSpec {
+		mpcSvc.Loadpoint = func(slotLenMin int) *mpc.LoadpointSpec {
 			for _, st := range lpMgr.States() {
 				if !st.PluggedIn {
 					continue
@@ -453,15 +448,19 @@ func main() {
 						break
 					}
 				}
-				// Map target time → slot index. The replan loop
-				// decides slot boundaries, so a "target by X" maps
-				// to "hours from now" → slot index. Anything past
-				// horizon maps to horizon end.
+				// Map target time → slot index using the DP's
+				// actual slot length (hour-of-prices vs. 15-min
+				// quarters vary by market). Anything past horizon
+				// gets clamped by the DP itself; negative means
+				// "no deadline".
+				if slotLenMin <= 0 {
+					slotLenMin = 60
+				}
 				targetSlot := -1
 				if !st.TargetTime.IsZero() {
 					delta := time.Until(st.TargetTime)
 					if delta > 0 {
-						targetSlot = int(delta / (15 * time.Minute))
+						targetSlot = int(delta / (time.Duration(slotLenMin) * time.Minute))
 					}
 				}
 				return &mpc.LoadpointSpec{
@@ -783,32 +782,32 @@ func main() {
 					if !plugged {
 						continue
 					}
+					// Resolve this tick's EV setpoint. Default 0 W so
+					// the charger is explicitly told to stand down
+					// whenever the MPC has no allocation for this
+					// slot — without an explicit command, the
+					// charger silently keeps drawing at its last
+					// setpoint from a previous slot.
+					var cmdW float64
 					d, ok := mpcSvc.SlotDirectiveAt(time.Now())
-					if !ok || d.LoadpointEnergyWh == nil {
-						continue
+					if ok {
+						if budgetWh, hasBudget := d.LoadpointEnergyWh[lpCfg.ID]; hasBudget {
+							remainingS := d.SlotEnd.Sub(time.Now()).Seconds()
+							// Subtract what's already been delivered
+							// so a mid-slot dispatch doesn't
+							// overshoot. Approximated from current
+							// power × fraction of slot elapsed.
+							elapsed := d.SlotEnd.Sub(d.SlotStart).Seconds() - remainingS
+							if elapsed < 0 {
+								elapsed = 0
+							}
+							alreadyWh := powerW * elapsed / 3600.0
+							remainingWh := budgetWh - alreadyWh
+							wantW := control.EnergyBudgetToPowerW(remainingWh, remainingS)
+							cmdW = control.SnapChargeW(wantW, lpCfg.MinChargeW,
+								lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
+						}
 					}
-					budgetWh, hasBudget := d.LoadpointEnergyWh[lpCfg.ID]
-					if !hasBudget {
-						continue
-					}
-					remainingS := d.SlotEnd.Sub(time.Now()).Seconds()
-					// The budget is total energy for the slot; we
-					// subtract what's already been delivered so far
-					// so a mid-slot dispatch doesn't overshoot.
-					// Without a per-slot start-energy anchor, we
-					// approximate "delivered this slot" as the
-					// charger's current power × fraction of slot
-					// elapsed. In practice most dispatch ticks are
-					// late in the slot so the error is small.
-					elapsed := d.SlotEnd.Sub(d.SlotStart).Seconds() - remainingS
-					if elapsed < 0 {
-						elapsed = 0
-					}
-					alreadyWh := powerW * elapsed / 3600.0
-					remainingWh := budgetWh - alreadyWh
-					wantW := control.EnergyBudgetToPowerW(remainingWh, remainingS)
-					cmdW := control.SnapChargeW(wantW, lpCfg.MinChargeW,
-						lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
 					payload, _ := json.Marshal(map[string]any{
 						"action":  "ev_set_current",
 						"power_w": cmdW,
@@ -906,6 +905,25 @@ func driverCapacitiesFrom(drivers []config.Driver) map[string]float64 {
 		if d.BatteryCapacityWh > 0 {
 			out[d.Name] = d.BatteryCapacityWh
 		}
+	}
+	return out
+}
+
+// buildLoadpointConfigs adapts YAML-facing config.Loadpoint entries
+// into the internal loadpoint.Config shape. Shared between initial
+// boot and the hot-reload watcher so the two paths can't drift.
+func buildLoadpointConfigs(src []config.Loadpoint) []loadpoint.Config {
+	out := make([]loadpoint.Config, 0, len(src))
+	for _, lp := range src {
+		out = append(out, loadpoint.Config{
+			ID:                lp.ID,
+			DriverName:        lp.DriverName,
+			MinChargeW:        lp.MinChargeW,
+			MaxChargeW:        lp.MaxChargeW,
+			AllowedStepsW:     lp.AllowedStepsW,
+			VehicleCapacityWh: lp.VehicleCapacityWh,
+			PluginSoCPct:      lp.PluginSoCPct,
+		})
 	}
 	return out
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -43,6 +43,7 @@ type Loadpoint struct {
 	MaxChargeW        float64   `yaml:"max_charge_w,omitempty" json:"max_charge_w,omitempty"`
 	AllowedStepsW     []float64 `yaml:"allowed_steps_w,omitempty" json:"allowed_steps_w,omitempty"`
 	VehicleCapacityWh float64   `yaml:"vehicle_capacity_wh,omitempty" json:"vehicle_capacity_wh,omitempty"`
+	PluginSoCPct      float64   `yaml:"plugin_soc_pct,omitempty" json:"plugin_soc_pct,omitempty"`
 }
 
 // OCPP configures the embedded OCPP 1.6J Central System for EV chargers.

--- a/go/internal/loadmodel/service.go
+++ b/go/internal/loadmodel/service.go
@@ -16,7 +16,10 @@ import (
 // package from the forecast module.
 type TempFunc func(t time.Time) (float64, bool)
 
-const stateKey = "loadmodel/state"
+// Bumped from "loadmodel/state" after HourOfWeek switched to UTC
+// coercion: pre-switch buckets were indexed in local zone and would
+// silently misalign if restored. Fresh init retrains from telemetry.
+const stateKey = "loadmodel/state_utc"
 
 // Service trains the load model online from telemetry. Mirrors
 // pvmodel.Service so operators + future code have one pattern.

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -117,7 +117,11 @@ func (m *Manager) Load(cfgs []Config) {
 		}
 		lp := &loadpointRuntime{Config: c}
 		if existing, ok := m.byID[c.ID]; ok {
-			// Preserve observed state across reload.
+			// Preserve observed state across reload. The session
+			// plug-in anchor is carried too — otherwise a config
+			// hot-reload during a charging session would drop our
+			// SoC reference and reset the estimate back to
+			// PluginSoCPct even though delivered_wh has grown.
 			lp.pluggedIn = existing.pluggedIn
 			lp.currentSoCPct = existing.currentSoCPct
 			lp.currentPowerW = existing.currentPowerW
@@ -125,6 +129,7 @@ func (m *Manager) Load(cfgs []Config) {
 			lp.targetSoCPct = existing.targetSoCPct
 			lp.targetTime = existing.targetTime
 			lp.updatedAtMs = existing.updatedAtMs
+			lp.sessionPluginSoCPct = existing.sessionPluginSoCPct
 		}
 		newByID[c.ID] = lp
 		newOrder = append(newOrder, c.ID)

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -453,6 +453,21 @@ func Optimize(slots []Slot, p Params) Plan {
 						}
 					}
 				}
+				// If every action at this (slot, soc, ev_soc) state
+				// was rejected (mode + PowerLimits combined out of
+				// feasibility), bestV stays +Inf and bestPolicy
+				// defaults to 0 — which encodes (battery action 0,
+				// EV action 0) = "full discharge, EV off", NOT
+				// "idle". A forward-sim that reaches this state
+				// would pick the worst possible action. Fall back
+				// to closest-to-idle: battery action at the middle
+				// of the grid (≈0 W when ActionLevels is odd) and
+				// EV off. The +Inf V propagates upstream so the
+				// DP avoids routing through this infeasible region
+				// when a legal path exists.
+				if math.IsInf(bestV, 1) {
+					bestPolicy = ((A - 1) / 2) * EA
+				}
 				V[t][si][ei] = bestV
 				Policy[t][si][ei] = bestPolicy
 			}

--- a/go/internal/mpc/power_limits_test.go
+++ b/go/internal/mpc/power_limits_test.go
@@ -112,6 +112,48 @@ func TestOptimizeRespectsImportCap(t *testing.T) {
 	}
 }
 
+// TestOptimizeInfeasibleStatePicksNearIdle — when every action at a
+// state violates limits or mode, the DP previously left Policy at 0
+// which encodes "full discharge, EV off" — the worst possible
+// fallback. We now pick the closest-to-idle action so forward-sim
+// produces something sensible. Codex flagged this in PR #99 review.
+func TestOptimizeInfeasibleStatePicksNearIdle(t *testing.T) {
+	// One slot with BOTH import and export hard-capped to 0 → no
+	// grid flow allowed. Baseline load (+ no PV) is 500 W of import,
+	// already violating MaxImportW=1. No feasible action exists.
+	// Forward-sim should pick battery action ≈ 0 (action index =
+	// (A-1)/2 with A=5 → index 2 → 0 W at the mid-point of the
+	// action grid).
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 20,
+			LoadW: 500, Confidence: 1.0,
+			Limits: PowerLimits{MaxImportW: 1, MaxExportW: 1}},
+	}
+	p := Params{
+		Mode:                ModeSelfConsumption,
+		SoCLevels:           11,
+		CapacityWh:          5000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        5,
+		MaxChargeW:          2000,
+		MaxDischargeW:       2000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(plan.Actions))
+	}
+	// Key assertion: fallback is near-idle, NOT full-discharge (−2000 W).
+	a := plan.Actions[0]
+	if a.BatteryW < -500 {
+		t.Errorf("infeasible fallback should be near-idle, "+
+			"got BatteryW=%.1f (full-discharge = −2000)", a.BatteryW)
+	}
+}
+
 // TestOptimizeRespectsExportCap mirrors the import test — PV surplus
 // exported into a negative-price slot must respect the cap.
 func TestOptimizeRespectsExportCap(t *testing.T) {

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -28,14 +28,16 @@ type LoadPredictor func(t time.Time) float64
 type PricePredictor func(zone string, t time.Time) float64
 
 // LoadpointProbe returns the EV loadpoint state the DP should extend
-// itself with. Called once per replan. Return nil when no loadpoint
+// itself with. Called once per replan with the slot length (minutes)
+// the DP will actually use — so the probe can map any user wall-clock
+// deadline to a correct slot index. Return nil when no loadpoint
 // should be optimized (unplugged, unconfigured, or during initial
 // rollout when operator wants to disable EV-in-DP).
 //
 // Wired in main.go against *loadpoint.Manager; kept as a plain
 // closure type to avoid the mpc package importing loadpoint (which
 // would risk a cycle if loadpoint ever needs mpc types).
-type LoadpointProbe func() *LoadpointSpec
+type LoadpointProbe func(slotLenMin int) *LoadpointSpec
 
 // Service wires the optimizer to the rest of the stack: pulls prices +
 // forecast from the SQLite store, reads current SoC from the telemetry
@@ -175,8 +177,12 @@ func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
 	if s == nil {
 		return SlotDirective{}, false
 	}
+	// Snapshot plan + loadpoint ID together under the same RLock so
+	// a concurrent replan() can't swap one without the other — a
+	// classic read-race that Codex flagged.
 	s.mu.RLock()
 	p := s.last
+	lpID := s.lastLoadpointID
 	s.mu.RUnlock()
 	if p == nil {
 		return SlotDirective{}, false
@@ -201,15 +207,15 @@ func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
 			Strategy:        s.Defaults.Mode,
 		}
 		// EV energy budget for the slot (single-loadpoint for now —
-		// keyed under lastLoadpointID so the dispatch layer routes
+		// keyed under lpID snapshot so the dispatch layer routes
 		// to the right driver).
-		if a.LoadpointW > 0 && s.lastLoadpointID != "" {
+		if a.LoadpointW > 0 && lpID != "" {
 			lpEnergyWh := a.LoadpointW * float64(a.SlotLenMin) / 60.0
 			d.LoadpointEnergyWh = map[string]float64{
-				s.lastLoadpointID: lpEnergyWh,
+				lpID: lpEnergyWh,
 			}
 			d.LoadpointSoCTargetPct = map[string]float64{
-				s.lastLoadpointID: a.LoadpointSoCPct,
+				lpID: a.LoadpointSoCPct,
 			}
 		}
 		return d, true
@@ -525,7 +531,11 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// support is on the roadmap.
 	var loadpointID string
 	if s.Loadpoint != nil {
-		if spec := s.Loadpoint(); spec != nil && spec.PluggedIn {
+		slotLenMin := 60 // safe fallback — most price sources are hourly
+		if len(slots) > 0 && slots[0].LenMin > 0 {
+			slotLenMin = slots[0].LenMin
+		}
+		if spec := s.Loadpoint(slotLenMin); spec != nil && spec.PluggedIn {
 			p.Loadpoint = spec
 			loadpointID = spec.ID
 		}

--- a/go/internal/pvmodel/service.go
+++ b/go/internal/pvmodel/service.go
@@ -12,7 +12,11 @@ import (
 )
 
 // stateKey is the config k/v key where we persist the model JSON.
-const stateKey = "pvmodel/state"
+// The `_utc` suffix invalidates pre-UTC-coercion models: learned β
+// coefficients were fitted against local-zone hour-of-day harmonic
+// features and would silently misalign if restored under the current
+// UTC-based Features(). Fresh init + ~50 samples retrains.
+const stateKey = "pvmodel/state_utc"
 
 // ClearSkyFunc is injected by main.go to decouple pvmodel from the
 // forecast package. Returns clear-sky GHI (W/m²) for the site's lat/lon


### PR DESCRIPTION
## Summary

Bundles the 8 issues Codex flagged across PRs #97-#101, ordered by how badly each blocks @erikarenhill's real-hardware testing on the v0.17.0 release.

### P1 — critical

1. **Charger kept running after slot ended** (from #101). When the current MPC slot had no EV allocation, dispatch `continue`d without sending anything — Easee kept drawing at its previous setpoint across a "stop" transition. Now we default `cmdW=0` and always send the explicit command so the charger actively stands down.

2. **`plugin_soc_pct` never reached the runtime** (from #101). Added to `loadpoint.Config` in Phase 4.1 but never copied from YAML. Plumbed through `config.Loadpoint` and centralised YAML→runtime in a new `buildLoadpointConfigs` helper so boot + hot-reload share one path.

3. **`TargetSlotIdx` assumed 15-min slots** (from #100). Nordic day-ahead prices come as 60-min slots, so a 2 h deadline mapped to slot 8 instead of slot 2 — DP saw 4× the time it actually had. `LoadpointProbe` now takes `slotLenMin` from the actual plan and the service passes in `slots[0].LenMin`.

4. **Race on `lastLoadpointID`** (from #100). `SlotDirectiveAt` read `s.last` under RLock then `s.lastLoadpointID` outside — a concurrent replan could swap one without the other, routing a directive under the wrong driver. Snapshot both under the same lock.

5. **Infeasible DP states picked full-discharge fallback** (from #99). When mode + PowerLimits eliminated every action, `bestPolicy` defaulted to 0 which encodes `(ba=0, ea=0)` = full battery discharge, EV off — the worst fallback. Now overrides to the closest-to-idle action so forward-sim produces a sane plan even in operator-induced infeasibility.

6. **Persisted PV/load models misaligned after UTC switch** (from #97). `pvmodel`'s β coefficients were fitted against local-zone harmonic features; `loadmodel`'s buckets were indexed on local weekday+hour. After Phase 1's UTC coercion, restoring the old state silently misaligned both models. Bumped state keys (`pvmodel/state` → `pvmodel/state_utc`, `loadmodel/state` → `loadmodel/state_utc`) so old state is ignored on upgrade. Models retrain from telemetry over ~a day.

### P2

7. **Config hot-reload didn't touch loadpoints** (from #99). `configreload` callback skipped `newCfg.Loadpoints` entirely. Now the manager reloads inside the callback — it preserves observed state across reloads, so live loadpoint edits no longer need a process restart.

8. **Session anchor lost on config reload** (from #101). `loadpoint.Manager.Load` preserved `pluggedIn` and `delivered_wh_session` but not `sessionPluginSoCPct`. A hot-reload mid-charge would reset the SoC inference baseline. Carry the anchor too.

## Tests

- New `mpc.TestOptimizeInfeasibleStatePicksNearIdle` — covers the DP fallback
- All existing tests pass (incl. e2e, 27 s)
- Build clean

## What @erikarenhill should expect after this lands

- Upgrade to whichever release includes this (will be v0.17.1+). First boot after upgrade: PV + load models start fresh — the twin quality badges go yellow for ~24 h while they retrain from telemetry. Not a regression; it's the correct behavior (old state was silently wrong).
- Your `plugin_soc_pct` config value will now actually take effect.
- Easee will cleanly pause at 0 W between charging slots instead of holding its last setpoint.
- `GET /api/mpc/diagnose` now reliably reflects the loadpoint's driver even under concurrent replans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)