### PR TITLE
feat(mpc): persist diagnostics per replan + time-travel API (PR-A of 2)

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -486,6 +486,17 @@ func main() {
 			mpcSvc.GridTariffOreKwh = cfg.Price.GridTariffOreKwh
 			mpcSvc.VATPercent = cfg.Price.VATPercent
 		}
+		// Persist every replan's Diagnostic so operators can time-
+		// travel. See docs/mpc-planner.md + planner_diagnostics
+		// table in state/store.go.
+		mpcSvc.SaveDiag = func(d *mpc.Diagnostic, reason string) error {
+			js, err := json.Marshal(d)
+			if err != nil {
+				return err
+			}
+			return st.SaveDiagnostic(d.ComputedAtMs, reason, d.Zone,
+				d.TotalCostOre, d.Horizon, string(js))
+		}
 		mpcSvc.Start(ctx)
 		defer mpcSvc.Stop()
 		// Inject plan → control.State. Both callbacks are wired:
@@ -546,6 +557,7 @@ func main() {
 		DtS:        float64(cfg.Site.ControlIntervalS),
 		SaveConfig: config.SaveAtomic,
 		WebDir:     *webDir,
+		ColdDir:    coldDir,
 		Prices:     priceSvc,
 		Forecast:   forecastSvc,
 		MPC:        mpcSvc,
@@ -870,10 +882,22 @@ func doRolloff(ctx context.Context, st *state.Store, coldDir string) {
 	rows, files, err := st.RolloffToParquet(ctx, coldDir)
 	if err != nil {
 		slog.Warn("parquet rolloff failed", "err", err)
+	} else if rows > 0 {
+		slog.Info("parquet rolloff", "rows", rows, "files", len(files))
+	}
+	// Planner diagnostics roll off on the same cadence but keep a
+	// longer hot tier (30 d vs. the 14 d of ts_samples) — they're
+	// sparse enough (~100/day) that the extra month in SQLite
+	// costs < 60 MB and makes the time-travel UI snappy for
+	// recent-incident debugging.
+	dRows, dFiles, err := st.RolloffDiagnosticsToParquet(ctx, coldDir)
+	if err != nil {
+		slog.Warn("diagnostics parquet rolloff failed", "err", err)
 		return
 	}
-	if rows > 0 {
-		slog.Info("parquet rolloff", "rows", rows, "files", len(files))
+	if dRows > 0 {
+		slog.Info("diagnostics parquet rolloff",
+			"rows", dRows, "files", len(dFiles))
 	}
 }
 

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -66,6 +66,7 @@ type Deps struct {
 	DtS        float64                                   // control interval seconds (for model τ / age displays)
 	SaveConfig func(path string, c *config.Config) error // injection for testability
 	WebDir     string                                    // static assets root (default "web")
+	ColdDir    string                                    // cold-storage root for parquet rolloff; empty disables cold fallback
 
 	// Optional: spot prices + weather forecast services. Nil if disabled.
 	Prices   *prices.Service
@@ -145,6 +146,8 @@ func (s *Server) routes() {
 	s.handle("GET  /api/mpc/plan", s.handleMPCPlan)
 	s.handle("POST /api/mpc/replan", s.handleMPCReplan)
 	s.handle("GET  /api/mpc/diagnose", s.handleMPCDiagnose)
+	s.handle("GET  /api/mpc/diagnose/history", s.handleMPCDiagnoseHistory)
+	s.handle("GET  /api/mpc/diagnose/at", s.handleMPCDiagnoseAt)
 	s.handle("GET  /api/pvmodel", s.handlePVModel)
 	s.handle("POST /api/pvmodel/reset", s.handlePVModelReset)
 	s.handle("GET  /api/loadmodel", s.handleLoadModel)
@@ -1099,6 +1102,119 @@ func (s *Server) handleMPCDiagnose(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, 200, map[string]any{"enabled": true, "diagnostic": diag})
+}
+
+// handleMPCDiagnoseHistory lists persisted replan snapshots as
+// lightweight summaries for the timeline UI. The full per-slot JSON
+// blob isn't included — call /api/mpc/diagnose/at?ts=<ms> for that.
+//
+// Query params:
+//
+//	since  unix-ms; default "now − 7d"
+//	until  unix-ms; default now
+//	limit  max rows returned; default 500, cap 5000
+//
+// Falls back to the cold-storage parquet files when the requested
+// window extends beyond DiagnosticsRecentRetention — keeps the UI
+// working for year-old incidents without a separate code path.
+func (s *Server) handleMPCDiagnoseHistory(w http.ResponseWriter, r *http.Request) {
+	if s.deps.State == nil {
+		writeJSON(w, 200, map[string]any{"enabled": false})
+		return
+	}
+	now := time.Now().UnixMilli()
+	since := now - 7*24*3600*1000
+	until := now
+	if v := r.URL.Query().Get("since"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			since = n
+		}
+	}
+	if v := r.URL.Query().Get("until"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			until = n
+		}
+	}
+	limit := 500
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+			if limit > 5000 {
+				limit = 5000
+			}
+		}
+	}
+	summaries, err := s.deps.State.LoadDiagnosticsInRange(since, until, limit)
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	// If the query window extends before the SQLite retention and we
+	// have a cold-storage root configured, top up with Parquet.
+	coldDir := s.deps.ColdDir
+	if coldDir != "" {
+		hotCutoff := now - int64(state.DiagnosticsRecentRetention/time.Millisecond)
+		if since < hotCutoff {
+			coldUntil := hotCutoff
+			if until < coldUntil {
+				coldUntil = until
+			}
+			cold, cerr := s.deps.State.LoadDiagnosticsFromParquet(coldDir, since, coldUntil)
+			if cerr == nil {
+				summaries = append(summaries, cold...)
+			}
+		}
+	}
+	writeJSON(w, 200, map[string]any{
+		"enabled":   true,
+		"snapshots": summaries,
+	})
+}
+
+// handleMPCDiagnoseAt returns the snapshot active at ?ts=<ms> — the
+// replan whose ts_ms is the largest one ≤ ts. That's the "plan that
+// was driving the EMS at that moment" semantics, so a query at 02:07
+// returns the 02:00 replan (not the 02:15 one that ran afterward).
+// Falls through to Parquet when the hit isn't in the hot table.
+func (s *Server) handleMPCDiagnoseAt(w http.ResponseWriter, r *http.Request) {
+	if s.deps.State == nil {
+		writeJSON(w, 200, map[string]any{"enabled": false})
+		return
+	}
+	ts, err := strconv.ParseInt(r.URL.Query().Get("ts"), 10, 64)
+	if err != nil || ts <= 0 {
+		writeJSON(w, 400, map[string]string{"error": "ts (unix ms) required"})
+		return
+	}
+	row, err := s.deps.State.LoadDiagnosticAt(ts)
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	if row == nil && s.deps.ColdDir != "" {
+		row, err = s.deps.State.LoadDiagnosticFullFromParquet(s.deps.ColdDir, ts)
+		if err != nil {
+			writeJSON(w, 500, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	if row == nil {
+		writeJSON(w, 200, map[string]any{"enabled": true, "snapshot": nil})
+		return
+	}
+	// Pass the stored JSON through raw so the client sees the exact
+	// mpc.Diagnostic shape it would have gotten from /api/mpc/diagnose.
+	// Wrapping in a typed struct would force an unmarshal + remarshal
+	// that adds ~1 ms on a 2880-slot snapshot for no benefit.
+	payload := map[string]any{
+		"ts_ms":          row.TsMs,
+		"reason":         row.Reason,
+		"zone":           row.Zone,
+		"total_cost_ore": row.TotalCostOre,
+		"horizon_slots":  row.HorizonSlots,
+		"diagnostic":     json.RawMessage(row.JSON),
+	}
+	writeJSON(w, 200, map[string]any{"enabled": true, "snapshot": payload})
 }
 
 // ---- Long-format time-series ----

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -54,6 +54,15 @@ type Service struct {
 	Price     PricePredictor // optional — fills in future slots when day-ahead isn't published yet
 	Loadpoint LoadpointProbe // optional — when non-nil, the DP extends its state with EV dimensions
 
+	// SaveDiag is called synchronously after every successful replan
+	// with the same Diagnostic the /api/mpc/diagnose endpoint would
+	// return + the trigger reason ("scheduled" / "reactive-pv" /
+	// "reactive-load" / "manual"). Nil disables persistence — the
+	// in-memory diagnose still works. Wired in main.go against
+	// state.Store.SaveDiagnostic so operators can time-travel past
+	// decisions; see docs/mpc-planner.md.
+	SaveDiag func(d *Diagnostic, reason string) error
+
 	// Reactive replan: when the integrated energy gap between actual
 	// and the plan's current-slot prediction exceeds a threshold over
 	// a rolling ~15-minute window, trigger an off-schedule replan so
@@ -578,6 +587,19 @@ func (s *Service) replan(_ context.Context) *Plan {
 		"soc_start", p.InitialSoCPct,
 		"cost_ore", plan.TotalCostOre,
 		"reason", reason)
+
+	// Persist a diagnostic snapshot so operators can time-travel to
+	// this replan later. Best-effort: errors log and continue so a
+	// flaky disk never blocks planning. Runs outside the lock — the
+	// plan pointer is already swapped in, so Diagnose() reads
+	// consistent state without needing us to hold anything.
+	if s.SaveDiag != nil {
+		if d := s.Diagnose(); d != nil {
+			if err := s.SaveDiag(d, reason); err != nil {
+				slog.Warn("mpc: persist diagnostic failed", "err", err)
+			}
+		}
+	}
 	return &plan
 }
 

--- a/go/internal/mpc/service_persist_test.go
+++ b/go/internal/mpc/service_persist_test.go
@@ -1,0 +1,100 @@
+package mpc
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/state"
+)
+
+// TestReplanCallsSaveDiag — after a successful replan, the SaveDiag
+// hook fires once with (non-nil Diagnostic, reason). Verifies the hook
+// wiring end-to-end without having to spin up the full stack.
+func TestReplanCallsSaveDiag(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("Open state: %v", err)
+	}
+	defer st.Close()
+
+	// Seed a few price rows so buildSlots produces a non-empty plan.
+	now := time.Now().UTC().Truncate(time.Hour)
+	for i := 0; i < 4; i++ {
+		err := st.SavePrices([]state.PricePoint{{
+			Zone: "SE3", SlotTsMs: now.Add(time.Duration(i) * time.Hour).UnixMilli(),
+			SlotLenMin: 60, SpotOreKwh: 50, TotalOreKwh: 100,
+			Source: "test", FetchedAtMs: now.UnixMilli(),
+		}})
+		if err != nil {
+			t.Fatalf("SavePrices: %v", err)
+		}
+	}
+
+	svc := New(st, nil, "SE3", Params{
+		Mode:                ModeSelfConsumption,
+		SoCLevels:           11,
+		CapacityWh:          10000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        5,
+		MaxChargeW:          3000,
+		MaxDischargeW:       3000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    80,
+	})
+	svc.BaseLoad = 500
+
+	var called atomic.Int32
+	var gotReason atomic.Value
+	var gotZone atomic.Value
+	svc.SaveDiag = func(d *Diagnostic, reason string) error {
+		called.Add(1)
+		gotReason.Store(reason)
+		gotZone.Store(d.Zone)
+		if len(d.Slots) == 0 {
+			t.Error("Diagnostic.Slots empty — DP ran but no slots reached the snapshot")
+		}
+		return nil
+	}
+
+	if plan := svc.Replan(context.Background()); plan == nil {
+		t.Fatal("Replan returned nil — buildSlots likely empty")
+	}
+	if n := called.Load(); n != 1 {
+		t.Errorf("SaveDiag called %d times, want 1", n)
+	}
+	if r, _ := gotReason.Load().(string); r == "" {
+		t.Error("SaveDiag reason was empty")
+	}
+	if z, _ := gotZone.Load().(string); z != "SE3" {
+		t.Errorf("SaveDiag zone = %q, want SE3", z)
+	}
+}
+
+// TestReplanWithoutSaveDiagDoesNotPanic — the persistence hook is
+// optional. A service without the hook must replan cleanly.
+func TestReplanWithoutSaveDiagDoesNotPanic(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := time.Now().UTC().Truncate(time.Hour)
+	_ = st.SavePrices([]state.PricePoint{{
+		Zone: "SE3", SlotTsMs: now.UnixMilli(), SlotLenMin: 60,
+		SpotOreKwh: 50, TotalOreKwh: 100, Source: "test",
+		FetchedAtMs: now.UnixMilli(),
+	}})
+	svc := New(st, nil, "SE3", Params{
+		Mode: ModeSelfConsumption, SoCLevels: 11, CapacityWh: 10000,
+		SoCMinPct: 10, SoCMaxPct: 95, InitialSoCPct: 50,
+		ActionLevels: 5, MaxChargeW: 2000, MaxDischargeW: 2000,
+		ChargeEfficiency: 0.95, DischargeEfficiency: 0.95,
+	})
+	_ = svc.Replan(context.Background())
+}

--- a/go/internal/state/diagnostics.go
+++ b/go/internal/state/diagnostics.go
@@ -1,0 +1,170 @@
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// DiagnosticsRecentRetention is how long planner snapshots stay queryable
+// in SQLite before rolling off to daily Parquet files. 30 days matches the
+// typical "how far back do you need to look to debug?" window while
+// keeping the hot table small (~2880 rows at 15-min cadence × 30 d).
+const DiagnosticsRecentRetention = 30 * 24 * time.Hour
+
+// DiagnosticSummary is the light-weight row the timeline UI consumes. No
+// full JSON blob — the UI fetches that on demand via LoadDiagnosticAt.
+type DiagnosticSummary struct {
+	TsMs          int64   `json:"ts_ms"`
+	Reason        string  `json:"reason"`
+	Zone          string  `json:"zone"`
+	TotalCostOre  float64 `json:"total_cost_ore"`
+	HorizonSlots  int     `json:"horizon_slots"`
+}
+
+// DiagnosticRow is the full persisted record — used by the detail view
+// and the rolloff path.
+type DiagnosticRow struct {
+	DiagnosticSummary
+	JSON string `json:"json"`
+}
+
+// SaveDiagnostic persists one planner replan snapshot. Upserts on conflict
+// so a replan that happens to reuse a ts_ms (should not in practice —
+// time.Now().UnixMilli() has ms precision and replans are minutes apart)
+// overwrites cleanly rather than failing.
+func (s *Store) SaveDiagnostic(tsMs int64, reason, zone string,
+	totalCostOre float64, horizonSlots int, js string) error {
+	if tsMs <= 0 {
+		return fmt.Errorf("SaveDiagnostic: ts_ms must be positive")
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO planner_diagnostics
+		 (ts_ms, reason, zone, total_cost_ore, horizon_slots, json)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT (ts_ms) DO UPDATE SET
+		   reason=excluded.reason, zone=excluded.zone,
+		   total_cost_ore=excluded.total_cost_ore,
+		   horizon_slots=excluded.horizon_slots,
+		   json=excluded.json`,
+		tsMs, reason, zone, totalCostOre, horizonSlots, js)
+	return err
+}
+
+// LoadDiagnosticsInRange returns summaries for replans in [sinceMs, untilMs],
+// newest first. Caller-chosen `limit` caps the result; 0 = no limit. Used
+// by the timeline list in the UI.
+func (s *Store) LoadDiagnosticsInRange(sinceMs, untilMs int64,
+	limit int) ([]DiagnosticSummary, error) {
+	var args []any
+	q := `SELECT ts_ms, reason, zone, total_cost_ore, horizon_slots
+	      FROM planner_diagnostics
+	      WHERE ts_ms >= ? AND ts_ms <= ?
+	      ORDER BY ts_ms DESC`
+	args = append(args, sinceMs, untilMs)
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]DiagnosticSummary, 0, 32)
+	for rows.Next() {
+		var r DiagnosticSummary
+		if err := rows.Scan(&r.TsMs, &r.Reason, &r.Zone,
+			&r.TotalCostOre, &r.HorizonSlots); err != nil {
+			return out, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// LoadDiagnosticAt returns the snapshot that was active at tsMs — the
+// most recent one with ts_ms <= tsMs. This is the correct semantics for
+// "what plan was driving the EMS at this moment?": if a replan ran at
+// 02:00:00 and another at 02:15:00, then asking for 02:07:00 returns the
+// 02:00 snapshot. Returns (nil, nil) when no snapshot is ≤ tsMs.
+func (s *Store) LoadDiagnosticAt(tsMs int64) (*DiagnosticRow, error) {
+	row := s.db.QueryRow(
+		`SELECT ts_ms, reason, zone, total_cost_ore, horizon_slots, json
+		 FROM planner_diagnostics
+		 WHERE ts_ms <= ?
+		 ORDER BY ts_ms DESC
+		 LIMIT 1`, tsMs)
+	var r DiagnosticRow
+	err := row.Scan(&r.TsMs, &r.Reason, &r.Zone,
+		&r.TotalCostOre, &r.HorizonSlots, &r.JSON)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// DeleteDiagnosticsBefore drops all snapshots with ts_ms < cutoffMs. Used
+// by the rolloff path after successfully writing Parquet, and by a
+// periodic retention prune if cold storage is disabled.
+func (s *Store) DeleteDiagnosticsBefore(ctx context.Context, cutoffMs int64) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM planner_diagnostics WHERE ts_ms < ?`, cutoffMs)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// DiagnosticsBefore streams rows older than cutoffMs in batches — used by
+// the Parquet rolloff to avoid loading 30 days of snapshots into memory
+// at once. Visitor returning an error stops the scan.
+func (s *Store) DiagnosticsBefore(ctx context.Context, cutoffMs int64,
+	batchSize int, visit func(batch []DiagnosticRow) error) error {
+	if batchSize <= 0 {
+		batchSize = 256
+	}
+	// Keyset pagination on ts_ms — PK ordering means this is a simple
+	// forward scan without offset scanning overhead.
+	var lastTs int64 = -1
+	for {
+		q := `SELECT ts_ms, reason, zone, total_cost_ore, horizon_slots, json
+		      FROM planner_diagnostics
+		      WHERE ts_ms < ? AND ts_ms > ?
+		      ORDER BY ts_ms ASC
+		      LIMIT ?`
+		rows, err := s.db.QueryContext(ctx, q, cutoffMs, lastTs, batchSize)
+		if err != nil {
+			return err
+		}
+		batch := make([]DiagnosticRow, 0, batchSize)
+		for rows.Next() {
+			var r DiagnosticRow
+			if err := rows.Scan(&r.TsMs, &r.Reason, &r.Zone,
+				&r.TotalCostOre, &r.HorizonSlots, &r.JSON); err != nil {
+				rows.Close()
+				return err
+			}
+			batch = append(batch, r)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := visit(batch); err != nil {
+			return err
+		}
+		lastTs = batch[len(batch)-1].TsMs
+		if len(batch) < batchSize {
+			return nil
+		}
+	}
+}

--- a/go/internal/state/diagnostics_test.go
+++ b/go/internal/state/diagnostics_test.go
@@ -1,0 +1,234 @@
+package state
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	st, err := Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestSaveDiagnosticRoundTrip(t *testing.T) {
+	st := openTestStore(t)
+	ts := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC).UnixMilli()
+	if err := st.SaveDiagnostic(ts, "scheduled", "SE3", 345.6, 96, `{"foo":"bar"}`); err != nil {
+		t.Fatalf("SaveDiagnostic: %v", err)
+	}
+	got, err := st.LoadDiagnosticAt(ts)
+	if err != nil {
+		t.Fatalf("LoadDiagnosticAt: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil; want the row back")
+	}
+	if got.TsMs != ts || got.Reason != "scheduled" || got.Zone != "SE3" ||
+		got.TotalCostOre != 345.6 || got.HorizonSlots != 96 || got.JSON != `{"foo":"bar"}` {
+		t.Errorf("round-trip mismatch: got %+v", got)
+	}
+}
+
+func TestSaveDiagnosticUpsertsOnConflict(t *testing.T) {
+	st := openTestStore(t)
+	ts := int64(1745000000000)
+	_ = st.SaveDiagnostic(ts, "scheduled", "SE3", 100, 96, "v1")
+	if err := st.SaveDiagnostic(ts, "manual", "SE3", 200, 48, "v2"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ := st.LoadDiagnosticAt(ts)
+	if got == nil || got.Reason != "manual" || got.JSON != "v2" {
+		t.Errorf("upsert did not replace; got %+v", got)
+	}
+}
+
+func TestLoadDiagnosticAtFindsClosestEarlier(t *testing.T) {
+	st := openTestStore(t)
+	// Snapshots at 12:00, 12:15, 12:30
+	base := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	for i, q := range []string{"s0", "s1", "s2"} {
+		_ = st.SaveDiagnostic(base.Add(time.Duration(i)*15*time.Minute).UnixMilli(),
+			"scheduled", "SE3", float64(i), 96, q)
+	}
+	// Query 12:07 → should return s0 (the 12:00 one — it was the
+	// plan driving the EMS at 12:07).
+	got, err := st.LoadDiagnosticAt(base.Add(7 * time.Minute).UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.JSON != "s0" {
+		t.Errorf("at 12:07 expected s0, got %+v", got)
+	}
+	// Query 12:20 → s1.
+	got, _ = st.LoadDiagnosticAt(base.Add(20 * time.Minute).UnixMilli())
+	if got == nil || got.JSON != "s1" {
+		t.Errorf("at 12:20 expected s1, got %+v", got)
+	}
+	// Query before the first snapshot → nil (no plan existed yet).
+	got, _ = st.LoadDiagnosticAt(base.Add(-1 * time.Minute).UnixMilli())
+	if got != nil {
+		t.Errorf("before first snapshot expected nil, got %+v", got)
+	}
+}
+
+func TestLoadDiagnosticsInRangeNewestFirst(t *testing.T) {
+	st := openTestStore(t)
+	base := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		_ = st.SaveDiagnostic(base.Add(time.Duration(i)*15*time.Minute).UnixMilli(),
+			"scheduled", "SE3", float64(i*10), 96, "")
+	}
+	since := base.UnixMilli()
+	until := base.Add(2 * time.Hour).UnixMilli()
+	rows, err := st.LoadDiagnosticsInRange(since, until, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rows))
+	}
+	// Newest first.
+	if rows[0].TsMs <= rows[1].TsMs {
+		t.Errorf("not ordered newest first: %v", rows)
+	}
+	// Limit works.
+	rows, _ = st.LoadDiagnosticsInRange(since, until, 2)
+	if len(rows) != 2 {
+		t.Errorf("limit=2 returned %d rows", len(rows))
+	}
+}
+
+func TestDeleteDiagnosticsBefore(t *testing.T) {
+	st := openTestStore(t)
+	base := time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 10; i++ {
+		_ = st.SaveDiagnostic(base.Add(time.Duration(i)*time.Hour).UnixMilli(),
+			"scheduled", "SE3", 0, 96, "")
+	}
+	cutoff := base.Add(5 * time.Hour).UnixMilli()
+	n, err := st.DeleteDiagnosticsBefore(context.Background(), cutoff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 5 {
+		t.Errorf("DeleteBefore returned n=%d, want 5", n)
+	}
+	rows, _ := st.LoadDiagnosticsInRange(0, base.Add(24*time.Hour).UnixMilli(), 0)
+	if len(rows) != 5 {
+		t.Errorf("after delete expected 5 rows, got %d", len(rows))
+	}
+}
+
+func TestDiagnosticsBeforeBatches(t *testing.T) {
+	st := openTestStore(t)
+	base := time.Date(2026, 4, 18, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 30; i++ {
+		_ = st.SaveDiagnostic(base.Add(time.Duration(i)*time.Hour).UnixMilli(),
+			"scheduled", "SE3", float64(i), 96, "")
+	}
+	cutoff := base.Add(100 * time.Hour).UnixMilli()
+	var visited int
+	err := st.DiagnosticsBefore(context.Background(), cutoff, 8, func(batch []DiagnosticRow) error {
+		visited += len(batch)
+		// Each batch should be monotonic in ts.
+		for i := 1; i < len(batch); i++ {
+			if batch[i].TsMs <= batch[i-1].TsMs {
+				t.Errorf("non-monotonic batch: %v", batch)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if visited != 30 {
+		t.Errorf("visited %d rows, want 30", visited)
+	}
+}
+
+func TestRolloffDiagnosticsToParquet(t *testing.T) {
+	st := openTestStore(t)
+	coldDir := t.TempDir()
+	// Insert 5 rows well before the retention cutoff so they're all
+	// eligible to roll off. DiagnosticsRecentRetention is 30 d; put
+	// them 60 d back.
+	base := time.Now().Add(-60 * 24 * time.Hour).UTC().Truncate(24 * time.Hour)
+	for i := 0; i < 5; i++ {
+		ts := base.Add(time.Duration(i) * 2 * time.Hour).UnixMilli()
+		_ = st.SaveDiagnostic(ts, "scheduled", "SE3", float64(i), 96,
+			`{"idx":`+itoa(i)+`}`)
+	}
+	// Plus one fresh row that must stay.
+	freshTs := time.Now().UnixMilli()
+	_ = st.SaveDiagnostic(freshTs, "scheduled", "SE3", 999, 96, "fresh")
+
+	n, files, err := st.RolloffDiagnosticsToParquet(context.Background(), coldDir)
+	if err != nil {
+		t.Fatalf("Rolloff: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("rolled %d rows, want 5", n)
+	}
+	if len(files) == 0 {
+		t.Error("no parquet files produced")
+	}
+	// Fresh row still queryable.
+	got, _ := st.LoadDiagnosticAt(freshTs)
+	if got == nil {
+		t.Error("fresh row got deleted — rolloff cut too aggressively")
+	}
+	// Old rows are GONE from SQLite.
+	rows, _ := st.LoadDiagnosticsInRange(base.UnixMilli(), base.Add(time.Hour*24).UnixMilli(), 0)
+	if len(rows) != 0 {
+		t.Errorf("old rows still in SQLite: %v", rows)
+	}
+	// Round-trip via cold storage.
+	coldSummaries, err := st.LoadDiagnosticsFromParquet(coldDir,
+		base.UnixMilli(), base.Add(24*time.Hour).UnixMilli())
+	if err != nil {
+		t.Fatalf("LoadDiagnosticsFromParquet: %v", err)
+	}
+	if len(coldSummaries) != 5 {
+		t.Errorf("cold storage returned %d, want 5", len(coldSummaries))
+	}
+	// Full-blob readback.
+	full, err := st.LoadDiagnosticFullFromParquet(coldDir,
+		base.Add(4*time.Hour).UnixMilli())
+	if err != nil {
+		t.Fatalf("LoadDiagnosticFullFromParquet: %v", err)
+	}
+	if full == nil || full.JSON == "" {
+		t.Errorf("cold full-row not returned: %+v", full)
+	}
+}
+
+// itoa — avoid strconv import for a tiny helper in tests.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var buf [12]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/go/internal/state/parquet_diag.go
+++ b/go/internal/state/parquet_diag.go
@@ -1,0 +1,236 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/parquet-go/parquet-go/compress/zstd"
+)
+
+// parquetDiagRow is the column-oriented form of DiagnosticRow. Reason +
+// zone get dictionary-encoded (only a handful of distinct values across
+// thousands of rows). The JSON blob is compressed with zstd alongside.
+type parquetDiagRow struct {
+	TsMs          int64   `parquet:"ts_ms"`
+	Reason        string  `parquet:"reason,dict,zstd"`
+	Zone          string  `parquet:"zone,dict,zstd"`
+	TotalCostOre  float64 `parquet:"total_cost_ore,zstd"`
+	HorizonSlots  int64   `parquet:"horizon_slots,zstd"`
+	JSON          string  `parquet:"json,zstd"`
+}
+
+// RolloffDiagnosticsToParquet exports snapshots older than
+// DiagnosticsRecentRetention into one parquet file per UTC day under
+// <coldDir>/diagnostics/YYYY/MM/DD.parquet, then deletes the rolled-off
+// rows from SQLite. Mirrors RolloffToParquet in structure; the diagnostics
+// live in their own subdirectory so they don't collide with ts_samples
+// files at the cold-storage root.
+//
+// Idempotent: re-running for a day that already has a file rewrites it.
+func (s *Store) RolloffDiagnosticsToParquet(ctx context.Context, coldDir string) (rolledRows int64, files []string, err error) {
+	if coldDir == "" {
+		return 0, nil, fmt.Errorf("RolloffDiagnosticsToParquet: coldDir must be set")
+	}
+	cutoff := time.Now().Add(-DiagnosticsRecentRetention).UnixMilli()
+
+	type dayKey struct{ year, month, day int }
+	byDay := make(map[dayKey][]parquetDiagRow, 4)
+
+	err = s.DiagnosticsBefore(ctx, cutoff, 512, func(batch []DiagnosticRow) error {
+		for _, r := range batch {
+			t := time.UnixMilli(r.TsMs).UTC()
+			k := dayKey{t.Year(), int(t.Month()), t.Day()}
+			byDay[k] = append(byDay[k], parquetDiagRow{
+				TsMs:          r.TsMs,
+				Reason:        r.Reason,
+				Zone:          r.Zone,
+				TotalCostOre:  r.TotalCostOre,
+				HorizonSlots:  int64(r.HorizonSlots),
+				JSON:          r.JSON,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("read diagnostics: %w", err)
+	}
+	if len(byDay) == 0 {
+		return 0, nil, nil
+	}
+
+	diagDir := filepath.Join(coldDir, "diagnostics")
+	for k, rows := range byDay {
+		sort.Slice(rows, func(i, j int) bool { return rows[i].TsMs < rows[j].TsMs })
+		dayDir := filepath.Join(diagDir, fmt.Sprintf("%04d/%02d", k.year, k.month))
+		if err := os.MkdirAll(dayDir, 0o755); err != nil {
+			return rolledRows, files, fmt.Errorf("mkdir %s: %w", dayDir, err)
+		}
+		path := filepath.Join(dayDir, fmt.Sprintf("%02d.parquet", k.day))
+		if err := writeParquetDiagDay(path, rows); err != nil {
+			return rolledRows, files, fmt.Errorf("write %s: %w", path, err)
+		}
+		files = append(files, path)
+		rolledRows += int64(len(rows))
+	}
+
+	// Atomic delete of the rolled-off rows.
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM planner_diagnostics WHERE ts_ms < ?`, cutoff); err != nil {
+		return rolledRows, files, fmt.Errorf("delete rolled diagnostics: %w", err)
+	}
+	return rolledRows, files, nil
+}
+
+func writeParquetDiagDay(path string, rows []parquetDiagRow) error {
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	w := parquet.NewGenericWriter[parquetDiagRow](f,
+		parquet.Compression(&zstd.Codec{Level: zstd.DefaultLevel}))
+	if _, err := w.Write(rows); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := w.Close(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// LoadDiagnosticsFromParquet reads snapshot summaries from cold storage
+// for the given range. Omits the heavy JSON blob — callers that need the
+// full Diagnostic call LoadDiagnosticFullFromParquet with a specific ts.
+func (s *Store) LoadDiagnosticsFromParquet(coldDir string, sinceMs, untilMs int64) ([]DiagnosticSummary, error) {
+	if coldDir == "" {
+		return nil, nil
+	}
+	since := time.UnixMilli(sinceMs).UTC()
+	until := time.UnixMilli(untilMs).UTC()
+	out := make([]DiagnosticSummary, 0, 64)
+	diagDir := filepath.Join(coldDir, "diagnostics")
+	for d := since; !d.After(until); d = d.AddDate(0, 0, 1) {
+		path := filepath.Join(diagDir,
+			fmt.Sprintf("%04d/%02d/%02d.parquet", d.Year(), int(d.Month()), d.Day()))
+		f, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return out, err
+		}
+		stat, err := f.Stat()
+		if err != nil {
+			f.Close()
+			return out, err
+		}
+		pf, err := parquet.OpenFile(f, stat.Size())
+		if err != nil {
+			f.Close()
+			return out, err
+		}
+		reader := parquet.NewGenericReader[parquetDiagRow](pf)
+		buf := make([]parquetDiagRow, 256)
+		for {
+			n, rerr := reader.Read(buf)
+			for i := 0; i < n; i++ {
+				r := buf[i]
+				if r.TsMs < sinceMs || r.TsMs > untilMs {
+					continue
+				}
+				out = append(out, DiagnosticSummary{
+					TsMs:         r.TsMs,
+					Reason:       r.Reason,
+					Zone:         r.Zone,
+					TotalCostOre: r.TotalCostOre,
+					HorizonSlots: int(r.HorizonSlots),
+				})
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		reader.Close()
+		f.Close()
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TsMs < out[j].TsMs })
+	return out, nil
+}
+
+// LoadDiagnosticFullFromParquet returns the single snapshot whose ts_ms
+// is closest to and ≤ the given ts. Used when the UI clicks a point in
+// cold storage and wants the full JSON blob.
+func (s *Store) LoadDiagnosticFullFromParquet(coldDir string, tsMs int64) (*DiagnosticRow, error) {
+	if coldDir == "" {
+		return nil, nil
+	}
+	// Look in the target day's file first; fall back to earlier days
+	// when the target day has no rows ≤ tsMs.
+	t := time.UnixMilli(tsMs).UTC()
+	diagDir := filepath.Join(coldDir, "diagnostics")
+	for i := 0; i < 30; i++ { // scan up to 30 days back
+		d := t.AddDate(0, 0, -i)
+		path := filepath.Join(diagDir,
+			fmt.Sprintf("%04d/%02d/%02d.parquet", d.Year(), int(d.Month()), d.Day()))
+		f, err := os.Open(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		stat, _ := f.Stat()
+		pf, err := parquet.OpenFile(f, stat.Size())
+		if err != nil {
+			f.Close()
+			return nil, err
+		}
+		reader := parquet.NewGenericReader[parquetDiagRow](pf)
+		buf := make([]parquetDiagRow, 256)
+		var best *parquetDiagRow
+		for {
+			n, rerr := reader.Read(buf)
+			for j := 0; j < n; j++ {
+				r := buf[j]
+				if r.TsMs > tsMs {
+					continue
+				}
+				if best == nil || r.TsMs > best.TsMs {
+					cp := r
+					best = &cp
+				}
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		reader.Close()
+		f.Close()
+		if best != nil {
+			return &DiagnosticRow{
+				DiagnosticSummary: DiagnosticSummary{
+					TsMs:         best.TsMs,
+					Reason:       best.Reason,
+					Zone:         best.Zone,
+					TotalCostOre: best.TotalCostOre,
+					HorizonSlots: int(best.HorizonSlots),
+				},
+				JSON: best.JSON,
+			}, nil
+		}
+	}
+	return nil, nil
+}

--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -172,6 +172,25 @@ func (s *Store) migrate() error {
 			last_seen_ms  INTEGER NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_devices_name ON devices(driver_name)`,
+
+		// ---- Planner diagnostics (one snapshot per replan) ----
+		// Persists the full structured output of mpc.Service.Diagnose() so
+		// operators can time-travel: load any past moment and see what the
+		// DP saw + what it decided + why. Denormalized total_cost_ore +
+		// horizon_slots so the timeline UI can render summary rows without
+		// unmarshalling every JSON blob.
+		//
+		// Retention: DiagnosticsRecentRetention (30 d) in SQLite; older
+		// rows roll off to <coldDir>/diagnostics/YYYY/MM/DD.parquet via
+		// RolloffDiagnosticsToParquet.
+		`CREATE TABLE IF NOT EXISTS planner_diagnostics (
+			ts_ms          INTEGER PRIMARY KEY NOT NULL,
+			reason         TEXT    NOT NULL,
+			zone           TEXT    NOT NULL,
+			total_cost_ore REAL    NOT NULL,
+			horizon_slots  INTEGER NOT NULL,
+			json           TEXT    NOT NULL
+		) STRICT`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.Exec(stmt); err != nil {


### PR DESCRIPTION
## Summary

After v0.17.1, Erik immediately asked a question we couldn't answer from the live dashboard: *"why did grid import at 02:00 last night when I thought I was in self-consumption?"*

Right now the MPC's only observability for a past moment is `/api/mpc/plan` — which shows the **current** plan. Anything older is gone: compute a plan, cache in memory, overwrite on next replan. Operators cannot time-travel.

This PR lands the **backend half** of the fix. PR-B (follow-up) will add the UI tab.

## What changes

- **New SQLite table** `planner_diagnostics(ts_ms PRIMARY KEY, reason, zone, total_cost_ore, horizon_slots, json)` — one row per replan (~100/day, ~18 KB each).
- **`Service.SaveDiag` hook** fires after every successful replan, best-effort (error logs and continues, never blocks planning).
- **30-day hot retention** in SQLite, then daily Parquet rolloff to `<coldDir>/diagnostics/YYYY/MM/DD.parquet` — mirrors the existing `ts_samples → parquet` pipeline in structure.
- **`GET /api/mpc/diagnose/history?since=<ms>&until=<ms>&limit=<n>`** — lightweight summaries (no JSON blobs) for the timeline UI.
- **`GET /api/mpc/diagnose/at?ts=<ms>`** — full diagnostic for the snapshot that was active at that instant (largest `ts_ms ≤ query`). This is the correct "what plan was driving the EMS at that moment?" semantics — 02:07 returns the 02:00 replan, not the 02:15 one.
- **Cold-storage fallback** — both endpoints transparently read from parquet when the requested window extends past SQLite retention. No separate code path.

## Storage math

- Hot: ~18 KB × 100/day × 30 d ≈ 52 MB — trivial for a Pi.
- Cold: parquet with zstd + dict-encoded strings gives ~3-5× compression → ~12 MB/month per site.

## Tests

| Layer | Tests |
|---|---|
| `state` | SaveDiagnostic upsert, LoadDiagnosticAt closest-earlier, LoadDiagnosticsInRange newest-first ordering, DeleteDiagnosticsBefore, DiagnosticsBefore batch pagination, RolloffDiagnosticsToParquet (rows move, old deleted, fresh preserved, parquet round-trip reads) |
| `mpc` | TestReplanCallsSaveDiag (hook fires with correct payload + reason), TestReplanWithoutSaveDiagDoesNotPanic (nil hook safe) |
| Suite | `go test ./...` incl. e2e (27 s) — all green |

## Manual smoke plan

After one hour of operation on a Pi:

```bash
sqlite3 state.db "SELECT ts_ms, reason, total_cost_ore FROM planner_diagnostics ORDER BY ts_ms DESC LIMIT 10;"
curl 'localhost:8080/api/mpc/diagnose/history?since=0' | jq '.snapshots | length'
curl 'localhost:8080/api/mpc/diagnose/at?ts=<ms>' | jq '.snapshot.diagnostic.slots[0]'
```

## What's next — PR-B

Will refactor `web/index.html` into a tab shell (`Live | Diagnose`), add a `diagnose.js` timeline + detail pane, and overlay actual vs. planned for each past slot so divergence becomes visible at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)