### PR TITLE
feat(ui): Diagnose tab — time-travel through persisted planner snapshots (PR-B)

### DIFF
--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -1,0 +1,408 @@
+// diagnose.js — time-travel through persisted planner snapshots.
+//
+// Listens to hash routing:
+//   #live                 → show Live view (default)
+//   #diagnose             → show Diagnose, no specific snapshot selected
+//   #diagnose/<ts_ms>     → show Diagnose and load that snapshot's detail
+//
+// Fetches from /api/mpc/diagnose/history for the timeline list and
+// /api/mpc/diagnose/at?ts=<ms> for the detail pane. Persistence lands
+// in SQLite planner_diagnostics + parquet cold storage — see PR-A.
+//
+// The detail canvas chart is intentionally simpler than plan.js — just
+// a stacked band of price + battery + grid + EV power + SoC so the
+// operator can eyeball "what did the DP decide each slot and why".
+
+(function () {
+  'use strict';
+
+  // ---- Tab routing ----
+  const tabs = document.getElementById('app-tabs');
+  const viewLive = document.getElementById('view-live');
+  const viewDiag = document.getElementById('view-diagnose');
+
+  function applyHash() {
+    const h = (location.hash || '#live').replace(/^#/, '');
+    const parts = h.split('/');
+    const view = parts[0] === 'diagnose' ? 'diagnose' : 'live';
+    viewLive.classList.toggle('hidden', view !== 'live');
+    viewDiag.classList.toggle('hidden', view !== 'diagnose');
+    if (tabs) {
+      tabs.querySelectorAll('.tab-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.view === view);
+      });
+    }
+    if (view === 'diagnose') {
+      state.selectedTs = parts[1] ? Number(parts[1]) : null;
+      loadTimeline().then(() => {
+        if (state.selectedTs) loadDetail(state.selectedTs);
+        else if (state.timeline.length > 0) {
+          // Default selection: newest snapshot, update hash without
+          // pushing history so "back" still returns to Live.
+          const ts = state.timeline[0].ts_ms;
+          history.replaceState(null, '', '#diagnose/' + ts);
+          loadDetail(ts);
+        }
+      });
+    }
+  }
+
+  if (tabs) {
+    tabs.addEventListener('click', (e) => {
+      const b = e.target.closest('.tab-btn');
+      if (!b) return;
+      location.hash = b.dataset.view === 'diagnose' ? '#diagnose' : '#live';
+    });
+  }
+  window.addEventListener('hashchange', applyHash);
+
+  // ---- Data state ----
+  const state = {
+    timeline: [],      // [{ts_ms, reason, zone, total_cost_ore, horizon_slots}]
+    selectedTs: null,  // currently loaded snapshot
+    detail: null,      // full snapshot object
+    rangeMs: 24 * 3600 * 1000,
+  };
+
+  const rangeSelect = document.getElementById('diagnose-range-select');
+  if (rangeSelect) {
+    rangeSelect.addEventListener('change', () => {
+      state.rangeMs = parseRange(rangeSelect.value);
+      loadTimeline();
+    });
+  }
+  const refreshBtn = document.getElementById('diagnose-refresh');
+  if (refreshBtn) refreshBtn.addEventListener('click', () => loadTimeline());
+
+  function parseRange(v) {
+    const map = { '1h': 3600e3, '6h': 6 * 3600e3, '24h': 86400e3,
+                  '7d': 7 * 86400e3, '30d': 30 * 86400e3 };
+    return map[v] || 86400e3;
+  }
+
+  // ---- Timeline fetch + render ----
+  async function loadTimeline() {
+    const until = Date.now();
+    const since = until - state.rangeMs;
+    try {
+      const r = await fetch(`/api/mpc/diagnose/history?since=${since}&until=${until}&limit=2000`);
+      const j = await r.json();
+      state.timeline = (j && j.snapshots) || [];
+      renderTimeline();
+    } catch (e) {
+      const el = document.getElementById('diagnose-timeline');
+      if (el) el.innerHTML = `<div class="diagnose-empty">Error loading: ${escapeHtml(e.message)}</div>`;
+    }
+    const meta = document.getElementById('diagnose-meta');
+    if (meta) meta.textContent = state.timeline.length + ' snapshot' +
+      (state.timeline.length === 1 ? '' : 's');
+  }
+
+  function renderTimeline() {
+    const el = document.getElementById('diagnose-timeline');
+    if (!el) return;
+    if (state.timeline.length === 0) {
+      el.innerHTML = '<div class="diagnose-empty">No snapshots in range.</div>';
+      return;
+    }
+    const rows = state.timeline.map(s => {
+      const cls = 'diag-row diag-reason-' + reasonClass(s.reason);
+      const active = s.ts_ms === state.selectedTs ? ' active' : '';
+      return `<button class="${cls}${active}" data-ts="${s.ts_ms}">
+        <span class="diag-row-time">${fmtHHMM(s.ts_ms)} <span class="diag-row-date">${fmtMonthDay(s.ts_ms)}</span></span>
+        <span class="diag-row-reason">${escapeHtml(s.reason)}</span>
+        <span class="diag-row-cost">${Math.round(s.total_cost_ore)} öre · ${s.horizon_slots} slots</span>
+      </button>`;
+    }).join('');
+    el.innerHTML = rows;
+    el.querySelectorAll('.diag-row').forEach(b => {
+      b.addEventListener('click', () => {
+        const ts = Number(b.dataset.ts);
+        location.hash = '#diagnose/' + ts;
+      });
+    });
+  }
+
+  function reasonClass(r) {
+    if (r === 'scheduled') return 'scheduled';
+    if (r === 'reactive-pv') return 'reactive-pv';
+    if (r === 'reactive-load') return 'reactive-load';
+    if (r === 'manual') return 'manual';
+    return 'unknown';
+  }
+
+  // ---- Detail fetch + render ----
+  async function loadDetail(tsMs) {
+    state.selectedTs = tsMs;
+    const el = document.getElementById('diagnose-detail');
+    if (el) el.innerHTML = '<div class="diagnose-empty">Loading snapshot…</div>';
+    renderTimeline();  // refresh "active" class
+    try {
+      const r = await fetch('/api/mpc/diagnose/at?ts=' + tsMs);
+      const j = await r.json();
+      if (!j || !j.snapshot) {
+        if (el) el.innerHTML = '<div class="diagnose-empty">Snapshot not found.</div>';
+        return;
+      }
+      state.detail = j.snapshot;
+      renderDetail();
+    } catch (e) {
+      if (el) el.innerHTML = `<div class="diagnose-empty">Error: ${escapeHtml(e.message)}</div>`;
+    }
+  }
+
+  function renderDetail() {
+    const s = state.detail;
+    if (!s) return;
+    const d = s.diagnostic;
+    const el = document.getElementById('diagnose-detail');
+    if (!el) return;
+    // Header metadata
+    const ageMin = Math.round((Date.now() - s.ts_ms) / 60000);
+    const params = d.params || {};
+    const lpActive = d.slots && d.slots.some(x => x.loadpoint_w);
+    const header = `
+      <div class="diagnose-detail-header">
+        <div>
+          <div class="detail-title">Plan @ ${fmtDateTime(s.ts_ms)}</div>
+          <div class="detail-sub">
+            <span class="diag-reason-${reasonClass(s.reason)} diag-pill">${escapeHtml(s.reason)}</span>
+            zone <b>${escapeHtml(s.zone)}</b> ·
+            ${s.horizon_slots} slots ·
+            expected ${Math.round(s.total_cost_ore)} öre ·
+            ${ageMin} min ago
+          </div>
+        </div>
+        <div class="detail-params">
+          <span title="Mode"><b>${escapeHtml(params.mode || '—')}</b></span>
+          <span title="Initial SoC">SoC start ${params.initial_soc_pct != null ? params.initial_soc_pct.toFixed(1) : '—'}%</span>
+          <span title="Battery capacity">${params.capacity_wh ? (params.capacity_wh/1000).toFixed(1)+' kWh' : ''}</span>
+          ${lpActive ? '<span class="diag-pill diag-ev">EV in plan</span>' : ''}
+        </div>
+      </div>
+      <div class="diagnose-chart-wrap">
+        <canvas id="diag-chart" height="320"></canvas>
+      </div>
+      <div class="diagnose-table-wrap">
+        <table class="diag-table">
+          <thead>
+            <tr>
+              <th>#</th><th>Time</th>
+              <th>Price</th><th>Spot</th><th>Conf</th>
+              <th>PV</th><th>Load</th>
+              <th>Battery</th><th>Grid</th><th>SoC end</th>
+              ${lpActive ? '<th>EV W</th><th>EV SoC</th>' : ''}
+              <th>Cost</th><th>Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${(d.slots || []).map((sl, i) => slotRow(sl, i, lpActive)).join('')}
+          </tbody>
+        </table>
+      </div>
+    `;
+    el.innerHTML = header;
+    drawChart(d);
+  }
+
+  function slotRow(sl, i, lpActive) {
+    const conf = sl.confidence != null ? sl.confidence.toFixed(2) : '—';
+    const confCls = sl.confidence < 0.9 ? 'conf-low' : '';
+    const gridCls = sl.grid_w > 0 ? 'val-import' : (sl.grid_w < 0 ? 'val-export' : 'val-neutral');
+    const batCls = sl.battery_w > 0 ? 'val-charging' : (sl.battery_w < 0 ? 'val-discharging' : 'val-neutral');
+    return `<tr>
+      <td>${sl.idx}</td>
+      <td>${fmtHHMM(sl.slot_start_ms)}</td>
+      <td>${fmt1(sl.price_ore)}</td>
+      <td>${fmt1(sl.spot_ore)}</td>
+      <td class="${confCls}">${conf}</td>
+      <td class="val-generation">${fmtW(sl.pv_w)}</td>
+      <td>${fmtW(sl.load_w)}</td>
+      <td class="${batCls}">${fmtW(sl.battery_w)}</td>
+      <td class="${gridCls}">${fmtW(sl.grid_w)}</td>
+      <td>${fmt1(sl.soc_pct)}%</td>
+      ${lpActive ? `<td>${fmtW(sl.loadpoint_w || 0)}</td><td>${fmt1(sl.loadpoint_soc_pct || 0)}%</td>` : ''}
+      <td>${fmt1(sl.cost_ore)}</td>
+      <td class="diag-reason-cell">${escapeHtml(sl.reason || '')}</td>
+    </tr>`;
+  }
+
+  // ---- Chart: stacked bands for price / power / SoC ----
+  function drawChart(d) {
+    const canvas = document.getElementById('diag-chart');
+    if (!canvas || !d.slots || d.slots.length === 0) return;
+    const dpr = window.devicePixelRatio || 1;
+    const cssW = canvas.clientWidth || 800;
+    const cssH = 320;
+    canvas.width = cssW * dpr;
+    canvas.height = cssH * dpr;
+    canvas.style.width = cssW + 'px';
+    canvas.style.height = cssH + 'px';
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const pad = { t: 16, r: 40, b: 24, l: 44 };
+    const plotW = cssW - pad.l - pad.r;
+    const plotH = cssH - pad.t - pad.b;
+
+    const slots = d.slots;
+    const nSlots = slots.length;
+    const barW = Math.max(1, plotW / nSlots);
+
+    // Three horizontal bands: top third = price, middle third = power, bottom third = SoC
+    const priceH = plotH * 0.30;
+    const powerH = plotH * 0.45;
+    const socH = plotH * 0.25;
+    const priceY0 = pad.t;
+    const powerY0 = pad.t + priceH;
+    const socY0 = pad.t + priceH + powerH;
+
+    // Price scale
+    let maxPrice = 1;
+    slots.forEach(s => { if (s.price_ore > maxPrice) maxPrice = s.price_ore; });
+    // Power scale — symmetric around 0
+    let maxAbsPower = 1;
+    slots.forEach(s => {
+      [s.grid_w || 0, s.battery_w || 0, s.pv_w || 0, s.load_w || 0, s.loadpoint_w || 0]
+        .forEach(v => { if (Math.abs(v) > maxAbsPower) maxAbsPower = Math.abs(v); });
+    });
+
+    // Background bands
+    ctx.fillStyle = 'rgba(255,255,255,0.02)';
+    ctx.fillRect(pad.l, priceY0, plotW, priceH);
+    ctx.fillRect(pad.l, socY0, plotW, socH);
+
+    // Price bars — green cheap, red expensive (relative to horizon mean)
+    const priceMean = slots.reduce((a, s) => a + s.price_ore, 0) / nSlots;
+    slots.forEach((s, i) => {
+      const x = pad.l + i * barW;
+      const h = (s.price_ore / maxPrice) * priceH;
+      const y = priceY0 + priceH - h;
+      // Cheap slots (below mean) in green, expensive in red, low-confidence dimmed
+      const alpha = s.confidence < 0.9 ? 0.35 : 0.75;
+      ctx.fillStyle = s.price_ore < priceMean
+        ? `rgba(34,197,94,${alpha})`
+        : `rgba(239,68,68,${alpha})`;
+      ctx.fillRect(x, y, barW, h);
+    });
+
+    // Power zero line
+    const powerMidY = powerY0 + powerH / 2;
+    ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(pad.l, powerMidY);
+    ctx.lineTo(pad.l + plotW, powerMidY);
+    ctx.stroke();
+
+    // Battery + EV (stacked positive = load on site, negative = source)
+    const powerScale = (powerH / 2) / maxAbsPower;
+    slots.forEach((s, i) => {
+      const x = pad.l + i * barW;
+      // Battery — orange charge up, purple discharge down
+      const bw = s.battery_w || 0;
+      if (bw !== 0) {
+        const h = bw * powerScale;
+        ctx.fillStyle = bw > 0 ? 'rgba(245,158,11,0.75)' : 'rgba(139,92,246,0.75)';
+        ctx.fillRect(x, powerMidY - h, barW, h);
+      }
+      // EV — stacked atop battery when both charging
+      const ew = s.loadpoint_w || 0;
+      if (ew > 0) {
+        const bh = (bw > 0 ? bw : 0) * powerScale;
+        const h = ew * powerScale;
+        ctx.fillStyle = 'rgba(6,182,212,0.75)';
+        ctx.fillRect(x, powerMidY - bh - h, barW, h);
+      }
+    });
+
+    // Grid line — overlay
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    slots.forEach((s, i) => {
+      const x = pad.l + i * barW + barW / 2;
+      const y = powerMidY - (s.grid_w || 0) * powerScale;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // PV line — green, negative is pulled up visually (PV is −W site sign)
+    ctx.strokeStyle = '#22c55e';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    slots.forEach((s, i) => {
+      const x = pad.l + i * barW + barW / 2;
+      const y = powerMidY - (s.pv_w || 0) * powerScale;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // SoC line — blue, in bottom band
+    ctx.strokeStyle = '#60a5fa';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    slots.forEach((s, i) => {
+      const x = pad.l + i * barW + barW / 2;
+      const y = socY0 + socH - ((s.soc_pct || 0) / 100) * socH;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+
+    // Y-axis labels
+    ctx.fillStyle = '#94a3b8';
+    ctx.font = '10px system-ui, -apple-system, sans-serif';
+    ctx.textAlign = 'right';
+    ctx.fillText(maxPrice.toFixed(0) + 'ö', pad.l - 4, priceY0 + 10);
+    ctx.fillText('0', pad.l - 4, priceY0 + priceH - 2);
+    ctx.fillText('+' + (maxAbsPower / 1000).toFixed(1) + 'kW', pad.l - 4, powerY0 + 10);
+    ctx.fillText('0', pad.l - 4, powerMidY + 3);
+    ctx.fillText('−' + (maxAbsPower / 1000).toFixed(1) + 'kW', pad.l - 4, powerY0 + powerH - 2);
+    ctx.fillText('100%', pad.l - 4, socY0 + 10);
+    ctx.fillText('0', pad.l - 4, socY0 + socH - 2);
+
+    // X-axis time labels — every 6th slot
+    ctx.textAlign = 'center';
+    for (let i = 0; i < nSlots; i += Math.max(1, Math.floor(nSlots / 8))) {
+      const x = pad.l + i * barW + barW / 2;
+      ctx.fillText(fmtHHMM(slots[i].slot_start_ms), x, cssH - 6);
+    }
+  }
+
+  // ---- Helpers ----
+  function fmtHHMM(ts) {
+    const d = new Date(ts);
+    return d.getHours().toString().padStart(2, '0') + ':' +
+      d.getMinutes().toString().padStart(2, '0');
+  }
+  function fmtMonthDay(ts) {
+    const d = new Date(ts);
+    return (d.getMonth() + 1) + '/' + d.getDate();
+  }
+  function fmtDateTime(ts) {
+    const d = new Date(ts);
+    return d.toLocaleString();
+  }
+  function fmt1(n) {
+    if (n == null) return '—';
+    return n.toFixed(1);
+  }
+  function fmtW(w) {
+    if (w == null) return '—';
+    if (Math.abs(w) >= 1000) return (w / 1000).toFixed(2) + ' kW';
+    return w.toFixed(0) + ' W';
+  }
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    })[c]);
+  }
+
+  // ---- Boot ----
+  // Apply hash on load so refreshing the page keeps you on Diagnose.
+  applyHash();
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -16,6 +16,10 @@
 <body>
   <header>
     <img src="/logo.jpg" alt="42W" class="header-logo"><h1>42W</h1>
+    <nav class="app-tabs" id="app-tabs" role="tablist">
+      <button data-view="live" class="tab-btn active" role="tab">Live</button>
+      <button data-view="diagnose" class="tab-btn" role="tab" title="Time-travel through past planner decisions">Diagnose</button>
+    </nav>
     <div class="header-right">
       <button id="ui-mode-toggle" class="btn-link" title="Show advanced controls + diagnostics">Advanced</button>
       <button id="settings-btn" class="settings-btn" title="Settings">⚙</button>
@@ -50,7 +54,7 @@
     </div>
   </div>
 
-  <main>
+  <main id="view-live">
     <!-- Summary Cards — compact 5-in-a-row -->
     <section class="summary-cards">
       <div class="card summary-card" id="card-grid">
@@ -251,6 +255,42 @@
     </section>
   </main>
 
+  <!-- Diagnose view — time-travel through persisted planner snapshots -->
+  <main id="view-diagnose" class="hidden">
+    <section class="diagnose-header">
+      <div class="diagnose-header-row">
+        <div class="diagnose-title">
+          <h2>Diagnose</h2>
+          <span class="plan-summary" id="diagnose-meta">—</span>
+        </div>
+        <div class="diagnose-range">
+          <label>Range:
+            <select id="diagnose-range-select">
+              <option value="1h">Last 1h</option>
+              <option value="6h">Last 6h</option>
+              <option value="24h" selected>Last 24h</option>
+              <option value="7d">Last 7d</option>
+              <option value="30d">Last 30d</option>
+            </select>
+          </label>
+          <button id="diagnose-refresh" class="btn-send" title="Reload snapshots">↻</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="diagnose-body">
+      <!-- Left: timeline of replans -->
+      <aside class="diagnose-timeline" id="diagnose-timeline">
+        <div class="diagnose-empty">Loading snapshots…</div>
+      </aside>
+
+      <!-- Right: detail pane for selected snapshot -->
+      <section class="diagnose-detail" id="diagnose-detail">
+        <div class="diagnose-empty">Select a snapshot from the timeline to inspect what the planner saw and decided.</div>
+      </section>
+    </section>
+  </main>
+
   <!-- Self-tune Modal -->
   <div id="self-tune-modal" class="modal hidden">
     <div class="modal-content" style="max-width:520px">
@@ -293,11 +333,12 @@
     </div>
   </div>
 
-  <script src="/app.js?v=de88f43m"></script>
-  <script src="/settings.js?v=de88f43m"></script>
-  <script src="/models.js?v=de88f43m"></script>
-  <script src="/plan.js?v=de88f43m"></script>
-  <script src="/twins.js?v=de88f43m"></script>
+  <script src="/app.js?v=diag1"></script>
+  <script src="/settings.js?v=diag1"></script>
+  <script src="/models.js?v=diag1"></script>
+  <script src="/plan.js?v=diag1"></script>
+  <script src="/twins.js?v=diag1"></script>
+  <script src="/diagnose.js?v=diag1"></script>
   <script>
     <!-- Status bar — always visible at bottom -->
     <footer class="status-bar" id="status-bar">

--- a/web/style.css
+++ b/web/style.css
@@ -76,6 +76,220 @@ header h1 {
   color: var(--red);
 }
 
+/* ---- Top-level tab nav (Live | Diagnose) ---- */
+.app-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: 1.5rem;
+  flex: 1;
+}
+.tab-btn {
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.tab-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+}
+.tab-btn.active {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--border);
+}
+
+/* ---- Diagnose view ---- */
+#view-diagnose {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  min-height: calc(100vh - 120px);
+}
+#view-diagnose.hidden { display: none; }
+
+.diagnose-header {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+.diagnose-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.diagnose-title { display: flex; align-items: baseline; gap: 0.75rem; }
+.diagnose-title h2 { font-size: 1rem; font-weight: 600; }
+.diagnose-range { display: flex; align-items: center; gap: 0.5rem; }
+.diagnose-range label { font-size: 0.85rem; color: var(--text-dim); }
+.diagnose-range select {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.diagnose-body {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.diagnose-timeline {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow-y: auto;
+  max-height: calc(100vh - 220px);
+}
+.diagnose-empty {
+  padding: 1rem;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+.diag-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 0.15rem 0.5rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: background 0.1s;
+}
+.diag-row:hover { background: rgba(255,255,255,0.03); }
+.diag-row.active { background: rgba(96,165,250,0.12); border-left: 3px solid #60a5fa; padding-left: calc(0.75rem - 3px); }
+.diag-row-time { font-weight: 600; }
+.diag-row-date { color: var(--text-dim); font-weight: 400; font-size: 0.7rem; }
+.diag-row-reason {
+  grid-column: 2;
+  grid-row: 1;
+  text-align: right;
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(255,255,255,0.05);
+}
+.diag-row-cost {
+  grid-column: 1 / span 2;
+  grid-row: 2;
+  color: var(--text-dim);
+  font-size: 0.7rem;
+}
+
+/* reason colour stripes */
+.diag-reason-scheduled .diag-row-reason,
+.diag-reason-scheduled.diag-pill { background: rgba(148,163,184,0.18); color: #cbd5e1; }
+.diag-reason-reactive-pv .diag-row-reason,
+.diag-reason-reactive-pv.diag-pill { background: rgba(251,146,60,0.20); color: #fdba74; }
+.diag-reason-reactive-load .diag-row-reason,
+.diag-reason-reactive-load.diag-pill { background: rgba(250,204,21,0.20); color: #facc15; }
+.diag-reason-manual .diag-row-reason,
+.diag-reason-manual.diag-pill { background: rgba(96,165,250,0.20); color: #93c5fd; }
+.diag-reason-unknown .diag-row-reason,
+.diag-reason-unknown.diag-pill { background: rgba(148,163,184,0.12); color: #94a3b8; }
+
+.diag-pill {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-right: 0.4rem;
+}
+.diag-ev { background: rgba(6,182,212,0.18); color: #67e8f9; }
+
+/* Detail pane */
+.diagnose-detail {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.diagnose-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.detail-title { font-size: 0.95rem; font-weight: 600; }
+.detail-sub { font-size: 0.8rem; color: var(--text-dim); margin-top: 0.2rem; }
+.detail-params { display: flex; gap: 0.75rem; font-size: 0.8rem; color: var(--text-dim); align-items: center; flex-wrap: wrap; }
+.detail-params b { color: var(--text); }
+
+.diagnose-chart-wrap {
+  padding: 0.5rem 1rem;
+}
+.diagnose-chart-wrap canvas { width: 100%; }
+
+.diagnose-table-wrap {
+  flex: 1;
+  overflow: auto;
+  padding: 0 0.5rem 1rem 0.5rem;
+}
+.diag-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+.diag-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  color: var(--text-dim);
+  font-weight: 500;
+  text-align: right;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.diag-table thead th:nth-child(-n+2),
+.diag-table thead th:last-child { text-align: left; }
+.diag-table td {
+  padding: 0.25rem 0.5rem;
+  text-align: right;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.diag-table td:nth-child(-n+2),
+.diag-table td:last-child { text-align: left; }
+.diag-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+.diag-reason-cell { color: var(--text-dim); white-space: nowrap; max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
+.conf-low { color: #fde68a; }
+
+@media (max-width: 900px) {
+  .diagnose-body { grid-template-columns: 1fr; }
+  .diagnose-timeline { max-height: 260px; }
+  .app-tabs { margin-left: 0.5rem; }
+}
+
 /* ---- Setup banner (bootstrap / no-config) ---- */
 .setup-banner {
   background: rgba(245, 158, 11, 0.15);


### PR DESCRIPTION
## Summary

Consumes the backend from #104. New top-level **Diagnose** tab beside Live, so operators can scrub through past replans and answer "why did the planner decide X at 02:00 last night?" from a browser instead of curl-piping jq.

## Layout

```
┌──────────────────────────────────────────────────────────────┐
│ 42W        [Live] [Diagnose]               Advanced · ⚙ · ● │
├──────────────────────────────────────────────────────────────┤
│ Diagnose  N snapshots        Range: [Last 24h ▼]      [↻]   │
├──────────────────┬───────────────────────────────────────────┤
│ 10:14 scheduled  │ Plan @ 2026-04-18 10:14:01                │
│   193 slots ·    │ [scheduled] zone SE4 · 193 slots · 18597ö │
│   18597ö         │ mode: cheap_charge · SoC start 50.0% ·    │
│                  │ 99.8 kWh                                  │
│ 09:59 scheduled  │ ┌───────────────────────────────────────┐ │
│   193 slots ·    │ │ Price bars (green cheap, red pricey)  │ │
│   18597ö         │ │ Battery + EV (orange↑ / purple↓)      │ │
│                  │ │ Grid line (red) · PV line (green)     │ │
│ ...              │ │ SoC trajectory (blue) bottom band     │ │
│                  │ └───────────────────────────────────────┘ │
│                  │ Per-slot table: idx time price spot conf │
│                  │                 PV load bat grid SoC EV  │
│                  │                 cost reason               │
└──────────────────┴───────────────────────────────────────────┘
```

## Routing & UX

- `#live` (default), `#diagnose`, `#diagnose/<ts_ms>` — hash-routing makes snapshots **deep-linkable**. Paste `/#diagnose/1776498221028` in a bug report, reviewer lands on the exact replan you're talking about.
- First visit auto-selects newest snapshot (you always see something).
- Timeline is color-coded by trigger reason: scheduled grey, reactive-pv orange, reactive-load yellow, manual blue — makes it trivial to spot "which replan was triggered by a divergence event".
- Range picker + refresh — one `/history` call on change, one `/at` call per selection. No background polling on this tab; zero extra API pressure when not actively browsing.

## Chart detail

- **Price band** (top 30%): bars scaled to max price, **green if below horizon mean / red if above**, dimmed alpha for confidence < 0.9 (forecasted vs day-ahead).
- **Power band** (middle 45%): bars symmetric around 0, battery charge (+) orange up, discharge (−) purple down, **EV power stacked on top in teal** when loadpoint is active. Grid flow overlaid as a red line so it's easy to spot "grid covered the gap" moments. PV as a green line below zero.
- **SoC band** (bottom 25%): the plan's expected SoC trajectory in blue.

## What it does NOT yet do (intentionally deferred)

- Overlay of **actual** telemetry vs plan — the backend supports it via `/api/series`, but this MVP shows only what the planner *expected*. Will be a follow-up once operators tell us where the divergences actually matter most.
- Auto-refresh of the timeline when a new replan lands. Manual refresh for now; polling would be overkill for the 15-min replan cadence.
- Diff highlighting between adjacent snapshots.

## Files

| File | Change |
|---|---|
| `web/index.html` | Added `<nav class="app-tabs">`; wrapped existing content in `<main id="view-live">`; new `<main id="view-diagnose" class="hidden">` with header/timeline/detail layout |
| `web/diagnose.js` | 408 LOC — tab routing, `/history` + `/at` fetch, canvas chart, table renderer. Self-contained IIFE, no framework |
| `web/style.css` | +214 LOC — tab nav, Diagnose grid layout, reason color stripes, table styling |

## Test plan

- [x] Local boot + 3 sample snapshots in SQLite via `make dev`-style run
- [x] `/#diagnose` loads, picks newest snapshot, renders chart + table
- [x] Clicking older row updates hash + re-renders detail
- [x] Deep-link `/#diagnose/<ts>` pre-selects on page load
- [x] Range selector re-fetches with correct `since`/`until` params
- [x] `/#live` returns to Live, polling resumes unaffected
- [x] `go build + test` clean including e2e
- [ ] @erikarenhill: after deploy, open `/` → switch to Diagnose → confirm timeline shows last few replans from his system

## Follow-ups

- Plan-vs-actual overlay via `/api/series`
- Diff between adjacent snapshots ("slot 14 changed: charge → idle")
- Per-replan "forced replan" button for retroactive what-if

🤖 Generated with [Claude Code](https://claude.com/claude-code)