### PR TITLE
fix(diagnose): Codex review follow-ups on #104 + #105 (P1+P2)

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1150,7 +1151,11 @@ func (s *Server) handleMPCDiagnoseHistory(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// If the query window extends before the SQLite retention and we
-	// have a cold-storage root configured, top up with Parquet.
+	// have a cold-storage root configured, top up with Parquet. After
+	// merging we re-sort newest-first and re-apply the caller's limit
+	// so the combined response honours the same contract as the
+	// pure-hot path (otherwise cold rows would append at the tail and
+	// break the "newest first" promise + could overshoot `limit`).
 	coldDir := s.deps.ColdDir
 	if coldDir != "" {
 		hotCutoff := now - int64(state.DiagnosticsRecentRetention/time.Millisecond)
@@ -1160,8 +1165,14 @@ func (s *Server) handleMPCDiagnoseHistory(w http.ResponseWriter, r *http.Request
 				coldUntil = until
 			}
 			cold, cerr := s.deps.State.LoadDiagnosticsFromParquet(coldDir, since, coldUntil)
-			if cerr == nil {
+			if cerr == nil && len(cold) > 0 {
 				summaries = append(summaries, cold...)
+				sort.Slice(summaries, func(i, j int) bool {
+					return summaries[i].TsMs > summaries[j].TsMs
+				})
+				if limit > 0 && len(summaries) > limit {
+					summaries = summaries[:limit]
+				}
 			}
 		}
 	}

--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -78,17 +78,29 @@ func (s *Service) Diagnose() *Diagnostic {
 	if s.last == nil || len(s.lastSlots) == 0 {
 		return nil
 	}
-	// Slots and Actions are generated in the same order by Optimize:
-	// action[i] corresponds to slot[i]. Guard against a mismatch
-	// anyway — better one-off wrong row than a panic in production.
-	n := len(s.lastSlots)
-	if len(s.last.Actions) < n {
-		n = len(s.last.Actions)
+	return buildDiagnostic(s.last, s.lastSlots, s.lastParams, s.Zone,
+		s.lastReplanAt.UnixMilli(), s.lastReason)
+}
+
+// buildDiagnostic assembles a Diagnostic from explicit inputs — no
+// access to Service state. Used by Diagnose() (holds the read lock
+// while calling) and by replan() which passes its locally-captured
+// plan/slots/params to guarantee the persisted snapshot + reason are
+// atomically paired even when a concurrent replan swaps s.last mid-
+// flight.
+func buildDiagnostic(plan *Plan, slots []Slot, p Params, zone string,
+	replanAtMs int64, reason string) *Diagnostic {
+	if plan == nil || len(slots) == 0 {
+		return nil
+	}
+	n := len(slots)
+	if len(plan.Actions) < n {
+		n = len(plan.Actions)
 	}
 	out := make([]DiagnosticSlot, n)
 	for i := 0; i < n; i++ {
-		slot := s.lastSlots[i]
-		action := s.last.Actions[i]
+		slot := slots[i]
+		action := plan.Actions[i]
 		out[i] = DiagnosticSlot{
 			Idx:         i,
 			SlotStartMs: slot.StartMs,
@@ -108,12 +120,11 @@ func (s *Service) Diagnose() *Diagnostic {
 			PVLimitW:    action.PVLimitW,
 		}
 	}
-	p := s.lastParams
 	return &Diagnostic{
-		ComputedAtMs: s.last.GeneratedAtMs,
-		Zone:         s.Zone,
-		Horizon:      s.last.HorizonSlots,
-		TotalCostOre: s.last.TotalCostOre,
+		ComputedAtMs: plan.GeneratedAtMs,
+		Zone:         zone,
+		Horizon:      plan.HorizonSlots,
+		TotalCostOre: plan.TotalCostOre,
 		Params: DiagnosticParams{
 			Mode:                p.Mode,
 			InitialSoCPct:       p.InitialSoCPct,
@@ -131,7 +142,7 @@ func (s *Service) Diagnose() *Diagnostic {
 			ExportFeeOreKwh:     p.ExportFeeOreKwh,
 		},
 		Slots:          out,
-		LastReplanAtMs: s.lastReplanAt.UnixMilli(),
-		LastReason:     s.lastReason,
+		LastReplanAtMs: replanAtMs,
+		LastReason:     reason,
 	}
 }

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -581,6 +581,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 	if reason == "" {
 		reason = "manual"
 	}
+	replanAtMs := s.lastReplanAt.UnixMilli()
 	s.mu.Unlock()
 	slog.Info("mpc: replanned",
 		"slots", len(slots),
@@ -590,11 +591,16 @@ func (s *Service) replan(_ context.Context) *Plan {
 
 	// Persist a diagnostic snapshot so operators can time-travel to
 	// this replan later. Best-effort: errors log and continue so a
-	// flaky disk never blocks planning. Runs outside the lock — the
-	// plan pointer is already swapped in, so Diagnose() reads
-	// consistent state without needing us to hold anything.
+	// flaky disk never blocks planning.
+	//
+	// Critically: build from the LOCAL plan/slots/p we just computed,
+	// not from s.last via Diagnose(). A concurrent replan could have
+	// swapped s.last between our unlock and the Diagnose() call,
+	// which would pair a different plan with OUR reason — writing a
+	// corrupt snapshot. Using the locals keeps (plan, reason)
+	// atomically consistent even under concurrent replans.
 	if s.SaveDiag != nil {
-		if d := s.Diagnose(); d != nil {
+		if d := buildDiagnostic(&plan, slots, p, s.Zone, replanAtMs, reason); d != nil {
 			if err := s.SaveDiag(d, reason); err != nil {
 				slog.Warn("mpc: persist diagnostic failed", "err", err)
 			}

--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -140,6 +140,11 @@
     try {
       const r = await fetch('/api/mpc/diagnose/at?ts=' + tsMs);
       const j = await r.json();
+      // Discard stale responses: if the user clicked a different
+      // snapshot while this fetch was in flight, state.selectedTs
+      // has moved on. Rendering here would flash the old detail
+      // on top of the user's newer click.
+      if (state.selectedTs !== tsMs) return;
       if (!j || !j.snapshot) {
         if (el) el.innerHTML = '<div class="diagnose-empty">Snapshot not found.</div>';
         return;
@@ -147,6 +152,7 @@
       state.detail = j.snapshot;
       renderDetail();
     } catch (e) {
+      if (state.selectedTs !== tsMs) return;
       if (el) el.innerHTML = `<div class="diagnose-empty">Error: ${escapeHtml(e.message)}</div>`;
     }
   }

--- a/web/style.css
+++ b/web/style.css
@@ -111,7 +111,8 @@ header h1 {
   padding: 1rem 1.5rem;
   min-height: calc(100vh - 120px);
 }
-#view-diagnose.hidden { display: none; }
+#view-diagnose.hidden,
+#view-live.hidden { display: none; }
 
 .diagnose-header {
   background: var(--surface);


### PR DESCRIPTION
## Summary

Four issues Codex flagged after #104/#105 landed. All reproducible, ordered by severity.

### P1 — Live view stacked on top of Diagnose

`applyHash()` puts a `hidden` class on `#view-live`, but only `#view-diagnose.hidden { display: none }` was declared. Result: the Diagnose tab rendered both views on top of each other. Visible in the browser you just deployed. One-liner CSS.

### P1 — Replan race: persisted snapshot could be paired with a different plan

`Service.replan()` snapshotted `reason` under the write lock, unlocked, then called `s.Diagnose()` which re-reads `s.last` under its own RLock. A concurrent replan between unlock and `Diagnose()` would swap `s.last` — persisting the NEW plan keyed under THIS replan's `reason`. Corrupt audit trail.

**Fix:** extract `buildDiagnostic(plan, slots, p, zone, replanAtMs, reason)` that takes everything as explicit args (no Service-state reads). `replan()` calls it with its locally-captured plan/slots/p so `(plan, reason)` is atomically consistent even under concurrent replans. `Diagnose()` delegates to the same helper while holding its RLock.

### P2 — Cold-fallback broke ordering + could overshoot limit

`/api/mpc/diagnose/history` appends parquet summaries to hot rows without re-sorting or re-limiting. Cold rows ended up at the tail (breaks "newest first" UI contract), and combined length could exceed caller's `limit`. Fix: sort newest-first + truncate after merge.

### P2 — Stale-response race in the UI

Clicking two timeline rows in quick succession could render the first response on top of the user's newer selection. Fix: check `state.selectedTs !== tsMs` before rendering; bail if the user moved on.

## Test plan

- [x] `go build + test` full suite incl. e2e — green
- [x] `TestDiagnoseJoinsSlotsAndActions` still passes (Diagnose() now delegates to the new helper)
- [ ] After deploy: @erikarenhill — Diagnose tab should no longer show ghost Live content behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)