### PR TITLE
feat(updater): gate self-update behind FTW_SELFUPDATE_ENABLED

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,13 @@ services:
     container_name: forty-two-watts
     restart: unless-stopped
 
+    environment:
+      # Turns on the in-app self-update feature (version-check banner +
+      # Update/Restart buttons). Only meaningful alongside the ftw-updater
+      # sidecar below; native / OS-image deploys leave this unset so the
+      # UI hides the feature entirely. See docs/self-update.md.
+      FTW_SELFUPDATE_ENABLED: "1"
+
     # Host networking is required for:
     #   - Modbus TCP to inverters / meters on the LAN
     #   - MQTT brokers on the LAN (no port forwarding)

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -112,10 +112,24 @@ a version you hid earlier resurfaces as soon as you ask about it.
 - **Rollback**: snapshot the pre-update image digest so a subsequent
   "Rollback" button can retag and recreate.
 
-## Disabling
+## Enabling and disabling
 
-Set `FTW_UPDATER_SOCKET=""` in the main container's env to disable the
-Trigger path while keeping the GH probe; the UI buttons will fail fast
-with a clear error. Remove the `ftw-updater` service from
-`docker-compose.yml` if you want the sidecar gone entirely — the main
-container ignores the missing socket gracefully.
+The entire feature is gated on `FTW_SELFUPDATE_ENABLED=1`. The shipped
+`docker-compose.yml` sets this on the main service; any deploy that
+doesn't use the sidecar (bare-metal binary, native OS image, dev build
+started with `go run`, etc.) leaves it unset and the UI hides the badge
+entirely. Handlers under `/api/version/*` return `503 self-update
+disabled` when the flag is off.
+
+Finer-grained knobs, only relevant once the feature is enabled:
+
+- `FTW_UPDATER_SOCKET=""` — keep the GH probe and the "Update available"
+  banner but disable the Update/Restart buttons. The UI shows the
+  notification dot and release notes; clicking Update surfaces a 502.
+- Remove the `ftw-updater` service block from `docker-compose.yml` — the
+  main container ignores the missing socket gracefully and behaves the
+  same as the previous option.
+
+Future native / OS-image builds will ship their own update mechanism and
+either leave this flag off (and wire their own gate) or reuse the same
+name with a different backend.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -545,15 +545,24 @@ func main() {
 
 	// ---- Self-update checker ----
 	// Probes the GitHub Releases API in the background; the UI reads the
-	// cached result via /api/version/check. Socket/status paths default to
-	// the sidecar layout defined in docker-compose.yml — empty on bare-metal
-	// runs, which disables Trigger/Status gracefully.
-	selfUpdater := selfupdate.New(selfupdate.Config{
-		CurrentVersion: Version,
-		SocketPath:     envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"),
-		StatusPath:     envOr("FTW_UPDATER_STATUS", "/run/ftw-update/state.json"),
-	}, st)
-	selfUpdater.Start(ctx)
+	// cached result via /api/version/check. Gated behind FTW_SELFUPDATE_ENABLED
+	// because the ftw-updater sidecar only exists in the docker-compose deploy.
+	// Native / OS-image builds will ship their own update mechanism and set
+	// their own gate (or leave this one off). Deps.SelfUpdate stays nil when
+	// disabled, which makes every /api/version/* handler return 503 and the
+	// UI hide the badge.
+	var selfUpdater *selfupdate.Checker
+	if envBool("FTW_SELFUPDATE_ENABLED") {
+		selfUpdater = selfupdate.New(selfupdate.Config{
+			CurrentVersion: Version,
+			SocketPath:     envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"),
+			StatusPath:     envOr("FTW_UPDATER_STATUS", "/run/ftw-update/state.json"),
+		}, st)
+		selfUpdater.Start(ctx)
+		slog.Info("selfupdate enabled", "socket", envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"))
+	} else {
+		slog.Info("selfupdate disabled — set FTW_SELFUPDATE_ENABLED=1 to turn on")
+	}
 
 	// ---- Start HTTP API ----
 	// Forward-declare haBridge so Deps can reference it; the bridge
@@ -1172,4 +1181,14 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool returns true iff the env var is set to a positive value
+// (1/true/yes/on, case-insensitive). Unset or any other value = false.
+func envBool(key string) bool {
+	switch strings.ToLower(os.Getenv(key)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }

--- a/web/index.html
+++ b/web/index.html
@@ -344,13 +344,22 @@
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
     // (the <ftw-update-badge> dot is tiny and easy to miss). Kept inline so
-    // app.js stays untouched by the self-update feature.
+    // app.js stays untouched by the self-update feature. When the backend
+    // reports the feature disabled (503 on /api/version/check — e.g. native
+    // build with FTW_SELFUPDATE_ENABLED unset), the badge fires
+    // `ftw-selfupdate-disabled` and we strip the pointer affordance here.
     document.addEventListener("DOMContentLoaded", function () {
       var v = document.getElementById("version");
       if (!v) return;
-      v.addEventListener("click", function () {
+      function onClick() {
         var badge = document.querySelector("ftw-update-badge");
         if (badge && typeof badge.open === "function") badge.open();
+      }
+      v.addEventListener("click", onClick);
+      document.addEventListener("ftw-selfupdate-disabled", function () {
+        v.removeEventListener("click", onClick);
+        v.style.cursor = "default";
+        v.removeAttribute("title");
       });
     });
   </script>

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -26,6 +26,7 @@
       this._updateOriginalVersion = null;
       this._checkTimer = null;
       this._statusTimer = null;
+      this._disabled = false;         // set true on 503 (feature gated off)
       this._render();
     }
 
@@ -40,28 +41,53 @@
     }
 
     // Public: called by the header #version click handler in index.html so
-    // the operator can open the modal without aiming at the tiny dot.
+    // the operator can open the modal without aiming at the tiny dot. No-op
+    // when the backend has told us the feature is gated off.
     open() {
+      if (this._disabled) return;
       this._phase = "dialog";
       this._render();
       this._refresh(false); // surface the freshest info when opened
     }
 
+    // Permanently shut the element down: stop polling, clear shadow DOM, hide
+    // from layout, and fire an event so the #version bridge can drop its
+    // cursor/pointer affordance. Called when the backend returns 503, which
+    // means the feature is gated off (FTW_SELFUPDATE_ENABLED unset) — not a
+    // transient error, so we don't ever retry.
+    _disable() {
+      if (this._disabled) return;
+      this._disabled = true;
+      clearInterval(this._checkTimer);
+      clearInterval(this._statusTimer);
+      this._shadow.innerHTML = "";
+      this.hidden = true;
+      this.dispatchEvent(new CustomEvent("ftw-selfupdate-disabled", { bubbles: true }));
+    }
+
     // ---- data ----
     _refresh(force) {
+      if (this._disabled) return;
       const url = force ? "/api/version/check?force=1" : "/api/version/check";
       fetch(url)
-        .then((r) =>
-          r.json()
+        .then((r) => {
+          // 503 = feature disabled by the backend. Stop polling and get out
+          // of the way entirely — this is deployment config, not a bug.
+          if (r.status === 503) {
+            this._disable();
+            return null;
+          }
+          return r.json()
             .then((body) => ({ ok: r.ok, body }))
-            .catch(() => ({ ok: r.ok, body: null }))
-        )
-        .then(({ ok, body }) => {
+            .catch(() => ({ ok: r.ok, body: null }));
+        })
+        .then((result) => {
+          if (!result) return; // disabled, nothing to render
           // The handler returns the full Info schema on both success and the
-          // force=1 error path, so we render either way. When ok=false, body.err
-          // carries the reason and the UI shows "Last check failed: …".
-          if (body && typeof body === "object") {
-            this._info = body;
+          // force=1 error path, so we render either way. When ok=false,
+          // body.err carries the reason and the UI shows "Last check failed".
+          if (result.body && typeof result.body === "object") {
+            this._info = result.body;
             this._render();
           }
         })


### PR DESCRIPTION
The feature only works when the ftw-updater sidecar is present (today: docker-compose deploys), so wiring it on by default means bare-metal + native / OS-image runs would show a broken button. Explicit opt-in via env keeps each deploy flavor honest: set the flag from docker-compose, leave it unset elsewhere, and future native mechanisms can wire their own backend under the same gate.

- main.go: skip selfupdate.New() when FTW_SELFUPDATE_ENABLED is unset; Deps.SelfUpdate stays nil and every /api/version/* handler returns 503 "self-update disabled" (the existing nil-check path)
- docker-compose.yml: set FTW_SELFUPDATE_ENABLED=1 on the main service
- update-badge.js: on 503 from /check, enter a terminal disabled state — stop polling, clear the shadow DOM, hide the host, dispatch ftw-selfupdate-disabled so callers can react
- index.html: header #version click-bridge listens for the disable event and drops cursor:pointer + click handler so the span stops pretending to be interactive on native builds
- docs/self-update.md: rewrite the Disabling section to lead with the new gate and keep the finer-grained knobs as follow-ons

Verified both paths locally:
  enabled:  'selfupdate enabled', /api/version/check → 200 disabled: 'selfupdate disabled — set FTW_SELFUPDATE_ENABLED=1', 503