### PR TITLE
fix(updater): drop "(test)" suffix from Restart button

### DIFF
--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -79,7 +79,7 @@ docker compose up -d
 docker compose ps
 
 # Open the UI, click the version text in the top-right header
-# → modal opens → click "Restart (test)"
+# → modal opens → click "Restart"
 # → the overlay counts down while the sidecar runs pull + up -d --force-recreate
 # → the new main container writes state=done
 # → UI hard-reloads into the (same) version

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -217,12 +217,12 @@
       const actions = hasUpdate
         ? `
             <button class="btn btn-primary" data-action="update">Update to ${escapeHTML(info.latest || "")}</button>
-            <button class="btn" data-action="restart">Restart (test)</button>
+            <button class="btn" data-action="restart">Restart</button>
             <button class="btn btn-ghost" data-action="skip">Skip this version</button>
           `
         : `
             <button class="btn" data-action="check">Check for updates</button>
-            <button class="btn" data-action="restart">Restart (test)</button>
+            <button class="btn" data-action="restart">Restart</button>
           `;
 
       const notesHref = safeHref(info.release_notes_url);


### PR DESCRIPTION
Restart without an available update is a legitimate operator flow (kick the service after a config tweak, recover from a wedged driver), not just a dev-test affordance. The suffix was misleading.