### PR TITLE
feat(loadpoint): operator SoC override + EV columns always visible

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -167,6 +167,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
+	s.handle("POST /api/loadpoints/{id}/soc", s.handleLoadpointSoC)
 	s.handle("GET  /api/version/check", s.handleVersionCheck)
 	s.handle("POST /api/version/skip", s.handleVersionSkip)
 	s.handle("POST /api/version/unskip", s.handleVersionUnskip)
@@ -1582,6 +1583,54 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Trigger replan so the new target lands in the schedule fast.
+	if s.deps.MPC != nil {
+		go s.deps.MPC.Replan(r.Context())
+	}
+	writeJSON(w, 200, map[string]any{"ok": true})
+}
+
+// POST /api/loadpoints/{id}/soc lets the operator correct the
+// inferred vehicle SoC. Easee (and most chargers) are blind to the
+// vehicle's BMS — without a vehicle API integration (Tesla, VW, …)
+// we have no way to know actual SoC. We infer from
+// `plugin_soc_pct + delivered_wh / capacity`, but if the plug-in
+// anchor was wrong the estimate drifts. This endpoint re-anchors so
+// `current_soc_pct` equals the value the operator reads off their
+// car, and future observations accumulate from there.
+//
+// Body: {"soc_pct": 60}
+//
+// Returns 409 if the loadpoint is unplugged (can't set SoC on a
+// vehicle that isn't in the session).
+func (s *Server) handleLoadpointSoC(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Loadpoints == nil {
+		writeJSON(w, 404, map[string]string{"error": "loadpoints not configured"})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, 400, map[string]string{"error": "id required"})
+		return
+	}
+	var req struct {
+		SoCPct float64 `json:"soc_pct"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	// Confirm loadpoint exists before inspecting plug state.
+	if _, ok := s.deps.Loadpoints.State(id); !ok {
+		writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
+		return
+	}
+	if !s.deps.Loadpoints.SetCurrentSoC(id, req.SoCPct) {
+		writeJSON(w, 409, map[string]string{
+			"error": "loadpoint not plugged in — SoC can only be set during an active session",
+		})
+		return
+	}
+	// Trigger replan so the corrected SoC feeds into the next plan.
 	if s.deps.MPC != nil {
 		go s.deps.MPC.Replan(r.Context())
 	}

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -252,6 +252,50 @@ func (m *Manager) SetTarget(id string, socPct float64, targetTime time.Time) boo
 	return true
 }
 
+// SetCurrentSoC lets an operator correct the inferred vehicle SoC
+// mid-session. Chargers like Easee don't report the vehicle's actual
+// BMS state, so the manager defaults to
+// `plugin_soc_pct + session_wh / capacity` — which drifts if the
+// plug-in anchor was wrong. This resets the session anchor so the
+// CURRENT estimate equals `socPct` and future observations accumulate
+// from there. Only applies while plugged in; no-op otherwise.
+//
+// Returns false for unknown IDs or when the loadpoint is unplugged.
+func (m *Manager) SetCurrentSoC(id string, socPct float64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return false
+	}
+	if !lp.pluggedIn {
+		return false
+	}
+	if socPct < 0 {
+		socPct = 0
+	}
+	if socPct > 100 {
+		socPct = 100
+	}
+	// Re-anchor: new_anchor + delivered/capacity*100 == socPct.
+	// → new_anchor = socPct − delivered/capacity*100
+	deliveredPct := 0.0
+	if lp.VehicleCapacityWh > 0 {
+		deliveredPct = lp.deliveredWhSession / lp.VehicleCapacityWh * 100.0
+	}
+	anchor := socPct - deliveredPct
+	if anchor < 0 {
+		anchor = 0
+	}
+	if anchor > 100 {
+		anchor = 100
+	}
+	lp.sessionPluginSoCPct = anchor
+	lp.currentSoCPct = estimateSoCPct(anchor, lp.deliveredWhSession, lp.VehicleCapacityWh)
+	lp.updatedAtMs = time.Now().UnixMilli()
+	return true
+}
+
 func (lp *loadpointRuntime) snapshot() State {
 	steps := make([]float64, len(lp.AllowedStepsW))
 	copy(steps, lp.AllowedStepsW)

--- a/go/internal/loadpoint/loadpoint_test.go
+++ b/go/internal/loadpoint/loadpoint_test.go
@@ -128,6 +128,65 @@ func TestObserveNewSessionAnchor(t *testing.T) {
 	}
 }
 
+// TestSetCurrentSoCReAnchors — operator corrects the inferred SoC
+// mid-session. After SetCurrentSoC, current_soc equals the provided
+// value, and any further delivered Wh advance from that anchor.
+// Chargers can't read vehicle BMS, so this is the only way the
+// operator can correct drift.
+func TestSetCurrentSoCReAnchors(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000, PluginSoCPct: 25}})
+	// Plug in, deliver 9 kWh → naive estimate = 25 + 9000/60000*100 = 40 %.
+	m.Observe("a", true, 7400, 9000)
+	if st, _ := m.State("a"); st.CurrentSoCPct < 39 || st.CurrentSoCPct > 41 {
+		t.Fatalf("pre-correction SoC: got %.2f want ~40", st.CurrentSoCPct)
+	}
+	// Operator looks at their dashboard: car is actually 60 %.
+	if !m.SetCurrentSoC("a", 60) {
+		t.Fatal("SetCurrentSoC returned false on plugged-in loadpoint")
+	}
+	st, _ := m.State("a")
+	if st.CurrentSoCPct < 59 || st.CurrentSoCPct > 61 {
+		t.Errorf("post-correction SoC: got %.2f want ~60", st.CurrentSoCPct)
+	}
+	// Deliver another 3 kWh → should be ~65 % (60 + 3000/60000*100).
+	m.Observe("a", true, 7400, 12000)
+	st, _ = m.State("a")
+	if st.CurrentSoCPct < 64 || st.CurrentSoCPct > 66 {
+		t.Errorf("after more delivery SoC: got %.2f want ~65", st.CurrentSoCPct)
+	}
+}
+
+// TestSetCurrentSoCRejectsUnplugged — SoC is meaningless without an
+// active session. Chargers may cling to the last known vehicle state
+// briefly after unplug; blocking this avoids anchoring against noise.
+func TestSetCurrentSoCRejectsUnplugged(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000}})
+	if m.SetCurrentSoC("a", 55) {
+		t.Error("should reject SetCurrentSoC on never-plugged loadpoint")
+	}
+	m.Observe("a", true, 0, 0)
+	m.Observe("a", false, 0, 0)
+	if m.SetCurrentSoC("a", 55) {
+		t.Error("should reject SetCurrentSoC after unplug")
+	}
+}
+
+func TestSetCurrentSoCClampsRange(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000}})
+	m.Observe("a", true, 0, 0)
+	m.SetCurrentSoC("a", 150)
+	if st, _ := m.State("a"); st.CurrentSoCPct != 100 {
+		t.Errorf("clamp high: got %.2f", st.CurrentSoCPct)
+	}
+	m.SetCurrentSoC("a", -10)
+	if st, _ := m.State("a"); st.CurrentSoCPct != 0 {
+		t.Errorf("clamp low: got %.2f", st.CurrentSoCPct)
+	}
+}
+
 func TestStatesReturnsAllInOrder(t *testing.T) {
 	m := NewManager()
 	m.Load([]Config{

--- a/web/app.js
+++ b/web/app.js
@@ -1440,16 +1440,122 @@
     evModalBody.appendChild(p);
   }
 
+  // renderLoadpointSoCSection — operator-facing SoC correction UI.
+  // The Easee cloud API is blind to the vehicle's BMS; our current_soc
+  // is inferred from plug-in anchor + delivered_wh. If that drifts
+  // from reality (wrong anchor, mid-session plug-swap, different car)
+  // the operator needs a way to tell us the actual SoC off the
+  // dashboard. This posts to /api/loadpoints/{id}/soc which re-anchors
+  // the session so future observations accumulate from the correct
+  // baseline.
+  function renderLoadpointSoCSection(loadpoints) {
+    var section = document.createElement("div");
+    section.style.marginTop = "1rem";
+    section.style.paddingTop = "0.75rem";
+    section.style.borderTop = "1px solid var(--border)";
+    var h = document.createElement("div");
+    h.style.fontSize = "0.75rem";
+    h.style.color = "var(--text-dim)";
+    h.style.textTransform = "uppercase";
+    h.style.letterSpacing = "0.04em";
+    h.style.marginBottom = "0.5rem";
+    h.textContent = "Loadpoints (planner)";
+    section.appendChild(h);
+    loadpoints.forEach(function (lp) {
+      var row = document.createElement("div");
+      row.style.display = "flex";
+      row.style.alignItems = "center";
+      row.style.gap = "0.5rem";
+      row.style.marginBottom = "0.4rem";
+      var name = document.createElement("span");
+      name.style.flex = "1";
+      name.style.fontWeight = "600";
+      name.textContent = lp.id;
+      var state = document.createElement("span");
+      state.style.fontSize = "0.75rem";
+      state.style.color = "var(--text-dim)";
+      state.textContent = lp.plugged_in
+        ? (lp.current_power_w > 1
+           ? Math.round(lp.current_power_w) + " W"
+           : "plugged, idle")
+        : "unplugged";
+      var socLabel = document.createElement("span");
+      socLabel.style.fontSize = "0.75rem";
+      socLabel.style.color = "var(--text-dim)";
+      socLabel.textContent = "SoC:";
+      var socInput = document.createElement("input");
+      socInput.type = "number";
+      socInput.min = "0";
+      socInput.max = "100";
+      socInput.step = "1";
+      socInput.style.width = "4.5rem";
+      socInput.style.background = "var(--bg)";
+      socInput.style.color = "var(--text)";
+      socInput.style.border = "1px solid var(--border)";
+      socInput.style.borderRadius = "3px";
+      socInput.style.padding = "0.2rem 0.35rem";
+      socInput.disabled = !lp.plugged_in;
+      socInput.title = lp.plugged_in
+        ? "Correct to what your car actually shows"
+        : "Plug in the car to set SoC";
+      socInput.value = lp.plugged_in && lp.current_soc_pct != null
+        ? Math.round(lp.current_soc_pct) : "";
+      var btn = document.createElement("button");
+      btn.textContent = "Set";
+      btn.className = "btn-send";
+      btn.style.padding = "0.2rem 0.55rem";
+      btn.style.fontSize = "0.75rem";
+      btn.disabled = !lp.plugged_in;
+      btn.addEventListener("click", function () {
+        var v = Number(socInput.value);
+        if (!(v >= 0 && v <= 100)) return;
+        btn.disabled = true; btn.textContent = "…";
+        fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/soc", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ soc_pct: v }),
+        }).then(function (r) {
+          btn.textContent = r.ok ? "✓" : "×";
+          setTimeout(function () {
+            btn.textContent = "Set"; btn.disabled = !lp.plugged_in;
+            refreshEvModal();
+          }, 800);
+        }).catch(function () {
+          btn.textContent = "×";
+          setTimeout(function () { btn.textContent = "Set"; btn.disabled = false; }, 1200);
+        });
+      });
+      row.appendChild(name);
+      row.appendChild(state);
+      row.appendChild(socLabel);
+      row.appendChild(socInput);
+      row.appendChild(btn);
+      section.appendChild(row);
+    });
+    return section;
+  }
+
   function refreshEvModal() {
-    fetch("/api/ev/status").then(function (r) { return r.json(); }).then(function (d) {
-      if (!d || d.connected === false) {
+    // Fetch both the legacy EV status AND the loadpoint manager state
+    // — the latter is what the MPC actually optimizes against. Shown
+    // as a separate section so operators can correct the inferred
+    // vehicle SoC (our infer is blind without a vehicle API).
+    Promise.all([
+      fetch("/api/ev/status").then(function (r) { return r.json(); }).catch(function () { return null; }),
+      fetch("/api/loadpoints").then(function (r) { return r.json(); }).catch(function () { return null; }),
+    ]).then(function (pair) {
+      var ev = pair[0];
+      var lps = pair[1];
+      evModalBody.textContent = "";
+      if (ev && ev.connected !== false) {
+        evModalBody.appendChild(renderEvStatusTable(ev));
+      } else if (!lps || !lps.loadpoints || lps.loadpoints.length === 0) {
         setEvModalMessage("No EV charger connected");
         return;
       }
-      evModalBody.textContent = "";
-      evModalBody.appendChild(renderEvStatusTable(d));
-    }).catch(function () {
-      setEvModalMessage("Failed to load EV status");
+      if (lps && lps.enabled && lps.loadpoints && lps.loadpoints.length > 0) {
+        evModalBody.appendChild(renderLoadpointSoCSection(lps.loadpoints));
+      }
     });
   }
 

--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -166,7 +166,14 @@
     // Header metadata
     const ageMin = Math.round((Date.now() - s.ts_ms) / 60000);
     const params = d.params || {};
-    const lpActive = d.slots && d.slots.some(x => x.loadpoint_w);
+    // Show EV columns whenever the snapshot tracked EV state — either
+    // because the DP chose to charge (loadpoint_w > 0) OR because a
+    // loadpoint was plugged in so ev_soc is meaningful even when
+    // charging = 0. Otherwise we'd hide the columns on snapshots
+    // where the plan said "idle the EV this hour" and operators
+    // would never see the SoC trajectory.
+    const lpActive = d.slots && d.slots.some(x =>
+      x.loadpoint_w || x.loadpoint_soc_pct);
     const header = `
       <div class="diagnose-detail-header">
         <div>

--- a/web/index.html
+++ b/web/index.html
@@ -334,13 +334,13 @@
     </div>
   </div>
 
-  <script src="/app.js?v=diag1"></script>
-  <script src="/settings.js?v=diag1"></script>
-  <script src="/models.js?v=diag1"></script>
-  <script src="/plan.js?v=diag1"></script>
-  <script src="/twins.js?v=diag1"></script>
-  <script src="/diagnose.js?v=diag1"></script>
-  <script src="/update-badge.js?v=diag1" defer></script>
+  <script src="/app.js?v=soc1"></script>
+  <script src="/settings.js?v=soc1"></script>
+  <script src="/models.js?v=soc1"></script>
+  <script src="/plan.js?v=soc1"></script>
+  <script src="/twins.js?v=soc1"></script>
+  <script src="/diagnose.js?v=soc1"></script>
+  <script src="/update-badge.js?v=soc1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
     // (the <ftw-update-badge> dot is tiny and easy to miss). Kept inline so


### PR DESCRIPTION
## Summary

Erik reported `current_soc_pct: 73` on a car that was actually at 60 %. Easee is blind to the vehicle's BMS, so we can't automate this — but we also didn't give the operator a way to correct the drift. Now they can.

## New

- **`Manager.SetCurrentSoC(id, socPct)`** — re-anchors the session so `current_soc` equals the provided value; future observations accumulate from there. Rejects unplugged loadpoints (anchoring against charger noise after unplug is meaningless).
- **`POST /api/loadpoints/{id}/soc`** — `{"soc_pct": 60}`. Triggers an MPC replan so the corrected SoC feeds straight into the next schedule.
- **UI** — EV modal (clicking the EV card) gets a "Loadpoints (planner)" section with per-loadpoint SoC input + "Set" button. Disabled when unplugged. Refreshes the modal on success.

## Also fixed

- **EV columns in the Diagnose per-slot table** — now show whenever loadpoint state was tracked (plugged + SoC reported), not only when the DP chose to charge. Previously an "EV plugged but planner chose idle" snapshot hid the EV SoC trajectory entirely.
- Cache-buster bumped `v=diag1` → `v=soc1` so browsers reload the new JS.

## Test plan

- [x] `go test ./...` green incl. e2e.
- [x] New tests: `TestSetCurrentSoCReAnchors`, `TestSetCurrentSoCRejectsUnplugged`, `TestSetCurrentSoCClampsRange`.
- [ ] @erikarenhill: hard-refresh the Pi's UI, click the EV card, correct your car's SoC, verify the Diagnose tab shows the corrected trajectory on the next replan.

## Discord context

@frahlg: *"APIt kommer inte ge någon faktisk SoC. Då måste vi koppla in bilens API vilket vi inte har. Så denna behöver på något sätt komma från användaren. Laddaren är blind för vilken bil det är."*

Exactly — this PR gives the operator that path. Vehicle-API integrations (Tesla, VW, …) stay open as a follow-up if/when we want automatic SoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)