### PR TITLE
feat(diagnose): cross-highlight chart and slot table

### DIFF
--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -62,6 +62,8 @@
     selectedTs: null,  // currently loaded snapshot
     detail: null,      // full snapshot object
     rangeMs: 24 * 3600 * 1000,
+    chartGeom: null,   // {padL, padT, barW, plotH, nSlots} — for hover hit-testing
+    hoverSlotIdx: null,
   };
 
   const rangeSelect = document.getElementById('diagnose-range-select');
@@ -195,6 +197,7 @@
       </div>
       <div class="diagnose-chart-wrap">
         <canvas id="diag-chart" height="320"></canvas>
+        <div id="diag-chart-highlight" class="diag-chart-highlight hidden"></div>
       </div>
       <div class="diagnose-table-wrap">
         <table class="diag-table">
@@ -216,6 +219,89 @@
     `;
     el.innerHTML = header;
     drawChart(d);
+    bindRowHover(el);
+    bindChartHover(el);
+  }
+
+  function bindRowHover(root) {
+    const rows = root.querySelectorAll('.diag-table tbody tr');
+    rows.forEach(tr => {
+      tr.addEventListener('mouseenter', () => {
+        const i = Number(tr.dataset.slotIdx);
+        showChartHighlight(i);
+      });
+      tr.addEventListener('mouseleave', hideChartHighlight);
+    });
+  }
+
+  function bindChartHover(root) {
+    const canvas = root.querySelector('#diag-chart');
+    if (!canvas) return;
+    canvas.addEventListener('mousemove', onChartMove);
+    canvas.addEventListener('mouseleave', onChartLeave);
+  }
+
+  function onChartMove(e) {
+    const g = state.chartGeom;
+    if (!g) return;
+    const canvas = e.currentTarget;
+    const rect = canvas.getBoundingClientRect();
+    // Scale from client px to the CSS px coords captured at draw time,
+    // in case the canvas was resized after drawChart.
+    const scale = rect.width > 0 ? (canvas.clientWidth / rect.width) : 1;
+    const xCss = (e.clientX - rect.left) * scale;
+    const xInPlot = xCss - g.padL;
+    if (xInPlot < 0 || xInPlot >= g.barW * g.nSlots) {
+      onChartLeave();
+      return;
+    }
+    const i = Math.floor(xInPlot / g.barW);
+    if (i === state.hoverSlotIdx) return;
+    state.hoverSlotIdx = i;
+    showChartHighlight(i);
+    applyRowFilter(i);
+  }
+
+  function onChartLeave() {
+    if (state.hoverSlotIdx == null) return;
+    state.hoverSlotIdx = null;
+    hideChartHighlight();
+    clearRowFilter();
+  }
+
+  function applyRowFilter(center) {
+    const rows = document.querySelectorAll('.diag-table tbody tr');
+    const window = 6;
+    rows.forEach((tr, idx) => {
+      const inWindow = Math.abs(idx - center) <= window;
+      tr.classList.toggle('diag-row-hidden', !inWindow);
+      tr.classList.toggle('diag-row-hover', idx === center);
+    });
+  }
+
+  function clearRowFilter() {
+    document.querySelectorAll('.diag-table tbody tr').forEach(tr => {
+      tr.classList.remove('diag-row-hidden', 'diag-row-hover');
+    });
+  }
+
+  function showChartHighlight(i) {
+    const g = state.chartGeom;
+    const hi = document.getElementById('diag-chart-highlight');
+    const canvas = document.getElementById('diag-chart');
+    if (!g || !hi || !canvas || i < 0 || i >= g.nSlots) return;
+    const offX = canvas.offsetLeft;
+    const offY = canvas.offsetTop;
+    hi.style.left = (offX + g.padL + i * g.barW) + 'px';
+    hi.style.top = (offY + g.padT) + 'px';
+    hi.style.width = Math.max(2, g.barW) + 'px';
+    hi.style.height = g.plotH + 'px';
+    hi.classList.remove('hidden');
+  }
+
+  function hideChartHighlight() {
+    const hi = document.getElementById('diag-chart-highlight');
+    if (hi) hi.classList.add('hidden');
   }
 
   function slotRow(sl, i, lpActive) {
@@ -223,7 +309,7 @@
     const confCls = sl.confidence < 0.9 ? 'conf-low' : '';
     const gridCls = sl.grid_w > 0 ? 'val-import' : (sl.grid_w < 0 ? 'val-export' : 'val-neutral');
     const batCls = sl.battery_w > 0 ? 'val-charging' : (sl.battery_w < 0 ? 'val-discharging' : 'val-neutral');
-    return `<tr>
+    return `<tr data-slot-idx="${i}">
       <td>${sl.idx}</td>
       <td>${fmtHHMM(sl.slot_start_ms)}</td>
       <td>${fmt1(sl.price_ore)}</td>
@@ -262,6 +348,9 @@
     const slots = d.slots;
     const nSlots = slots.length;
     const barW = Math.max(1, plotW / nSlots);
+
+    // Geometry for the row-hover highlight overlay.
+    state.chartGeom = { padL: pad.l, padT: pad.t, barW, plotH, nSlots };
 
     // Three horizontal bands: top third = price, middle third = power, bottom third = SoC
     const priceH = plotH * 0.30;

--- a/web/style.css
+++ b/web/style.css
@@ -98,7 +98,7 @@ header h1 {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem 1.5rem;
-  min-height: calc(100vh - 120px);
+  height: calc(100vh - 120px);
 }
 #view-diagnose.hidden,
 #view-live.hidden { display: none; }
@@ -234,8 +234,17 @@ header h1 {
 
 .diagnose-chart-wrap {
   padding: 0.5rem 1rem;
+  position: relative;
 }
 .diagnose-chart-wrap canvas { width: 100%; }
+.diag-chart-highlight {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(96, 165, 250, 0.14);
+  border-left: 1px solid rgba(96, 165, 250, 0.65);
+  border-right: 1px solid rgba(96, 165, 250, 0.65);
+}
+.diag-chart-highlight.hidden { display: none; }
 
 .diagnose-table-wrap {
   flex: 1;
@@ -271,6 +280,8 @@ header h1 {
 .diag-table td:nth-child(-n+2),
 .diag-table td:last-child { text-align: left; }
 .diag-table tbody tr:hover { background: rgba(255,255,255,0.02); }
+.diag-table tbody tr.diag-row-hover { background: rgba(96, 165, 250, 0.14); }
+.diag-table tbody tr.diag-row-hidden { display: none; }
 .diag-reason-cell { color: var(--text-dim); white-space: nowrap; max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
 .conf-low { color: #fde68a; }
 


### PR DESCRIPTION
Hovering a table row paints a vertical slice across the chart's plot bands at that slot's x-range. Hovering the chart reverse-maps the cursor to a slot, tints the matching row, and filters the table to ±6 rows centered on it. Bounds the diagnose pane height so the chart stays pinned and the table scrolls within its pane instead of the whole page.