### PR TITLE
fix(ui): update-badge modal clipping above viewport

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -347,7 +347,7 @@
   <script src="/plan.js?v=soc1"></script>
   <script src="/twins.js?v=soc1"></script>
   <script src="/diagnose.js?v=soc1"></script>
-  <script src="/update-badge.js?v=soc1" defer></script>
+  <script src="/update-badge.js?v=modal1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
     // (the <ftw-update-badge> dot is tiny and easy to miss). Kept inline so

--- a/web/next.html
+++ b/web/next.html
@@ -376,7 +376,7 @@
   <script src="/plan.js?v=diag1"></script>
   <script src="/twins.js?v=diag1"></script>
   <script src="/diagnose.js?v=diag1"></script>
-  <script src="/update-badge.js?v=diag1" defer></script>
+  <script src="/update-badge.js?v=modal1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
     // (the <ftw-update-badge> dot is tiny and easy to miss). Kept inline so

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -349,6 +349,14 @@
           top: 50%; left: 50%;
           transform: translate(-50%, -50%);
           width: min(92vw, 460px);
+          /* Cap height + scroll so shorter viewports can't push the
+             header (close ×) or the footer (Update / Restart / Skip)
+             off-screen. Without this the modal clipped above the
+             viewport and the operator saw only the middle "Release
+             notes" block with no actionable buttons — reported on a
+             laptop-height browser running the /next dashboard. */
+          max-height: 85vh;
+          overflow-y: auto;
           background: var(--surface, #1e293b);
           color: var(--text, #e2e8f0);
           border: 1px solid var(--border, #334155);
@@ -393,6 +401,12 @@
           padding: 0.75rem 1rem;
           border-top: 1px solid var(--border, #334155);
           flex-wrap: wrap;
+          /* Stick to the bottom of the modal while body scrolls so
+             the primary action (Update / Restart) remains visible
+             however long the release-notes body grows. */
+          position: sticky;
+          bottom: 0;
+          background: var(--surface, #1e293b);
         }
         .btn {
           appearance: none;


### PR DESCRIPTION
## Summary

@frahlg reported the update modal rendering with only the middle block visible (\"A newer release / Release notes\"), the header + footer with the Update button clipped off-screen above the viewport. Confirmed end-to-end: the update API worked fine via curl, so it was purely a UI-positioning bug.

## Cause

\`\`\`css
.modal {
  position: fixed;
  top: 50%; left: 50%;
  transform: translate(-50%, -50%);
  /* no max-height, no overflow */
}
\`\`\`

On a laptop-height browser (~900 px visible + dev-tools), the modal + its action row overflows and \`top: 50%\` pushes the header above the top edge. The excess clips silently.

## Fix

- \`max-height: 85vh; overflow-y: auto\` on `.modal` → taller content scrolls inside the modal instead of clipping.
- \`position: sticky; bottom: 0\` on \`.modal footer\` → the action row always stays visible while body scrolls. The Update button was what the operator came here for; it should never be the thing that disappears.
- Cache-bust bumped on both \`index.html\` and \`next.html\`.

## Test plan

- [x] Syntax-check — update-badge.js clean.
- [ ] Open on a short viewport (≤900 px) — modal is scrollable, footer sticks to bottom.
- [ ] Open on a tall viewport (≥1200 px) — unchanged behaviour (modal fits naturally, sticky footer is no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)