### PR TITLE
fix(mpc): exclude EV chargers from MPC battery-pool capacity (investigation PR 3/4)

### DIFF
--- a/go/cmd/forty-two-watts/capacities_test.go
+++ b/go/cmd/forty-two-watts/capacities_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+// TestDriverCapacitiesFromExcludesEV is the regression test for the
+// bug where an Easee cloud driver's YAML entry with
+// `battery_capacity_wh: 75000` inflated the MPC battery pool from
+// ~24 kWh to ~100 kWh. Any driver referenced by a loadpoint is an EV
+// charger — its capacity is VEHICLE capacity, not site battery.
+func TestDriverCapacitiesFromExcludesEV(t *testing.T) {
+	drivers := []config.Driver{
+		{Name: "ferroamp", BatteryCapacityWh: 15200},
+		{Name: "sungrow", BatteryCapacityWh: 9600},
+		{Name: "easee", BatteryCapacityWh: 75000},
+	}
+	loadpoints := []config.Loadpoint{
+		{ID: "garage", DriverName: "easee"},
+	}
+	got := driverCapacitiesFrom(drivers, loadpoints)
+	if _, ok := got["easee"]; ok {
+		t.Errorf("easee should be filtered out; got %v", got)
+	}
+	if got["ferroamp"] != 15200 {
+		t.Errorf("ferroamp kept wrong value: %v", got["ferroamp"])
+	}
+	if got["sungrow"] != 9600 {
+		t.Errorf("sungrow kept wrong value: %v", got["sungrow"])
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(got), got)
+	}
+}
+
+func TestDriverCapacitiesFromNoLoadpointsBehavesAsBefore(t *testing.T) {
+	drivers := []config.Driver{
+		{Name: "ferroamp", BatteryCapacityWh: 15200},
+		{Name: "meter", BatteryCapacityWh: 0},
+	}
+	got := driverCapacitiesFrom(drivers, nil)
+	if got["ferroamp"] != 15200 {
+		t.Errorf("lost ferroamp: %v", got)
+	}
+	if _, ok := got["meter"]; ok {
+		t.Error("zero-capacity driver should not appear")
+	}
+}
+
+func TestDriverCapacitiesFromMultipleLoadpoints(t *testing.T) {
+	drivers := []config.Driver{
+		{Name: "ferroamp", BatteryCapacityWh: 15200},
+		{Name: "easee", BatteryCapacityWh: 75000},
+		{Name: "zap", BatteryCapacityWh: 60000},
+	}
+	loadpoints := []config.Loadpoint{
+		{ID: "garage", DriverName: "easee"},
+		{ID: "street", DriverName: "zap"},
+	}
+	got := driverCapacitiesFrom(drivers, loadpoints)
+	if len(got) != 1 || got["ferroamp"] != 15200 {
+		t.Errorf("expected only ferroamp, got %v", got)
+	}
+}

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -140,7 +140,10 @@ func main() {
 	}
 
 	// ---- Driver capacities (site, for control + fuse guard) ----
-	capacities := driverCapacitiesFrom(cfg.Drivers)
+	// Loadpoint drivers are filtered out — their battery_capacity_wh
+	// is vehicle capacity, not site-battery capacity.
+	capacities := driverCapacitiesFrom(cfg.Drivers, cfg.Loadpoints)
+	warnIfEVHasBatteryCapacity(cfg.Drivers, cfg.Loadpoints)
 
 	// ---- Battery models — restore from SQLite + ensure one per driver ----
 	models := make(map[string]*battery.Model)
@@ -247,7 +250,7 @@ func main() {
 			// reference the api server still holds.
 			capMu.Lock()
 			for k := range capacities { delete(capacities, k) }
-			for k, v := range driverCapacitiesFrom(newCfg.Drivers) {
+			for k, v := range driverCapacitiesFrom(newCfg.Drivers, newCfg.Loadpoints) {
 				capacities[k] = v
 			}
 			capMu.Unlock()
@@ -974,14 +977,71 @@ func registerAllDevices(st *state.Store, reg *drivers.Registry) {
 	}
 }
 
-func driverCapacitiesFrom(drivers []config.Driver) map[string]float64 {
-	out := make(map[string]float64, len(drivers))
-	for _, d := range drivers {
-		if d.BatteryCapacityWh > 0 {
-			out[d.Name] = d.BatteryCapacityWh
+// driverCapacitiesFrom builds the driver-name → battery-capacity map
+// the MPC sums into Params.CapacityWh and the control layer uses for
+// fuse-guard / peak-shave sizing.
+//
+// Critically: drivers that are referenced by a loadpoint entry are
+// EV chargers, not home batteries — their `battery_capacity_wh`
+// represents VEHICLE capacity and must NOT land in the MPC battery
+// pool (doing so inflates SoC %, terminal-value credit, and the
+// discharge-headroom DP arithmetic). Found live on Fredrik's Pi: his
+// Easee entry had battery_capacity_wh=75000, which combined with
+// Ferroamp (15.2 kWh) + Sungrow (9.6 kWh) gave a fantasy 99.8 kWh
+// battery pool.
+//
+// Filtering here rather than at config-parse time means the vehicle
+// capacity is still available for EV-side logic (loadpoint manager)
+// without a schema migration.
+func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint) map[string]float64 {
+	evDrivers := make(map[string]struct{}, len(loadpoints))
+	for _, lp := range loadpoints {
+		if lp.DriverName != "" {
+			evDrivers[lp.DriverName] = struct{}{}
 		}
 	}
+	out := make(map[string]float64, len(drivers))
+	for _, d := range drivers {
+		if d.BatteryCapacityWh <= 0 {
+			continue
+		}
+		if _, isEV := evDrivers[d.Name]; isEV {
+			// Don't count EV vehicle capacity as battery capacity.
+			// (Value remains in cfg.Drivers for any driver-side use.)
+			continue
+		}
+		out[d.Name] = d.BatteryCapacityWh
+	}
 	return out
+}
+
+// warnIfEVHasBatteryCapacity surfaces operator mis-config where an EV
+// driver's YAML entry still carries battery_capacity_wh. The value is
+// now ignored for MPC battery-pool purposes, but we log at WARN so the
+// operator moves it to the loadpoint's vehicle_capacity_wh (where it
+// serves the DP's EV SoC inference) rather than leaving it as a
+// silent no-op.
+func warnIfEVHasBatteryCapacity(drivers []config.Driver, loadpoints []config.Loadpoint) {
+	evDrivers := make(map[string]struct{}, len(loadpoints))
+	for _, lp := range loadpoints {
+		if lp.DriverName != "" {
+			evDrivers[lp.DriverName] = struct{}{}
+		}
+	}
+	for _, d := range drivers {
+		if d.BatteryCapacityWh <= 0 {
+			continue
+		}
+		if _, isEV := evDrivers[d.Name]; !isEV {
+			continue
+		}
+		slog.Warn("driver is referenced by a loadpoint — battery_capacity_wh "+
+			"is being ignored for MPC battery-pool sizing. Move the value "+
+			"to loadpoints[].vehicle_capacity_wh to keep EV SoC inference "+
+			"working.",
+			"driver", d.Name,
+			"battery_capacity_wh", d.BatteryCapacityWh)
+	}
 }
 
 // buildLoadpointConfigs adapts YAML-facing config.Loadpoint entries


### PR DESCRIPTION
## Summary

Part 3 of 4 in the planner-logic investigation round. Fixes the single biggest arithmetic error upstream of Fredrik's Incident B.

## The bug, live

```yaml
drivers:
  - name: ferroamp   battery_capacity_wh: 15200
  - name: sungrow    battery_capacity_wh: 9600
  - name: easee      battery_capacity_wh: 75000   # EV vehicle!
loadpoints:
  - id: garage       driver_name: easee
```

`driverCapacitiesFrom` sums every driver with `battery_capacity_wh > 0`. Easee's 75 kWh — the car's battery — got counted as site-battery capacity. MPC saw 99.8 kWh of battery pool instead of 24.8 kWh.

Confirmed from `/api/mpc/diagnose/at` on Fredrik's Pi:

```
params.capacity_wh: 99800
```

Should be 24800. Everything downstream (SoC %, terminal-value credit, DP discharge-headroom) runs against the inflated pool.

## Fix

`driverCapacitiesFrom(drivers, loadpoints)` filters out drivers referenced by any `loadpoints[].driver_name`. Simple heuristic, no config schema migration needed.

`warnIfEVHasBatteryCapacity` logs at WARN when the operator has left `battery_capacity_wh` on an EV driver entry, pointing them at `loadpoints[].vehicle_capacity_wh` as the proper field.

Boot + hot-reload call sites both updated.

## Tests

- `TestDriverCapacitiesFromExcludesEV` — Fredrik's exact config; easee filtered, ferroamp + sungrow kept.
- `TestDriverCapacitiesFromNoLoadpointsBehavesAsBefore` — backward compatibility.
- `TestDriverCapacitiesFromMultipleLoadpoints` — two EV chargers both filtered.
- `go test ./...` incl. e2e — green.

## What this unblocks

Post-deploy, Fredrik's `params.capacity_wh` drops to 24 800. `terminal_soc_price` recomputes. The DP's discharge-vs-idle arithmetic now operates on the real pool, which should already help Incident B. PR 4 (strict self_consumption) closes the remaining gap by making discharge preference explicit rather than emergent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)