### PR TITLE
feat(mpc): strict self_consumption — discharge before grid import (investigation PR 4/4)

### DIFF
--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -389,6 +389,40 @@ func Optimize(slots []Slot, p Params) Plan {
 							cost = -slotExportOre(slot) * (-gridKWh)
 						}
 
+						// Strict self-consumption bias. When the mode
+						// is self_consumption and the battery has
+						// headroom above the SoC floor + 20 %, we
+						// triple the cost the DP sees for any grid-
+						// import slot. That makes discharge (which
+						// avoids the tripled cost) strictly cheaper
+						// than idle whenever the battery can
+						// physically supply the load — even after
+						// accounting for the terminal-SoC credit
+						// the DP would otherwise use to justify
+						// preserving SoC for later.
+						//
+						// Rationale: operator picked self_consumption
+						// because they want "use my battery before
+						// grid." Pure cost-minimisation over a long
+						// horizon with a high horizon-mean will
+						// sometimes prefer importing today to
+						// preserve SoC for tomorrow's peak — that's
+						// arbitrage behaviour, not self-consumption.
+						// The 20-% floor stops the DP from draining
+						// a nearly-empty battery on a cloudy
+						// morning; above it, discharge wins.
+						//
+						// Factor 3 chosen so: (import_cost × 3) beats
+						// (terminal_credit × discharge_wh) on any
+						// reasonable TerminalSoCPrice ≤ retail_mean.
+						// Above that terminal value the DP is
+						// probably misconfigured anyway.
+						if p.Mode == ModeSelfConsumption &&
+							gridKWh > 0 &&
+							soc > p.SoCMinPct+20 {
+							cost *= 3.0
+						}
+
 						// Deadline slot: if this slot is the EV's
 						// deadline AND target isn't met with this
 						// action's evSoc2, add a shortfall penalty.

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -218,23 +218,34 @@ func TestSelectPlannerPVWRadiationZeroForecastIgnoresBlend(t *testing.T) {
 	}
 }
 
-// Guardrail: if we had used the OLD default (mean retail import price as
-// terminal value), the same scenario wouldn't discharge. This test exists
-// to document *why* the fix matters.
-func TestOptimizeSelfConsumptionDoesNotDischargeWithOldTerminalPrice(t *testing.T) {
+// Strict self_consumption: even with a high terminal price (= mean
+// import), the DP must still discharge when battery has headroom
+// (SoC > min + 20). This used to be a guardrail documenting the
+// OPPOSITE behaviour — that a too-high terminal price blocked
+// discharge and we'd just sit and import. The strict-SC bias
+// introduced in the planner-logic investigation round inverts it:
+// self_consumption now means "use the battery first" regardless of
+// the terminal-value arithmetic. That matches the operator intent
+// the mode name implies.
+func TestOptimizeSelfConsumptionDischargesDespiteHighTerminal(t *testing.T) {
 	slots := []Slot{
 		{StartMs: 0, LenMin: 60, PriceOre: 300, SpotOre: 80, LoadW: 3000, PVW: -500, Confidence: 1},
 		{StartMs: 3600 * 1000, LenMin: 60, PriceOre: 300, SpotOre: 80, LoadW: 3000, PVW: -500, Confidence: 1},
 	}
 	p := baseParams(ModeSelfConsumption)
 	p.InitialSoCPct = 80
-	p.TerminalSoCPrice = 300 // old default = mean import price
+	p.TerminalSoCPrice = 300 // mean import price — pre-strict this would have blocked discharge.
 
 	plan := Optimize(slots, p)
+	var anyDischarge bool
 	for _, a := range plan.Actions {
-		if a.BatteryW < -1e-6 {
-			t.Fatalf("OLD behavior unexpectedly discharged — test is stale. got %+v", plan.Actions)
+		if a.BatteryW < -100 {
+			anyDischarge = true
+			break
 		}
+	}
+	if !anyDischarge {
+		t.Fatalf("strict SC should discharge despite terminal=mean; got actions %+v", plan.Actions)
 	}
 }
 

--- a/go/internal/mpc/strict_sc_test.go
+++ b/go/internal/mpc/strict_sc_test.go
@@ -1,0 +1,58 @@
+package mpc
+
+import "testing"
+
+// TestStrictSelfConsumptionDischargesWhenSoCHealthy mirrors Fredrik's
+// 2026-04-19 08:19 incident: self_consumption mode, ~50% SoC of a
+// small battery, grid would import 2 kW at 166 öre. Before the
+// strict-SC bias the DP happily idled and imported, treating
+// "preserve SoC for later" as a better bet than "use battery now".
+// After the bias, any action that reduces import should beat idle.
+func TestStrictSelfConsumptionDischargesWhenSoCHealthy(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 166, SpotOre: 63,
+			LoadW: 3480, PVW: -1390, Confidence: 1.0},
+		{StartMs: 3600 * 1000, LenMin: 60, PriceOre: 165, SpotOre: 63,
+			LoadW: 3480, PVW: -1985, Confidence: 1.0},
+	}
+	p := baseParams(ModeSelfConsumption)
+	p.InitialSoCPct = 50
+	p.TerminalSoCPrice = 107 // roughly selfConsumptionTerminalPrice output
+
+	plan := Optimize(slots, p)
+	if len(plan.Actions) == 0 {
+		t.Fatal("no actions — plan empty")
+	}
+	first := plan.Actions[0]
+	if first.BatteryW >= -100 {
+		t.Errorf("strict SC expected battery discharge > 100 W, got BatteryW=%.1f "+
+			"(GridW=%.1f, SoC=%.1f%%, reason=%q)",
+			first.BatteryW, first.GridW, first.SoCPct, first.Reason)
+	}
+	// GridW should be lower than baseline 2090 W import — discharging
+	// pulls it down.
+	if first.GridW > 2000 {
+		t.Errorf("GridW still near baseline (%.1f); battery not helping", first.GridW)
+	}
+}
+
+// TestStrictSelfConsumptionBacksOffNearSoCFloor — below floor+20% the
+// strict bias shouldn't kick in, so a nearly-empty battery doesn't
+// suicide trying to cover a big load.
+func TestStrictSelfConsumptionBacksOffNearSoCFloor(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 166, LoadW: 3480, PVW: -1390, Confidence: 1.0},
+	}
+	p := baseParams(ModeSelfConsumption)
+	p.InitialSoCPct = 15  // just above min (10) but well below min+20
+	p.TerminalSoCPrice = 200
+	plan := Optimize(slots, p)
+	// Either the DP idles or discharges only modestly — the key
+	// property is that it's not forced to discharge aggressively.
+	// We check that it doesn't push SoC down by more than a few
+	// percent (action × 1h × 1/eff).
+	if plan.Actions[0].SoCPct < 12 {
+		t.Errorf("strict SC should respect min+20 floor; SoC dropped to %.1f",
+			plan.Actions[0].SoCPct)
+	}
+}


### PR DESCRIPTION
## Summary

Part 4 of 4 in the planner-logic investigation round. Closes the gap between operator intent ("I picked self_consumption — use my battery") and DP behaviour ("preserve SoC for tomorrow's peak").

## The bug (Incident B, confirmed live)

Fredrik 2026-04-19 08:19, mode = `self_consumption`, SoC ≈ 50 % of a then-inflated 99.8 kWh pool (PR #121 fixes the pool inflation separately), first-slot load 3.48 kW, PV -1.39 kW, price 166 öre. Plan: `battery = 0 W`, `grid = 2.09 kW import`.

The DP's arithmetic: terminal credit at ~107 öre/kWh × 0.5 kWh discharge ≈ 54 öre saved terminal, vs ~83 öre import avoided. Discharge *should* have won. It didn't — because forecasted-horizon mean is 183 öre, and the DP sees cheaper future slots to preserve SoC for. Classic arbitrage reasoning that happens to be dressed up as self_consumption.

## Fix

Bias the DP cost function so that whenever `Mode == ModeSelfConsumption` AND `soc > SoCMinPct + 20`, grid-import slots cost 3× what the DP would otherwise see. Discharge-to-cover-load stays at normal cost. Consequence: any action that reduces import beats idle, regardless of terminal arithmetic.

Properties:

- **Floor at `SoC ≥ SoCMinPct + 20 %`** — stops the DP from draining a near-empty battery to cover a big morning load.
- **Factor 3** — tuned so `import_cost × 3` beats any reasonable `TerminalSoCPrice × discharge_eff × kWh`. Well above the 5 % efficiency loss of cycling.
- **Persistent throughout horizon** — operator intent is "use the battery whenever it covers load, ever", not "only for the first hour". Below the floor, DP reverts to normal reasoning.
- Only applies to `self_consumption`. `arbitrage` and `cheap_charge` are untouched — those modes are the operator saying "do what's cheapest".

## Tests

- **`TestStrictSelfConsumptionDischargesWhenSoCHealthy`** — Fredrik's exact 08:19 scenario (50 % SoC, 166 öre, baseline 2.09 kW import). Asserts first-slot `BatteryW < -100 W`.
- **`TestStrictSelfConsumptionBacksOffNearSoCFloor`** — 15 % SoC (floor+5). DP doesn't force aggressive discharge.
- **`TestOptimizeSelfConsumptionDischargesDespiteHighTerminal`** — repurposed guardrail: now asserts DP discharges even when `TerminalSoCPrice = retail_mean`. (Old version documented that exactly this case was broken.)
- Full `go test ./...` incl. e2e — green.

## What this does NOT do

- Doesn't touch arbitrage or cheap_charge — those stay cost-minimising.
- Doesn't eliminate confidence-blending over-hedging (C5 in the plan, deferred).
- Doesn't change `modeAllows` — self_consumption still forbids grid-to-battery charging and battery-to-grid export.

## After deploy

Fredrik's next self_consumption replan should show `battery_w < 0` for every slot where SoC > 30 % and grid is importing. Compare with the pre-deploy diag snapshot already persisted — delta should be measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)