### PR TITLE
fix(mpc): detect EV drivers by Lua filename when loadpoints absent

### DIFF
--- a/go/cmd/forty-two-watts/capacities_test.go
+++ b/go/cmd/forty-two-watts/capacities_test.go
@@ -64,3 +64,61 @@ func TestDriverCapacitiesFromMultipleLoadpoints(t *testing.T) {
 		t.Errorf("expected only ferroamp, got %v", got)
 	}
 }
+
+// TestDriverCapacitiesFromLuaFilenameFallback covers the case where
+// an operator has not (yet) migrated to a `loadpoints:` config block
+// but still has an EV driver with a vehicle-sized `battery_capacity_wh`.
+// On Fredrik's Pi there are no loadpoints, yet the easee driver's
+// 75000 Wh was inflating the MPC pool. Filename-based detection is
+// the safety net.
+func TestDriverCapacitiesFromLuaFilenameFallback(t *testing.T) {
+	drivers := []config.Driver{
+		{Name: "ferroamp", Lua: "drivers/ferroamp.lua", BatteryCapacityWh: 15200},
+		{Name: "sungrow", Lua: "drivers/sungrow.lua", BatteryCapacityWh: 9600},
+		{Name: "easee", Lua: "drivers/easee_cloud.lua", BatteryCapacityWh: 75000},
+	}
+	got := driverCapacitiesFrom(drivers, nil)
+	if _, ok := got["easee"]; ok {
+		t.Errorf("easee should be filtered out by filename fallback; got %v", got)
+	}
+	if got["ferroamp"] != 15200 {
+		t.Errorf("ferroamp kept wrong value: %v", got["ferroamp"])
+	}
+	if got["sungrow"] != 9600 {
+		t.Errorf("sungrow kept wrong value: %v", got["sungrow"])
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(got), got)
+	}
+}
+
+func TestIsLikelyEVDriver(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// EV chargers — should match.
+		{"drivers/easee_cloud.lua", true},
+		{"drivers/easee.lua", true},
+		{"drivers/ocpp_cp.lua", true},
+		{"drivers/ocpp_csms.lua", true},
+		{"drivers/ctek.lua", true},
+		{"drivers/ctek_mqtt.lua", true},
+		{"drivers/chargestorm.lua", true},
+		{"/abs/path/to/drivers/EASEE.LUA", true}, // case-insensitive
+		// Batteries / inverters / meters — must NOT match.
+		{"drivers/ferroamp.lua", false},
+		{"drivers/sungrow.lua", false},
+		{"drivers/p1meter.lua", false},
+		{"drivers/huawei_battery.lua", false},
+		{"drivers/sim_ev.lua", false}, // "ev" substring not a prefix
+		// Degenerate inputs.
+		{"", false},
+		{"easee_cloud.lua", true}, // bare filename also supported
+	}
+	for _, c := range cases {
+		if got := isLikelyEVDriver(c.in); got != c.want {
+			t.Errorf("isLikelyEVDriver(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1010,9 +1010,44 @@ func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint
 			// (Value remains in cfg.Drivers for any driver-side use.)
 			continue
 		}
+		// Fallback detection: operators who haven't migrated to a
+		// `loadpoints:` config block still have EV drivers with
+		// `battery_capacity_wh` pointing at vehicle capacity. Match
+		// on Lua filename prefix — narrow allowlist of known EV
+		// charger drivers so we don't accidentally exclude a battery
+		// driver whose name happens to share a substring.
+		if isLikelyEVDriver(d.Lua) {
+			continue
+		}
 		out[d.Name] = d.BatteryCapacityWh
 	}
 	return out
+}
+
+// isLikelyEVDriver classifies a Lua path as pointing at an EV charger
+// driver based on the filename prefix. Kept narrow + allowlist-style —
+// a battery driver named "easy_battery.lua" would be wrongly excluded
+// by a broader regex, so we only match EV chargers we actually ship.
+func isLikelyEVDriver(luaPath string) bool {
+	if luaPath == "" {
+		return false
+	}
+	base := strings.ToLower(luaPath)
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.TrimSuffix(base, ".lua")
+	for _, p := range []string{
+		"easee",       // easee_cloud.lua, easee.lua
+		"ocpp",        // ocpp_cp.lua, ocpp_csms.lua
+		"ctek",        // ctek.lua, ctek_mqtt.lua, ctek_v2.lua
+		"chargestorm", // CTEK Chargestorm variants
+	} {
+		if strings.HasPrefix(base, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // warnIfEVHasBatteryCapacity surfaces operator mis-config where an EV
@@ -1032,14 +1067,21 @@ func warnIfEVHasBatteryCapacity(drivers []config.Driver, loadpoints []config.Loa
 		if d.BatteryCapacityWh <= 0 {
 			continue
 		}
-		if _, isEV := evDrivers[d.Name]; !isEV {
+		_, isEVByLoadpoint := evDrivers[d.Name]
+		isEVByFilename := isLikelyEVDriver(d.Lua)
+		if !isEVByLoadpoint && !isEVByFilename {
 			continue
 		}
-		slog.Warn("driver is referenced by a loadpoint — battery_capacity_wh "+
-			"is being ignored for MPC battery-pool sizing. Move the value "+
-			"to loadpoints[].vehicle_capacity_wh to keep EV SoC inference "+
+		reason := "driver is referenced by a loadpoint"
+		if !isEVByLoadpoint && isEVByFilename {
+			reason = "driver's Lua filename matches a known EV charger"
+		}
+		slog.Warn(reason+" — battery_capacity_wh is being ignored for MPC "+
+			"battery-pool sizing. Move the value to "+
+			"loadpoints[].vehicle_capacity_wh to keep EV SoC inference "+
 			"working.",
 			"driver", d.Name,
+			"lua", d.Lua,
 			"battery_capacity_wh", d.BatteryCapacityWh)
 	}
 }


### PR DESCRIPTION
## Summary
- Follow-up to #121. The loadpoints-based EV filter only fires when `config.yaml` has a `loadpoints:` section. Fredrik's production Pi does not — so the easee driver's 75 kWh vehicle capacity is still being aggregated into the MPC battery pool (`capacity_wh = 99800` instead of 24800).
- Add a narrow filename-prefix allowlist (`easee`, `ocpp`, `ctek`, `chargestorm`) as a fallback inside `driverCapacitiesFrom` and `warnIfEVHasBatteryCapacity`.
- Without this, PR #122's strict self_consumption bias has no effect on Fredrik's morning replan because the SoC floor (SoCMin+20) is computed against the inflated pool.

## Why the prefix allowlist and not a regex
A battery driver named `easy_battery.lua` would be wrongly excluded by anything broader. Keep the list to EV chargers we actually ship.

## Test plan
- [x] `go test ./cmd/forty-two-watts/...` passes (existing 3 capacity tests + 2 new: filename fallback + prefix classifier truth table)
- [x] `go test ./...` incl. e2e stays green
- [ ] After deploy, check Pi logs: `mpc: replanned ... capacity_wh=24800` (down from 99800)
- [ ] Check Fredrik's next replan shows `battery_w < 0` in import slots (strict SC now actually biting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)