### PR TITLE
fix(modbus): reconnect on transport errors (Sungrow silent-zeros bug)

### DIFF
--- a/go/internal/modbus/client.go
+++ b/go/internal/modbus/client.go
@@ -2,8 +2,13 @@
 package modbus
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	sv "github.com/simonvetter/modbus"
@@ -11,25 +16,35 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/drivers"
 )
 
-// Capability wraps a simonvetter/modbus client.
+// Capability wraps a simonvetter/modbus client. Each call serializes through
+// the mutex; on a transport-level error a single reconnect + retry is
+// attempted so a silently closed TCP socket (common on Sungrow + several
+// other inverter firmwares after idle timeout or after receiving a write)
+// doesn't condemn the driver to silent zeros until a full process restart.
 type Capability struct {
 	mu     sync.Mutex
 	client *sv.ModbusClient
+	url    string
+	unitID int
 }
 
 // Dial opens a Modbus TCP connection.
 func Dial(host string, port, unitID int) (*Capability, error) {
+	url := fmt.Sprintf("tcp://%s:%d", host, port)
 	cli, err := sv.NewClient(&sv.ClientConfiguration{
-		URL:     fmt.Sprintf("tcp://%s:%d", host, port),
+		URL:     url,
 		Timeout: 5 * time.Second,
 	})
-	if err != nil { return nil, err }
-	if err := cli.Open(); err != nil { return nil, err }
-	// unitID is ignored in TCP (already in PDU) but some devices require a specific value
+	if err != nil {
+		return nil, err
+	}
+	if err := cli.Open(); err != nil {
+		return nil, err
+	}
 	if unitID > 0 {
 		_ = cli.SetUnitId(uint8(unitID))
 	}
-	return &Capability{client: cli}, nil
+	return &Capability{client: cli, url: url, unitID: unitID}, nil
 }
 
 // Close the underlying connection.
@@ -39,29 +54,146 @@ func (c *Capability) Close() error {
 	return c.client.Close()
 }
 
-// Read — implements drivers.ModbusCap.
+// Read — implements drivers.ModbusCap. Reconnects once on transport error.
 func (c *Capability) Read(addr, count uint16, kind int32) ([]uint16, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var rt sv.RegType
 	switch kind {
-	case drivers.ModbusInput: rt = sv.INPUT_REGISTER
-	case drivers.ModbusHolding: rt = sv.HOLDING_REGISTER
-	default: rt = sv.INPUT_REGISTER
+	case drivers.ModbusInput:
+		rt = sv.INPUT_REGISTER
+	case drivers.ModbusHolding:
+		rt = sv.HOLDING_REGISTER
+	default:
+		rt = sv.INPUT_REGISTER
+	}
+	regs, err := c.client.ReadRegisters(addr, count, rt)
+	if err == nil || !isTransportError(err) {
+		return regs, err
+	}
+	if rerr := c.reconnect(); rerr != nil {
+		return nil, fmt.Errorf("read after reconnect: %w (original: %v)", rerr, err)
 	}
 	return c.client.ReadRegisters(addr, count, rt)
 }
 
-// WriteSingle — implements drivers.ModbusCap.
+// WriteSingle — implements drivers.ModbusCap. Reconnects once on transport error.
 func (c *Capability) WriteSingle(addr, value uint16) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	err := c.client.WriteRegister(addr, value)
+	if err == nil || !isTransportError(err) {
+		return err
+	}
+	if rerr := c.reconnect(); rerr != nil {
+		return fmt.Errorf("write after reconnect: %w (original: %v)", rerr, err)
+	}
 	return c.client.WriteRegister(addr, value)
 }
 
-// WriteMulti — implements drivers.ModbusCap.
+// WriteMulti — implements drivers.ModbusCap. Reconnects once on transport error.
 func (c *Capability) WriteMulti(addr uint16, values []uint16) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	err := c.client.WriteRegisters(addr, values)
+	if err == nil || !isTransportError(err) {
+		return err
+	}
+	if rerr := c.reconnect(); rerr != nil {
+		return fmt.Errorf("write-multi after reconnect: %w (original: %v)", rerr, err)
+	}
 	return c.client.WriteRegisters(addr, values)
+}
+
+// reconnect tears down the current socket and dials a fresh one. Caller
+// must hold c.mu. The simonvetter client doesn't self-heal from a closed
+// TCP socket — subsequent reads return errors forever until Open() is
+// called again.
+func (c *Capability) reconnect() error {
+	_ = c.client.Close()
+	cli, err := sv.NewClient(&sv.ClientConfiguration{
+		URL:     c.url,
+		Timeout: 5 * time.Second,
+	})
+	if err != nil {
+		return err
+	}
+	if err := cli.Open(); err != nil {
+		return err
+	}
+	if c.unitID > 0 {
+		_ = cli.SetUnitId(uint8(c.unitID))
+	}
+	c.client = cli
+	slog.Info("modbus reconnected", "url", c.url)
+	return nil
+}
+
+// isTransportError classifies an error as a TCP transport failure where
+// a reconnect is the correct response. Modbus protocol errors (illegal
+// function, illegal address, slave busy) are NOT transport errors —
+// they come from a live peer and the connection is still usable.
+func isTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNABORTED) || errors.Is(err, syscall.ENOTCONN) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	// simonvetter wraps some errors as plain strings; match on the text as
+	// a last resort. Narrow set of known-transport messages only.
+	msg := err.Error()
+	for _, s := range []string{
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"use of closed network connection",
+		"i/o timeout",
+		"EOF",
+	} {
+		if containsFold(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsFold is strings.Contains with a case-insensitive fold. Avoids
+// pulling in strings just for one call.
+func containsFold(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(haystack) < len(needle) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		ok := true
+		for j := 0; j < len(needle); j++ {
+			a, b := haystack[i+j], needle[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
 }

--- a/go/internal/modbus/client_test.go
+++ b/go/internal/modbus/client_test.go
@@ -1,0 +1,150 @@
+package modbus
+
+import (
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/drivers"
+)
+
+func TestIsTransportError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{io.EOF, true},
+		{io.ErrClosedPipe, true},
+		{syscall.ECONNRESET, true},
+		{syscall.EPIPE, true},
+		{syscall.ETIMEDOUT, true},
+		{errors.New("connection reset by peer"), true},
+		{errors.New("broken pipe"), true},
+		{errors.New("use of closed network connection"), true},
+		{errors.New("i/o timeout"), true},
+		{errors.New("EOF"), true},
+		// Modbus protocol errors — live peer, connection usable, no reconnect.
+		{errors.New("illegal data address"), false},
+		{errors.New("illegal function"), false},
+		{errors.New("slave device busy"), false},
+		// Unrelated errors.
+		{errors.New("some random error"), false},
+	}
+	for _, c := range cases {
+		if got := isTransportError(c.err); got != c.want {
+			t.Errorf("isTransportError(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+// TestReadReconnectsAfterServerClosesConnection stands up a TCP
+// server that accepts ONE Modbus request on a connection, then drops
+// the socket. The Capability should detect the transport error and
+// reconnect transparently so the second Read succeeds.
+//
+// This mirrors the Sungrow incident (2026-04-19): after the inverter
+// silently closed our TCP connection following a write command at
+// startup, every subsequent read returned transport errors and our
+// driver emitted zeros for hours. The fix must reconnect on error.
+func TestReadReconnectsAfterServerClosesConnection(t *testing.T) {
+	// Toy Modbus TCP server: responds to read-input-registers once per
+	// connection with a canned value, then closes. Subsequent reads
+	// force the client to reconnect.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	type conn struct{ value uint16 }
+	conns := make(chan conn, 4)
+	conns <- conn{value: 111}
+	conns <- conn{value: 222}
+
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				// Canned "one request per connection". Read MBAP header
+				// (7 bytes) + PDU (5 for read-registers) = 12. Echo back
+				// a one-register response with the queued value.
+				hdr := make([]byte, 12)
+				if _, err := io.ReadFull(c, hdr); err != nil {
+					return
+				}
+				// Pull next queued value (non-blocking default = 0).
+				var v uint16
+				select {
+				case cv := <-conns:
+					v = cv.value
+				default:
+				}
+				// Response: MBAP (transaction id echo, proto 0, len=5, unit id
+				// echo) + PDU (fc echo, byte count=2, val hi/lo).
+				resp := []byte{
+					hdr[0], hdr[1], // tx id
+					0, 0, // protocol
+					0, 5, // length
+					hdr[6],      // unit id
+					hdr[7],      // function code
+					2,           // byte count
+					byte(v >> 8), byte(v),
+				}
+				_, _ = c.Write(resp)
+				// Close intentionally — mimic Sungrow's behavior.
+			}(c)
+		}
+	}()
+
+	host, portStr, _ := net.SplitHostPort(listener.Addr().String())
+	var port int
+	if _, err := fmtSscan(portStr, &port); err != nil {
+		t.Fatalf("bad listener port: %v", err)
+	}
+
+	cap, err := Dial(host, port, 1)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer cap.Close()
+
+	// First read — server accepts, responds 111, closes.
+	regs, err := cap.Read(0, 1, drivers.ModbusInput)
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if len(regs) != 1 || regs[0] != 111 {
+		t.Errorf("first read = %v, want [111]", regs)
+	}
+
+	// Second read — initial socket is dead. Cap should reconnect and
+	// return 222 from the queued-conn value.
+	regs, err = cap.Read(0, 1, drivers.ModbusInput)
+	if err != nil {
+		t.Fatalf("second read (reconnect path): %v", err)
+	}
+	if len(regs) != 1 || regs[0] != 222 {
+		t.Errorf("second read after reconnect = %v, want [222]", regs)
+	}
+}
+
+// tiny strconv-free int parser to avoid pulling strconv in a single spot.
+func fmtSscan(s string, out *int) (int, error) {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, errors.New("bad digit")
+		}
+		n = n*10 + int(c-'0')
+	}
+	*out = n
+	return len(s), nil
+}


### PR DESCRIPTION
## Summary

On 2026-04-19 Fredrik's Sungrow SH10RT silently stopped reporting telemetry — pv/bat/meter/SoC all stuck at zero for hours, SoC slowly draining below the configured 10 % floor with no visibility. Root cause: after our watchdog-triggered write at startup, the inverter's TCP Modbus server dropped the session. The simonvetter/modbus client does **not** auto-reopen — subsequent `ReadRegisters` calls return transport errors until `Open()` is called again. Our driver's `pcall` around `host.modbus_read` caught those errors silently and emitted zeros. A manual driver-restart fixed it, confirming the theory.

## Fix

`Capability.Read / WriteSingle / WriteMulti` now classify errors:

- **Transport** (`EOF`, `ECONNRESET`, `EPIPE`, `i/o timeout`, `net.Error.Timeout=true`, plus a narrow allowlist of simonvetter's wrapped string-errors) → reconnect + retry once
- **Protocol** (illegal address / illegal function / slave busy) → bubble up — peer is alive, connection is fine

## Test plan

- [x] `isTransportError` truth table (10 cases)
- [x] Toy TCP server responds once then closes the socket; verifies `Read` reconnects and returns the next queued value
- [x] Full `go test ./...` incl. e2e stays green
- [ ] Deploy to Fredrik's Pi; Sungrow telemetry should now survive any mid-session disconnect automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)