### PR TITLE
fix(mpc,config): address Codex review on #119 #121 #122 #124

### DIFF
--- a/go/cmd/forty-two-watts/capacities_test.go
+++ b/go/cmd/forty-two-watts/capacities_test.go
@@ -92,6 +92,30 @@ func TestDriverCapacitiesFromLuaFilenameFallback(t *testing.T) {
 	}
 }
 
+// TestDriverCapacitiesFromIgnoresInvalidLoadpoints covers the
+// Codex P2 on PR #121: loadpoint entries with missing id are
+// rejected by loadpoint.Manager but were silently excluding their
+// driver from the MPC pool anyway. A malformed config row should
+// never cause a real battery to vanish from the planner.
+func TestDriverCapacitiesFromIgnoresInvalidLoadpoints(t *testing.T) {
+	drivers := []config.Driver{
+		{Name: "ferroamp", BatteryCapacityWh: 15200},
+		{Name: "sungrow", BatteryCapacityWh: 9600},
+	}
+	// Malformed loadpoint row: no id. Manager would reject this.
+	// Must NOT cause ferroamp to be excluded from MPC capacity.
+	loadpoints := []config.Loadpoint{
+		{ID: "", DriverName: "ferroamp"},
+	}
+	got := driverCapacitiesFrom(drivers, loadpoints)
+	if got["ferroamp"] != 15200 {
+		t.Errorf("ferroamp dropped by invalid loadpoint row: %v", got)
+	}
+	if got["sungrow"] != 9600 {
+		t.Errorf("sungrow missing: %v", got)
+	}
+}
+
 func TestIsLikelyEVDriver(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -232,6 +232,12 @@ func main() {
 		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
 	}
 
+	// Forward-declared so the hot-reload closure below can push
+	// capacity changes into the running planner. Assigned at line
+	// ~450 after all its dependencies (pvSvc, loadSvc, priceFc) are
+	// wired up. nil until that point — the reload closure guards.
+	var mpcSvc *mpc.Service
+
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
@@ -254,6 +260,19 @@ func main() {
 				capacities[k] = v
 			}
 			capMu.Unlock()
+
+			// Push the new pool totals into the planner so its next
+			// replan uses the right CapacityWh / MaxChargeW /
+			// MaxDischargeW. Without this the MPC keeps the snapshot
+			// it took at buildMPC time; SoC % and terminal credit go
+			// stale after an EV loadpoint is added/removed. Codex P1
+			// on PR #121.
+			if mpcSvc != nil {
+				totalCap, maxChg, maxDis := aggregateBatteryLimits(newCfg, capacities)
+				mpcSvc.UpdateCapacity(totalCap, maxChg, maxDis)
+				slog.Info("mpc: capacity updated via hot-reload",
+					"capacity_wh", totalCap, "max_charge_w", maxChg, "max_discharge_w", maxDis)
+			}
 
 			// Hot-reload EV loadpoints so operators can add / remove /
 			// retune them without restarting. Manager preserves
@@ -430,7 +449,7 @@ func main() {
 	slog.Info("loadmodel started", "peak_w", loadPeakW, "quality", loadSvc.Model().Quality())
 
 	// ---- Start MPC planner (optional) ----
-	mpcSvc := buildMPC(cfg, st, tel, capacities)
+	mpcSvc = buildMPC(cfg, st, tel, capacities)
 	if mpcSvc != nil {
 		if pvSvc != nil {
 			mpcSvc.PV = pvSvc.Predict
@@ -530,7 +549,19 @@ func main() {
 		// telemetry, not plan forecasts). See docs/plan-ems-contract.md.
 		// `planner.legacy_dispatch: true` opts back to the old
 		// PI-on-grid-target path for emergency rollback.
+		//
+		// Back-compat: honor the deprecated `use_energy_dispatch`
+		// key when explicitly set. An operator who had
+		// `use_energy_dispatch: false` in their config before v0.27.0
+		// chose legacy on purpose — don't silently flip them.
 		ctrl.UseEnergyDispatch = cfg.Planner == nil || !cfg.Planner.LegacyDispatch
+		if cfg.Planner != nil && cfg.Planner.UseEnergyDispatch != nil {
+			v := *cfg.Planner.UseEnergyDispatch
+			slog.Warn("planner.use_energy_dispatch is deprecated — use planner.legacy_dispatch: "+
+				"true to opt out of the energy path instead. Honored for this run.",
+				"value", v)
+			ctrl.UseEnergyDispatch = v
+		}
 		// If the restored control mode is a planner variant, push the
 		// corresponding mpc.Mode so the plan is built with the strategy
 		// the user actually picked — not whatever cfg.planner.mode says.
@@ -1002,9 +1033,16 @@ func registerAllDevices(st *state.Store, reg *drivers.Registry) {
 func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint) map[string]float64 {
 	evDrivers := make(map[string]struct{}, len(loadpoints))
 	for _, lp := range loadpoints {
-		if lp.DriverName != "" {
-			evDrivers[lp.DriverName] = struct{}{}
+		// Only treat a loadpoint row as authoritative when it's
+		// valid enough for loadpoint.Manager to actually load it.
+		// An entry with an empty id is rejected by the manager (see
+		// loadpoint.Manager.Load) — accepting it here would silently
+		// drop a real battery from the MPC pool on nothing but
+		// config noise.
+		if lp.ID == "" || lp.DriverName == "" {
+			continue
 		}
+		evDrivers[lp.DriverName] = struct{}{}
 	}
 	out := make(map[string]float64, len(drivers))
 	for _, d := range drivers {
@@ -1065,9 +1103,10 @@ func isLikelyEVDriver(luaPath string) bool {
 func warnIfEVHasBatteryCapacity(drivers []config.Driver, loadpoints []config.Loadpoint) {
 	evDrivers := make(map[string]struct{}, len(loadpoints))
 	for _, lp := range loadpoints {
-		if lp.DriverName != "" {
-			evDrivers[lp.DriverName] = struct{}{}
+		if lp.ID == "" || lp.DriverName == "" {
+			continue
 		}
+		evDrivers[lp.DriverName] = struct{}{}
 	}
 	for _, d := range drivers {
 		if d.BatteryCapacityWh <= 0 {
@@ -1111,17 +1150,12 @@ func buildLoadpointConfigs(src []config.Loadpoint) []loadpoint.Config {
 	return out
 }
 
-// buildMPC constructs a planner from config. Returns nil if disabled,
-// if prices aren't configured, or if there are no batteries with capacity.
-func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacities map[string]float64) *mpc.Service {
-	if cfg.Planner == nil || !cfg.Planner.Enabled {
-		return nil
-	}
-	if cfg.Price == nil || cfg.Price.Provider == "" || cfg.Price.Provider == "none" {
-		slog.Warn("mpc requires price provider — skipping")
-		return nil
-	}
-	var totalCap, maxChg, maxDis float64
+// aggregateBatteryLimits sums capacity + max charge/discharge across
+// battery drivers the MPC should plan for, applying fuse-capacity
+// clamps. Returned values are what buildMPC used to compute inline at
+// startup — hoisted into a helper so the config-reload path can call
+// it and push the new totals into an already-running mpc.Service.
+func aggregateBatteryLimits(cfg *config.Config, capacities map[string]float64) (totalCap, maxChg, maxDis float64) {
 	for _, d := range cfg.Drivers {
 		cap := capacities[d.Name]
 		if cap <= 0 {
@@ -1165,10 +1199,6 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		maxChg += chg
 		maxDis += dis
 	}
-	if totalCap <= 0 {
-		slog.Warn("mpc: no battery capacity — skipping")
-		return nil
-	}
 	// Clamp aggregate charge/discharge to the grid fuse capacity. The
 	// control loop's fuse guard enforces this per-tick anyway, but a
 	// planner that schedules 45 kW of charge through a 16 A fuse (11 kW)
@@ -1188,6 +1218,24 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 				"requested_w", maxDis, "fuse_w", fuseMaxW)
 			maxDis = fuseMaxW
 		}
+	}
+	return totalCap, maxChg, maxDis
+}
+
+// buildMPC constructs a planner from config. Returns nil if disabled,
+// if prices aren't configured, or if there are no batteries with capacity.
+func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacities map[string]float64) *mpc.Service {
+	if cfg.Planner == nil || !cfg.Planner.Enabled {
+		return nil
+	}
+	if cfg.Price == nil || cfg.Price.Provider == "" || cfg.Price.Provider == "none" {
+		slog.Warn("mpc requires price provider — skipping")
+		return nil
+	}
+	totalCap, maxChg, maxDis := aggregateBatteryLimits(cfg, capacities)
+	if totalCap <= 0 {
+		slog.Warn("mpc: no battery capacity — skipping")
+		return nil
 	}
 	pl := cfg.Planner
 	zone := "SE3"

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -95,6 +95,14 @@ type Planner struct {
 	// live data" and is the correct architecture (see
 	// docs/plan-ems-contract.md).
 	LegacyDispatch bool `yaml:"legacy_dispatch,omitempty" json:"legacy_dispatch,omitempty"`
+
+	// UseEnergyDispatch is the deprecated inverse of LegacyDispatch.
+	// Pointer so we can distinguish "unset" (nil) from "explicitly
+	// false" (*false) — the latter matters because an operator who
+	// previously picked legacy dispatch must not be silently flipped
+	// to the energy path on upgrade. Honored with a startup WARN
+	// and will be removed after one release.
+	UseEnergyDispatch *bool `yaml:"use_energy_dispatch,omitempty" json:"use_energy_dispatch,omitempty"`
 }
 
 // Site is the top-level control loop config.

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -48,6 +48,47 @@ func TestLoadMinimalYAML(t *testing.T) {
 	}
 }
 
+// TestDeprecatedUseEnergyDispatchParsesAsPointer covers the
+// Codex P1 on PR #124: an operator who explicitly set
+// `use_energy_dispatch: false` to pick legacy dispatch pre-v0.27
+// must not be silently flipped to the energy path on upgrade. The
+// field lives on as a deprecated *bool so main.go can distinguish
+// "unset" (nil) from "explicitly false" and honor prior intent.
+func TestDeprecatedUseEnergyDispatchParsesAsPointer(t *testing.T) {
+	yaml := minimalYAML + `
+planner:
+  enabled: true
+  use_energy_dispatch: false
+`
+	c, err := Parse([]byte(yaml), "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Planner == nil {
+		t.Fatal("planner not parsed")
+	}
+	if c.Planner.UseEnergyDispatch == nil {
+		t.Fatal("UseEnergyDispatch should be non-nil when key is present")
+	}
+	if *c.Planner.UseEnergyDispatch != false {
+		t.Errorf("UseEnergyDispatch = %v, want false", *c.Planner.UseEnergyDispatch)
+	}
+}
+
+func TestUseEnergyDispatchNilWhenUnset(t *testing.T) {
+	yaml := minimalYAML + `
+planner:
+  enabled: true
+`
+	c, err := Parse([]byte(yaml), "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Planner.UseEnergyDispatch != nil {
+		t.Errorf("UseEnergyDispatch should be nil when YAML omits the key, got %v", *c.Planner.UseEnergyDispatch)
+	}
+}
+
 func TestRelativeDriverPathResolved(t *testing.T) {
 	c, err := Parse([]byte(minimalYAML), "/base/dir")
 	if err != nil {

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -392,14 +392,22 @@ func Optimize(slots []Slot, p Params) Plan {
 						// Strict self-consumption bias. When the mode
 						// is self_consumption and the battery has
 						// headroom above the SoC floor + 20 %, we
-						// triple the cost the DP sees for any grid-
-						// import slot. That makes discharge (which
-						// avoids the tripled cost) strictly cheaper
-						// than idle whenever the battery can
-						// physically supply the load — even after
-						// accounting for the terminal-SoC credit
-						// the DP would otherwise use to justify
-						// preserving SoC for later.
+						// add a penalty equal to 2× effPrice per kWh
+						// of HOUSE-driven grid import — so the total
+						// house-import cost the DP sees is tripled.
+						// That makes discharge strictly cheaper than
+						// idle whenever the battery can physically
+						// supply house load.
+						//
+						// The penalty applies only to the house
+						// portion of the import (gridW minus EV). EV
+						// charging has its own deadline-shortfall
+						// penalty (below, 4× meanPrice per kWh of
+						// shortfall); applying the SC bias on top
+						// would let the DP prefer missing an EV
+						// deadline over charging it whenever the
+						// slot price exceeded ~4/3 of the horizon
+						// mean — Codex P1 on PR #122.
 						//
 						// Rationale: operator picked self_consumption
 						// because they want "use my battery before
@@ -411,16 +419,13 @@ func Optimize(slots []Slot, p Params) Plan {
 						// The 20-% floor stops the DP from draining
 						// a nearly-empty battery on a cloudy
 						// morning; above it, discharge wins.
-						//
-						// Factor 3 chosen so: (import_cost × 3) beats
-						// (terminal_credit × discharge_wh) on any
-						// reasonable TerminalSoCPrice ≤ retail_mean.
-						// Above that terminal value the DP is
-						// probably misconfigured anyway.
 						if p.Mode == ModeSelfConsumption &&
-							gridKWh > 0 &&
 							soc > p.SoCMinPct+20 {
-							cost *= 3.0
+							houseGridW := slot.LoadW + slot.PVW + battW
+							if houseGridW > 0 {
+								houseKWh := houseGridW * dtH / 1000.0
+								cost += 2.0 * effPrice(slot) * houseKWh
+							}
 						}
 
 						// Deadline slot: if this slot is the EV's
@@ -746,8 +751,14 @@ func reasonFor(s Slot, batteryW, gridW, meanPrice float64) string {
 
 	switch {
 	// --- charging branches ---
-	case batteryW > chargeThresh && baseline < -chargeThresh && !gridExports:
-		// PV surplus fully absorbed into the battery.
+	case batteryW > chargeThresh && baseline < -chargeThresh && !gridImports:
+		// PV-dominant baseline + battery charging + not pulling extra
+		// from grid → the battery is absorbing (part of) the PV
+		// surplus. Partial absorption (grid still exports some) still
+		// counts as "absorb PV surplus" — the operator is seeing the
+		// battery act as a sink for solar energy. Only flip to the
+		// "charge — import" branches when the battery's appetite
+		// exceeds PV output and drags grid into actual import.
 		return "absorb PV surplus" + priceTag
 	case batteryW > chargeThresh && gridImports && priceBelow:
 		return "charge from cheap grid" + priceTag

--- a/go/internal/mpc/reason_test.go
+++ b/go/internal/mpc/reason_test.go
@@ -70,6 +70,29 @@ func TestReasonForLabelsBranchOnGridW(t *testing.T) {
 			batteryW: 0, gridW: 2500,
 			wantContain: "import to cover",
 		},
+		// Codex P2 on PR #119 — the "absorb PV surplus" branch used
+		// !gridExports which broke both edges.
+		{
+			// Partial PV absorption: battery charges, takes some of
+			// the surplus, rest still exports to grid. Operator is
+			// seeing the battery act as a solar sink, so the label
+			// should reflect that — not generic "charge".
+			name:        "partial PV absorption — battery charging, grid still exporting",
+			loadW:       1000, pvW: -4000,
+			priceOre: 100, meanPrice: 180,
+			batteryW: 2000, gridW: -1000, // baseline=-3000, grid exports 1kW residual
+			wantContain: "absorb PV surplus",
+		},
+		{
+			// Over-charging: battery charges harder than PV provides,
+			// dragging the grid into actual import. Should NOT be
+			// labelled PV absorption — it's grid-charging.
+			name:        "over-charging — battery takes more than PV, grid imports",
+			loadW:       1000, pvW: -1500,
+			priceOre: 100, meanPrice: 180,
+			batteryW: 3000, gridW: 2500, // baseline=-500, battery > PV → import 2.5kW
+			wantContain: "cheap grid", // 100 < 180*0.9 → priceBelow branch
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -133,6 +133,29 @@ func New(st *state.Store, tl *telemetry.Store, zone string, p Params) *Service {
 	}
 }
 
+// UpdateCapacity swaps the aggregate battery capacity + charge/discharge
+// bounds on the active planner. Called from the config-reload path when
+// the operator adds or removes a driver (or promotes/demotes an EV
+// loadpoint) and the MPC battery pool changes. Without this, the
+// planner would keep optimising against its startup-time capacity
+// snapshot while the dispatch layer already saw the new numbers — the
+// plan's SoC% and terminal credit would drift from reality until the
+// next process restart. Codex P1 on PR #121.
+//
+// Caller is expected to pass the same totals buildMPC would have
+// computed from the new config: totalCap across battery drivers,
+// aggregate max charge/discharge clamped to fuse capacity.
+func (s *Service) UpdateCapacity(totalCapWh, maxChargeW, maxDischargeW float64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.Defaults.CapacityWh = totalCapWh
+	s.Defaults.MaxChargeW = maxChargeW
+	s.Defaults.MaxDischargeW = maxDischargeW
+	s.mu.Unlock()
+}
+
 // Latest returns the most recently computed plan (nil before first run).
 func (s *Service) Latest() *Plan {
 	if s == nil {

--- a/go/internal/mpc/strict_sc_test.go
+++ b/go/internal/mpc/strict_sc_test.go
@@ -36,6 +36,85 @@ func TestStrictSelfConsumptionDischargesWhenSoCHealthy(t *testing.T) {
 	}
 }
 
+// TestStrictSelfConsumptionDoesNotStarveEVDeadline is Codex P1 on
+// PR #122: the original strict-SC bias multiplied the cost of every
+// importing action by 3, including EV-charging import. At slot
+// prices above ~4/3 × meanPrice the DP would prefer missing the
+// EV's deadline (shortfall penalty = 4×meanPrice per kWh) over
+// paying the tripled import cost. The fix scopes the bias to the
+// HOUSE portion of the grid import only — EV import keeps its
+// un-biased cost so the deadline-penalty comparison stays honest.
+//
+// Scenario: 3-slot horizon with a peak-price deadline slot.
+// meanPrice = (400+100+100)/3 ≈ 200. Slot 0 price 400 = 2× mean,
+// comfortably above the 4/3 breakpoint where the pre-fix bias
+// would have chosen to miss the deadline. MaxDischargeW is
+// limited to 1000 W so the battery physically CANNOT cover both
+// house load and the EV's 2.5 kW draw — the DP has to import
+// something, and the question is whether that import is priced
+// under the SC bias (pre-fix → starves EV) or left at its plain
+// cost (post-fix → DP charges to meet deadline).
+func TestStrictSelfConsumptionDoesNotStarveEVDeadline(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 400, SpotOre: 200,
+			LoadW: 500, PVW: -200, Confidence: 1.0},
+		{StartMs: 3600 * 1000, LenMin: 60, PriceOre: 100, SpotOre: 40,
+			LoadW: 500, PVW: -200, Confidence: 1.0},
+		{StartMs: 2 * 3600 * 1000, LenMin: 60, PriceOre: 100, SpotOre: 40,
+			LoadW: 500, PVW: -200, Confidence: 1.0},
+	}
+	p := baseParams(ModeSelfConsumption)
+	p.InitialSoCPct = 80 // well above floor+20
+	p.TerminalSoCPrice = 100
+	p.MaxDischargeW = 1000 // battery can't cover load + EV alone
+	p.MaxChargeW = 1000
+	p.Loadpoint = &LoadpointSpec{
+		ID:               "garage",
+		CapacityWh:       10000,
+		Levels:           11,
+		MaxPct:           100,
+		InitialSoCPct:    20,
+		PluggedIn:        true,
+		TargetSoCPct:     40, // need 2 kWh
+		TargetSlotIdx:    0,  // deadline = slot 0
+		MaxChargeW:       2500,
+		AllowedStepsW:    []float64{0, 2500},
+		ChargeEfficiency: 0.95,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) == 0 {
+		t.Fatal("empty plan")
+	}
+	evW := plan.Actions[0].LoadpointW
+	if evW < 1000 {
+		t.Errorf("EV deadline starved: slot 0 LoadpointW=%.0f W (expected ≈ 2500). "+
+			"Before the Codex fix the strict-SC import bias applied to EV energy, "+
+			"making missed-deadline cost cheaper than charging at peak price.", evW)
+	}
+}
+
+// TestUpdateCapacityPropagatesToDefaults covers Codex P1 on PR #121
+// — the hot-reload path now pushes new totals into the running
+// service so the next replan uses them instead of the startup
+// snapshot. The field is mutex-protected because a reactive replan
+// could race the reload.
+func TestUpdateCapacityPropagatesToDefaults(t *testing.T) {
+	s := &Service{Defaults: Params{CapacityWh: 99800, MaxChargeW: 11040, MaxDischargeW: 11040}}
+	s.UpdateCapacity(24800, 8000, 8000)
+	if s.Defaults.CapacityWh != 24800 {
+		t.Errorf("CapacityWh = %f, want 24800", s.Defaults.CapacityWh)
+	}
+	if s.Defaults.MaxChargeW != 8000 {
+		t.Errorf("MaxChargeW = %f, want 8000", s.Defaults.MaxChargeW)
+	}
+	if s.Defaults.MaxDischargeW != 8000 {
+		t.Errorf("MaxDischargeW = %f, want 8000", s.Defaults.MaxDischargeW)
+	}
+	// Nil receiver must no-op, not panic.
+	var nilSvc *Service
+	nilSvc.UpdateCapacity(1, 2, 3)
+}
+
 // TestStrictSelfConsumptionBacksOffNearSoCFloor — below floor+20% the
 // strict bias shouldn't kick in, so a nearly-empty battery doesn't
 // suicide trying to cover a big load.


### PR DESCRIPTION
## Summary

Follow-up to this morning's planner-overhaul batch (PRs #119 → #125). `chatgpt-codex-connector` flagged 4 P1 and 2 P2 issues across those PRs — all real, all verified by reading the code. This PR addresses them.

## Fixes

| PR | Sev | Issue | Fix |
|---|---|---|---|
| #119 | P2 | `reasonFor` "absorb PV surplus" used `!gridExports` — labelled partial absorption as generic "charge" and over-charging as PV absorption | Flipped to `!gridImports`; added two test cases |
| #121 | P1 | Hot-reload updated dispatch capacity map but planner kept startup snapshot — SoC % / terminal credit went stale until restart | Hoisted capacity aggregation into helper + `mpc.Service.UpdateCapacity()`; reload closure now pushes new totals |
| #121 | P2 | Any non-empty `loadpoints[].driver_name` excluded a driver — malformed rows (missing id) silently dropped real batteries | Require `lp.ID != ""` before using the reference; regression test |
| #122 | P1 | Strict-SC 3× bias applied to total import incl. EV; at slot price > 4/3 × mean, DP chose missing EV deadline over charging | Rewrote as `+2× effPrice` additive on HOUSE-portion only; EV import keeps plain cost |
| #124 | P1 | Dropped `use_energy_dispatch` key entirely; operators who explicitly set it to `false` would silently flip to energy path | Added back as `*bool` alias with deprecation WARN; honors prior intent |

## Test plan

- [x] Five new/updated test cases, one per issue
- [x] `go test ./...` incl. e2e stays green
- [ ] Deploy to Fredrik's Pi; verify reload-path pushes new capacity into planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)