### PR TITLE
fix(web): raise header z-index so update modal covers energy-flow hero

### DIFF
--- a/web/next.css
+++ b/web/next.css
@@ -32,12 +32,19 @@ body.ftw-next::before {
     linear-gradient(to bottom, transparent 0%, oklch(0.1 0.015 250) 100%);
 }
 
-body.ftw-next > header,
 body.ftw-next > main,
 body.ftw-next > footer,
 body.ftw-next > section {
   position: relative;
   z-index: 1;
+}
+/* Header sits in its own stacking context above main so the
+   <ftw-update-badge> modal (rendered inside the header pill) can cover
+   the energy-flow hero. Without this the header and main share z-index 1
+   and main wins on paint order, clipping the modal behind the hero. */
+body.ftw-next > header {
+  position: relative;
+  z-index: 10;
 }
 
 body.ftw-next main {


### PR DESCRIPTION
## Summary
- `<ftw-update-badge>` lives inside the `/next` header pill's shadow DOM. Header and main both sat at `z-index: 1`, so main painted above header by DOM order and the energy-flow hero clipped the update modal on desktop.
- Promote `body.ftw-next > header` to `z-index: 10` so its descendants (including the modal at shadow z-index 1001) stack above the hero.
- Mobile `header.menu-open { z-index: 1000 }` rule and `header::before { z-index: -1 }` backdrop are unaffected.

## Test plan
- [ ] Open `/next` on desktop, click the version in the header, confirm the update modal overlays the energy-flow hero.
- [ ] Resize to ≤720 px, open the hamburger drawer, confirm the drawer still layers correctly.
- [ ] Confirm the header pill's backdrop-filter blur (`::before`) still clips inside the pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)