### PR TITLE
feat(setup): pre-setup update check via <ftw-update-check>

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,7 +45,7 @@ inherit into every shadow DOM via `:root`.
 
 ### Light (flipped when `data-theme="light"`)
 
-Only the next-era tokens flip — legacy hex tokens stay for `/index.html`.
+Only the next-era tokens flip — legacy hex tokens stay for `/legacy`.
 
 | Token | Value |
 |---|---|
@@ -63,7 +63,8 @@ light mode so they keep contrast on paper without looking neon.
 
 Hex tokens `--bg / --surface / --surface2 / --border / --text /
 --text-dim / --accent / --green / --red / --radius` live at `:root`
-alongside the next palette so `/index.html` keeps its historical
+alongside the next palette so `/legacy` (the pre-redesign dashboard,
+still served for regression comparison) keeps its historical
 appearance. **Do not use these for new work** — reach for the oklch
 tokens above.
 
@@ -222,7 +223,8 @@ on cards, large rounded boxes (> 18 px radius), gradient-filled buttons.
 |---|---|
 | `web/components/theme.css` | All tokens, both themes. Loaded first by every page. |
 | `web/components/ftw-element.js` | Base class that gives every `<ftw-*>` shadow DOM the token inheritance for free. |
-| `web/style.css` | Legacy `/index.html` styling. **Read-only** for new work. |
+| `web/style.css` | Shared foundation — loaded by `/`, `/legacy`, `/setup`. Holds resets, form defaults, and legacy dashboard rules that haven't migrated yet. Retire once `/legacy` goes away. |
+| `web/next.css` | `/` (default dashboard) specific layer — scoped to `body.ftw-next` so it doesn't bleed into `/legacy`. |
 | `web/next.css` | `/next` dashboard specific layout. |
 | `web/setup.html` (inline `<style>`) | `/setup` wizard chrome. |
 
@@ -236,7 +238,7 @@ light theme can flip it cleanly.
 - Do not reintroduce Google Fonts. Self-host or fall back to system.
 - Do not hard-code `#ffb020` — use `var(--accent-e)`.
 - Do not use the legacy hex palette (`--surface`, `--accent`, `--green`)
-  in new code; those tokens will be retired once `/index.html` is
+  in new code; those tokens will be retired once `/legacy` is
   decommissioned.
 - Do not stack multiple accent colours. One accent, restraint, hierarchy
   through mono / sans contrast and type weight.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,244 @@
+# forty-two-watts — UI design system
+
+One source of truth for tokens, typography, and the component vocabulary
+shared across the landing page (fortytwowatts.com), the `/next` dashboard,
+and the `/setup` wizard. Tokens live in `web/components/theme.css` and
+inherit into every shadow DOM via `:root`.
+
+## Principles
+
+- **Flat, technical, editorial.** No drop shadows, no gradients (outside
+  the hero flow diagram), no noise / grain. Hairline 1 px borders and
+  a single warm accent do all the visual work.
+- **One accent.** Amber (`--accent-e`). Everything else is ink or text.
+  Status colours (red / green / cyan) exist but are reserved for
+  state — not decoration.
+- **Monospace as a texture.** Tabular numerics, eyebrow labels, API
+  output, and section titles use `var(--mono)`. Prose uses `var(--sans)`.
+- **Dark-first.** Dark is default; light is opt-in via
+  `<html data-theme="light">`. Both themes share token *names*; only
+  their values flip.
+- **No network fonts.** Fallbacks resolve to `system-ui` / `ui-monospace`
+  so every page renders on a fresh Pi with no WAN.
+
+## Palette
+
+### Dark (default)
+
+| Token | Role | Value |
+|---|---|---|
+| `--ink` | Page background | `oklch(0.14 0.015 250)` |
+| `--ink-raised` | Cards, surfaces | `oklch(0.18 0.02 250)` |
+| `--ink-sunken` | Inputs, recessed areas | `oklch(0.11 0.015 250)` |
+| `--line` | Default 1 px border | `oklch(0.26 0.015 250)` |
+| `--line-soft` | Subtle divider | `oklch(0.22 0.015 250)` |
+| `--fg` | Body text | `oklch(0.96 0.01 250)` |
+| `--fg-dim` | Secondary text | `oklch(0.70 0.015 250)` |
+| `--fg-muted` | Eyebrow / caption text | `oklch(0.50 0.015 250)` |
+| `--accent-e` | Primary accent (amber) | `oklch(0.82 0.16 65)` |
+| `--amber`, `--amber-d` | Warm chart / decorative | amber pair |
+| `--green-e` | "Ok", online, success | `oklch(0.78 0.16 150)` |
+| `--red-e` | Error, remove, critical | `oklch(0.72 0.18 20)` |
+| `--cyan`, `--cyan-dim` | PV / informational | cyan pair |
+| `--violet` | MPC / plan layer | `oklch(0.80 0.14 300)` |
+| `--white-s` | Strong on-accent text | `oklch(0.95 0.01 250)` |
+
+### Light (flipped when `data-theme="light"`)
+
+Only the next-era tokens flip — legacy hex tokens stay for `/index.html`.
+
+| Token | Value |
+|---|---|
+| `--ink` | `oklch(0.985 0.005 250)` |
+| `--ink-raised` | `oklch(0.975 0.005 250)` |
+| `--line` | `oklch(0.85 0.01 250)` |
+| `--fg` | `oklch(0.22 0.02 250)` |
+| `--fg-dim` | `oklch(0.40 0.02 250)` |
+| `--accent-e` | `oklch(0.68 0.16 65)` |
+
+Functional colours (`--red-e`, `--green-e`, …) pull ~15 % darker in
+light mode so they keep contrast on paper without looking neon.
+
+### Legacy palette (deprecated, still loaded)
+
+Hex tokens `--bg / --surface / --surface2 / --border / --text /
+--text-dim / --accent / --green / --red / --radius` live at `:root`
+alongside the next palette so `/index.html` keeps its historical
+appearance. **Do not use these for new work** — reach for the oklch
+tokens above.
+
+## Accent hue
+
+`--accent-e` is derived from `--accent-hue` (default `65`, warm amber).
+Changing the hue once rotates every accent-derived surface (hero
+stroke, ring, load-text, glow) to match — do not hard-code amber
+values.
+
+## Typography
+
+### Stacks (no CDN)
+
+```css
+--sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto,
+        'Helvetica Neue', Arial, sans-serif;
+--mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas,
+        'Liberation Mono', monospace;
+```
+
+Inter / JetBrains Mono win if locally installed; otherwise the page
+resolves to the OS's native UI font (Segoe UI, SF, Roboto). We
+deliberately do **not** fetch either from Google Fonts — fresh-Pi
+deploys have to boot without WAN. If exact typographic parity with
+the landing page becomes a hard requirement, self-host the variable
+woff2 under `/web/fonts/` and add `@font-face` — do not reintroduce
+fonts.googleapis.com.
+
+### Scale
+
+| Role | Family | Size | Weight | Letter-spacing |
+|---|---|---|---|---|
+| H1 / hero | sans | clamp(44–80 px) | 700 | −0.035em |
+| H2 / page heading | sans | 1.35 rem | 700 | −0.015em |
+| H3 / card title | sans | 1 rem | 600 | — |
+| Eyebrow / section label | **mono** | 0.68–0.72 rem | 500 | **0.18em**, UPPERCASE |
+| Body | sans | 14 px / 0.9 rem | 400 | — |
+| Numeric callout | **mono** | varies | 500–700 | `font-variant-numeric: tabular-nums` |
+| Button label | sans | 14 px | 500 | — |
+| Dim caption | sans | 0.78–0.82 rem | 400 | — |
+
+Body `line-height: 1.58`. Headings `line-height: 1.1–1.15`.
+
+## Shape & depth
+
+| Token | Value | Used on |
+|---|---|---|
+| `--radius-lg` | 18 px | Hero, large pill headers |
+| `--radius-md` | 14 px | Header drawer, big cards |
+| `--radius-sm` | 10 px | Default card, input group |
+| `--radius` (legacy) | 8 px | Buttons, small controls |
+| (inline) | 999 px | Eyebrow / status pills |
+
+- **Borders**: 1 px solid `var(--line)` everywhere a card exists.
+- **Shadows**: avoid. Single permitted case is
+  `box-shadow: 0 0 10px var(--accent-e)` on a 6 px status / step dot.
+- **Backdrop filters**: `blur(14px)` on the `/next` header
+  pseudo-element only — never on the element itself (it creates a new
+  containing block and breaks `position: fixed` modal descendants,
+  which is why the `<ftw-update-badge>` modal was centring against
+  the header pill before #127).
+
+## Component vocabulary
+
+### Primary CTA
+
+```css
+background: var(--accent-e);
+color: #0a0a0a;          /* on-accent text is near-black, never white */
+padding: 11px 18px;
+border-radius: 8px;
+font-weight: 500; font-size: 14px;
+```
+
+Hover: `transform: translateY(-1px)`, no colour shift.
+
+### Secondary / ghost
+
+```css
+background: transparent;
+color: var(--fg);
+border: 1px solid var(--line);
+border-radius: 8px;
+```
+
+Hover: `border-color: var(--fg-dim)`. Never change background.
+
+### Eyebrow label / section header
+
+```css
+font-family: var(--mono);
+font-size: 0.7rem;
+text-transform: uppercase;
+letter-spacing: 0.18em;
+color: var(--accent-e);   /* or var(--fg-muted) for input labels */
+font-weight: 500;
+```
+
+Use this for every `<label>`, `<h3>` above a card, step title prefix,
+and status-pill content.
+
+### Card
+
+```css
+background: var(--ink-raised);
+border: 1px solid var(--line);
+border-radius: 10px;
+padding: 12px 14px;       /* tight */
+                          /* or 16px 18px for integration sections */
+```
+
+### Input / select
+
+```css
+background: var(--ink-raised);
+border: 1px solid var(--line);
+border-radius: 8px;
+padding: 10px 12px;
+color: var(--fg);
+font-family: var(--sans);
+font-size: 0.9rem;
+```
+
+Focus: `border-color: var(--accent-e)`, no outline.
+
+### Status / step dot
+
+```css
+width: 6px; height: 6px;
+border-radius: 999px;
+background: var(--line);        /* inactive */
+/* active */
+background: var(--accent-e);
+box-shadow: 0 0 10px var(--accent-e);
+/* done */
+background: var(--fg-muted);
+```
+
+## Decorative touches worth echoing
+
+- **Mono numeric prefixes** (`01`, `02`, …) in `var(--accent-e)` before
+  step titles when the page is a workflow.
+- **Pill eyebrows** with `background: color-mix(in srgb, var(--accent-e) 10%, transparent)`,
+  accent text, 999 px radius, mono uppercase.
+- **Accent glow** on small status / step dots
+  (`box-shadow: 0 0 10px var(--accent-e)`).
+- **Hairline section dividers** (1 px `var(--line)`, no shadow).
+
+Avoid: marketing-style radial gradients, noise textures, drop shadows
+on cards, large rounded boxes (> 18 px radius), gradient-filled buttons.
+
+## Files
+
+| File | Owns |
+|---|---|
+| `web/components/theme.css` | All tokens, both themes. Loaded first by every page. |
+| `web/components/ftw-element.js` | Base class that gives every `<ftw-*>` shadow DOM the token inheritance for free. |
+| `web/style.css` | Legacy `/index.html` styling. **Read-only** for new work. |
+| `web/next.css` | `/next` dashboard specific layout. |
+| `web/setup.html` (inline `<style>`) | `/setup` wizard chrome. |
+
+New components read tokens from `:root`; they never redeclare
+colours locally. When a `<ftw-*>` component needs a
+component-specific hue, extend the `--*-e` naming convention so the
+light theme can flip it cleanly.
+
+## What NOT to do
+
+- Do not reintroduce Google Fonts. Self-host or fall back to system.
+- Do not hard-code `#ffb020` — use `var(--accent-e)`.
+- Do not use the legacy hex palette (`--surface`, `--accent`, `--green`)
+  in new code; those tokens will be retired once `/index.html` is
+  decommissioned.
+- Do not stack multiple accent colours. One accent, restraint, hierarchy
+  through mono / sans contrast and type weight.
+- Do not add `box-shadow` on cards or modals. The only sanctioned shadow
+  is the accent glow on status dots.

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,10 +57,10 @@ WARN proxy enabled — /api/* forwards upstream  upstream=http://192.168.1.139:8
 | Path | Handler |
 |---|---|
 | `/api/*` | Forwarded to `FTW_PROXY_UPSTREAM` |
-| `/`, `/index.html`, `/next`, `/setup` | Local `web/` files |
+| `/`, `/index.html`, `/legacy`, `/setup` | Local `web/` files |
 | `/style.css`, `/components/*`, `/app.js`, … | Local `web/` files |
 
-Editing `web/next.html` or `web/components/ftw-modal.js` shows up on
+Editing `web/index.html` or `web/components/ftw-modal.js` shows up on
 the next browser refresh. `/api/status` still shows live SoC from the
 Pi.
 
@@ -93,20 +93,20 @@ Need to exercise write paths for a specific debugging session? Set
   Server-Sent Events / WebSockets wouldn't work through it today.
   The project doesn't use either yet (`clients poll`).
 
-## Side-by-side UI: `/` vs `/next`
+## Side-by-side UI: `/` vs `/legacy`
 
-The web-component refactor lands incrementally. While it's in
-progress, both versions run off the same backend:
+The web-component rewrite is now the default at `/`. The original
+layout is still served at `/legacy` for comparison / regression
+checks while the old file set is wound down:
 
 | URL | HTML | JS | Purpose |
 |---|---|---|---|
-| `/` | `index.html` | `app.js` | Legacy layout, do not touch |
-| `/next` | `next.html` | `next-app.js` | Web-components rewrite |
+| `/` | `index.html` | `next-app.js` | Web-components dashboard (default) |
+| `/legacy` | `legacy.html` | `app.js` | Pre-redesign layout — do not touch |
 
-Both share the same proxy, the same `style.css`, the same theme
-tokens in `/components/theme.css`. Edit on `/next` without
-regressing `/`. The eventual cutover replaces `index.html` with the
-contents of `next.html` and retires the legacy files.
+`/next` stays registered as a 301 to `/` so older bookmarks still
+land on the right page. Both pages share the same proxy, the same
+`style.css`, and the theme tokens in `/components/theme.css`.
 
 ## docker compose dev
 

--- a/go/cmd/forty-two-watts/bootstrap.go
+++ b/go/cmd/forty-two-watts/bootstrap.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/frahlg/forty-two-watts/go/internal/config"
 	"github.com/frahlg/forty-two-watts/go/internal/drivers"
+	"github.com/frahlg/forty-two-watts/go/internal/evcloud"
 	"github.com/frahlg/forty-two-watts/go/internal/scanner"
 	"github.com/frahlg/forty-two-watts/go/internal/selfupdate"
 )
@@ -134,6 +135,45 @@ func runBootstrap(configPath, webDir, driverDir string) {
 			return
 		}
 		writeBootstrapJSON(w, 200, selfUpdater.Status())
+	})
+
+	// POST /api/ev/chargers — authenticate with an EV cloud provider and
+	// list chargers. Mirror of the full-app handler so the setup wizard
+	// can offer a picker instead of asking the operator to transcribe a
+	// serial. No state store here, so password comes only from the body
+	// (no fallback to the persisted ev_charger.password).
+	mux.HandleFunc("POST /api/ev/chargers", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Provider string `json:"provider"`
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+			writeBootstrapJSON(w, 400, map[string]string{"error": "invalid request"})
+			return
+		}
+		if req.Provider == "" {
+			req.Provider = "easee"
+		}
+		if req.Email == "" {
+			writeBootstrapJSON(w, 400, map[string]string{"error": "email required"})
+			return
+		}
+		if req.Password == "" {
+			writeBootstrapJSON(w, 400, map[string]string{"error": "password required"})
+			return
+		}
+		p, err := evcloud.Get(req.Provider)
+		if err != nil {
+			writeBootstrapJSON(w, 400, map[string]string{"error": err.Error()})
+			return
+		}
+		chargers, err := p.ListChargers(req.Email, req.Password)
+		if err != nil {
+			writeBootstrapJSON(w, 502, map[string]string{"error": err.Error()})
+			return
+		}
+		writeBootstrapJSON(w, 200, chargers)
 	})
 
 	// POST /api/config → validate, write, restart

--- a/go/cmd/forty-two-watts/bootstrap.go
+++ b/go/cmd/forty-two-watts/bootstrap.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/config"
 	"github.com/frahlg/forty-two-watts/go/internal/drivers"
 	"github.com/frahlg/forty-two-watts/go/internal/scanner"
+	"github.com/frahlg/forty-two-watts/go/internal/selfupdate"
 )
 
 // runBootstrap starts a minimal HTTP server that serves the setup wizard.
@@ -21,6 +23,30 @@ import (
 // process so the normal startup path takes over.
 func runBootstrap(configPath, webDir, driverDir string) {
 	slog.Info("no config found — starting setup wizard", "url", "http://localhost:8080/setup")
+
+	// Self-update checker runs here too — <ftw-update-check> on the setup
+	// welcome step is useless without /api/version/check, and the whole
+	// point of that banner is to let the operator pull-and-refresh BEFORE
+	// committing config on an outdated release. Store is nil because there
+	// is no SQLite yet; skip persistence falls back to no-op which is fine
+	// for one-shot setup (dismiss is session-only anyway).
+	var selfUpdater *selfupdate.Checker
+	if envBool("FTW_SELFUPDATE_ENABLED") {
+		current := Version
+		if v, ok := os.LookupEnv("FTW_SELFUPDATE_CURRENT_VERSION"); ok && v != "" {
+			current = v
+			slog.Warn("selfupdate: CurrentVersion overridden for testing",
+				"real_version", Version, "reported_version", current,
+				"env", "FTW_SELFUPDATE_CURRENT_VERSION")
+		}
+		selfUpdater = selfupdate.New(selfupdate.Config{
+			CurrentVersion: current,
+			SocketPath:     envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"),
+			StatusPath:     envOr("FTW_UPDATER_STATUS", "/run/ftw-update/state.json"),
+		}, nil)
+		selfUpdater.Start(context.Background())
+		slog.Info("selfupdate enabled in bootstrap", "socket", envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"))
+	}
 
 	mux := http.NewServeMux()
 
@@ -66,6 +92,48 @@ func runBootstrap(configPath, webDir, driverDir string) {
 			return
 		}
 		writeBootstrapJSON(w, 200, devices)
+	})
+
+	// Self-update routes — mirror the subset of /api/version/* that the
+	// setup-wizard's <ftw-update-check> component needs: check, update,
+	// status. Skip/unskip/restart aren't needed from the wizard (dismiss
+	// is session-only; Restart is a dashboard affordance) so we don't
+	// register them — POST hits land on the default 404 path.
+	mux.HandleFunc("GET /api/version/check", func(w http.ResponseWriter, r *http.Request) {
+		if selfUpdater == nil {
+			writeBootstrapJSON(w, 503, map[string]string{"error": "self-update disabled"})
+			return
+		}
+		if r.URL.Query().Get("force") == "1" {
+			info, err := selfUpdater.Check(r.Context(), true)
+			if err != nil {
+				info.Err = err.Error()
+				writeBootstrapJSON(w, 502, info)
+				return
+			}
+		}
+		writeBootstrapJSON(w, 200, selfUpdater.Info())
+	})
+
+	mux.HandleFunc("POST /api/version/update", func(w http.ResponseWriter, r *http.Request) {
+		if selfUpdater == nil {
+			writeBootstrapJSON(w, 503, map[string]string{"error": "self-update disabled"})
+			return
+		}
+		info := selfUpdater.Info()
+		if err := selfUpdater.Trigger(r.Context(), "update", info.Latest); err != nil {
+			writeBootstrapJSON(w, 502, map[string]string{"error": err.Error()})
+			return
+		}
+		writeBootstrapJSON(w, 202, map[string]any{"status": "started", "action": "update", "target": info.Latest})
+	})
+
+	mux.HandleFunc("GET /api/version/update/status", func(w http.ResponseWriter, r *http.Request) {
+		if selfUpdater == nil {
+			writeBootstrapJSON(w, 503, map[string]string{"error": "self-update disabled"})
+			return
+		}
+		writeBootstrapJSON(w, 200, selfUpdater.Status())
 	})
 
 	// POST /api/config → validate, write, restart

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -595,8 +595,20 @@ func main() {
 	// UI hide the badge.
 	var selfUpdater *selfupdate.Checker
 	if envBool("FTW_SELFUPDATE_ENABLED") {
+		// FTW_SELFUPDATE_CURRENT_VERSION overrides what the checker thinks
+		// it's running so dev / QA can force update_available=true without
+		// rebuilding with a fake -ldflags Version. Scoped to the checker
+		// only — /api/status, User-Agent, HA discovery keep reporting the
+		// real build version. Unset in production; logged loudly when set.
+		current := Version
+		if v, ok := os.LookupEnv("FTW_SELFUPDATE_CURRENT_VERSION"); ok && v != "" {
+			current = v
+			slog.Warn("selfupdate: CurrentVersion overridden for testing",
+				"real_version", Version, "reported_version", current,
+				"env", "FTW_SELFUPDATE_CURRENT_VERSION")
+		}
 		selfUpdater = selfupdate.New(selfupdate.Config{
-			CurrentVersion: Version,
+			CurrentVersion: current,
 			SocketPath:     envOr("FTW_UPDATER_SOCKET", "/run/ftw-update/sock"),
 			StatusPath:     envOr("FTW_UPDATER_STATUS", "/run/ftw-update/state.json"),
 		}, st)

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1415,8 +1415,15 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	if path == "/setup" {
 		path = "/setup.html"
 	}
-	if path == "/next" {
-		path = "/next.html"
+	// Legacy dashboard moved behind /legacy; /next is now the default
+	// at /. Keep /next working as a 301 so old bookmarks land correctly
+	// without advertising two URLs for the same content.
+	if path == "/next" || path == "/next.html" {
+		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+		return
+	}
+	if path == "/legacy" {
+		path = "/legacy.html"
 	}
 	// Prevent path traversal
 	clean := filepath.Clean(filepath.Join(s.deps.WebDir, path))

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -576,9 +576,12 @@ func applyDefaults(c *Config) {
 
 // Validate ensures the config is internally consistent and safe to run with.
 func (c *Config) Validate() error {
-	if len(c.Drivers) == 0 {
-		return errors.New("at least one driver must be configured")
-	}
+	// Empty drivers list is a valid shape — e.g. an EV-only site that
+	// configured a cloud EV charger in the setup wizard and doesn't
+	// own local inverter/meter hardware. Control loop becomes a no-op
+	// (SiteMeterDriver() returns "" and telemetry lookups just miss);
+	// the site meter check below only fires once at least one driver
+	// exists.
 	siteMeters := 0
 	names := make(map[string]bool, len(c.Drivers))
 	for _, d := range c.Drivers {
@@ -600,7 +603,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("driver %q: must have mqtt, modbus, or http capability", d.Name)
 		}
 	}
-	if siteMeters == 0 {
+	if len(c.Drivers) > 0 && siteMeters == 0 {
 		return errors.New("at least one driver must be is_site_meter: true")
 	}
 

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -100,15 +100,18 @@ func TestRelativeDriverPathResolved(t *testing.T) {
 	}
 }
 
-func TestRejectsNoDrivers(t *testing.T) {
+func TestAcceptsNoDrivers(t *testing.T) {
+	// EV-only sites (cloud charger configured via the setup wizard Step 7
+	// without any local hardware) ship an empty drivers list; validator
+	// must accept it. Control loop becomes a no-op at runtime.
 	yaml := `
 site: { name: x }
 fuse: { max_amps: 16 }
 drivers: []
 api: { port: 8080 }
 `
-	if _, err := Parse([]byte(yaml), "."); err == nil {
-		t.Fatal("expected error for empty drivers")
+	if _, err := Parse([]byte(yaml), "."); err != nil {
+		t.Fatalf("expected empty drivers to be accepted, got: %v", err)
 	}
 }
 

--- a/go/internal/proxy/proxy.go
+++ b/go/internal/proxy/proxy.go
@@ -3,7 +3,7 @@
 // upstream forty-two-watts instance so the local dev server can render
 // the UI against live data without running real drivers locally.
 //
-// Static assets (/, /index.html, /next.html, /components/*.css, *.js, …)
+// Static assets (/, /index.html, /legacy.html, /components/*.css, *.js, …)
 // always serve locally — those are the files being iterated on.
 //
 // Safety: read-only mode (on by default when an upstream is configured)

--- a/go/internal/selfupdate/selfupdate.go
+++ b/go/internal/selfupdate/selfupdate.go
@@ -71,6 +71,13 @@ type Info struct {
 	Skipped         bool      `json:"skipped"`
 	SkippedVersion  string    `json:"skipped_version,omitempty"`
 	Err             string    `json:"err,omitempty"`
+	// SidecarReady is true only when the ftw-updater sidecar's Unix socket
+	// is present at SocketPath — i.e. the full pull+restart flow is wired
+	// up, which in practice means a docker-compose deploy. Native / WSL
+	// dev runs with FTW_SELFUPDATE_ENABLED=1 still report update_available
+	// honestly, but the UI uses this flag to decide whether to offer an
+	// actionable Update button vs just a notify-only indicator.
+	SidecarReady bool `json:"sidecar_ready"`
 }
 
 // UpdateStatus mirrors the sidecar's state.json so handlers can pass it
@@ -216,12 +223,31 @@ func (c *Checker) recordErr(err error) (Info, error) {
 
 // Info returns the cached view. Skip state is re-read from the store on each
 // call so a Skip/Unskip from another request is reflected immediately without
-// broadcasting.
+// broadcasting. SidecarReady is re-probed on every call so a sidecar that
+// came up (or crashed) after boot is reflected without waiting for the next
+// periodic Check.
 func (c *Checker) Info() Info {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.reloadSkipLocked()
-	return c.info
+	info := c.info
+	info.SidecarReady = c.sidecarReadyLocked()
+	return info
+}
+
+// sidecarReadyLocked reports whether the updater socket is present as an
+// actual Unix socket. An empty SocketPath means the feature was never
+// configured for this deploy — docker-compose sets it, native installs
+// typically don't.
+func (c *Checker) sidecarReadyLocked() bool {
+	if c.cfg.SocketPath == "" {
+		return false
+	}
+	fi, err := os.Stat(c.cfg.SocketPath)
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeSocket != 0
 }
 
 func (c *Checker) reloadSkipLocked() {

--- a/web/components/ftw-badge.js
+++ b/web/components/ftw-badge.js
@@ -20,38 +20,40 @@ class FtwBadge extends FtwElement {
       align-items: center;
       padding: 0.15rem 0.55rem;
       border-radius: 999px;
-      font-size: 0.75rem;
-      font-weight: 600;
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      font-weight: 500;
       line-height: 1.4;
-      letter-spacing: 0.02em;
-      border: 1px solid transparent;
-      background: var(--surface2);
-      color: var(--text-dim);
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      border: 1px solid var(--line);
+      background: var(--ink-raised);
+      color: var(--fg-muted);
       white-space: nowrap;
     }
     :host([size="sm"]) {
       padding: 0.05rem 0.4rem;
-      font-size: 0.7rem;
+      font-size: 0.65rem;
     }
     :host([status="ok"]) {
-      color: var(--green);
-      border-color: color-mix(in srgb, var(--green) 45%, transparent);
-      background: color-mix(in srgb, var(--green) 14%, var(--surface2));
+      color: var(--green-e);
+      border-color: color-mix(in srgb, var(--green-e) 45%, transparent);
+      background: color-mix(in srgb, var(--green-e) 12%, var(--ink-raised));
     }
     :host([status="warn"]) {
-      color: var(--yellow);
-      border-color: color-mix(in srgb, var(--yellow) 45%, transparent);
-      background: color-mix(in srgb, var(--yellow) 14%, var(--surface2));
+      color: var(--amber);
+      border-color: color-mix(in srgb, var(--amber) 45%, transparent);
+      background: color-mix(in srgb, var(--amber) 12%, var(--ink-raised));
     }
     :host([status="error"]) {
-      color: var(--red);
-      border-color: color-mix(in srgb, var(--red) 45%, transparent);
-      background: color-mix(in srgb, var(--red) 14%, var(--surface2));
+      color: var(--red-e);
+      border-color: color-mix(in srgb, var(--red-e) 45%, transparent);
+      background: color-mix(in srgb, var(--red-e) 12%, var(--ink-raised));
     }
     :host([status="info"]) {
-      color: var(--blue);
-      border-color: color-mix(in srgb, var(--blue) 45%, transparent);
-      background: color-mix(in srgb, var(--blue) 14%, var(--surface2));
+      color: var(--cyan);
+      border-color: color-mix(in srgb, var(--cyan) 45%, transparent);
+      background: color-mix(in srgb, var(--cyan) 12%, var(--ink-raised));
     }
   `;
 

--- a/web/components/ftw-card.js
+++ b/web/components/ftw-card.js
@@ -29,9 +29,9 @@ class FtwCard extends FtwElement {
   static styles = `
     :host {
       display: block;
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
       padding: 1rem 1.25rem;
     }
     :host([variant="compact"]) {
@@ -46,11 +46,11 @@ class FtwCard extends FtwElement {
       transition: transform 0.1s ease, border-color 0.15s ease;
     }
     :host([interactive]:hover) {
-      border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+      border-color: color-mix(in srgb, var(--accent-e) 60%, var(--line));
       transform: translateY(-1px);
     }
     :host([interactive]:focus-visible) {
-      outline: 2px solid var(--accent);
+      outline: 2px solid var(--accent-e);
       outline-offset: 2px;
     }
     header {
@@ -67,7 +67,7 @@ class FtwCard extends FtwElement {
     header ::slotted([slot="title"]) {
       font-size: 0.9rem;
       font-weight: 600;
-      color: var(--text);
+      color: var(--fg);
     }
   `;
 

--- a/web/components/ftw-element.js
+++ b/web/components/ftw-element.js
@@ -15,7 +15,7 @@
 //   class FtwBadge extends FtwElement {
 //     static styles = `
 //       :host { display: inline-flex; }
-//       .pill { background: var(--surface); color: var(--text); }
+//       .pill { background: var(--ink-raised); color: var(--fg); }
 //     `;
 //     render() {
 //       return `<span class="pill"><slot></slot></span>`;

--- a/web/components/ftw-energy-flow.js
+++ b/web/components/ftw-energy-flow.js
@@ -1,51 +1,84 @@
 // <ftw-energy-flow> — hero diagram for /next.
 //
-// Layout (site convention: +ve = INTO the site):
+// Planet/sun layout. The HOUSE sits at the center (the sun), and every
+// other device — PV inverters, batteries, grid, EV chargers, whatever
+// future category — is a "planet" that orbits it. A planet declares
+// which CORNER it belongs to:
 //
-//   [pv₀] [pv₁] [pv₂]            TOP row  — solar cluster, horizontal
-//              │
-//              ▼
-//   [grid] ───►[HOUSE]───►[bat₀]  MIDDLE  — grid left, battery column right
-//                      │ [bat₁]
-//                      │ [bat₂]
-//                      ▼
-//              [ev]                BOTTOM — EV single slot
+//       top-left  (225°)       top-right (315°)
+//                    ╲       ╱
+//                     ╲     ╱
+//                   ┌──HOUSE──┐
+//                     ╱     ╲
+//                    ╱       ╲
+//     bottom-left (135°)       bottom-right (45°)
+//
+// Corners are hard-wired at 45° diagonals so the overall X is uniform
+// no matter how many planets each corner holds. Adding a second (or
+// third) planet at the same corner makes the earlier ones scoot aside:
+// they cluster along an arc centered on that corner's anchor angle,
+// same orbit radius, so every power beam stays the same length.
+// When no planets report at a corner, a "no data" placeholder fills
+// it so the X reads as complete even on first paint.
 //
 // Flow edges carry two simultaneous animations:
 //   1. A dashed, blurred stroke whose dash-offset animates via CSS —
 //      gives a "current flowing" feel without redrawing any DOM.
-//   2. Three particle circles riding the edge via <animateMotion>, spaced
-//      by 1/3 of the cycle so the flow looks continuous. Speed scales
-//      inversely with |kW| / maxKw — more power, faster particles.
+//   2. Particle circles riding the edge via a single rAF loop, with
+//      damped-oscillator perpendicular motion so the spray looks
+//      turbulent rather than a rotating screw. Speed scales with |kW|.
 // Both effects are skipped when |kW| < 50 W so idle edges read as still.
 //
 // Update pattern — next-app.js calls `setReadings(...)` each status poll
-// with the full multi-driver payload. The component never introspects
-// /api/status itself; keep the transformation in next-app.js so all
-// driver-name logic stays in one place.
+// with a fully-resolved planet list. The component never introspects
+// /api/status itself and has no knowledge of driver roles — all
+// role→corner/color/sub-text logic lives in the caller.
 //
 //   flow.setReadings({
-//     grid: 0.5, load: 1.2, ev: 0,
-//     pvs:       [{ name: "solaredge", kw: -5.3 }],
-//     batteries: [{ name: "pixii",     kw: 2.2, soc: 78 }],
+//     load: 1.2,
+//     planets: [
+//       { id: "grid",     corner: "bottom-left",  title: "GRID",
+//         kw:  0.5, toHub: true,  color: "var(--red-e)", sub: "importing" },
+//       { id: "pv-east",  corner: "top-left",     title: "SOLAR", name: "east",
+//         kw:  3.1, toHub: true,  color: "var(--amber)", sub: "generating" },
+//       { id: "bat-main", corner: "top-right",    title: "BATTERY",
+//         kw:  2.2, toHub: false, color: "var(--cyan)",  sub: "charging", soc: 78 },
+//       { id: "ev",       corner: "bottom-right", title: "EV CHARGER",
+//         kw:  3.7, toHub: false, color: "var(--green-e)", sub: "charging" },
+//     ],
 //   });
 
 import { FtwElement } from "./ftw-element.js";
 
-const W = 1000, H = 530;
-const CX = W / 2, CY = H / 2;
-const HUB_R = 64;
-const BOX_W = 170, BOX_H = 78;
-const GAP_H = 34;   // horizontal gap between stacked PV boxes
-const GAP_V = 14;   // vertical gap between stacked battery boxes
-// TOP_Y / BOT_Y picked so the vertical beam is ~107 px between box edge
-// and hub edge — 30% longer than the earlier 82 px. Extra room lets
-// the particle fountain spiral visibly into the hub instead of being
-// crammed into a short run.
-const TOP_Y = 55;
-const BOT_Y = H - 55;
-const LEFT_X = 150;
-const RIGHT_X = W - 150;
+// World width is fixed at 1000; CX is always at the center of whatever
+// crop we render. The viewBox HEIGHT (and CY = H/2) are computed per
+// render — they grow with the largest cluster size so the arc never
+// pushes a planet outside the box. Keeping H dynamic is what lets the
+// hero card grow when the user adds a second/third PV/battery/etc.
+const W = 1000;
+const CX = W / 2;
+// Baseline height used when no cluster has more than one planet — also
+// the floor for the dynamic computation so the diagram never shrinks
+// below the single-device size.
+const H_BASE = 580;
+
+// Corner → anchor angle in screen coordinates (0°=east, 90°=south).
+// Fixed at exactly 45° so the whole diagram reads as a uniform X
+// regardless of how many planets live at any corner.
+const CORNER_ANGLE = {
+  "top-left":     -3 * Math.PI / 4, // 225°
+  "top-right":    -Math.PI / 4,     // 315°
+  "bottom-right":  Math.PI / 4,     //  45°
+  "bottom-left":   3 * Math.PI / 4, // 135°
+};
+// Default title shown when a corner has no planets reporting yet.
+// Keeps the first-paint X intact; updated as soon as drivers push.
+const CORNER_PLACEHOLDER_TITLE = {
+  "top-left":     "SOLAR",
+  "top-right":    "BATTERY",
+  "bottom-right": "EV CHARGER",
+  "bottom-left":  "GRID",
+};
 
 class FtwEnergyFlow extends FtwElement {
   static styles = `
@@ -56,7 +89,7 @@ class FtwEnergyFlow extends FtwElement {
         var(--hero-bg-bot) 100%);
       border: 1px solid var(--line);
       border-radius: var(--radius-lg);
-      padding: 14px 28px 6px;
+      padding: 20px 28px;
       position: relative;
       overflow: hidden;
     }
@@ -70,19 +103,20 @@ class FtwEnergyFlow extends FtwElement {
     }
     .title {
       font-family: var(--mono);
-      font-size: 13px;
+      font-size: 16px;
       font-weight: 600;
       letter-spacing: 0.22em;
       text-transform: uppercase;
       color: var(--fg);
       text-align: center;
       padding: 2px 0;
-      margin-bottom: 2px;
+      margin-top: 10px;
+      margin-bottom: 48px;
       position: relative;
     }
     svg {
       width: 100%;
-      height: 490px;
+      height: calc(var(--efl-h-factor, 1) * 535px);
       display: block;
     }
     /* SVG text classes — font-size values are in viewBox units (the SVG
@@ -106,8 +140,9 @@ class FtwEnergyFlow extends FtwElement {
       animation: ef-spin 24s linear infinite;
     }
     @media (max-width: 900px) {
-      :host { padding: 10px 12px 4px; }
-      svg { height: 465px; }
+      :host { padding: 20px 12px; }
+      .title { margin-bottom: 8px; }
+      svg { height: calc(var(--efl-h-factor, 1) * 510px); }
       .sv-node-title { font-size: 13px; }
       .sv-node-value { font-size: 24px; }
       .sv-node-sub   { font-size: 13px; }
@@ -115,7 +150,7 @@ class FtwEnergyFlow extends FtwElement {
       .sv-hub-label  { font-size: 11px; }
     }
     @media (max-width: 600px) {
-      svg { height: 420px; }
+      svg { height: calc(var(--efl-h-factor, 1) * 460px); }
       .sv-node-title { font-size: 18px; }
       .sv-node-value { font-size: 30px; }
       .sv-node-sub   { font-size: 16px; }
@@ -128,10 +163,7 @@ class FtwEnergyFlow extends FtwElement {
     super();
     // Start with empty clusters; render shows placeholder slots until the
     // first setReadings() push arrives from next-app.js.
-    this._readings = {
-      grid: 0, load: 0, ev: 0,
-      pvs: [], batteries: [],
-    };
+    this._readings = { load: 0, planets: [] };
     // JS-driven particle system — one rAF loop animates every "electron"
     // independently. Each particle has its own amp/phase/freq/speed plus
     // a low-frequency 2D noise term, so even at high particle counts
@@ -160,26 +192,47 @@ class FtwEnergyFlow extends FtwElement {
     if (this._mq) {
       this._mq.addEventListener("change", this._onMqChange);
     }
+    // Generic viewport listener — covers desktop window resizes and
+    // device rotations that don't cross the 600px matchMedia threshold
+    // (which `_mq` already handles). Throttled via rAF so a continuous
+    // resize-drag triggers at most one re-render per frame.
+    this._onResize = () => {
+      if (this._resizeRaf) return;
+      this._resizeRaf = requestAnimationFrame(() => {
+        this._resizeRaf = 0;
+        this.update();
+      });
+    };
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", this._onResize, { passive: true });
+      window.addEventListener("orientationchange", this._onResize, { passive: true });
+    }
   }
 
   disconnectedCallback() {
     if (this._rafId) cancelAnimationFrame(this._rafId);
     this._rafId = null;
     this._particles = [];
+    if (this._resizeRaf) {
+      cancelAnimationFrame(this._resizeRaf);
+      this._resizeRaf = 0;
+    }
     if (this._mq) {
       this._mq.removeEventListener("change", this._onMqChange);
     }
+    if (typeof window !== "undefined" && this._onResize) {
+      window.removeEventListener("resize", this._onResize);
+      window.removeEventListener("orientationchange", this._onResize);
+    }
   }
 
-  // Bulk setter — preferred update path. Scalars merge; arrays replace
-  // when provided. Passing `undefined` for an array leaves the previous
-  // cluster intact (useful during transient /api/status errors).
+  // Bulk setter — preferred update path. `load` merges; `planets`
+  // replaces the whole list when provided. Passing `undefined` for
+  // `planets` leaves the previous cluster intact (useful during
+  // transient /api/status errors so the diagram doesn't blank out).
   setReadings(r) {
-    if (r.grid != null) this._readings.grid = r.grid;
-    if (r.load != null) this._readings.load = r.load;
-    if (r.ev   != null) this._readings.ev   = r.ev;
-    if (Array.isArray(r.pvs))       this._readings.pvs       = r.pvs;
-    if (Array.isArray(r.batteries)) this._readings.batteries = r.batteries;
+    if (r.load != null)         this._readings.load    = r.load;
+    if (Array.isArray(r.planets)) this._readings.planets = r.planets;
     this.update();
   }
 
@@ -304,102 +357,124 @@ class FtwEnergyFlow extends FtwElement {
   }
 
   render() {
-    const { grid, load, ev } = this._readings;
+    const { load } = this._readings;
 
-    // Show one placeholder box per side when no drivers report — keeps
-    // the layout stable during first paint + disables flow animation.
-    const pvList = this._readings.pvs.length
-      ? this._readings.pvs
-      : [{ name: "", kw: 0, placeholder: true }];
-    const batList = this._readings.batteries.length
-      ? this._readings.batteries
-      : [{ name: "", kw: 0, soc: null, placeholder: true }];
+    // Two tiers of base parameters. Desktop keeps the full 0..1000 viewBox
+    // with larger circles + hub; compact crops to 180..820 and shrinks the
+    // base orbit so phone widths render legibly. Both tiers are FLOORS:
+    // the dynamic-sizing block below grows orbitR + viewBox H/W when any
+    // corner holds 2+ planets so the arc never pushes a node off-canvas.
+    const tier = this._compact
+      ? { vbX: 180, vbW: 640, orbitR: 268, baseR: 86, hubR: 95 }
+      : { vbX: 0,   vbW: W,   orbitR: 288, baseR: 84, hubR: 99 };
 
-    // × layout with circular nodes at every viewport size. Two tiers of
-    // parameters: desktop keeps the full 0..1000 viewBox with larger
-    // circles + hub; compact crops to 180..820 and shrinks the
-    // geometry so the uniform zoom from preserveAspectRatio lands
-    // readable at phone widths. Hub text y-offsets are tier-specific
-    // so the load value sits visually centered between the house icon
-    // and the CONSUMING label at both sizes.
-    const P = this._compact
-      ? {
-          vbX: 180, vbW: 640,
-          leftX: 285, rightX: 715,
-          topY: 90, botY: 440,
-          baseR: 86, hubR: 95,
-          hubIconY: CY - 49, hubValueY: CY + 10, hubLabelY: CY + 34,
-        }
-      : {
-          vbX: 0, vbW: W,
-          leftX: 240, rightX: 760,
-          topY: 130, botY: 400,
-          baseR: 84, hubR: 99,
-          hubIconY: CY - 50, hubValueY: CY + 10, hubLabelY: CY + 36,
-        };
+    // Group planets by corner. Missing corners get a placeholder so
+    // the X silhouette is complete on first paint even before any
+    // drivers report.
+    const groups = {
+      "top-left": [], "top-right": [],
+      "bottom-right": [], "bottom-left": [],
+    };
+    for (const p of this._readings.planets) {
+      if (groups[p.corner]) groups[p.corner].push(p);
+    }
+    for (const c of Object.keys(groups)) {
+      if (groups[c].length === 0) {
+        groups[c].push({
+          id: `_placeholder-${c}`, corner: c,
+          title: CORNER_PLACEHOLDER_TITLE[c], name: null,
+          kw: 0, toHub: true,
+          color: "var(--fg-muted)", sub: "no data", soc: null,
+          placeholder: true,
+        });
+      }
+    }
+    const maxN = Math.max(1, ...Object.values(groups).map(g => g.length));
 
-    // Multi-device cluster in the PV (top-left) quadrant. Bounds run
-    // from the viewBox left edge to the hub's left edge; clusterAt
-    // shrinks the circles to fit n side-by-side and centers the row
-    // within those bounds. Single-device keeps baseR and sits on the
-    // corner anchor for the classic × silhouette.
-    const pvC = clusterAt(
-      pvList.length, P.leftX, P.topY, P.baseR,
-      P.vbX + 10, CX - P.hubR - 18,
-    );
-    // Battery: top-right quadrant, hub-left to viewBox-right.
-    const batC = clusterAt(
-      batList.length, P.rightX, P.topY, P.baseR,
-      CX + P.hubR + 18, P.vbX + P.vbW - 10,
-    );
-    const gridPos = { x: P.leftX,  y: P.botY };
-    const evPos   = { x: P.rightX, y: P.botY };
+    // -- Dynamic orbit + container sizing --------------------------------
+    // For N>=3 the arc would either spill past 60° (clusterArc's maxSpan)
+    // or shrink baseR — so we grow orbitR instead, keeping every node
+    // full-sized. For N=1 or 2 the natural step already fits and orbitR
+    // stays at the tier floor.
+    const gap = 16;
+    const maxSpan = Math.PI / 3;
+    let orbitR = tier.orbitR;
+    if (maxN >= 3) {
+      const step = maxSpan / (maxN - 1);
+      const required = (2 * tier.baseR + gap) / (2 * Math.sin(step / 2));
+      orbitR = Math.max(orbitR, Math.ceil(required));
+    }
 
-    // Build all edges: each entry carries geometry + magnitude + direction.
-    const edges = [];
-    pvList.forEach((pv, i) => {
-      const magnitude = Math.max(0, -pv.kw);
-      edges.push(edge(
-        `pv-${i}`,
-        pvC.positions[i], gridPos /* unused for diagonal */,
-        "top", +1,
-        magnitude,
-        "var(--amber)",
-        !pv.placeholder && magnitude > 0.05,
-        0, 0, /* boxW/boxH unused in diagonal */ true, pvC.r, P.hubR,
-      ));
+    // Recompute the actual step + half-span at this orbitR (mirrors the
+    // formula clusterArc uses), so we know how far the outermost arc
+    // position lies from the corner anchor.
+    const naturalStep = 2 * Math.asin(Math.min(1, (2 * tier.baseR + gap) / (2 * orbitR)));
+    const stepActual = maxN <= 1 ? 0 : Math.min(naturalStep, maxSpan / (maxN - 1));
+    const halfSpan = ((maxN - 1) * stepActual) / 2;
+
+    // Worst-case x/y offsets from CX/CY across all four corners (each
+    // anchor ± halfSpan). Whichever planet sits closest to the
+    // top/bottom/left/right of the world drives the container size.
+    const margin = 12;
+    const corners = Object.values(CORNER_ANGLE);
+    let maxYOff = 0, maxXOff = 0;
+    for (const a0 of corners) {
+      for (const da of [-halfSpan, +halfSpan]) {
+        const ay = Math.abs(orbitR * Math.sin(a0 + da));
+        const ax = Math.abs(orbitR * Math.cos(a0 + da));
+        if (ay > maxYOff) maxYOff = ay;
+        if (ax > maxXOff) maxXOff = ax;
+      }
+    }
+    const Hdyn = Math.max(H_BASE, Math.ceil(2 * (maxYOff + tier.baseR + margin)));
+    const Wneeded = Math.ceil(2 * (maxXOff + tier.baseR + margin));
+    let vbW = tier.vbW, vbX = tier.vbX;
+    if (Wneeded > vbW) {
+      // Hub stays at world x=500; recenter the crop around it.
+      vbW = Wneeded;
+      vbX = Math.round(W / 2 - vbW / 2); // negative is fine — the viewBox can extend past world bounds
+    }
+    // Scale the rendered CSS height so the SVG keeps its on-screen
+    // visual proportions as the viewBox grows. CSS picks the per-tier
+    // base (535/510/460) via media queries; we just multiply.
+    this.style.setProperty("--efl-h-factor", (Hdyn / H_BASE).toFixed(3));
+
+    // Per-render layout struct. CY now varies — every helper that used
+    // to read module-level CY now takes (cx, cy) explicitly.
+    const cy = Hdyn / 2;
+    const P = {
+      vbX, vbW, H: Hdyn, cy,
+      orbitR, baseR: tier.baseR, hubR: tier.hubR,
+      hubIconY: cy - (this._compact ? 49 : 50),
+      hubValueY: cy + 10,
+      hubLabelY: cy + (this._compact ? 34 : 36),
+    };
+    // -- /Dynamic sizing -------------------------------------------------
+
+    // Per-corner arc placement. Every corner uses the same orbitR so
+    // beams are identical-length radial lines.
+    const placed = [];
+    for (const c of Object.keys(groups)) {
+      const g = groups[c];
+      const pl = clusterArc(g.length, CX, P.cy, P.orbitR, CORNER_ANGLE[c], P.baseR);
+      g.forEach((planet, i) => {
+        placed.push({ ...planet,
+          _pos: pl.positions[i], _r: pl.r, _groupSize: g.length });
+      });
+    }
+
+    // Build edges. Each planet owns one radial beam; `toHub` decides
+    // particle direction (house-inward vs house-outward).
+    const edges = placed.map(p => {
+      const kwAbs = Math.abs(p.kw);
+      return {
+        id: p.id,
+        ...radialEndpoints(p._pos, p._r, P.hubR, p.toHub, CX, P.cy),
+        kw: kwAbs,
+        color: p.color,
+        active: !p.placeholder && kwAbs > 0.05,
+      };
     });
-    edges.push(edge(
-      "grid",
-      gridPos, gridPos,
-      "left",
-      grid >= 0 ? +1 : -1,
-      Math.abs(grid),
-      grid >= 0 ? "var(--red-e)" : "var(--green-e)",
-      Math.abs(grid) > 0.05,
-      0, 0, true, P.baseR, P.hubR,
-    ));
-    batList.forEach((bat, i) => {
-      edges.push(edge(
-        `bat-${i}`,
-        batC.positions[i], batC.positions[i],
-        "right",
-        bat.kw >= 0 ? +1 : -1,
-        Math.abs(bat.kw),
-        "var(--cyan)",
-        !bat.placeholder && Math.abs(bat.kw) > 0.05,
-        0, 0, true, batC.r, P.hubR,
-      ));
-    });
-    edges.push(edge(
-      "ev",
-      evPos, evPos,
-      "bottom", +1,
-      Math.max(0, ev),
-      "var(--white-s)",
-      ev > 0.05,
-      0, 0, true, P.baseR, P.hubR,
-    ));
 
     const maxKw = Math.max(0.5, ...edges.map(e => e.kw));
     // Stash the particle-param list on the instance so afterRender()
@@ -409,56 +484,24 @@ class FtwEnergyFlow extends FtwElement {
     this._particles = [];
     const edgesSvg = edges.map(e => renderEdge(e, maxKw, this._particles)).join("");
 
-    // Every node is a circle now — renderNode (rectangular) is retired.
-    const pvNodes = pvList.map((pv, i) =>
+    // Nodes. The driver name only appears (as a second title line) when
+    // >1 planet shares the corner — keeps single-device rigs clean.
+    const nodesSvg = placed.map(p =>
       renderCircleNode({
-        pos: pvC.positions[i],
-        // Solar shows POSITIVE kW — sign flip is display-only, all
-        // internal state (chartHistory, math) stays on site convention.
-        value: pv.placeholder ? "—" : fmtKw(-pv.kw),
-        title: labelWithName("SOLAR", pv.name, pvList.length),
-        sub: pv.placeholder ? "no data" : (pv.kw < -0.05 ? "generating" : "idle"),
-        color: !pv.placeholder && pv.kw < -0.05 ? "var(--amber)" : "var(--fg-muted)",
-        radius: pvC.r,
+        pos: p._pos,
+        value: p.placeholder ? "—" : fmtKw(p.kw),
+        title: p.title,
+        nameLabel: p._groupSize > 1 && p.name ? p.name.toUpperCase() : null,
+        sub: p.sub,
+        color: p.color,
+        soc: p.placeholder ? null : p.soc,
+        radius: p._r,
       })
     ).join("");
-
-    const gridNode = renderCircleNode({
-      pos: gridPos,
-      value: fmtKw(grid),
-      title: "GRID",
-      sub: Math.abs(grid) < 0.05 ? "balanced" : (grid >= 0 ? "importing" : "exporting"),
-      color: Math.abs(grid) < 0.05 ? "var(--fg-muted)" :
-             (grid >= 0 ? "var(--red-e)" : "var(--green-e)"),
-      radius: P.baseR,
-    });
-
-    const batNodes = batList.map((bat, i) =>
-      renderCircleNode({
-        pos: batC.positions[i],
-        value: bat.placeholder ? "—" : fmtKw(bat.kw),
-        title: labelWithName("BATTERY", bat.name, batList.length),
-        sub: bat.placeholder ? "no data" :
-             (Math.abs(bat.kw) < 0.05 ? "idle" :
-              (bat.kw >= 0 ? "charging" : "discharging")),
-        color: bat.placeholder ? "var(--fg-muted)" : "var(--cyan)",
-        soc: bat.placeholder ? null : bat.soc,
-        radius: batC.r,
-      })
-    ).join("");
-
-    const evNode = renderCircleNode({
-      pos: evPos,
-      value: fmtKw(ev),
-      title: "EV CHARGER",
-      sub: ev > 0.05 ? "charging" : "idle",
-      color: ev > 0.05 ? "var(--green-e)" : "var(--white-s)",
-      radius: P.baseR,
-    });
 
     return `
       <div class="title">Energy balance</div>
-      <svg viewBox="${P.vbX} 0 ${P.vbW} ${H}" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
+      <svg viewBox="${P.vbX} 0 ${P.vbW} ${P.H}" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
         <defs>
           <radialGradient id="ef-hub" cx="50%" cy="50%" r="50%">
             <stop offset="0%" stop-color="oklch(0.85 0.18 var(--accent-hue))" stop-opacity="0.55"/>
@@ -479,16 +522,16 @@ class FtwEnergyFlow extends FtwElement {
           </filter>
         </defs>
 
-        <circle cx="${CX}" cy="${CY}" r="200" fill="url(#ef-hub)"/>
+        <circle cx="${CX}" cy="${P.cy}" r="200" fill="url(#ef-hub)"/>
 
         ${edgesSvg}
 
         <!-- HOUSE / hub: load reading lives here -->
         <g>
-          <circle cx="${CX}" cy="${CY}" r="${P.hubR}"
+          <circle cx="${CX}" cy="${P.cy}" r="${P.hubR}"
                   fill="var(--hero-house-fill)"
                   stroke="var(--hero-house-stroke)" stroke-width="1.5"/>
-          <circle class="ring" cx="${CX}" cy="${CY}" r="${P.hubR - 8}"
+          <circle class="ring" cx="${CX}" cy="${P.cy}" r="${P.hubR - 8}"
                   fill="none"
                   stroke="var(--hero-house-ring)" stroke-width="1"
                   stroke-dasharray="2 4"/>
@@ -508,10 +551,7 @@ class FtwEnergyFlow extends FtwElement {
           </text>
         </g>
 
-        ${pvNodes}
-        ${gridNode}
-        ${batNodes}
-        ${evNode}
+        ${nodesSvg}
       </svg>
     `;
   }
@@ -519,102 +559,64 @@ class FtwEnergyFlow extends FtwElement {
 
 // ---------- geometry + edge helpers ----------
 
-// Multi-device horizontal cluster inside the × layout's corner
-// quadrant. For n = 1 the device sits on the corner anchor with full
-// baseR. For n > 1 the circles shrink so they fit between the given
-// [leftBound, rightBound] (inner viewBox edge and the hub's edge),
-// then sit evenly spaced and centered in that span. The radius floor
-// keeps multi-device circles readable even when bounds are tight.
-function clusterAt(n, anchorX, anchorY, baseR, leftBound, rightBound) {
+// Place N nodes on a hub-centered circle of radius `orbitR` along an
+// arc around `anchorAngle` (the polar angle that points to the
+// quadrant's corner). Every node sits on the same circle, so its
+// radial beam to the hub is the same length as every other satellite's
+// beam — the "circle around the house" layout.
+//
+// Sizing:
+//   • n === 1 → node sits exactly on the anchor with full baseR.
+//   • n  >= 2 → angular step is whatever keeps adjacent circles gap
+//               apart on the orbit (chord = 2*baseR + gap). If that
+//               would spread the cluster past `maxSpan`, we cap the
+//               span and shrink nodeR so non-overlap still holds.
+//
+// `maxSpan` (≈60°) keeps the arc comfortably inside its quadrant — PV
+// stops short of the grid anchor, battery stops short of EV — so the
+// four regions stay visually distinct even with many devices.
+function clusterArc(n, cx, cy, orbitR, anchorAngle, baseR) {
   if (n <= 1) {
-    return { positions: [{ x: anchorX, y: anchorY }], r: baseR };
+    return { positions: [polar(cx, cy, orbitR, anchorAngle)], r: baseR };
   }
-  const gap = 14;
-  const span = rightBound - leftBound;
-  // Max radius that fits n circles + (n-1) gaps inside span:
-  //   n * 2r + (n-1) * gap <= span
-  const maxR = Math.floor((span - (n - 1) * gap) / (2 * n));
-  const r = Math.max(34, Math.min(Math.floor(baseR * 0.85), maxR));
-  const stride = 2 * r + gap;
-  const cx = (leftBound + rightBound) / 2;
-  const half = ((n - 1) * stride) / 2;
-  const positions = Array.from({ length: n }, (_, i) => ({
-    x: cx - half + i * stride,
-    y: anchorY,
-  }));
+  const gap = 16;
+  const maxSpan = Math.PI / 3; // 60°
+  const idealChord = 2 * baseR + gap;
+  let step = 2 * Math.asin(Math.min(1, idealChord / (2 * orbitR)));
+  let r = baseR;
+  if (step * (n - 1) > maxSpan) {
+    step = maxSpan / (n - 1);
+    const chord = 2 * orbitR * Math.sin(step / 2);
+    r = Math.max(32, Math.floor((chord - gap) / 2));
+  }
+  const half = ((n - 1) * step) / 2;
+  const positions = Array.from({ length: n }, (_, i) =>
+    polar(cx, cy, orbitR, anchorAngle - half + i * step),
+  );
   return { positions, r };
 }
 
-// Spread N items along a horizontal axis, centered on (anchorX, fixedY).
-// Spacing is box-width + gap so boxes never overlap, even at N=3+.
-function clusterH(n, anchorX, fixedY, boxW, gap) {
-  const stride = boxW + gap;
-  return Array.from({ length: n }, (_, i) => ({
-    x: anchorX - ((n - 1) / 2) * stride + i * stride,
-    y: fixedY,
-  }));
+function polar(cx, cy, r, a) {
+  return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
 }
 
-function clusterV(n, fixedX, anchorY, boxH, gap) {
-  const stride = boxH + gap;
-  return Array.from({ length: n }, (_, i) => ({
-    x: fixedX,
-    y: anchorY - ((n - 1) / 2) * stride + i * stride,
-  }));
-}
-
-// Compute the two endpoints of an edge given a box position and which
-// side of the hub it lives on. `dir > 0` means energy flows INTO the hub
-// (displayed as particles moving from box → hub). dir < 0 reverses the
-// endpoints so animateMotion runs box-ward.
-function edge(id, pos, _unused, side, dir, kw, color, active, boxW = BOX_W, boxH = BOX_H, diagonal = false, nodeR = 0, hubR = HUB_R) {
-  let from, to;
-  if (diagonal) {
-    // Diagonal beam for × layout: endpoints sit on the unit vector
-    // between box and hub centers. When nodeR > 0 the node is a circle
-    // and the box-side endpoint lands on its perimeter along that
-    // vector; otherwise we fall back to the nearest box corner. The
-    // hub-side endpoint sits on the hub perimeter. Default orientation
-    // (before the dir-based swap below) has to match the cardinal side
-    // it replaces — pv/grid default box→hub (dir=+1 means flow into
-    // the hub), bat/ev default hub→box (dir=+1 means flow out of it).
-    // Getting this wrong means a discharging battery animates toward
-    // the battery instead of toward the house.
-    const dx = CX - pos.x;
-    const dy = CY - pos.y;
-    const len = Math.hypot(dx, dy) || 1;
-    const ux = dx / len;
-    const uy = dy / len;
-    const boxEdge = nodeR > 0
-      ? { x: pos.x + ux * nodeR, y: pos.y + uy * nodeR }
-      : {
-          x: pos.x + (ux > 0 ? boxW / 2 : -boxW / 2),
-          y: pos.y + (uy > 0 ? boxH / 2 : -boxH / 2),
-        };
-    const hubEdge = { x: CX - ux * hubR, y: CY - uy * hubR };
-    if (side === "right" || side === "bottom") {
-      from = hubEdge; to = boxEdge;
-    } else {
-      from = boxEdge; to = hubEdge;
-    }
-  } else if (side === "top") {
-    from = { x: pos.x, y: pos.y + boxH / 2 };
-    to   = { x: CX,    y: CY - hubR };
-  } else if (side === "bottom") {
-    from = { x: CX,    y: CY + hubR };
-    to   = { x: pos.x, y: pos.y - boxH / 2 };
-  } else if (side === "left") {
-    from = { x: pos.x + boxW / 2, y: pos.y };
-    to   = { x: CX - hubR,        y: CY };
-  } else { // right
-    from = { x: CX + hubR,        y: CY };
-    to   = { x: pos.x - boxW / 2, y: pos.y };
-  }
-  // Swap when energy flows the "unusual" way for that side (grid export,
-  // battery discharge). animateMotion always walks the path start→end,
-  // so reversing from/to flips the particle direction with no extra CSS.
-  if (dir < 0) [from, to] = [to, from];
-  return { id, from, to, kw, color, active };
+// Radial beam endpoints for a planet sitting on the hub's orbit. Both
+// endpoints lie on the line between the planet center and the hub
+// center; the planet endpoint lands on its circle perimeter, the hub
+// endpoint on the hub perimeter. `toHub` picks the particle direction
+// (animateMotion always walks from → to, so swapping them flips the
+// flow — cheaper than maintaining two edge variants).
+function radialEndpoints(pos, nodeR, hubR, toHub, cx, cy) {
+  const dx = cx - pos.x;
+  const dy = cy - pos.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const ux = dx / len;
+  const uy = dy / len;
+  const planetEdge = { x: pos.x + ux * nodeR, y: pos.y + uy * nodeR };
+  const hubEdge    = { x: cx    - ux * hubR,   y: cy    - uy * hubR  };
+  return toHub
+    ? { from: planetEdge, to: hubEdge }
+    : { from: hubEdge,    to: planetEdge };
 }
 
 // Render a single edge as beam paths + plain particle circles. Each
@@ -780,13 +782,27 @@ function hashStr(s) {
 // a multi-device 55 px circle both read proportionally. Stroke is the
 // accent color so each node carries its identity on the edge of the
 // circle — no separate stripe needed the way rectangular boxes have.
-function renderCircleNode({ pos, title, value, sub, color, soc, radius = 86 }) {
+function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc, radius = 86 }) {
   const r = radius;
   const { x, y } = pos;
-  const titleY = Math.round(-0.42 * r);
+  // When a per-device name suffix is present, the title becomes two
+  // stacked lines ("SOLAR" / "SUNGROW"). That preserves more horizontal
+  // room inside the disk than a single "SOLAR · SUNGROW" line.
+  const twoLine = !!nameLabel;
+  const titleY = Math.round((twoLine ? -0.50 : -0.42) * r);
   const valueY = Math.round(0.09  * r);
   const subY   = Math.round(0.42  * r);
   const socY   = Math.round(0.70  * r);
+  const titleSvg = twoLine
+    ? `<text x="${x}" y="${y + titleY}" text-anchor="middle"
+             fill="var(--hero-label-text)" class="sv-node-title">
+         <tspan x="${x}" dy="0">${escapeXml(title)}</tspan>
+         <tspan x="${x}" dy="1.2em">${escapeXml(nameLabel)}</tspan>
+       </text>`
+    : `<text x="${x}" y="${y + titleY}" text-anchor="middle"
+             fill="var(--hero-label-text)" class="sv-node-title">
+         ${escapeXml(title)}
+       </text>`;
   const socText = soc != null
     ? `<text x="${x}" y="${y + socY}" text-anchor="middle"
              fill="var(--cyan)" class="sv-node-sub">SoC ${Math.round(soc)}%</text>`
@@ -795,10 +811,7 @@ function renderCircleNode({ pos, title, value, sub, color, soc, radius = 86 }) {
     <g>
       <circle cx="${x}" cy="${y}" r="${r}"
               fill="var(--hero-box-fill)" stroke="${color}" stroke-width="2"/>
-      <text x="${x}" y="${y + titleY}" text-anchor="middle"
-            fill="var(--hero-label-text)" class="sv-node-title">
-        ${escapeXml(title)}
-      </text>
+      ${titleSvg}
       <text x="${x}" y="${y + valueY}" text-anchor="middle" fill="${color}" class="sv-node-value">
         ${value}
       </text>
@@ -808,57 +821,6 @@ function renderCircleNode({ pos, title, value, sub, color, soc, radius = 86 }) {
       </text>
       ${socText}
     </g>`;
-}
-
-function renderNode({
-  pos, title, value, sub, color, side, icon, soc,
-  boxW = BOX_W, boxH = BOX_H,
-  textY = { title: 20, value: 46, sub: 64, soc: 70 },
-}) {
-  const x = pos.x - boxW / 2;
-  const y = pos.y - boxH / 2;
-  // Accent stripe sits on the OUTER edge of each box (away from hub) so
-  // the eye follows the colored line back toward the house.
-  const stripe =
-    side === "left"   ? { x,                 y,                 w: 3,    h: boxH } :
-    side === "right"  ? { x: x + boxW - 3,   y,                 w: 3,    h: boxH } :
-    side === "top"    ? { x,                 y,                 w: boxW, h: 3 }    :
-                        { x,                 y: y + boxH - 3,   w: boxW, h: 3 };
-  const socBar = soc != null ? `
-    <rect x="${x + 14}" y="${y + textY.soc}" width="${boxW - 28}" height="2.5" rx="1.25"
-          fill="var(--hero-soc-track)"/>
-    <rect x="${x + 14}" y="${y + textY.soc}" width="${((boxW - 28) * (soc / 100)).toFixed(1)}" height="2.5" rx="1.25"
-          fill="var(--cyan)"/>` : "";
-  return `
-    <g>
-      <rect x="${x}" y="${y}" width="${boxW}" height="${boxH}" rx="12"
-            fill="var(--hero-box-fill)" stroke="var(--hero-box-border)" stroke-width="1"/>
-      <rect x="${stripe.x}" y="${stripe.y}" width="${stripe.w}" height="${stripe.h}" rx="1.5"
-            fill="${color}"/>
-      <text x="${x + 14}" y="${y + textY.title}"
-            fill="var(--hero-label-text)" class="sv-node-title">
-        ${escapeXml(title)}
-      </text>
-      <text x="${x + 14}" y="${y + textY.value}" fill="${color}" class="sv-node-value">
-        ${value}
-      </text>
-      <text x="${x + 14}" y="${y + textY.sub}"
-            fill="var(--hero-sub-text)" class="sv-node-sub">
-        ${escapeXml(sub)}
-      </text>
-      <g transform="translate(${x + boxW - 30}, ${y + 12})" opacity="0.55">
-        ${iconGlyph(icon, color)}
-      </g>
-      ${socBar}
-    </g>`;
-}
-
-// Title includes the driver name only when more than one of its kind
-// exists — avoids visual clutter ("SOLAR · solaredge") in the common
-// single-driver case while still disambiguating multi-driver rigs.
-function labelWithName(base, name, count, suffix = "") {
-  if (count > 1 && name) return `${base} · ${name.toUpperCase()}${suffix}`;
-  return `${base}${suffix}`;
 }
 
 // ---------- primitives ----------
@@ -873,15 +835,6 @@ function clamp(v, a, b) { return Math.max(a, Math.min(b, v)); }
 function escapeXml(s) {
   return String(s).replace(/[<>&"']/g, c =>
     ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&apos;" }[c]));
-}
-
-function iconGlyph(kind, color) {
-  const a = `stroke="${color}" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"`;
-  if (kind === "sun")  return `<g ${a}><circle cx="10" cy="10" r="4"/><path d="M10 1v2M10 17v2M1 10h2M17 10h2M4 4l1.4 1.4M14.6 14.6L16 16M4 16l1.4-1.4M14.6 5.4L16 4"/></g>`;
-  if (kind === "grid") return `<g ${a}><path d="M4 3v14M16 3v14M3 6h14M3 14h14"/></g>`;
-  if (kind === "bat")  return `<g ${a}><rect x="3" y="5" width="13" height="10" rx="1.5"/><path d="M16 8v4M8 8v4M12 8v4"/></g>`;
-  if (kind === "ev")   return `<g ${a}><rect x="3" y="7" width="12" height="7" rx="1.5"/><path d="M5 7V5h8v2M6 16v1M12 16v1M15 9l2 1v3l-2 1"/></g>`;
-  return "";
 }
 
 customElements.define("ftw-energy-flow", FtwEnergyFlow);

--- a/web/components/ftw-legend.js
+++ b/web/components/ftw-legend.js
@@ -34,7 +34,7 @@ class FtwLegend extends FtwElement {
       gap: 0.25rem 0.9rem;
       align-items: center;
       font-size: 0.8rem;
-      color: var(--text-dim);
+      color: var(--fg-dim);
     }
     .item {
       display: inline-flex;
@@ -47,7 +47,7 @@ class FtwLegend extends FtwElement {
       transition: opacity 0.15s, color 0.15s;
     }
     .item:hover {
-      color: var(--text);
+      color: var(--fg);
     }
     .item.hidden {
       opacity: 0.35;
@@ -103,7 +103,7 @@ class FtwLegend extends FtwElement {
       .map((it) => {
         const hidden = this._hidden.has(it.key) ? " hidden" : "";
         const dash = it.dash ? " dash" : "";
-        const color = escapeAttr(it.color || "var(--text)");
+        const color = escapeAttr(it.color || "var(--fg)");
         return `
           <span class="item${hidden}" data-key="${escapeAttr(it.key)}" style="color:${color}">
             <span class="swatch${dash}"></span>

--- a/web/components/ftw-modal.js
+++ b/web/components/ftw-modal.js
@@ -50,18 +50,19 @@ class FtwModal extends FtwElement {
       max-height: 90vh;
       display: flex;
       flex-direction: column;
-      background: var(--surface);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+      background: var(--ink-raised);
+      color: var(--fg);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      /* No shadow — DESIGN.md forbids drop-shadows on cards/modals.
+         The 0.55 backdrop carries the elevation contrast instead. */
     }
     header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       padding: 0.9rem 1rem;
-      border-bottom: 1px solid var(--border);
+      border-bottom: 1px solid var(--line);
     }
     header ::slotted([slot="title"]) {
       font-size: 1rem;
@@ -71,14 +72,14 @@ class FtwModal extends FtwElement {
       appearance: none;
       background: transparent;
       border: none;
-      color: var(--text-dim);
+      color: var(--fg-dim);
       cursor: pointer;
       font-size: 1.25rem;
       line-height: 1;
       padding: 0 0.25rem;
     }
     .close:hover {
-      color: var(--text);
+      color: var(--fg);
     }
     .body {
       padding: 1rem;
@@ -87,7 +88,7 @@ class FtwModal extends FtwElement {
     }
     footer {
       padding: 0.75rem 1rem;
-      border-top: 1px solid var(--border);
+      border-top: 1px solid var(--line);
       display: flex;
       gap: 0.5rem;
       justify-content: flex-end;

--- a/web/components/ftw-progress-bar.js
+++ b/web/components/ftw-progress-bar.js
@@ -26,7 +26,7 @@ class FtwProgressBar extends FtwElement {
     :host {
       display: block;
       height: var(--ftw-progress-height, 8px);
-      background: var(--surface2);
+      background: var(--ink-sunken);
       border-radius: 999px;
       overflow: hidden;
     }
@@ -36,25 +36,26 @@ class FtwProgressBar extends FtwElement {
       transition: width 0.3s ease, background 0.25s ease;
       border-radius: inherit;
     }
-    .solid-ok       { background: var(--green); }
-    .solid-warn     { background: var(--yellow); }
-    .solid-bad      { background: var(--red); }
-    .solid-neutral  { background: var(--text-dim); }
+    .solid-ok       { background: var(--green-e); }
+    .solid-warn     { background: var(--amber); }
+    .solid-bad      { background: var(--red-e); }
+    .solid-neutral  { background: var(--fg-muted); }
 
-    /* Gradient stops match the legacy .soc-fill look: reveal red→amber→
-     * green as the fill grows (ASC, low=bad, high=good — SoC) or
-     * green→amber→red (DESC, low=good, high=bad — fuse/peak load). */
+    /* Gradient stops: reveal red→amber→green as the fill grows (ASC,
+     * low=bad, high=good — SoC) or green→amber→red (DESC, low=good,
+     * high=bad — fuse/peak load). Uses the next-era functional tokens
+     * so the ramp flips correctly in the light theme. */
     .grad-asc {
       background: linear-gradient(90deg,
-        var(--red) 0%,
-        var(--yellow) 30%,
-        var(--green) 60%);
+        var(--red-e) 0%,
+        var(--amber) 30%,
+        var(--green-e) 60%);
     }
     .grad-desc {
       background: linear-gradient(90deg,
-        var(--green) 0%,
-        var(--yellow) 60%,
-        var(--red) 85%);
+        var(--green-e) 0%,
+        var(--amber) 60%,
+        var(--red-e) 85%);
     }
   `;
 

--- a/web/components/ftw-tabs.js
+++ b/web/components/ftw-tabs.js
@@ -29,7 +29,7 @@ class FtwTabs extends FtwElement {
     .strip {
       display: flex;
       gap: 0.25rem;
-      border-bottom: 1px solid var(--border);
+      border-bottom: 1px solid var(--line);
       margin-bottom: 0.75rem;
       overflow-x: auto;
     }
@@ -38,7 +38,7 @@ class FtwTabs extends FtwElement {
       background: transparent;
       border: none;
       border-bottom: 2px solid transparent;
-      color: var(--text-dim);
+      color: var(--fg-dim);
       padding: 0.5rem 0.9rem;
       font: inherit;
       font-size: 0.85rem;
@@ -48,12 +48,12 @@ class FtwTabs extends FtwElement {
       transition: color 0.15s, border-color 0.15s, background 0.15s;
     }
     button:hover {
-      color: var(--text);
-      background: color-mix(in srgb, var(--accent) 8%, transparent);
+      color: var(--fg);
+      background: color-mix(in srgb, var(--accent-e) 8%, transparent);
     }
     button[data-active="true"] {
-      color: var(--text);
-      border-bottom-color: var(--accent);
+      color: var(--fg);
+      border-bottom-color: var(--accent-e);
     }
   `;
 

--- a/web/components/ftw-update-check.js
+++ b/web/components/ftw-update-check.js
@@ -168,6 +168,7 @@ class FtwUpdateCheck extends FtwElement {
     this._phase = "idle";    // idle | updating | timedOut | failed
     this._status = null;     // last /api/version/update/status payload
     this._statusTimer = null;
+    this._pollAbort = null;  // AbortController for in-flight status fetches
     this._updateStartedAt = 0;
     this.classList.add("hidden");
   }
@@ -178,7 +179,7 @@ class FtwUpdateCheck extends FtwElement {
   }
 
   disconnectedCallback() {
-    clearInterval(this._statusTimer);
+    this._stopPolling();
   }
 
   // ---- data ----
@@ -229,34 +230,55 @@ class FtwUpdateCheck extends FtwElement {
   }
 
   _startPolling() {
-    clearInterval(this._statusTimer);
+    this._stopPolling();
+    this._pollAbort = new AbortController();
     this._statusTimer = setInterval(() => this._tick(), STATUS_POLL_MS);
     this._tick();
   }
 
+  // Stops the poll interval AND aborts any in-flight status fetch. Called
+  // from every transition out of "updating" (fail, timeout, cancel, modal
+  // close, disconnect) so a late `state === "done"` response can't hijack
+  // the setup flow with a surprise _reload() after the operator bailed.
+  _stopPolling() {
+    clearInterval(this._statusTimer);
+    this._statusTimer = null;
+    if (this._pollAbort) {
+      this._pollAbort.abort();
+      this._pollAbort = null;
+    }
+  }
+
   _tick() {
-    fetch("/api/version/update/status")
+    const signal = this._pollAbort ? this._pollAbort.signal : undefined;
+    fetch("/api/version/update/status", { signal })
       .then((r) => (r.ok ? r.json() : null))
       .then((st) => {
-        if (!st) return;
+        // Belt-and-braces: if the phase was reset while the fetch was in
+        // flight (cancel button / modal close / timeout), AbortController
+        // should have rejected the promise above — but guard anyway so a
+        // late resolution can never trigger _reload() after bailout.
+        if (!st || this._phase !== "updating") return;
         this._status = st;
         if (st.state === "failed") {
           this._fail(st.message || "Update failed");
           return;
         }
         if (st.state === "done") {
-          clearInterval(this._statusTimer);
+          this._stopPolling();
           // Give the new container a moment to open its listener,
           // then cache-bust reload so stale JS is replaced.
-          setTimeout(() => this._reload(), 800);
+          setTimeout(() => {
+            if (this._phase === "updating") this._reload();
+          }, 800);
         }
         this.update();
       })
-      .catch(() => { /* main container likely mid-restart; keep polling */ });
+      .catch(() => { /* aborted, or main container mid-restart — both fine */ });
 
     if (Date.now() - this._updateStartedAt > UPDATE_SOFT_TIMEOUT_MS) {
-      clearInterval(this._statusTimer);
       if (this._phase === "updating") {
+        this._stopPolling();
         this._phase = "timedOut";
         this.update();
       }
@@ -264,7 +286,7 @@ class FtwUpdateCheck extends FtwElement {
   }
 
   _fail(msg) {
-    clearInterval(this._statusTimer);
+    this._stopPolling();
     this._phase = "failed";
     this._status = { state: "failed", message: msg };
     this.update();
@@ -315,7 +337,7 @@ class FtwUpdateCheck extends FtwElement {
     const cancel = this.shadowRoot.querySelector('[data-action="cancel"]');
     if (cancel) {
       cancel.addEventListener("click", () => {
-        clearInterval(this._statusTimer);
+        this._stopPolling();
         this._phase = "idle";
         this.update();
       });
@@ -332,6 +354,7 @@ class FtwUpdateCheck extends FtwElement {
           return;
         }
         // In failed / timedOut, treat close as "Continue setup".
+        this._stopPolling();
         this._phase = "idle";
         this.update();
       });

--- a/web/components/ftw-update-check.js
+++ b/web/components/ftw-update-check.js
@@ -1,0 +1,426 @@
+// <ftw-update-check> — pre-setup update banner.
+//
+// Usage:
+//
+//   <ftw-update-check></ftw-update-check>
+//
+// Behavior:
+//   1. On connect, silently calls GET /api/version/check.
+//   2. If the backend returns 503 (self-update gated off) or a network
+//      error fires, the component stays invisible — setup is never
+//      blocked by the check.
+//   3. If the response says update_available && !skipped, renders a
+//      prominent "Update available" card with current → latest and
+//      Update-now / Continue-anyway buttons.
+//   4. Update-now posts /api/version/update, opens an <ftw-modal>-based
+//      progress overlay, polls /api/version/update/status, and
+//      cache-busts reloads on `done`. Failure and ~3-minute timeout
+//      swap the spinner for a Reload / Continue-setup escape hatch so
+//      the operator can bail out.
+//   5. Continue-anyway hides the card for this page load only. We do
+//      NOT POST /api/version/skip — that would silence the dashboard's
+//      <ftw-update-badge> too, which is a separate decision the operator
+//      should make from the dashboard itself.
+//
+// Reuse:
+//   - <ftw-modal> (already shipped for /next) supplies the overlay
+//     chrome, ESC/backdrop-close handling, and theming tokens.
+//   - Tokens (--surface, --border, --accent, --text-dim, --radius) are
+//     legacy palette values declared on :root in /components/theme.css,
+//     so the component looks at home in /setup.html (legacy look) and
+//     in /next.html (redesign) without per-context styling.
+
+import { FtwElement } from "./ftw-element.js";
+import "./ftw-modal.js";
+
+const STATUS_POLL_MS = 2000;
+const UPDATE_SOFT_TIMEOUT_MS = 180 * 1000;
+
+class FtwUpdateCheck extends FtwElement {
+  static styles = `
+    :host {
+      display: block;
+      width: 100%;
+    }
+    :host(.hidden) { display: none; }
+
+    .banner {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 14px 16px;
+      background: var(--surface2, var(--surface));
+      border: 1px solid var(--accent);
+      border-radius: var(--radius);
+      text-align: left;
+    }
+    .banner-title {
+      font-weight: 600;
+      color: var(--accent);
+      font-size: 0.9rem;
+    }
+    .banner-detail {
+      font-size: 0.82rem;
+      font-family: var(--mono, ui-monospace, monospace);
+      color: var(--text);
+    }
+    .banner-notes {
+      font-size: 0.78rem;
+      color: var(--accent);
+      text-decoration: none;
+      align-self: flex-start;
+    }
+    .banner-notes:hover { text-decoration: underline; }
+    .banner-actions {
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    /* Match the setup wizard's existing button vocabulary so the card
+       looks native to /setup. All three button classes fall back to
+       theme tokens if host page hasn't declared a green/red accent. */
+    button {
+      font-family: inherit;
+      cursor: pointer;
+    }
+    .btn-primary {
+      padding: 10px 24px;
+      border: none;
+      border-radius: var(--radius);
+      background: var(--green, var(--accent));
+      color: #fff;
+      font-size: 0.9rem;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+    .btn-primary:hover { opacity: 0.85; }
+    .btn-secondary {
+      padding: 8px 18px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface2, var(--surface));
+      color: var(--text);
+      font-size: 0.85rem;
+    }
+    .btn-secondary:hover { background: var(--border); }
+    .btn-skip {
+      background: none;
+      border: none;
+      color: var(--text-dim);
+      font-size: 0.8rem;
+      text-decoration: underline dotted;
+      padding: 4px 8px;
+    }
+    .btn-skip:hover { color: var(--text); }
+
+    /* Progress overlay content — lives inside <ftw-modal>. The modal
+       owns the backdrop, positioning, and ESC/click-close. We drive
+       the content and, while actively updating, block close by
+       cancelling the ftw-modal-close event in afterRender(). */
+    .progress { text-align: center; padding: 0.5rem 0; }
+    .progress .spinner {
+      display: inline-block;
+      width: 28px;
+      height: 28px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.9s linear infinite;
+      margin-bottom: 0.75rem;
+    }
+    .progress h3 {
+      margin: 0 0 0.4rem;
+      font-size: 1rem;
+    }
+    .progress .msg {
+      font-size: 0.88rem;
+      color: var(--text);
+      margin: 0 0 0.3rem;
+    }
+    .progress .hint {
+      font-size: 0.78rem;
+      color: var(--text-dim);
+      margin: 0;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* Hide the modal's X during an active update. The operator should
+       wait for the reload (or the timeout escape hatch) rather than
+       silently dismissing a container mid-recreate. */
+    ftw-modal.busy::part(close) { display: none; }
+
+    .overlay-actions {
+      display: flex;
+      gap: 10px;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+    }
+  `;
+
+  constructor() {
+    super();
+    this._info = null;       // last /api/version/check payload
+    this._phase = "idle";    // idle | updating | timedOut | failed
+    this._status = null;     // last /api/version/update/status payload
+    this._statusTimer = null;
+    this._updateStartedAt = 0;
+    this.classList.add("hidden");
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._check();
+  }
+
+  disconnectedCallback() {
+    clearInterval(this._statusTimer);
+  }
+
+  // ---- data ----
+  _check() {
+    fetch("/api/version/check")
+      .then((r) => {
+        // 503 = self-update disabled by deploy. Stay invisible — this
+        // is config, not an error.
+        if (r.status === 503) return null;
+        return r.json().catch(() => null);
+      })
+      .then((info) => {
+        if (!info || typeof info !== "object") return;
+        this._info = info;
+        this.update();
+      })
+      .catch(() => { /* silent — never a setup blocker */ });
+  }
+
+  // ---- actions ----
+  _beginUpdate() {
+    this._phase = "updating";
+    this._status = { state: "starting" };
+    this._updateStartedAt = Date.now();
+    this.update();
+
+    fetch("/api/version/update", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    })
+      .then((r) => r.json().then((b) => ({ ok: r.ok, body: b })))
+      .then((res) => {
+        if (!res.ok) {
+          this._fail((res.body && res.body.error) || "failed to start");
+          return;
+        }
+        this._startPolling();
+      })
+      .catch((e) => this._fail(String(e)));
+  }
+
+  _dismiss() {
+    // Session-only: wipe the local flag so the banner hides but don't
+    // persist via /api/version/skip — the dashboard badge should still
+    // nudge afterwards.
+    if (this._info) this._info.update_available = false;
+    this.update();
+  }
+
+  _startPolling() {
+    clearInterval(this._statusTimer);
+    this._statusTimer = setInterval(() => this._tick(), STATUS_POLL_MS);
+    this._tick();
+  }
+
+  _tick() {
+    fetch("/api/version/update/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((st) => {
+        if (!st) return;
+        this._status = st;
+        if (st.state === "failed") {
+          this._fail(st.message || "Update failed");
+          return;
+        }
+        if (st.state === "done") {
+          clearInterval(this._statusTimer);
+          // Give the new container a moment to open its listener,
+          // then cache-bust reload so stale JS is replaced.
+          setTimeout(() => this._reload(), 800);
+        }
+        this.update();
+      })
+      .catch(() => { /* main container likely mid-restart; keep polling */ });
+
+    if (Date.now() - this._updateStartedAt > UPDATE_SOFT_TIMEOUT_MS) {
+      clearInterval(this._statusTimer);
+      if (this._phase === "updating") {
+        this._phase = "timedOut";
+        this.update();
+      }
+    }
+  }
+
+  _fail(msg) {
+    clearInterval(this._statusTimer);
+    this._phase = "failed";
+    this._status = { state: "failed", message: msg };
+    this.update();
+  }
+
+  _reload() {
+    const u = new URL(window.location.href);
+    u.searchParams.set("_u", String(Date.now()));
+    window.location.replace(u.toString());
+  }
+
+  // ---- render ----
+  render() {
+    const info = this._info;
+    const showBanner =
+      !!info && info.update_available && !info.skipped && this._phase === "idle";
+
+    // Toggle :host visibility so the element collapses when it has
+    // nothing to say — the wizard layout shouldn't reserve space.
+    if (showBanner || this._phase !== "idle") {
+      this.classList.remove("hidden");
+    } else {
+      this.classList.add("hidden");
+    }
+
+    return `
+      ${showBanner ? this._bannerHTML(info) : ""}
+      ${this._phase !== "idle" ? this._overlayHTML() : ""}
+    `;
+  }
+
+  afterRender() {
+    const upd = this.shadowRoot.querySelector('[data-action="update"]');
+    if (upd) upd.addEventListener("click", () => this._beginUpdate());
+    const dis = this.shadowRoot.querySelector('[data-action="dismiss"]');
+    if (dis) dis.addEventListener("click", () => this._dismiss());
+    const rel = this.shadowRoot.querySelector('[data-action="reload"]');
+    if (rel) rel.addEventListener("click", () => this._reload());
+    const cancel = this.shadowRoot.querySelector('[data-action="cancel"]');
+    if (cancel) {
+      cancel.addEventListener("click", () => {
+        clearInterval(this._statusTimer);
+        this._phase = "idle";
+        this.update();
+      });
+    }
+
+    // Block ftw-modal's self-close while we're mid-update. The operator
+    // uses our explicit Reload / Continue-setup buttons on fail/timeout;
+    // they shouldn't silently dismiss a container being recreated.
+    const modal = this.shadowRoot.querySelector("ftw-modal");
+    if (modal) {
+      modal.addEventListener("ftw-modal-close", (e) => {
+        if (this._phase === "updating") {
+          e.preventDefault();
+          return;
+        }
+        // In failed / timedOut, treat close as "Continue setup".
+        this._phase = "idle";
+        this.update();
+      });
+    }
+  }
+
+  _bannerHTML(info) {
+    const href = safeHref(info.release_notes_url);
+    const notes = href
+      ? `<a class="banner-notes" href="${escapeHTML(href)}" target="_blank" rel="noopener">Release notes ↗</a>`
+      : "";
+
+    return `
+      <div class="banner" part="banner">
+        <div class="banner-title">Update available</div>
+        <div class="banner-detail">${escapeHTML(info.current || "?")}  →  ${escapeHTML(info.latest || "?")}</div>
+        ${notes}
+        <div class="banner-actions">
+          <button class="btn-primary" data-action="update">Update now</button>
+          <button class="btn-skip" data-action="dismiss">Continue anyway</button>
+        </div>
+      </div>
+    `;
+  }
+
+  _overlayHTML() {
+    const st = this._status || { state: "starting" };
+    const busy = this._phase === "updating";
+    const failed = this._phase === "failed";
+    const timedOut = this._phase === "timedOut";
+
+    let title = "Updating";
+    let msg = stateLabel(st.state) + "…";
+    let hint = "The page will reload automatically.";
+    let actions = "";
+    if (failed) {
+      title = "Update failed";
+      msg = st.message || "Update failed";
+      hint = "";
+      actions = `
+        <div class="overlay-actions" slot="footer">
+          <button class="btn-secondary" data-action="cancel">Continue setup</button>
+          <button class="btn-primary" data-action="reload">Reload page</button>
+        </div>
+      `;
+    } else if (timedOut) {
+      const elapsed = Math.round((Date.now() - this._updateStartedAt) / 1000);
+      title = "Taking longer than expected";
+      msg = `Still working after ${elapsed}s. You can reload to check, or continue setup and let the update finish in the background.`;
+      hint = "";
+      actions = `
+        <div class="overlay-actions" slot="footer">
+          <button class="btn-secondary" data-action="cancel">Continue setup</button>
+          <button class="btn-primary" data-action="reload">Reload page</button>
+        </div>
+      `;
+    }
+
+    return `
+      <ftw-modal open class="${busy ? "busy" : ""}">
+        <span slot="title">${escapeHTML(title)}</span>
+        <div class="progress">
+          ${busy ? `<span class="spinner" aria-hidden="true"></span>` : ""}
+          <p class="msg">${escapeHTML(msg)}</p>
+          ${hint ? `<p class="hint">${escapeHTML(hint)}</p>` : ""}
+        </div>
+        ${actions}
+      </ftw-modal>
+    `;
+  }
+}
+
+// safeHref rejects anything that isn't http:/https:. release_notes_url
+// comes from the GitHub Releases API; belt-and-brace against a stray
+// javascript:/data: URL ending up in the payload.
+function safeHref(u) {
+  if (!u) return "";
+  try {
+    const p = new URL(String(u), window.location.href);
+    if (p.protocol === "http:" || p.protocol === "https:") return p.toString();
+  } catch (_) { /* fall through */ }
+  return "";
+}
+
+function escapeHTML(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function stateLabel(state) {
+  switch (state) {
+    case "pulling":    return "Pulling new image";
+    case "restarting": return "Applying update";
+    case "done":       return "Reloading";
+    case "failed":     return "Failed";
+    default:           return "Starting update";
+  }
+}
+
+customElements.define("ftw-update-check", FtwUpdateCheck);

--- a/web/components/ftw-update-check.js
+++ b/web/components/ftw-update-check.js
@@ -9,9 +9,12 @@
 //   2. If the backend returns 503 (self-update gated off) or a network
 //      error fires, the component stays invisible — setup is never
 //      blocked by the check.
-//   3. If the response says update_available && !skipped, renders a
-//      prominent "Update available" card with current → latest and
-//      Update-now / Continue-anyway buttons.
+//   3. The banner only renders when the response has
+//      update_available && !skipped && sidecar_ready. sidecar_ready
+//      is true exclusively in docker-compose deploys where the
+//      ftw-updater sidecar's Unix socket is reachable; native installs
+//      and dev runs keep the banner hidden so we don't offer an Update
+//      button that can only fail.
 //   4. Update-now posts /api/version/update, opens an <ftw-modal>-based
 //      progress overlay, polls /api/version/update/status, and
 //      cache-busts reloads on `done`. Failure and ~3-minute timeout
@@ -276,8 +279,17 @@ class FtwUpdateCheck extends FtwElement {
   // ---- render ----
   render() {
     const info = this._info;
+    // Banner is only useful when the full pull+restart flow is actionable.
+    // sidecar_ready is true in docker-compose deploys where the ftw-updater
+    // sidecar exposes its Unix socket at the configured SocketPath; native
+    // installs and dev runs leave the socket absent, so we stay invisible
+    // instead of offering an Update button that can only fail.
     const showBanner =
-      !!info && info.update_available && !info.skipped && this._phase === "idle";
+      !!info &&
+      info.update_available &&
+      !info.skipped &&
+      info.sidecar_ready === true &&
+      this._phase === "idle";
 
     // Toggle :host visibility so the element collapses when it has
     // nothing to say — the wizard layout shouldn't reserve space.

--- a/web/components/ftw-update-check.js
+++ b/web/components/ftw-update-check.js
@@ -47,29 +47,36 @@ class FtwUpdateCheck extends FtwElement {
     }
     :host(.hidden) { display: none; }
 
+    /* Tokens resolved against /components/theme.css — amber single-
+       accent palette (--accent-e), oklch ink canvas, hairline 1px
+       borders. The component looks native to /setup (legacy page
+       wrapper re-skinned onto the same tokens) and /next (dashboard). */
     .banner {
       display: flex;
       flex-direction: column;
       gap: 10px;
       padding: 14px 16px;
-      background: var(--surface2, var(--surface));
-      border: 1px solid var(--accent);
-      border-radius: var(--radius);
+      background: var(--ink-raised);
+      border: 1px solid color-mix(in srgb, var(--accent-e) 40%, var(--line));
+      border-radius: 10px;
       text-align: left;
     }
     .banner-title {
-      font-weight: 600;
-      color: var(--accent);
-      font-size: 0.9rem;
+      font-family: var(--mono, ui-monospace, monospace);
+      font-weight: 500;
+      color: var(--accent-e);
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
     }
     .banner-detail {
-      font-size: 0.82rem;
+      font-size: 0.85rem;
       font-family: var(--mono, ui-monospace, monospace);
-      color: var(--text);
+      color: var(--fg);
     }
     .banner-notes {
       font-size: 0.78rem;
-      color: var(--accent);
+      color: var(--accent-e);
       text-decoration: none;
       align-self: flex-start;
     }
@@ -81,42 +88,42 @@ class FtwUpdateCheck extends FtwElement {
       flex-wrap: wrap;
     }
 
-    /* Match the setup wizard's existing button vocabulary so the card
-       looks native to /setup. All three button classes fall back to
-       theme tokens if host page hasn't declared a green/red accent. */
     button {
-      font-family: inherit;
+      font-family: var(--sans, system-ui, sans-serif);
       cursor: pointer;
     }
     .btn-primary {
-      padding: 10px 24px;
+      padding: 11px 18px;
       border: none;
-      border-radius: var(--radius);
-      background: var(--green, var(--accent));
-      color: #fff;
-      font-size: 0.9rem;
-      font-weight: 600;
-      transition: opacity 0.2s;
+      border-radius: 8px;
+      background: var(--accent-e);
+      color: #0a0a0a;
+      font-size: 14px;
+      font-weight: 500;
+      transition: transform 0.12s;
     }
-    .btn-primary:hover { opacity: 0.85; }
+    .btn-primary:hover { transform: translateY(-1px); }
     .btn-secondary {
-      padding: 8px 18px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      background: var(--surface2, var(--surface));
-      color: var(--text);
-      font-size: 0.85rem;
+      padding: 10px 18px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: transparent;
+      color: var(--fg);
+      font-size: 14px;
+      transition: border-color 0.15s;
     }
-    .btn-secondary:hover { background: var(--border); }
+    .btn-secondary:hover { border-color: var(--fg-dim); }
     .btn-skip {
       background: none;
       border: none;
-      color: var(--text-dim);
-      font-size: 0.8rem;
-      text-decoration: underline dotted;
-      padding: 4px 8px;
+      color: var(--fg-muted);
+      font-family: var(--mono, ui-monospace, monospace);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      padding: 6px 10px;
+      transition: color 0.15s;
     }
-    .btn-skip:hover { color: var(--text); }
+    .btn-skip:hover { color: var(--fg); }
 
     /* Progress overlay content — lives inside <ftw-modal>. The modal
        owns the backdrop, positioning, and ESC/click-close. We drive
@@ -127,8 +134,8 @@ class FtwUpdateCheck extends FtwElement {
       display: inline-block;
       width: 28px;
       height: 28px;
-      border: 3px solid var(--border);
-      border-top-color: var(--accent);
+      border: 3px solid var(--line);
+      border-top-color: var(--accent-e);
       border-radius: 50%;
       animation: spin 0.9s linear infinite;
       margin-bottom: 0.75rem;
@@ -136,15 +143,16 @@ class FtwUpdateCheck extends FtwElement {
     .progress h3 {
       margin: 0 0 0.4rem;
       font-size: 1rem;
+      color: var(--fg);
     }
     .progress .msg {
       font-size: 0.88rem;
-      color: var(--text);
+      color: var(--fg);
       margin: 0 0 0.3rem;
     }
     .progress .hint {
       font-size: 0.78rem;
-      color: var(--text-dim);
+      color: var(--fg-dim);
       margin: 0;
     }
     @keyframes spin { to { transform: rotate(360deg); } }

--- a/web/components/index.js
+++ b/web/components/index.js
@@ -12,3 +12,4 @@ import "./ftw-card.js";
 import "./ftw-tabs.js";
 import "./ftw-legend.js";
 import "./ftw-energy-flow.js";
+import "./ftw-update-check.js";

--- a/web/components/theme.css
+++ b/web/components/theme.css
@@ -69,8 +69,14 @@
   --hero-sub-text:     oklch(0.5 0.015 250);
   --hero-soc-track:    oklch(0.25 0.015 250);
 
-  --sans: 'Inter', -apple-system, 'Segoe UI', Roboto, sans-serif;
-  --mono: 'JetBrains Mono', 'SF Mono', Menlo, ui-monospace, monospace;
+  /* No external font CDN — all fallbacks are either shipped with the
+     OS (system-ui, Segoe UI, Roboto, Helvetica Neue) or resolved by
+     the browser's native UI-font alias (-apple-system, ui-monospace).
+     'Inter' and 'JetBrains Mono' stay at the front of the stack so
+     they pick up automatically if the operator has them installed
+     locally (or if we later self-host via @font-face). */
+  --sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   --radius-lg: 18px;
   --radius-md: 14px;

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>forty-two-watts</title>
+  <title>forty-two-watts — next</title>
   <link rel="icon" type="image/jpeg" href="/logo.jpg">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
         integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
@@ -11,25 +11,55 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
           crossorigin=""></script>
-  <!-- Design tokens (--bg/--surface/etc) live in /components/theme.css;
-       style.css references them, so theme.css must load first. This page
-       is the legacy layout — /components/index.js is intentionally NOT
-       loaded here so the refactor work lives entirely in next.html until
-       we're ready to swap. (The existing <ftw-update-badge> predates the
-       refactor and has its own script, independent of /components/.) -->
+  <!-- Type: Inter preferred for UI, JetBrains Mono for tabular numerics.
+       No external font CDN — the Pi has to boot + render even without
+       internet; theme.css's --sans / --mono stacks fall back to the OS's
+       native UI + mono fonts. -->
+
+  <!-- Apply the saved theme BEFORE any stylesheet resolves so light-mode
+       users don't see a dark-to-light flash on reload. The full toggle
+       handler is at the bottom of <body>; this stub just sets the attr. -->
+  <script>
+    (function () {
+      var saved = null;
+      try { saved = localStorage.getItem('ftw-theme'); } catch (e) {}
+      var osLight = window.matchMedia &&
+                    window.matchMedia('(prefers-color-scheme: light)').matches;
+      document.documentElement.setAttribute(
+        'data-theme', saved || (osLight ? 'light' : 'dark'));
+    })();
+  </script>
+  <!-- Design tokens FIRST — every sheet and every <ftw-*> shadow root reads
+       from :root declared in /components/theme.css. -->
   <link rel="stylesheet" href="/components/theme.css">
   <link rel="stylesheet" href="/style.css">
+  <!-- /next-only visual redesign — layered on top of style.css and scoped
+       to body.ftw-next so legacy /index.html is untouched. -->
+  <link rel="stylesheet" href="/next.css?v=next2">
+  <script type="module" src="/components/index.js"></script>
 </head>
-<body>
+<body class="ftw-next">
   <header>
     <img src="/logo.jpg" alt="42W" class="header-logo"><h1>42W</h1>
     <nav class="app-tabs" id="app-tabs" role="tablist">
       <button data-view="live" class="tab-btn active" role="tab">Live</button>
       <button data-view="diagnose" class="tab-btn" role="tab" title="Time-travel through past planner decisions">Diagnose</button>
     </nav>
+    <!-- Hamburger — visible only on narrow viewports. Opens the header
+         drawer (tabs + toggles + settings + version) via CSS class flip
+         handled in the init block at the bottom of this file. -->
+    <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Open menu" aria-expanded="false" title="Menu">&#9776;</button>
     <div class="header-right">
+      <!-- Drawer-only navigation shortcuts (hidden on desktop). These
+           share [data-view] with the main .app-tabs so the global view
+           router in diagnose.js treats them the same as the top-row
+           tabs. Added so the mobile hamburger menu exposes Diagnose. -->
+      <button data-view="live" class="drawer-nav-btn" data-menu-label="Live view">&#9654;</button>
+      <button data-view="diagnose" class="drawer-nav-btn" data-menu-label="Diagnose">&#9202;</button>
+      <button id="hero-toggle" class="icon-btn" data-menu-label="Hero / tiles" title="Switch between hero diagram and numeric tiles">&#9638;</button>
+      <button id="theme-toggle" class="icon-btn" data-menu-label="Theme" title="Toggle light / dark theme">&#9790;</button>
       <button id="ui-mode-toggle" class="btn-link" title="Show advanced controls + diagnostics">Advanced</button>
-      <button id="settings-btn" class="settings-btn" title="Settings">⚙</button>
+      <button id="settings-btn" class="settings-btn" data-menu-label="Settings" title="Settings">⚙</button>
       <ftw-update-badge></ftw-update-badge>
       <span id="version" class="version" title="Click for version info" style="cursor:pointer">...</span>
       <span id="conn-status" class="conn-status connected" title="Connected">&#9679;</span>
@@ -63,24 +93,33 @@
   </div>
 
   <main id="view-live">
+    <!-- Energy-flow hero — central house, PV top, Grid left, Battery right,
+         EV bottom. next-app.js calls el.setReadings(...) each status tick. -->
+    <section class="flow-hero">
+      <ftw-energy-flow id="energy-flow" pv="0" grid="0" battery="0" load="0" ev="0" soc="0"></ftw-energy-flow>
+    </section>
+
     <!-- Summary Cards — compact 5-in-a-row -->
     <section class="summary-cards">
-      <div class="card summary-card" id="card-grid">
+      <!-- The four "big numbers" that duplicate what the energy-flow
+           hero shows. Hidden when body.mode-hero is active — the mode
+           toggle in the header flips between hero and numeric tiles. -->
+      <div class="card summary-card ftw-hide-in-hero" id="card-grid">
         <div class="card-label">Grid <span class="card-target" id="grid-target-display"></span></div>
         <div class="card-value" id="grid-w">-- W</div>
         <div class="card-sub" id="grid-dir">--</div>
       </div>
-      <div class="card summary-card" id="card-pv">
+      <div class="card summary-card ftw-hide-in-hero" id="card-pv">
         <div class="card-label">PV</div>
         <div class="card-value" id="pv-w">-- W</div>
         <div class="card-sub">gen</div>
       </div>
-      <div class="card summary-card" id="card-bat">
+      <div class="card summary-card ftw-hide-in-hero" id="card-bat">
         <div class="card-label">Battery</div>
         <div class="card-value" id="bat-w">-- W</div>
         <div class="card-sub" id="bat-dir">--</div>
       </div>
-      <div class="card summary-card" id="card-load">
+      <div class="card summary-card ftw-hide-in-hero" id="card-load">
         <div class="card-label">Load</div>
         <div class="card-value val-neutral" id="load-w">-- W</div>
         <div class="card-sub">house</div>
@@ -88,7 +127,8 @@
       <div class="card summary-card" id="card-soc">
         <div class="card-label">SoC</div>
         <div class="card-value" id="bat-soc">-- %</div>
-        <div class="soc-bar"><div class="soc-fill" id="soc-fill"></div></div>
+        <ftw-progress-bar id="soc-fill" mode="gradient" value="0" max="100"
+                          style="margin-top:0.5rem; --ftw-progress-height:10px"></ftw-progress-bar>
       </div>
       <div class="card summary-card" id="card-fuse">
         <div class="card-label">Fuse</div>
@@ -324,29 +364,24 @@
   </footer>
 
   <!-- EV detail popup -->
-  <div id="ev-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="ev-modal-title" aria-hidden="true">
-    <div class="modal-content" style="max-width:380px">
-      <div class="modal-header">
-        <h2 id="ev-modal-title">EV Charger</h2>
-        <button id="ev-modal-close" class="modal-close" aria-label="Close">&times;</button>
-      </div>
-      <div class="modal-body" id="ev-modal-body" style="padding:1rem">
-        <p style="color:var(--text-dim)">Loading...</p>
-      </div>
-      <div style="display:flex;gap:0.5rem;padding:0 1rem 1rem">
-        <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
-        <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
-        <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
-      </div>
+  <ftw-modal id="ev-modal" style="--ftw-modal-max-width:380px">
+    <span slot="title">EV Charger</span>
+    <div id="ev-modal-body">
+      <p style="color:var(--text-dim)">Loading...</p>
     </div>
-  </div>
+    <div slot="footer" style="display:flex;gap:0.5rem;width:100%">
+      <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
+      <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
+      <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
+    </div>
+  </ftw-modal>
 
-  <script src="/app.js?v=soc1"></script>
-  <script src="/settings.js?v=soc1"></script>
-  <script src="/models.js?v=soc1"></script>
-  <script src="/plan.js?v=soc1"></script>
-  <script src="/twins.js?v=soc1"></script>
-  <script src="/diagnose.js?v=soc1"></script>
+  <script src="/next-app.js?v=next1"></script>
+  <script src="/settings.js?v=diag1"></script>
+  <script src="/models.js?v=diag1"></script>
+  <script src="/plan.js?v=diag1"></script>
+  <script src="/twins.js?v=diag1"></script>
+  <script src="/diagnose.js?v=diag1"></script>
   <script src="/update-badge.js?v=modal1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
@@ -370,31 +405,116 @@
       });
     });
   </script>
-  <script>
-    <!-- Status bar — always visible at bottom -->
-    <footer class="status-bar" id="status-bar">
-      <span class="status-bar-item" id="sb-drivers">--</span>
-      <span class="status-bar-spacer"></span>
-      <span class="status-bar-item" id="sb-version">--</span>
-    </footer>
+  <!-- Status bar — always visible at bottom. Previously nested inside a
+       <script> tag, which made the HTML parser treat it as text and the
+       bar never rendered. Lifted out so next-app.js can actually find
+       the sb-drivers / sb-version spans. -->
+  <footer class="status-bar" id="status-bar">
+    <span class="status-bar-item" id="sb-drivers">--</span>
+    <span class="status-bar-spacer"></span>
+    <span class="status-bar-item" id="sb-version">--</span>
+  </footer>
 
-    <script>
-    // UI-mode toggle (simple / advanced). Persisted to localStorage.
+  <script>
+    // -------- UI-mode toggle (simple / advanced). Persisted. --------
     (function () {
-      const KEY = 'ui-mode';
-      const btn = document.getElementById('ui-mode-toggle');
+      var KEY = 'ui-mode';
+      var btn = document.getElementById('ui-mode-toggle');
       function apply(mode) {
         document.body.classList.remove('simple', 'advanced');
         document.body.classList.add(mode);
-        if (btn) btn.textContent = mode === 'advanced' ? '★ Advanced' : 'Advanced';
-        if (btn) btn.title = mode === 'advanced' ? 'Switch to simple view' : 'Show advanced controls + diagnostics';
+        if (!btn) return;
+        btn.textContent = mode === 'advanced' ? '★ Advanced' : 'Advanced';
+        btn.title = mode === 'advanced' ? 'Switch to simple view' : 'Show advanced controls + diagnostics';
       }
-      const initial = localStorage.getItem(KEY) || 'simple';
-      apply(initial);
+      apply(localStorage.getItem(KEY) || 'simple');
       if (btn) btn.addEventListener('click', function () {
-        const next = document.body.classList.contains('advanced') ? 'simple' : 'advanced';
+        var next = document.body.classList.contains('advanced') ? 'simple' : 'advanced';
         localStorage.setItem(KEY, next);
         apply(next);
+      });
+    })();
+
+    // -------- Theme toggle (light / dark). --------
+    // Attribute lives on <html> so it applies before <body> styles
+    // resolve — avoids a dark-to-light flash on reload in light mode.
+    // Default resolution: saved preference → OS preference → dark.
+    (function () {
+      var KEY = 'ftw-theme';
+      var root = document.documentElement;
+      var btn = document.getElementById('theme-toggle');
+      function iconFor(t) { return t === 'light' ? '\u263E' /* ☾ */ : '\u2600' /* ☀ */; }
+      function apply(theme) {
+        root.setAttribute('data-theme', theme);
+        if (btn) {
+          btn.textContent = iconFor(theme);
+          btn.title = 'Switch to ' + (theme === 'light' ? 'dark' : 'light') + ' theme';
+        }
+      }
+      var saved = localStorage.getItem(KEY);
+      var osLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+      apply(saved || (osLight ? 'light' : 'dark'));
+      if (btn) btn.addEventListener('click', function () {
+        var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+        localStorage.setItem(KEY, next);
+        apply(next);
+      });
+    })();
+
+    // -------- Hero / numbers toggle. --------
+    // mode-hero: show the energy-flow diagram, hide the big numeric
+    //   tiles for Grid/PV/Battery/Load (they're in the hero already).
+    // mode-numbers: hide the hero, show all tiles. Both paths leave
+    //   SoC, Fuse, EV, energy totals, controls + charts visible.
+    (function () {
+      var KEY = 'ftw-hero-mode';
+      var btn = document.getElementById('hero-toggle');
+      function iconFor(m) { return m === 'hero' ? '\u25A6' /* ▦ */ : '\u2638' /* ☸ */; }
+      function apply(mode) {
+        document.body.classList.remove('mode-hero', 'mode-numbers');
+        document.body.classList.add('mode-' + mode);
+        if (btn) {
+          btn.textContent = iconFor(mode);
+          btn.title = mode === 'hero' ? 'Show numeric tiles' : 'Show energy-flow hero';
+          btn.setAttribute('aria-pressed', mode === 'hero' ? 'true' : 'false');
+        }
+      }
+      apply(localStorage.getItem(KEY) || 'hero');
+      if (btn) btn.addEventListener('click', function () {
+        var next = document.body.classList.contains('mode-numbers') ? 'hero' : 'numbers';
+        localStorage.setItem(KEY, next);
+        apply(next);
+      });
+    })();
+
+    // -------- Mobile menu drawer. --------
+    // On narrow viewports the header right-cluster (tabs + toggles +
+    // settings + version) collapses behind a hamburger. Clicking the
+    // hamburger flips `header.menu-open`; CSS does the rest. An
+    // outside-click listener closes the drawer so it doesn't get
+    // stuck open when the user taps past it.
+    (function () {
+      var btn = document.getElementById('mobile-menu-btn');
+      var hdr = document.querySelector('body.ftw-next > header');
+      if (!btn || !hdr) return;
+      function close() {
+        hdr.classList.remove('menu-open');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        var open = hdr.classList.toggle('menu-open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+      document.addEventListener('click', function (e) {
+        if (!hdr.classList.contains('menu-open')) return;
+        if (!hdr.contains(e.target)) close();
+      });
+      window.addEventListener('resize', function () {
+        // If the viewport grows past the mobile breakpoint, the drawer
+        // CSS stops applying — close explicitly so a resize-then-resize
+        // doesn't leave the drawer class dangling.
+        if (window.matchMedia('(min-width: 721px)').matches) close();
       });
     })();
   </script>

--- a/web/legacy.html
+++ b/web/legacy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>forty-two-watts — next</title>
+  <title>forty-two-watts</title>
   <link rel="icon" type="image/jpeg" href="/logo.jpg">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
         integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
@@ -11,55 +11,25 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
           crossorigin=""></script>
-  <!-- Type: Inter preferred for UI, JetBrains Mono for tabular numerics.
-       No external font CDN — the Pi has to boot + render even without
-       internet; theme.css's --sans / --mono stacks fall back to the OS's
-       native UI + mono fonts. -->
-
-  <!-- Apply the saved theme BEFORE any stylesheet resolves so light-mode
-       users don't see a dark-to-light flash on reload. The full toggle
-       handler is at the bottom of <body>; this stub just sets the attr. -->
-  <script>
-    (function () {
-      var saved = null;
-      try { saved = localStorage.getItem('ftw-theme'); } catch (e) {}
-      var osLight = window.matchMedia &&
-                    window.matchMedia('(prefers-color-scheme: light)').matches;
-      document.documentElement.setAttribute(
-        'data-theme', saved || (osLight ? 'light' : 'dark'));
-    })();
-  </script>
-  <!-- Design tokens FIRST — every sheet and every <ftw-*> shadow root reads
-       from :root declared in /components/theme.css. -->
+  <!-- Design tokens (--bg/--surface/etc) live in /components/theme.css;
+       style.css references them, so theme.css must load first. This page
+       is the legacy layout — /components/index.js is intentionally NOT
+       loaded here so the refactor work lives entirely in next.html until
+       we're ready to swap. (The existing <ftw-update-badge> predates the
+       refactor and has its own script, independent of /components/.) -->
   <link rel="stylesheet" href="/components/theme.css">
   <link rel="stylesheet" href="/style.css">
-  <!-- /next-only visual redesign — layered on top of style.css and scoped
-       to body.ftw-next so legacy /index.html is untouched. -->
-  <link rel="stylesheet" href="/next.css?v=next2">
-  <script type="module" src="/components/index.js"></script>
 </head>
-<body class="ftw-next">
+<body>
   <header>
     <img src="/logo.jpg" alt="42W" class="header-logo"><h1>42W</h1>
     <nav class="app-tabs" id="app-tabs" role="tablist">
       <button data-view="live" class="tab-btn active" role="tab">Live</button>
       <button data-view="diagnose" class="tab-btn" role="tab" title="Time-travel through past planner decisions">Diagnose</button>
     </nav>
-    <!-- Hamburger — visible only on narrow viewports. Opens the header
-         drawer (tabs + toggles + settings + version) via CSS class flip
-         handled in the init block at the bottom of this file. -->
-    <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Open menu" aria-expanded="false" title="Menu">&#9776;</button>
     <div class="header-right">
-      <!-- Drawer-only navigation shortcuts (hidden on desktop). These
-           share [data-view] with the main .app-tabs so the global view
-           router in diagnose.js treats them the same as the top-row
-           tabs. Added so the mobile hamburger menu exposes Diagnose. -->
-      <button data-view="live" class="drawer-nav-btn" data-menu-label="Live view">&#9654;</button>
-      <button data-view="diagnose" class="drawer-nav-btn" data-menu-label="Diagnose">&#9202;</button>
-      <button id="hero-toggle" class="icon-btn" data-menu-label="Hero / tiles" title="Switch between hero diagram and numeric tiles">&#9638;</button>
-      <button id="theme-toggle" class="icon-btn" data-menu-label="Theme" title="Toggle light / dark theme">&#9790;</button>
       <button id="ui-mode-toggle" class="btn-link" title="Show advanced controls + diagnostics">Advanced</button>
-      <button id="settings-btn" class="settings-btn" data-menu-label="Settings" title="Settings">⚙</button>
+      <button id="settings-btn" class="settings-btn" title="Settings">⚙</button>
       <ftw-update-badge></ftw-update-badge>
       <span id="version" class="version" title="Click for version info" style="cursor:pointer">...</span>
       <span id="conn-status" class="conn-status connected" title="Connected">&#9679;</span>
@@ -93,33 +63,24 @@
   </div>
 
   <main id="view-live">
-    <!-- Energy-flow hero — central house, PV top, Grid left, Battery right,
-         EV bottom. next-app.js calls el.setReadings(...) each status tick. -->
-    <section class="flow-hero">
-      <ftw-energy-flow id="energy-flow" pv="0" grid="0" battery="0" load="0" ev="0" soc="0"></ftw-energy-flow>
-    </section>
-
     <!-- Summary Cards — compact 5-in-a-row -->
     <section class="summary-cards">
-      <!-- The four "big numbers" that duplicate what the energy-flow
-           hero shows. Hidden when body.mode-hero is active — the mode
-           toggle in the header flips between hero and numeric tiles. -->
-      <div class="card summary-card ftw-hide-in-hero" id="card-grid">
+      <div class="card summary-card" id="card-grid">
         <div class="card-label">Grid <span class="card-target" id="grid-target-display"></span></div>
         <div class="card-value" id="grid-w">-- W</div>
         <div class="card-sub" id="grid-dir">--</div>
       </div>
-      <div class="card summary-card ftw-hide-in-hero" id="card-pv">
+      <div class="card summary-card" id="card-pv">
         <div class="card-label">PV</div>
         <div class="card-value" id="pv-w">-- W</div>
         <div class="card-sub">gen</div>
       </div>
-      <div class="card summary-card ftw-hide-in-hero" id="card-bat">
+      <div class="card summary-card" id="card-bat">
         <div class="card-label">Battery</div>
         <div class="card-value" id="bat-w">-- W</div>
         <div class="card-sub" id="bat-dir">--</div>
       </div>
-      <div class="card summary-card ftw-hide-in-hero" id="card-load">
+      <div class="card summary-card" id="card-load">
         <div class="card-label">Load</div>
         <div class="card-value val-neutral" id="load-w">-- W</div>
         <div class="card-sub">house</div>
@@ -127,8 +88,7 @@
       <div class="card summary-card" id="card-soc">
         <div class="card-label">SoC</div>
         <div class="card-value" id="bat-soc">-- %</div>
-        <ftw-progress-bar id="soc-fill" mode="gradient" value="0" max="100"
-                          style="margin-top:0.5rem; --ftw-progress-height:10px"></ftw-progress-bar>
+        <div class="soc-bar"><div class="soc-fill" id="soc-fill"></div></div>
       </div>
       <div class="card summary-card" id="card-fuse">
         <div class="card-label">Fuse</div>
@@ -364,24 +324,29 @@
   </footer>
 
   <!-- EV detail popup -->
-  <ftw-modal id="ev-modal" style="--ftw-modal-max-width:380px">
-    <span slot="title">EV Charger</span>
-    <div id="ev-modal-body">
-      <p style="color:var(--text-dim)">Loading...</p>
+  <div id="ev-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="ev-modal-title" aria-hidden="true">
+    <div class="modal-content" style="max-width:380px">
+      <div class="modal-header">
+        <h2 id="ev-modal-title">EV Charger</h2>
+        <button id="ev-modal-close" class="modal-close" aria-label="Close">&times;</button>
+      </div>
+      <div class="modal-body" id="ev-modal-body" style="padding:1rem">
+        <p style="color:var(--text-dim)">Loading...</p>
+      </div>
+      <div style="display:flex;gap:0.5rem;padding:0 1rem 1rem">
+        <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
+        <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
+        <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
+      </div>
     </div>
-    <div slot="footer" style="display:flex;gap:0.5rem;width:100%">
-      <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
-      <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
-      <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
-    </div>
-  </ftw-modal>
+  </div>
 
-  <script src="/next-app.js?v=next1"></script>
-  <script src="/settings.js?v=diag1"></script>
-  <script src="/models.js?v=diag1"></script>
-  <script src="/plan.js?v=diag1"></script>
-  <script src="/twins.js?v=diag1"></script>
-  <script src="/diagnose.js?v=diag1"></script>
+  <script src="/app.js?v=soc1"></script>
+  <script src="/settings.js?v=soc1"></script>
+  <script src="/models.js?v=soc1"></script>
+  <script src="/plan.js?v=soc1"></script>
+  <script src="/twins.js?v=soc1"></script>
+  <script src="/diagnose.js?v=soc1"></script>
   <script src="/update-badge.js?v=modal1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal
@@ -405,116 +370,31 @@
       });
     });
   </script>
-  <!-- Status bar — always visible at bottom. Previously nested inside a
-       <script> tag, which made the HTML parser treat it as text and the
-       bar never rendered. Lifted out so next-app.js can actually find
-       the sb-drivers / sb-version spans. -->
-  <footer class="status-bar" id="status-bar">
-    <span class="status-bar-item" id="sb-drivers">--</span>
-    <span class="status-bar-spacer"></span>
-    <span class="status-bar-item" id="sb-version">--</span>
-  </footer>
-
   <script>
-    // -------- UI-mode toggle (simple / advanced). Persisted. --------
+    <!-- Status bar — always visible at bottom -->
+    <footer class="status-bar" id="status-bar">
+      <span class="status-bar-item" id="sb-drivers">--</span>
+      <span class="status-bar-spacer"></span>
+      <span class="status-bar-item" id="sb-version">--</span>
+    </footer>
+
+    <script>
+    // UI-mode toggle (simple / advanced). Persisted to localStorage.
     (function () {
-      var KEY = 'ui-mode';
-      var btn = document.getElementById('ui-mode-toggle');
+      const KEY = 'ui-mode';
+      const btn = document.getElementById('ui-mode-toggle');
       function apply(mode) {
         document.body.classList.remove('simple', 'advanced');
         document.body.classList.add(mode);
-        if (!btn) return;
-        btn.textContent = mode === 'advanced' ? '★ Advanced' : 'Advanced';
-        btn.title = mode === 'advanced' ? 'Switch to simple view' : 'Show advanced controls + diagnostics';
+        if (btn) btn.textContent = mode === 'advanced' ? '★ Advanced' : 'Advanced';
+        if (btn) btn.title = mode === 'advanced' ? 'Switch to simple view' : 'Show advanced controls + diagnostics';
       }
-      apply(localStorage.getItem(KEY) || 'simple');
+      const initial = localStorage.getItem(KEY) || 'simple';
+      apply(initial);
       if (btn) btn.addEventListener('click', function () {
-        var next = document.body.classList.contains('advanced') ? 'simple' : 'advanced';
+        const next = document.body.classList.contains('advanced') ? 'simple' : 'advanced';
         localStorage.setItem(KEY, next);
         apply(next);
-      });
-    })();
-
-    // -------- Theme toggle (light / dark). --------
-    // Attribute lives on <html> so it applies before <body> styles
-    // resolve — avoids a dark-to-light flash on reload in light mode.
-    // Default resolution: saved preference → OS preference → dark.
-    (function () {
-      var KEY = 'ftw-theme';
-      var root = document.documentElement;
-      var btn = document.getElementById('theme-toggle');
-      function iconFor(t) { return t === 'light' ? '\u263E' /* ☾ */ : '\u2600' /* ☀ */; }
-      function apply(theme) {
-        root.setAttribute('data-theme', theme);
-        if (btn) {
-          btn.textContent = iconFor(theme);
-          btn.title = 'Switch to ' + (theme === 'light' ? 'dark' : 'light') + ' theme';
-        }
-      }
-      var saved = localStorage.getItem(KEY);
-      var osLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
-      apply(saved || (osLight ? 'light' : 'dark'));
-      if (btn) btn.addEventListener('click', function () {
-        var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
-        localStorage.setItem(KEY, next);
-        apply(next);
-      });
-    })();
-
-    // -------- Hero / numbers toggle. --------
-    // mode-hero: show the energy-flow diagram, hide the big numeric
-    //   tiles for Grid/PV/Battery/Load (they're in the hero already).
-    // mode-numbers: hide the hero, show all tiles. Both paths leave
-    //   SoC, Fuse, EV, energy totals, controls + charts visible.
-    (function () {
-      var KEY = 'ftw-hero-mode';
-      var btn = document.getElementById('hero-toggle');
-      function iconFor(m) { return m === 'hero' ? '\u25A6' /* ▦ */ : '\u2638' /* ☸ */; }
-      function apply(mode) {
-        document.body.classList.remove('mode-hero', 'mode-numbers');
-        document.body.classList.add('mode-' + mode);
-        if (btn) {
-          btn.textContent = iconFor(mode);
-          btn.title = mode === 'hero' ? 'Show numeric tiles' : 'Show energy-flow hero';
-          btn.setAttribute('aria-pressed', mode === 'hero' ? 'true' : 'false');
-        }
-      }
-      apply(localStorage.getItem(KEY) || 'hero');
-      if (btn) btn.addEventListener('click', function () {
-        var next = document.body.classList.contains('mode-numbers') ? 'hero' : 'numbers';
-        localStorage.setItem(KEY, next);
-        apply(next);
-      });
-    })();
-
-    // -------- Mobile menu drawer. --------
-    // On narrow viewports the header right-cluster (tabs + toggles +
-    // settings + version) collapses behind a hamburger. Clicking the
-    // hamburger flips `header.menu-open`; CSS does the rest. An
-    // outside-click listener closes the drawer so it doesn't get
-    // stuck open when the user taps past it.
-    (function () {
-      var btn = document.getElementById('mobile-menu-btn');
-      var hdr = document.querySelector('body.ftw-next > header');
-      if (!btn || !hdr) return;
-      function close() {
-        hdr.classList.remove('menu-open');
-        btn.setAttribute('aria-expanded', 'false');
-      }
-      btn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        var open = hdr.classList.toggle('menu-open');
-        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
-      });
-      document.addEventListener('click', function (e) {
-        if (!hdr.classList.contains('menu-open')) return;
-        if (!hdr.contains(e.target)) close();
-      });
-      window.addEventListener('resize', function () {
-        // If the viewport grows past the mobile breakpoint, the drawer
-        // CSS stops applying — close explicitly so a resize-then-resize
-        // doesn't leave the drawer class dangling.
-        if (window.matchMedia('(min-width: 721px)').matches) close();
       });
     })();
   </script>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -267,35 +267,76 @@
     batSoc.textContent = socPct + "%";
     socFill.setAttribute("value", socPct);
 
-    // Hero energy-flow diagram — walk `data.drivers` so multi-PV / multi-
-    // battery rigs render one node per source, stacked. Any driver that
-    // exposes pv_w is treated as a solar producer; any with bat_w is a
-    // battery. setReadings() replaces only the arrays it receives, so a
-    // transient /api/status error preserves the last good cluster.
+    // Hero energy-flow diagram — build a flat "planets" list where each
+    // entry declares which corner it orbits (top-left=PV, top-right=
+    // battery, bottom-left=grid, bottom-right=EV). The component knows
+    // nothing about driver roles — all role→color/sub-text/direction
+    // mapping lives here so the four corners stay a caller concern.
+    // setReadings() replaces `planets` atomically, so a transient
+    // /api/status error preserves the last good layout if we skip it.
     var flowEl = document.getElementById("energy-flow");
     if (flowEl && typeof flowEl.setReadings === "function") {
-      var pvs = [];
-      var batteries = [];
+      var planets = [];
+
+      // Grid — single utility, bottom-left corner. Import = toward house.
+      var gkw = (data.grid_w || 0) / 1000;
+      var gAbs = Math.abs(gkw);
+      planets.push({
+        id: "grid", corner: "bottom-left", title: "GRID",
+        kw: gkw, toHub: gkw >= 0,
+        color: gAbs < 0.05 ? "var(--fg-muted)" :
+               (gkw >= 0 ? "var(--red-e)" : "var(--green-e)"),
+        sub: gAbs < 0.05 ? "balanced" :
+             (gkw >= 0 ? "importing" : "exporting"),
+      });
+
       var drvs = data.drivers || {};
       Object.keys(drvs).forEach(function (name) {
         var d = drvs[name] || {};
+        // Solar — display positive kW when generating (site convention
+        // has pv_w negative for export into the house). All internal
+        // state (chart history, math) stays on site convention; the
+        // sign flip is display-only and lives in this function.
         if (d.pv_w != null) {
-          pvs.push({ name: name, kw: d.pv_w / 1000 });
+          var pvKw = -d.pv_w / 1000;
+          var pvGen = pvKw > 0.05;
+          planets.push({
+            id: "pv-" + name, corner: "top-left", title: "SOLAR", name: name,
+            kw: pvKw, toHub: true,
+            color: pvGen ? "var(--amber)" : "var(--fg-muted)",
+            sub: pvGen ? "generating" : "idle",
+          });
         }
+        // Battery — sign shows charge/discharge. Discharge flows toward
+        // the house; charge flows away from it.
         if (d.bat_w != null) {
-          batteries.push({
-            name: name,
-            kw: d.bat_w / 1000,
+          var bKw = d.bat_w / 1000;
+          var bAbs = Math.abs(bKw);
+          planets.push({
+            id: "bat-" + name, corner: "top-right", title: "BATTERY", name: name,
+            kw: bKw, toHub: bKw < 0,
+            color: "var(--cyan)",
+            sub: bAbs < 0.05 ? "idle" :
+                 (bKw >= 0 ? "charging" : "discharging"),
             soc: d.bat_soc != null ? Math.round(d.bat_soc * 100) : null,
           });
         }
+        // EV — always consumes from the house side.
+        if (d.ev_w != null) {
+          var eKw = d.ev_w / 1000;
+          var eActive = eKw > 0.05;
+          planets.push({
+            id: "ev-" + name, corner: "bottom-right", title: "EV CHARGER", name: name,
+            kw: eKw, toHub: false,
+            color: eActive ? "var(--green-e)" : "var(--white-s)",
+            sub: eActive ? "charging" : "idle",
+          });
+        }
       });
+
       flowEl.setReadings({
-        grid:      (data.grid_w || 0) / 1000,
-        load:      (data.load_w || 0) / 1000,
-        ev:        (data.ev_w   || 0) / 1000,
-        pvs:       pvs,
-        batteries: batteries,
+        load:    (data.load_w || 0) / 1000,
+        planets: planets,
       });
     }
 

--- a/web/next.css
+++ b/web/next.css
@@ -61,14 +61,19 @@ body.ftw-next main {
 }
 
 /* ---- Header — rounded pill with backdrop blur.
-       Horizontal padding matches main (28 px) so the pill's content
-       edges align with the cards below it — no "inset" look on wide
-       screens. Outer margin is 28 px left/right inside the 1560 px
-       max-width so the pill itself sits within the same rectangle as
-       main's padding box. ---- */
+       Outer rectangle lines up with main's CONTENT box (not main's
+       outer box): width caps at 1560 − 2×28 = 1504 px on wide screens,
+       and `width: calc(100% - 56px)` keeps it 28 px inside the viewport
+       on narrower ones — so the pill's visible border sits in the same
+       column as the cards inside main's 28 px gutter. Without this the
+       pill's border hugged the viewport edges while the cards sat 28 px
+       in, producing the "header goes 100% wide when body doesn't" look.
+       Interior padding (12 × 28) then positions logo / tabs / actions
+       a further 28 px in — same as an additional card's padding. ---- */
 body.ftw-next > header {
   box-sizing: border-box;
-  max-width: 1560px;
+  width: calc(100% - 56px);
+  max-width: 1504px;
   margin: 20px auto 20px;
   padding: 12px 28px;
   border: 1px solid var(--line);
@@ -574,12 +579,11 @@ body.ftw-next .diagnose-detail {
     padding: 0 12px 48px;
     gap: 12px;
   }
-  /* Horizontal margin is `auto` so the header's outer rectangle lines
-     up with main's outer rectangle; combined with 12 px padding this
-     puts header content at the same 12 px inset as main's cards.
-     Previous `margin: 10px 12px 14px` stacked a 12 px gutter + 12 px
-     padding (24 px inset) that visibly drifted from the grid below. */
+  /* Same rail alignment as desktop, but with the mobile 12 px gutter:
+     header's outer border sits 12 px inside the viewport, matching
+     main's 12 px content inset. */
   body.ftw-next > header {
+    width: calc(100% - 24px);
     margin: 10px auto 14px;
     grid-template-columns: auto 1fr auto;
     gap: 10px;
@@ -589,6 +593,7 @@ body.ftw-next .diagnose-detail {
   body.ftw-next > header h1 { font-size: 15px; }
   body.ftw-next > header .header-logo { height: 26px; }
   body.ftw-next footer {
+    width: calc(100% - 24px);
     margin: 10px auto 0;
     padding: 10px 12px;
   }

--- a/web/next.css
+++ b/web/next.css
@@ -47,6 +47,12 @@ body.ftw-next > header {
   z-index: 10;
 }
 
+/* Drawer-only Live / Diagnose nav duplicates are hidden everywhere by
+   default and only revealed when the mobile drawer is open (see the
+   ≤720 px block further down). The primary .app-tabs in the header
+   row is what the operator sees on wider viewports. */
+body.ftw-next .drawer-nav-btn { display: none; }
+
 body.ftw-next main {
   max-width: 1560px;
   margin: 0 auto;
@@ -568,8 +574,13 @@ body.ftw-next .diagnose-detail {
     padding: 0 12px 48px;
     gap: 12px;
   }
+  /* Horizontal margin is `auto` so the header's outer rectangle lines
+     up with main's outer rectangle; combined with 12 px padding this
+     puts header content at the same 12 px inset as main's cards.
+     Previous `margin: 10px 12px 14px` stacked a 12 px gutter + 12 px
+     padding (24 px inset) that visibly drifted from the grid below. */
   body.ftw-next > header {
-    margin: 10px 12px 14px;
+    margin: 10px auto 14px;
     grid-template-columns: auto 1fr auto;
     gap: 10px;
     padding: 10px 12px;
@@ -578,8 +589,8 @@ body.ftw-next .diagnose-detail {
   body.ftw-next > header h1 { font-size: 15px; }
   body.ftw-next > header .header-logo { height: 26px; }
   body.ftw-next footer {
-    margin: 10px 12px 0;
-    padding: 10px 6px;
+    margin: 10px auto 0;
+    padding: 10px 12px;
   }
 
   body.ftw-next .header-right,
@@ -593,12 +604,12 @@ body.ftw-next .diagnose-detail {
     justify-self: end;
   }
 
-  /* Drawer-only navigation buttons — hidden on desktop, rendered as
-     drawer items when the hamburger is open. We keep the main
-     .app-tabs completely hidden in the drawer and use these duplicates
-     instead so there's only one drawer rectangle to style and position. */
+  /* Drawer-only navigation buttons — styling for when the hamburger
+     drawer is open. Base `display: none` is hoisted out of the media
+     query below so desktop hides them globally (previously the rule
+     only fired at ≤720 px and the ▶/⏲ glyphs leaked into the header
+     right-cluster on wider viewports). */
   body.ftw-next .drawer-nav-btn {
-    display: none;
     background: transparent;
     border: 1px solid var(--line);
     color: var(--fg);

--- a/web/next.html
+++ b/web/next.html
@@ -11,11 +11,11 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
           crossorigin=""></script>
-  <!-- Type: Inter for UI, JetBrains Mono for tabular numerics. Preconnect
-       first so the /next first-paint isn't held up by DNS + handshake. -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Type: Inter preferred for UI, JetBrains Mono for tabular numerics.
+       No external font CDN — the Pi has to boot + render even without
+       internet; theme.css's --sans / --mono stacks fall back to the OS's
+       native UI + mono fonts. -->
+
   <!-- Apply the saved theme BEFORE any stylesheet resolves so light-mode
        users don't see a dark-to-light flash on reload. The full toggle
        handler is at the bottom of <body>; this stub just sets the attr. -->

--- a/web/setup.html
+++ b/web/setup.html
@@ -415,6 +415,12 @@
   <!-- Step 1: Welcome -->
   <div class="step" id="step-1" data-step="1">
     <div class="welcome-center">
+      <!-- Pre-setup update check. Autonomous: self-checks
+           /api/version/check, renders a banner iff an update is
+           available, drives the full pull-and-reload flow. Stays
+           invisible when the backend has self-update gated off. -->
+      <ftw-update-check></ftw-update-check>
+
       <h2>Welcome to forty-two-watts</h2>
       <p>Let's set up your home energy system in a few steps.</p>
       <button class="btn-primary" onclick="goStep(2)">Get started</button>
@@ -693,6 +699,10 @@
 
 </div>
 
+<!-- Components: registers <ftw-update-check> (pre-setup update banner)
+     and its dependencies. Loaded as a module so imports resolve without
+     a bundle step. -->
+<script type="module" src="/components/index.js"></script>
 <script src="/setup.js"></script>
 </body>
 </html>

--- a/web/setup.html
+++ b/web/setup.html
@@ -699,10 +699,12 @@
 
 </div>
 
-<!-- Components: registers <ftw-update-check> (pre-setup update banner)
-     and its dependencies. Loaded as a module so imports resolve without
-     a bundle step. -->
-<script type="module" src="/components/index.js"></script>
+<!-- Components: load only <ftw-update-check> (pre-setup update banner)
+     and its transitive deps (ftw-element + ftw-modal). Pulling the full
+     /components/index.js registry here would eagerly import the whole
+     /next dashboard catalogue (ftw-energy-flow etc.) — dead weight on
+     the first setup paint. -->
+<script type="module" src="/components/ftw-update-check.js"></script>
 <script src="/setup.js"></script>
 </body>
 </html>

--- a/web/setup.html
+++ b/web/setup.html
@@ -5,12 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Setup — forty-two-watts</title>
   <link rel="icon" type="image/jpeg" href="/logo.jpg">
-  <!-- Inter + JetBrains Mono — same pairing as /next.html and the
-       landing page (fortytwowatts.com). Preconnect first so the
-       critical chrome lands without a round-trip stall on cold starts. -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- No external font CDN — the wizard has to boot on a fresh Pi
+       that may not have internet yet. theme.css's --sans / --mono
+       stacks fall back to the OS's system fonts. -->
   <link rel="stylesheet" href="/components/theme.css">
   <link rel="stylesheet" href="/style.css">
   <style>

--- a/web/setup.html
+++ b/web/setup.html
@@ -5,14 +5,36 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Setup — forty-two-watts</title>
   <link rel="icon" type="image/jpeg" href="/logo.jpg">
+  <!-- Inter + JetBrains Mono — same pairing as /next.html and the
+       landing page (fortytwowatts.com). Preconnect first so the
+       critical chrome lands without a round-trip stall on cold starts. -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/components/theme.css">
   <link rel="stylesheet" href="/style.css">
   <style>
+    /* Setup wizard styling — matches the /next UI tokens
+       (components/theme.css) and the look of fortytwowatts.com:
+       dark ink canvas, hairline 1px borders, flat cards, warm amber
+       single-accent, Inter body + JetBrains Mono eyebrows. Kept inline
+       so the wizard's chrome is self-contained and doesn't cross into
+       legacy style.css rules on the dashboard. */
+
+    body {
+      background: var(--ink);
+      color: var(--fg);
+      font-family: var(--sans);
+      font-feature-settings: 'cv11', 'ss01';
+      -webkit-font-smoothing: antialiased;
+      line-height: 1.58;
+    }
+
     /* ---- Wizard layout ---- */
     .wizard {
-      max-width: 600px;
+      max-width: 620px;
       margin: 0 auto;
-      padding: 2rem 1rem;
+      padding: 3rem 1.25rem;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -24,9 +46,9 @@
     }
 
     .wizard-logo {
-      height: 64px;
+      height: 56px;
       width: auto;
-      border-radius: 8px;
+      border-radius: 7px;
     }
 
     .wizard-title {
@@ -34,12 +56,14 @@
       align-items: center;
       justify-content: center;
       gap: 12px;
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.25rem;
     }
 
     .wizard-title h1 {
-      font-size: 1.3rem;
-      font-weight: 600;
+      font-size: 1.15rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      color: var(--fg);
     }
 
     /* ---- Step indicator ---- */
@@ -47,23 +71,24 @@
       display: flex;
       justify-content: center;
       gap: 8px;
-      margin-bottom: 2rem;
+      margin-bottom: 2.5rem;
     }
 
     .step-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: var(--border);
-      transition: background 0.3s;
+      width: 6px;
+      height: 6px;
+      border-radius: 999px;
+      background: var(--line);
+      transition: background 0.3s, box-shadow 0.3s;
     }
 
     .step-dot.active {
-      background: var(--green);
+      background: var(--accent-e);
+      box-shadow: 0 0 10px var(--accent-e);
     }
 
     .step-dot.done {
-      background: var(--accent);
+      background: var(--fg-muted);
     }
 
     /* ---- Step panels ---- */
@@ -78,27 +103,33 @@
     }
 
     .step h2 {
-      font-size: 1.1rem;
-      margin-bottom: 0.75rem;
+      font-size: 1.35rem;
+      font-weight: 700;
+      letter-spacing: -0.015em;
+      color: var(--fg);
+      margin-bottom: 0.5rem;
     }
 
     .step p {
-      color: var(--text-dim);
-      font-size: 0.9rem;
-      margin-bottom: 1rem;
-      line-height: 1.5;
+      color: var(--fg-dim);
+      font-size: 0.92rem;
+      margin-bottom: 1.25rem;
+      line-height: 1.58;
     }
 
     /* ---- Form elements ---- */
     .form-group {
-      margin-bottom: 1rem;
+      margin-bottom: 1.1rem;
     }
 
     .form-group label {
       display: block;
-      font-size: 0.8rem;
-      color: var(--text-dim);
-      margin-bottom: 4px;
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--fg-muted);
+      margin-bottom: 6px;
     }
 
     .form-group input[type="text"],
@@ -106,13 +137,26 @@
     .form-group input[type="password"],
     .form-group select {
       width: 100%;
-      padding: 8px 10px;
-      background: var(--surface2);
-      border: 1px solid var(--border);
-      border-radius: 4px;
-      color: var(--text);
-      font-family: inherit;
-      font-size: 0.85rem;
+      padding: 10px 12px;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      color: var(--fg);
+      font-family: var(--sans);
+      font-size: 0.9rem;
+      transition: border-color 0.15s;
+    }
+
+    .form-group input:focus,
+    .form-group select:focus {
+      outline: none;
+      border-color: var(--accent-e);
+    }
+
+    .form-group input:disabled,
+    .form-group select:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
     }
 
     .form-row {
@@ -130,13 +174,14 @@
     .form-check {
       display: flex;
       align-items: center;
-      gap: 8px;
-      margin: 0.75rem 0;
-      font-size: 0.85rem;
+      gap: 10px;
+      margin: 0.9rem 0;
+      font-size: 0.88rem;
+      color: var(--fg);
     }
 
     .form-check input[type="checkbox"] {
-      accent-color: var(--green);
+      accent-color: var(--accent-e);
       width: 16px;
       height: 16px;
     }
@@ -147,49 +192,53 @@
       justify-content: space-between;
       align-items: center;
       margin-top: auto;
-      padding-top: 1.5rem;
+      padding-top: 2rem;
       gap: 12px;
     }
 
     .btn-primary {
-      padding: 10px 24px;
+      padding: 11px 18px;
       border: none;
-      border-radius: var(--radius);
-      background: var(--green);
-      color: #fff;
-      font-size: 0.9rem;
-      font-weight: 600;
+      border-radius: 8px;
+      background: var(--accent-e);
+      color: #0a0a0a;
+      font-family: var(--sans);
+      font-size: 14px;
+      font-weight: 500;
       cursor: pointer;
-      transition: opacity 0.2s;
+      transition: transform 0.12s, opacity 0.2s;
     }
 
-    .btn-primary:hover { opacity: 0.85; }
+    .btn-primary:hover:not(:disabled) { transform: translateY(-1px); }
     .btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
 
     .btn-secondary {
-      padding: 8px 18px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      background: var(--surface2);
-      color: var(--text);
-      font-size: 0.85rem;
+      padding: 10px 18px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: transparent;
+      color: var(--fg);
+      font-family: var(--sans);
+      font-size: 14px;
       cursor: pointer;
-      transition: background 0.2s;
+      transition: border-color 0.15s;
     }
 
-    .btn-secondary:hover { background: var(--border); }
+    .btn-secondary:hover { border-color: var(--fg-dim); }
 
     .btn-skip {
       background: none;
       border: none;
-      color: var(--text-dim);
+      color: var(--fg-muted);
       cursor: pointer;
-      font-size: 0.8rem;
-      text-decoration: underline dotted;
-      padding: 4px 8px;
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      padding: 6px 10px;
+      transition: color 0.15s;
     }
 
-    .btn-skip:hover { color: var(--text); }
+    .btn-skip:hover { color: var(--fg); }
 
     /* ---- Welcome step ---- */
     .welcome-center {
@@ -203,7 +252,14 @@
     }
 
     .welcome-center h2 {
-      font-size: 1.4rem;
+      font-size: clamp(1.7rem, 3vw, 2.1rem);
+      font-weight: 700;
+      letter-spacing: -0.025em;
+      line-height: 1.1;
+    }
+
+    .welcome-center p {
+      max-width: 420px;
     }
 
     /* When <ftw-update-check> has something to show (banner or update
@@ -223,62 +279,60 @@
       width: 100%;
       border-collapse: collapse;
       margin: 1rem 0;
-      font-size: 0.82rem;
     }
 
     .scan-table th {
       text-align: left;
-      padding: 6px 8px;
-      font-size: 0.72rem;
-      color: var(--text-dim);
+      padding: 10px 10px;
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      color: var(--fg-muted);
       text-transform: uppercase;
-      letter-spacing: 0.05em;
-      border-bottom: 1px solid var(--border);
+      letter-spacing: 0.18em;
+      border-bottom: 1px solid var(--line);
+      font-weight: 500;
     }
 
     .scan-table td {
-      padding: 8px;
-      border-bottom: 1px solid var(--border);
-      font-family: monospace;
+      padding: 10px;
+      border-bottom: 1px solid var(--line);
+      font-family: var(--mono);
       font-size: 0.82rem;
+      color: var(--fg);
     }
 
-    .scan-table tr:hover {
-      background: rgba(255,255,255,0.03);
-    }
+    .scan-table tr:hover td { background: var(--ink-raised); }
 
     .scan-table .btn-use {
-      padding: 4px 12px;
-      border: 1px solid var(--green);
-      border-radius: 4px;
+      padding: 5px 12px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
       background: transparent;
-      color: var(--green);
+      color: var(--accent-e);
       cursor: pointer;
-      font-size: 0.75rem;
+      font-family: var(--sans);
+      font-size: 0.78rem;
+      transition: border-color 0.15s;
     }
 
-    .scan-table .btn-use:hover {
-      background: rgba(0,204,102,0.1);
-    }
+    .scan-table .btn-use:hover { border-color: var(--accent-e); }
 
     .spinner {
       display: inline-block;
       width: 18px;
       height: 18px;
-      border: 2px solid var(--border);
-      border-top-color: var(--green);
+      border: 2px solid var(--line);
+      border-top-color: var(--accent-e);
       border-radius: 50%;
-      animation: spin 0.6s linear infinite;
+      animation: spin 0.7s linear infinite;
       vertical-align: middle;
-      margin-right: 8px;
+      margin-right: 10px;
     }
 
-    @keyframes spin {
-      to { transform: rotate(360deg); }
-    }
+    @keyframes spin { to { transform: rotate(360deg); } }
 
     .scan-status {
-      color: var(--text-dim);
+      color: var(--fg-dim);
       font-size: 0.85rem;
       margin: 1rem 0;
     }
@@ -286,13 +340,13 @@
     /* ---- Driver picker ---- */
     .driver-desc {
       margin-top: 0.5rem;
-      padding: 10px 12px;
-      background: rgba(255,255,255,0.03);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      font-size: 0.82rem;
-      color: var(--text-dim);
-      line-height: 1.4;
+      padding: 12px 14px;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      font-size: 0.85rem;
+      color: var(--fg-dim);
+      line-height: 1.55;
     }
 
     /* ---- Configured drivers summary ---- */
@@ -304,11 +358,11 @@
     }
 
     .driver-summary-item {
-      background: var(--surface2);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 10px 14px;
-      font-size: 0.85rem;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 12px 14px;
+      font-size: 0.88rem;
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -322,62 +376,72 @@
 
     .driver-summary-item .driver-info .driver-label {
       font-weight: 600;
+      color: var(--fg);
     }
 
     .driver-summary-item .driver-info .driver-detail {
       font-size: 0.75rem;
-      color: var(--text-dim);
-      font-family: monospace;
+      color: var(--fg-dim);
+      font-family: var(--mono);
     }
 
     .btn-remove-sm {
       background: transparent;
-      border: 1px solid var(--border);
-      color: var(--red);
-      padding: 4px 10px;
-      border-radius: 4px;
-      font-size: 0.72rem;
+      border: 1px solid var(--line);
+      color: var(--red-e);
+      padding: 5px 12px;
+      border-radius: 6px;
+      font-family: var(--sans);
+      font-size: 0.74rem;
       cursor: pointer;
+      transition: border-color 0.15s;
     }
 
-    .btn-remove-sm:hover {
-      background: rgba(239,68,68,0.1);
-    }
+    .btn-remove-sm:hover { border-color: var(--red-e); }
 
     /* ---- Review summary ---- */
     .review-section {
-      margin-bottom: 1rem;
+      margin-bottom: 1.25rem;
     }
 
     .review-section h3 {
-      font-size: 0.85rem;
-      color: var(--text-dim);
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      color: var(--accent-e);
       text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 6px;
+      letter-spacing: 0.18em;
+      font-weight: 500;
+      margin-bottom: 8px;
     }
 
     .review-item {
-      background: var(--surface2);
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 10px 14px;
-      font-size: 0.85rem;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 12px 14px;
+      font-size: 0.88rem;
       margin-bottom: 6px;
       line-height: 1.5;
+      color: var(--fg);
     }
 
     /* ---- Integration fieldset ---- */
     .integration-section {
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 14px 16px;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 16px 18px;
       margin-bottom: 1rem;
     }
 
     .integration-section h3 {
-      font-size: 0.9rem;
-      margin-bottom: 0.75rem;
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      color: var(--accent-e);
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 500;
+      margin-bottom: 1rem;
     }
 
     /* ---- Success screen ---- */
@@ -388,24 +452,24 @@
 
     .success-screen .checkmark {
       font-size: 3rem;
-      color: var(--green);
+      color: var(--accent-e);
       margin-bottom: 1rem;
     }
 
     .error-msg {
-      color: var(--red);
+      color: var(--red-e);
       font-size: 0.85rem;
       margin-top: 0.5rem;
-      padding: 8px 10px;
-      background: rgba(239,68,68,0.1);
-      border: 1px solid rgba(239,68,68,0.3);
-      border-radius: 4px;
+      padding: 10px 12px;
+      background: color-mix(in srgb, var(--red-e) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--red-e) 35%, var(--line));
+      border-radius: 8px;
     }
 
     @media (max-width: 480px) {
-      .wizard { padding: 1rem 0.75rem; }
+      .wizard { padding: 2rem 0.9rem; }
       .form-row, .form-row-3 { grid-template-columns: 1fr; }
-      .wizard-logo { height: 48px; }
+      .wizard-logo { height: 44px; }
     }
   </style>
 </head>

--- a/web/setup.html
+++ b/web/setup.html
@@ -631,8 +631,12 @@
           <input type="password" id="ev-password">
         </div>
         <div class="form-group">
-          <label for="ev-serial">Serial number</label>
-          <input type="text" id="ev-serial" placeholder="EHHZBKPF">
+          <button type="button" class="btn-secondary" id="ev-load-chargers" onclick="loadEVChargers()">Load chargers</button>
+          <span id="ev-chargers-status" class="scan-status" style="display:none; margin-left: 10px;"></span>
+        </div>
+        <div class="form-group" id="ev-serial-group" style="display:none">
+          <label for="ev-serial">Charger</label>
+          <select id="ev-serial"></select>
         </div>
       </div>
     </div>

--- a/web/setup.html
+++ b/web/setup.html
@@ -206,6 +206,18 @@
       font-size: 1.4rem;
     }
 
+    /* When <ftw-update-check> has something to show (banner or update
+       overlay), force the operator to acknowledge it before starting
+       setup. The component toggles its own `.hidden` class when idle;
+       the absence of it here means the update card is on screen, so we
+       collapse the "Welcome / Get started" block until the user picks
+       Update now or Continue anyway. */
+    .welcome-center:has(ftw-update-check:not(.hidden)) > h2,
+    .welcome-center:has(ftw-update-check:not(.hidden)) > p,
+    .welcome-center:has(ftw-update-check:not(.hidden)) > button.btn-primary {
+      display: none;
+    }
+
     /* ---- Scan results ---- */
     .scan-table {
       width: 100%;

--- a/web/setup.js
+++ b/web/setup.js
@@ -246,7 +246,16 @@
     var port = parseInt(document.getElementById('drv-port').value, 10);
     var unitId = parseInt(document.getElementById('drv-unitid').value, 10) || 1;
     var isSiteMeter = document.getElementById('drv-site-meter').checked;
-    var batteryKwh = parseFloat(document.getElementById('drv-battery-kwh').value) || 0;
+    // Only read battery capacity for drivers that actually support it —
+    // the <input> has a default value of 10, so without this gate a
+    // PV-only driver (e.g. solaredge_pv) would persist a phantom
+    // battery_capacity_wh = 10000 that the control loop later tries to
+    // target against a device with no battery.
+    var hasBattery = selectedCatalog && selectedCatalog.capabilities &&
+      selectedCatalog.capabilities.some(function (c) { return c === 'battery'; });
+    var batteryKwh = hasBattery
+      ? (parseFloat(document.getElementById('drv-battery-kwh').value) || 0)
+      : 0;
 
     if (!ip) { alert('IP address is required.'); return; }
 

--- a/web/setup.js
+++ b/web/setup.js
@@ -516,14 +516,10 @@
   // --- Save config ---
 
   window.saveConfig = function () {
-    if (configuredDrivers.length === 0) {
-      var errEl = document.getElementById('save-error');
-      errEl.className = 'error-msg';
-      errEl.textContent = 'At least one device must be configured.';
-      errEl.style.display = 'block';
-      return;
-    }
-
+    // Empty drivers list is valid — e.g. an EV-only site that only
+    // configured a cloud EV charger in step 7 and doesn't own local
+    // hardware. The backend accepts this and runs with a no-op
+    // control loop (no site meter to balance against).
     var btn = document.getElementById('save-btn');
     btn.disabled = true;
     btn.textContent = 'Saving...';

--- a/web/setup.js
+++ b/web/setup.js
@@ -391,6 +391,67 @@
     }
   }
 
+  // Populate the <select id="ev-serial"> by calling /api/ev/chargers —
+  // mirrors the settings screen so operators don't have to transcribe a
+  // serial off the side of the charger. The serial field only appears
+  // after a successful call returns at least one device.
+  window.loadEVChargers = function () {
+    var provider = document.getElementById('ev-provider').value || 'easee';
+    var email = document.getElementById('ev-email').value.trim();
+    var password = document.getElementById('ev-password').value;
+    var btn = document.getElementById('ev-load-chargers');
+    var statusEl = document.getElementById('ev-chargers-status');
+    var group = document.getElementById('ev-serial-group');
+    var sel = document.getElementById('ev-serial');
+
+    statusEl.style.display = 'inline';
+    statusEl.style.color = 'var(--text-dim)';
+    if (!email) { statusEl.textContent = 'Enter email first'; return; }
+    if (!password) { statusEl.textContent = 'Enter password first'; return; }
+
+    statusEl.textContent = 'Connecting…';
+    btn.disabled = true;
+
+    fetch('/api/ev/chargers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: provider, email: email, password: password })
+    })
+      .then(function (r) {
+        return r.json().then(function (j) { return { ok: r.ok, body: j }; });
+      })
+      .then(function (res) {
+        if (!res.ok) {
+          statusEl.style.color = 'var(--red)';
+          statusEl.textContent = (res.body && res.body.error) || 'Failed to load chargers';
+          return;
+        }
+        var chargers = Array.isArray(res.body) ? res.body : [];
+        if (chargers.length === 0) {
+          statusEl.textContent = 'No chargers found on this account';
+          group.style.display = 'none';
+          return;
+        }
+        sel.innerHTML = '';
+        chargers.forEach(function (c) {
+          var opt = document.createElement('option');
+          opt.value = c.id;
+          opt.textContent = c.id + (c.name ? '  —  ' + c.name : '');
+          sel.appendChild(opt);
+        });
+        group.style.display = 'block';
+        statusEl.style.color = 'var(--green)';
+        statusEl.textContent = chargers.length + ' charger' + (chargers.length === 1 ? '' : 's') + ' found';
+      })
+      .catch(function (e) {
+        statusEl.style.color = 'var(--red)';
+        statusEl.textContent = 'Error: ' + e.message;
+      })
+      .finally(function () {
+        btn.disabled = false;
+      });
+  };
+
   // --- Step 8: Review ---
 
   function renderReview() {


### PR DESCRIPTION
New web component surfaces a prominent "Update available" card on the setup wizard's welcome step so operators can refresh to the latest image before committing a config on an outdated release.

The component self-checks /api/version/check, silently hides when the feature is gated off (503) or the check fails, and composes <ftw-modal> for the progress overlay — reusing the /next UI's modal chrome plus theme tokens. During an active update, close is blocked so the operator can't silently dismiss a container mid-recreate; fail / timeout paths swap in explicit Reload / Continue-setup actions.