### PR TITLE
fix(control): planner_self executes as reactive self-consumption

### DIFF
--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -28,6 +28,25 @@ A one-sentence description refreshes every 5 seconds.
 Legacy modes (`idle` / manual `self_consumption` / `peak_shaving` /
 `charge`) remain available under the `Manual…` toggle.
 
+### Execution differs by strategy
+
+| Strategy | Dispatch layer |
+|---|---|
+| Self-consumption (Smart) | Reactive PI-on-gridW=0 + per-slot idle gate. The plan tells the EMS **whether** to participate this slot — the battery's power is still driven by the live meter, never by the plan's Wh allocation. This keeps the "never import / never export via battery" contract honest when the forecast is wrong. |
+| Cheap charging | Energy-allocation (default). Plan emits Wh-per-slot; EMS converts to W in real time; grid is the residual. See `docs/plan-ems-contract.md`. |
+| Arbitrage | Same as Cheap charging — energy-allocation. |
+
+When the plan is stale (> 30 min old) or absent, every strategy falls
+back to manual reactive self-consumption. Operators see `plan_stale: true`
+in the status endpoint.
+
+Under Self-consumption, a slot where the DP allocated `|battery_energy_wh|
+/ slot_hours < 100 W` (avg) is interpreted as **idle**: the EMS holds the
+battery at 0 even when live PV surplus exists, deferring absorption to a
+later slot the DP judged more profitable. Any larger allocation flips the
+slot to **participate reactively** — i.e. behave exactly like manual
+self-consumption.
+
 ---
 
 ## How it thinks

--- a/docs/plan-ems-contract.md
+++ b/docs/plan-ems-contract.md
@@ -4,11 +4,14 @@ Design note for the dispatch-layer rework. Three principles, the mode
 taxonomy they imply, the wire contract between the planner and the EMS,
 and the migration plan.
 
-**Status: shipped (2026-04-19).** Energy-allocation dispatch is the
-default path for every planner mode. The legacy PI-on-grid-target
-path remains as `planner.legacy_dispatch: true` for emergency rollback
-and as the plan-stale fallback. See `go/internal/control/dispatch.go`
-(energy branch at line 338) and `go/internal/mpc/service.go:185`
+**Status: shipped (2026-04-19), with a `planner_self` exception (2026-04-19,
+issue #130).** Energy-allocation dispatch is the default for
+`planner_cheap` and `planner_arbitrage`. `planner_self` is a reactive
+self-consumption controller with a plan-driven idle gate — see the
+"Exception" section below. The legacy PI-on-grid-target path remains as
+`planner.legacy_dispatch: true` for emergency rollback (applies to
+cheap/arbitrage only) and as the plan-stale fallback. See
+`go/internal/control/dispatch.go` and `go/internal/mpc/service.go`
 (`SlotDirectiveAt`).
 
 ## Motivating incident
@@ -87,6 +90,43 @@ grid flow.
 What the plan no longer commands directly:
 - Instantaneous grid flow
 - Instantaneous battery power
+
+## Exception: planner_self
+
+The "grid is the residual" principle assumes the planner mode *wants*
+the battery to cross the zero-grid line on purpose (arbitrage, cheap
+charge). `planner_self` doesn't — its contract is "never imports to
+charge, never exports via the battery" (UI tooltip + docs/mpc-planner.md).
+
+Under pure energy-allocation dispatch that contract breaks as soon as
+the forecast is wrong:
+
+- Forecast said 5 kW PV, reality is 2 kW. Plan allocated `battery_energy_wh
+  = +1000` for this slot. Dispatch commands +4 kW charge → grid imports
+  2 kW to make up the shortfall. (Issue #130 — operator report 2026-04-19.)
+- Forecast said 3 kW load, reality is 300 W. Plan allocated `−552 Wh`.
+  Dispatch commands −2.2 kW discharge → grid exports 2 kW via the
+  battery. (Symmetric failure — same bug, other direction.)
+
+The DP enforces `ModeSelfConsumption`'s grid-crossing invariant only on
+forecast. The EMS must enforce it on the live meter.
+
+`planner_self` therefore executes as **reactive self-consumption**:
+
+- PI loop on `gridW → 0` (identical to manual `self_consumption`).
+- The plan contributes a per-slot **idle gate**: if
+  `|SlotDirective.BatteryEnergyWh| / slot_hours < mpc.IdleGateThresholdW`
+  the EMS holds the battery at 0 for that slot — honouring the DP's
+  decision to save SoC for a later, more profitable slot. Otherwise the
+  battery participates reactively (absorbs whatever surplus actually
+  exists, covers whatever load actually exists).
+- When the plan is stale (`MaxPlanAge` exceeded) the idle gate is
+  disabled and execution is indistinguishable from manual
+  `self_consumption`.
+
+The plan becomes a **participation schedule** for this mode, not a
+power trajectory. The three principles still hold for the other planner
+modes where they make sense.
 
 ## Mode taxonomy
 

--- a/go/internal/control/CLAUDE.md
+++ b/go/internal/control/CLAUDE.md
@@ -28,15 +28,28 @@ Distribution (`distributeProportional`, `distributePriority`, `distributeWeighte
 
 ## How it talks to neighbors
 
-Imports `telemetry` only. Reads via `store.Get` (site meter, batteries), `store.ReadingsByType(DerPV)` (fuse guard), and `store.DriverHealth` (online check). **Does not call drivers** — `main.go` takes the returned `[]DispatchTarget` and forwards to the driver registry. `State.PlanTarget` is the only upward callback; main wires it to `mpc` so this package stays planner-agnostic. Consumers that mutate `State`: `api` (mode + grid_target changes), `ha.bridge` (Home Assistant select), `configreload.watcher` (YAML reload), `e2e` tests.
+Imports `telemetry` and `mpc` (only for the `IdleGateThresholdW` constant — no behaviour, no types). Reads via `store.Get` (site meter, batteries), `store.ReadingsByType(DerPV)` (fuse guard), and `store.DriverHealth` (online check). **Does not call drivers** — `main.go` takes the returned `[]DispatchTarget` and forwards to the driver registry. `State.PlanTarget` / `State.SlotDirective` are the only upward callbacks; main wires them to `mpc` so this package stays planner-agnostic at the behaviour level. Consumers that mutate `State`: `api` (mode + grid_target changes), `ha.bridge` (Home Assistant select), `configreload.watcher` (YAML reload), `e2e` tests.
 
 ## What to read first
 
 `dispatch.go` — `ComputeDispatch` (line 139) is the whole story in one function: planner override → idle/charge short-circuits → holdoff → read grid → pick error by mode → PI → distribute → slew → fuse guard. `pi.go` is ~60 lines; read it if you suspect integral windup.
 
+## Planner execution paths
+
+Three different execution strategies depending on the operator-selected planner mode — keep these straight:
+
+| Mode | Execution | Why |
+|---|---|---|
+| `planner_self` | Reactive PI-on-gridW=0 (same as manual `self_consumption`) + per-slot idle gate derived from `SlotDirective.BatteryEnergyWh` vs `mpc.IdleGateThresholdW`. | The mode's contract is "never imports to charge, never exports via the battery". Honouring the contract under forecast error requires reacting to the live meter, not executing planned Wh blindly. See issue #130 + `docs/plan-ems-contract.md` §"Exception: planner_self". |
+| `planner_cheap` / `planner_arbitrage` w/ `UseEnergyDispatch=true` (default) | Energy-allocation: `targetTotalW = remaining_wh × 3600 / remaining_s`. Grid is the residual. | The whole point of these modes is to cycle the battery across the zero-grid line on purpose. Wh-per-slot is the optimisation variable. |
+| `planner_cheap` / `planner_arbitrage` w/ `UseEnergyDispatch=false` (opt-out) | Legacy PI chasing `grid_target_w` returned by `PlanTarget`. | Emergency rollback only. |
+
+Stale/missing plan → fall back to manual reactive self_consumption with `grid_target=0` (identical across all planner modes).
+
 ## What NOT to do
 
-- **Do NOT expect planner modes to stay distinct inside `ComputeDispatch`.** They collapse to `self_consumption` right after setting `grid_target` from the plan (dispatch.go:170–173). The operator-visible mode is preserved on `state.Mode`; the local `effectiveMode` is what drives behavior.
+- **Do NOT expect planner_cheap / planner_arbitrage modes to stay distinct inside `ComputeDispatch`.** They collapse to `self_consumption` right after setting `grid_target` from the plan (dispatch.go legacy branch). The operator-visible mode is preserved on `state.Mode`; the local `effectiveMode` is what drives behaviour.
+- **Do NOT switch `planner_self` back to the energy-allocation path.** That would re-introduce issue #130: the battery follows planned Wh blindly and crosses the zero-grid line whenever the forecast is wrong. The test `TestPlannerSelfReactsToForecastOverestimate` is the regression guard.
 - **Do NOT distribute from the delta.** `distributeProportional` + `distributeWeighted` split the TOTAL desired site battery power (`currentTotal + totalCorrection`), not the correction alone. This is the fix for the "batteries drift apart" bug — keep it that way (dispatch.go:317, 368).
 - **Do NOT issue charge commands when SoC < 5 % and target < 0.** `clampWithSoC` (dispatch.go:410) blocks discharge of an empty battery. Per-command cap is hard-coded to 5 kW.
 - **Do NOT flip signs.** Everything in this package is site convention: `+` = charge (import), `−` = discharge (export). `applyFuseGuard` reads `|battery discharge| + |PV|` as total generation; that's correct because PV is always `−` at the meter.

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -69,6 +69,8 @@ func seedStore(gridW float64, batteries []struct {
 
 func caps(items map[string]float64) map[string]float64 { return items }
 
+func ptrF64(v float64) *float64 { return &v }
+
 func TestIdleModeReturnsNothing(t *testing.T) {
 	store := seedStore(2000, []struct{ name string; currentW, soc float64 }{
 		{"ferroamp", 0, 0.5},
@@ -664,29 +666,25 @@ func TestEnergyDispatchFallsBackToLegacyWhenDirectiveUnavailable(t *testing.T) {
 	}
 }
 
-// Fredrik's morning incident (2026-04-19, self_consumption): planner
-// forecasted load = 3.24 kW, actual load was ~300 W. Under the legacy
-// PI-on-grid-target path the battery command converged on whatever
-// would drive grid to 0, which after the load surprise meant a small
-// discharge that exported straight to grid at the day-ahead low price.
-// Under energy dispatch the battery follows the plan's energy
-// allocation for the slot; if reality diverges the reactive replan
-// takes over on the next cycle with updated forecasts. This test
-// confirms the battery stays on plan even when live grid swings
-// into export — i.e. "grid is the residual".
-func TestEnergyDispatchHoldsPlanWhenLoadForecastWrong(t *testing.T) {
+// Under planner_arbitrage — where the DP is explicitly allowed to export via
+// battery — energy dispatch holds the plan even when live grid diverges.
+// That's the point of "grid is the residual": arbitrage decides slot-by-slot
+// that this_slot_W × slot_duration of battery energy is the cost-optimal
+// cycle, and the EMS just executes it. Live export is a legal outcome.
+//
+// Contrast: under planner_self (see TestPlannerSelf* below) the same plan
+// would be ignored in favour of reactive self-consumption — because that
+// mode's contract is "never export via battery" regardless of what the
+// forecast-based plan prescribes.
+func TestEnergyDispatchHoldsPlanUnderArbitrage(t *testing.T) {
 	now := time.Now()
-	// Plan: discharge 552 Wh this slot (covers the forecasted 3.2 kW
-	// load for 15 min minus PV generation). In W terms that's −2208.
+	// Plan: discharge 552 Wh this slot. In W terms that's −2208.
 	dir := SlotDirective{
 		SlotStart:       now,
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: -552,
-		Strategy:        "self_consumption",
+		Strategy:        "arbitrage",
 	}
-	// Grid is exporting 1.3 kW (actual load tiny, PV + plan's discharge
-	// > load). Under legacy PI chasing grid_target=0 the controller
-	// would back the battery off toward idle, missing the plan's intent.
 	store := seedStore(-1310, []struct {
 		name          string
 		currentW, soc float64
@@ -697,17 +695,267 @@ func TestEnergyDispatchHoldsPlanWhenLoadForecastWrong(t *testing.T) {
 	store.DriverHealthMut("pv-1").RecordSuccess()
 
 	st := newStateWithEnergyDispatch(dir, "ferroamp")
-	st.Mode = ModePlannerSelf
+	// Mode stays ModePlannerArbitrage from the helper — the point.
 
 	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
 	if len(targets) != 1 {
 		t.Fatalf("want 1 target, got %d", len(targets))
 	}
-	// Plan says −2208 W average over the slot. Near slot start with
-	// nothing delivered yet, the per-tick target should be close to
-	// that. Accept a ±200 W band for time drift.
 	got := targets[0].TargetW
 	if got > -1900 || got < -2500 {
-		t.Errorf("TargetW = %f W — battery should follow plan (~−2208 W) even when grid is exporting (regression: legacy PI would back off toward 0)", got)
+		t.Errorf("TargetW = %f W — arbitrage battery should follow plan (~−2208 W) regardless of live grid flow", got)
+	}
+}
+
+// ---- planner_self reactive execution (issue #130) ----
+//
+// planner_self promises "never imports to charge, never exports via the
+// battery" (UI tooltip + docs/mpc-planner.md). The DP enforces this on
+// forecast, but the energy-allocation dispatch path honours plan Wh
+// regardless of live grid flow — so when PV or load diverges from the
+// forecast the battery can cross the zero-grid invariant both ways.
+//
+// The fix: planner_self bypasses energy-allocation and uses reactive
+// self-consumption (PI → gridW=0), with the plan providing only a
+// per-slot *idle gate*. When the DP decided not to participate this
+// slot (|planned BatteryEnergyWh| < IdleGateThresholdW when averaged
+// over the slot) the EMS holds the battery at 0 and lets PV flow to
+// grid — deferring opportunity to a richer later slot.
+
+// Motivating scenario (operator report 2026-04-19): plan wanted to charge
+// aggressively (forecast said big PV surplus), but actual PV came in low.
+// Under energy dispatch the battery imports from grid to hit the Wh budget.
+// Under the fix, the battery only absorbs what's actually available.
+func TestPlannerSelfReactsToForecastOverestimate(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 2000, // plan: charge 2000 Wh ≈ 8 kW avg
+		Strategy:        "self_consumption",
+	}
+	// Live: grid exporting 300 W (actual PV minus actual load).
+	// Under energy dispatch the battery would charge at ~8 kW and
+	// drag grid to +7.7 kW import. Under reactive planner_self the
+	// battery's charge is bounded by the live surplus (~300 W).
+	store := seedStore(-300, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp") // tolerance=0 so PI fires
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000 // unbounded for single-tick formula test
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Reactive PI on grid=-300 with Kp=0.5 yields ~+150 W charge. The
+	// key assertion is "nowhere near the 8 kW the energy path would
+	// command" — that's the bug.
+	if got > 1000 {
+		t.Errorf("TargetW = %f W — planner_self must NOT charge beyond live surplus (issue #130 regression). Plan said +8 kW but reality had ~300 W surplus.", got)
+	}
+	if got < 0 {
+		t.Errorf("TargetW = %f W — expected modest charge absorbing live surplus, got discharge", got)
+	}
+}
+
+// Idle-gate scenario: DP decided to sit this slot out (save SoC for a
+// later, more profitable slot). Plan's Wh is below threshold → EMS holds
+// battery at 0 even when live PV surplus exists.
+func TestPlannerSelfIdleGateHoldsBatteryAtZero(t *testing.T) {
+	now := time.Now()
+	// Plan: avg ~0 W (well below IdleGateThresholdW=100).
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 0,
+		Strategy:        "self_consumption",
+	}
+	// Live: grid exporting 4 kW (real surplus exists). Battery currently
+	// discharging 1 kW — should ramp toward 0, not toward absorbing
+	// the surplus.
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1000, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 500 // realistic — expect one slew step from −1000 toward 0
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Anchor on actual SmoothedW=-1000. Moving toward 0 by one slew
+	// step of 500 W → -500 W. Not pushing toward -4000 to absorb surplus.
+	if got < -500.001 || got > 0.001 {
+		t.Errorf("TargetW = %f W — idle-gated battery should ramp toward 0 (expected [−500, 0]), not react to live surplus", got)
+	}
+}
+
+// Plan says discharge this slot (above idle threshold) and live grid is
+// importing. Reactive PI drives battery to cover live import exactly —
+// not the planned Wh magnitude (which was larger because forecast load
+// was higher than reality). Never crosses into export.
+func TestPlannerSelfParticipatesReactivelyCoveringImport(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -800, // plan: discharge 800 Wh ≈ −3.2 kW avg
+		Strategy:        "self_consumption",
+	}
+	// Live: importing 2 kW. Reactive PI wants to kill the import —
+	// battery should discharge ~2 kW (NOT the planned −3.2 kW).
+	store := seedStore(2000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	if got >= 0 {
+		t.Errorf("TargetW = %f W — expected discharge (negative) to cover live import", got)
+	}
+	// Bounded by live import magnitude, not the plan's larger ask.
+	// PI with Kp=0.5 on 2 kW error gives ~−1000 W first cycle.
+	// Anything past −2500 W would be over-discharging toward export.
+	if got < -2500 {
+		t.Errorf("TargetW = %f W — reactive discharge should be bounded by live import (~2 kW), not the planned −3.2 kW", got)
+	}
+}
+
+// Multi-cycle steady-state: idle-gated battery starts far from 0 and must
+// reach 0 monotonically (no PI integral-windup overshoot, slew respected).
+// Guards against the "gate goes on but PI wound up from earlier cycles
+// keeps pushing" class of bug.
+func TestPlannerSelfIdleGateRampsBatteryToZeroOverCycles(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 0, // idle-gated
+		Strategy:        "self_consumption",
+	}
+	// Battery at -2000 W (discharging), live grid exporting 4 kW.
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -2000, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 500
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	// Simulate N cycles. Each cycle advances the battery's SmoothedW
+	// toward the prev target so the slew anchor tracks reality.
+	var last float64
+	for i := 0; i < 10; i++ {
+		targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+		if len(targets) != 1 {
+			t.Fatalf("cycle %d: want 1 target, got %d", i, len(targets))
+		}
+		last = targets[0].TargetW
+		// Fake the battery responding instantly to the new command.
+		store.Update("ferroamp", telemetry.DerBattery, last, ptrF64(0.5), nil)
+		store.DriverHealthMut("ferroamp").RecordSuccess()
+	}
+	if math.Abs(last) > 1 {
+		t.Errorf("after 10 cycles with slew=500 from -2000 toward 0, expected final target ≈ 0, got %f", last)
+	}
+}
+
+// EV load on the grid meter is subtracted from gridW before the PI kicks
+// in (dispatch.go: `gridW := rawGridW - state.EVChargingW`). Verify that
+// planner_self inherits this — an active EV should NOT drive the battery
+// to cover EV charging.
+func TestPlannerSelfRespectsEVChargingSignal(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -200, // plan above idle threshold
+		Strategy:        "self_consumption",
+	}
+	// Grid reads +3000 (total import), but 3000 W of it is the EV.
+	// Effective house gridW = 0 → battery should sit still.
+	store := seedStore(3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.EVChargingW = 3000
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	// Effective house grid is 0 — within the 50 W deadband — dispatch skips.
+	if len(targets) != 0 {
+		t.Errorf("expected no dispatch when EV absorbs all import (effective gridW=0), got %d targets: %+v", len(targets), targets)
+	}
+}
+
+// When the plan is absent (SlotDirective returns false) planner_self
+// degrades to plain manual self_consumption — same behaviour as the
+// operator gets today when they pick "Self-consumption" without planner.
+func TestPlannerSelfWithoutPlanActsLikeManual(t *testing.T) {
+	// Live: importing 1 kW — same setup as TestSelfConsumptionDischargesOnImport.
+	store := seedStore(1000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModePlannerSelf
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return SlotDirective{}, false }
+	st.PlanTarget = func(time.Time) (string, float64, bool) { return "", 0, false }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if targets[0].TargetW >= 0 {
+		t.Errorf("TargetW = %f W — planner_self with stale plan must still cover import (fall through to reactive self_consumption)", targets[0].TargetW)
+	}
+	if !st.PlanStale {
+		t.Error("expected PlanStale=true when planner_self sees no directive")
 	}
 }

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/frahlg/forty-two-watts/go/internal/mpc"
 	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
 )
 
@@ -196,27 +197,61 @@ func ComputeDispatch(
 ) []DispatchTarget {
 	// ---- Planner modes: the plan is a scheduler, not a regulator ----
 	// The plan decides WHEN each strategy applies (self-consumption now,
-	// charge at 02:00, export at 17:00). The EMS's existing mode logic
-	// decides HOW batteries respond every 5 s based on the live meter.
+	// charge at 02:00, export at 17:00). The EMS decides HOW batteries
+	// respond every 5 s based on the live meter.
 	//
-	// Two dispatch paths are supported during the rollout:
+	// Three execution paths, selected by the operator-picked planner mode:
 	//
-	//   1. Legacy (UseEnergyDispatch=false): plan returns grid_target_w,
-	//      PI chases it, batteries absorb anything that differs — the
-	//      behavior this package has shipped since the port.
+	//   * planner_self — reactive self-consumption (PI → gridW=0) with a
+	//     per-slot idle gate from the plan. Honours the mode's contract
+	//     ("never imports to charge, never exports via the battery")
+	//     against forecast error. See docs/plan-ems-contract.md §"Exception:
+	//     planner_self" and issue #130.
 	//
-	//   2. Energy-allocation (UseEnergyDispatch=true, SlotDirective set):
-	//      plan returns battery energy for the slot; EMS converts to
-	//      instantaneous power from (remaining_wh / remaining_s); grid
-	//      flow is the residual. See docs/plan-ems-contract.md.
+	//   * planner_cheap / planner_arbitrage with UseEnergyDispatch=true
+	//     (default): energy-allocation. Plan returns battery energy for
+	//     the slot; EMS converts to instantaneous power from
+	//     (remaining_wh / remaining_s); grid flow is the residual.
 	//
-	// The two paths share all of gather-batteries → distribute → slew →
-	// fuse. They differ only in how `totalCorrection` is computed below.
+	//   * planner_cheap / planner_arbitrage with UseEnergyDispatch=false
+	//     (opt-out): legacy PI-on-grid-target path. Plan returns
+	//     grid_target_w; PI chases it.
+	//
+	// All three share gather-batteries → distribute → slew → fuse below.
+	// They differ only in how `totalCorrection` is computed and whether
+	// the deadband applies.
 	effectiveMode := state.Mode
 	useEnergyPath := false
+	// plannerSelfIdleGate is true when operator picked planner_self AND the
+	// plan allocated a below-threshold amount of battery action for the
+	// current slot — the EMS holds the battery at 0 (ramping via slew)
+	// regardless of live surplus, so the DP's decision to save SoC for a
+	// later slot is honoured.
+	plannerSelfIdleGate := false
 	var currentDirective SlotDirective
-	if state.Mode.IsPlannerMode() {
-		// Try the energy-allocation path first when enabled.
+	switch {
+	case state.Mode == ModePlannerSelf:
+		effectiveMode = ModeSelfConsumption
+		state.SetGridTarget(0)
+		planFresh := false
+		if state.SlotDirective != nil {
+			if dir, ok := state.SlotDirective(time.Now()); ok {
+				planFresh = true
+				state.PlanStale = false
+				slotH := dir.SlotEnd.Sub(dir.SlotStart).Hours()
+				if slotH > 0 && math.Abs(dir.BatteryEnergyWh)/slotH < mpc.IdleGateThresholdW {
+					plannerSelfIdleGate = true
+				}
+			}
+		}
+		if !planFresh {
+			if !state.PlanStale {
+				slog.Warn("planner_self: plan stale — reactive self_consumption, no idle gates")
+			}
+			state.PlanStale = true
+		}
+	case state.Mode.IsPlannerMode():
+		// planner_cheap / planner_arbitrage.
 		if state.UseEnergyDispatch && state.SlotDirective != nil {
 			if dir, ok := state.SlotDirective(time.Now()); ok {
 				currentDirective = dir
@@ -230,8 +265,6 @@ func ComputeDispatch(
 				state.PlanStale = false
 			}
 		}
-		// Fall through to legacy path if energy path is off or its plan
-		// is stale.
 		if !useEnergyPath {
 			var modeStr string
 			var gridW float64
@@ -333,9 +366,19 @@ func ComputeDispatch(
 		currentTotal += b.currentW
 	}
 
-	// ---- Compute totalCorrection — two paths diverge here ----
+	// ---- Compute totalCorrection — three paths diverge here ----
 	var totalCorrection float64
-	if useEnergyPath {
+	switch {
+	case plannerSelfIdleGate:
+		// planner_self + plan says idle this slot: drive the battery
+		// total toward 0 regardless of live grid flow. Slew ramps it
+		// down over several cycles; the PI stays out of it so no
+		// integral wind-up carries into the next slot.
+		state.PI.Reset()
+		totalCorrection = -currentTotal
+		// deliberately skip the deadband — it's a gridW check and
+		// doesn't see "battery wants to be at zero but isn't yet".
+	case useEnergyPath:
 		// Energy-allocation path: plan's slot directive says "this many Wh
 		// over this slot". Derive the instantaneous power needed to hit the
 		// remaining energy in the remaining time, then pass (target - currentTotal)
@@ -373,8 +416,12 @@ func ComputeDispatch(
 		state.SetGridTarget(0)
 		state.PI.Reset()
 		totalCorrection = targetTotalW - currentTotal
-	} else {
-		// Legacy path: PI on grid target.
+	default:
+		// Legacy PI-on-grid-target path. Used by:
+		//   - manual modes (self_consumption, peak_shaving, priority, weighted)
+		//   - planner_self (the "participate reactively" branch — idle-gate
+		//     already handled above)
+		//   - planner_cheap / planner_arbitrage when UseEnergyDispatch=false
 		var errW float64
 		switch effectiveMode {
 		case ModePeakShaving:

--- a/go/internal/mpc/CLAUDE.md
+++ b/go/internal/mpc/CLAUDE.md
@@ -72,6 +72,9 @@ Core optimizer (`mpc.go`):
 
 - `Optimize(slots []Slot, p Params) Plan`
 - `Mode` + constants `ModeSelfConsumption` / `ModeCheapCharge` / `ModeArbitrage`
+- `IdleGateThresholdW` — constant consumed by `control` to decide whether
+  a `planner_self` slot's `BatteryEnergyWh` counts as "DP picked idle".
+  Mirrors the `chargeThresh` used by `reasonFor`; keep the two in sync.
 - Types `Slot`, `Params`, `Action`, `Plan`.
 
 Service (`service.go`):
@@ -85,9 +88,15 @@ Service (`service.go`):
 
 ## How it talks to neighbors
 
-- `control/dispatch.go:42` injects `Service.GridTargetAt` as `PlanTargetFunc`.
-  Control loop consults it each cycle; falls back to self-consumption when
-  `(_, false)` is returned.
+- `control/dispatch.go` injects `Service.SlotAt` as `PlanTargetFunc` and
+  `Service.SlotDirectiveAt` as `SlotDirectiveFunc`. Control loop consults
+  them each cycle; falls back to self-consumption when `(_, false)` is
+  returned. For `planner_self` the dispatch reads `BatteryEnergyWh` out of
+  `SlotDirective` only as an "idle-gate" signal (below `IdleGateThresholdW`
+  average power ⇒ hold battery at 0); actual power is still driven by
+  reactive PI-on-gridW=0. For `planner_cheap` / `planner_arbitrage` the
+  dispatch follows the Wh allocation directly. See issue #130 +
+  `docs/plan-ems-contract.md`.
 - Reads price history via `state.Store.LoadPrices` and forecast via
   `LoadForecasts` (`service.go:324,343`).
 - Reads live PV / battery / meter via `telemetry.Store` for SoC + divergence

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -59,6 +59,15 @@ const (
 	ModeArbitrage Mode = "arbitrage"
 )
 
+// IdleGateThresholdW is the per-slot average battery power below which the
+// plan is treated as "idle this slot" by the planner_self control branch.
+// Mirrors the chargeThresh used by reasonFor — a slot averaging less than
+// this much battery action is interpreted as the DP declining to
+// participate (e.g. saving surplus for a later slot with a richer price/PV
+// mix). The control package duplicates this constant (same import-avoidance
+// trick as SlotDirective) — keep the two in sync.
+const IdleGateThresholdW = 100.0
+
 // Slot is one input time slot for the optimizer.
 type Slot struct {
 	StartMs  int64
@@ -736,7 +745,7 @@ func modeAllows(m Mode, baselineGridW, gridW, actW float64) bool {
 // discharge from an aggressive export-for-arbitrage.
 func reasonFor(s Slot, batteryW, gridW, meanPrice float64) string {
 	baseline := s.LoadW + s.PVW // what grid would see with no battery
-	const chargeThresh = 100.0
+	const chargeThresh = IdleGateThresholdW
 	const gridThresh = 100.0
 	priceTag := ""
 	if s.Confidence < 1.0 {


### PR DESCRIPTION
Closes #130.

## Summary

- `planner_self` now runs **reactive PI-on-gridW=0** (identical to manual `self_consumption`) with a plan-driven **per-slot idle gate**. When the DP allocated average battery power `< mpc.IdleGateThresholdW` (= 100 W) for the current slot the EMS holds the battery at 0; otherwise it participates reactively and the live meter drives the power.
- `planner_cheap` / `planner_arbitrage` are unchanged — they keep the energy-allocation path (`UseEnergyDispatch=true` default) where Wh-per-slot is the optimisation variable.
- Regression guards added to `go/internal/control/control_test.go`; docs updated.

## Root cause (from #130)

Since #124 defaulted every planner mode to energy-allocation dispatch, `planner_self` honoured the plan's `BatteryEnergyWh` regardless of live grid flow. The DP enforces `ModeSelfConsumption`'s grid-crossing invariant only on forecast — so when the PV forecast over-estimated vs actual, the battery kept chasing the planned charge rate and pulled the shortfall from the grid, breaking the UI tooltip's "never imports to charge, never exports via the battery" promise.

The EMS must enforce the self-consumption invariant on the live meter, not on the plan. For that mode specifically, the plan becomes a *participation schedule*, not a power trajectory.

## Architecture note

Three execution paths now live in `ComputeDispatch`:

| Mode | Execution |
|---|---|
| `planner_self` | Reactive PI → gridW=0 + per-slot idle gate from `SlotDirective.BatteryEnergyWh` |
| `planner_cheap` / `planner_arbitrage` w/ `UseEnergyDispatch=true` (default) | Energy-allocation (grid is the residual) |
| `planner_cheap` / `planner_arbitrage` w/ `legacy_dispatch: true` | Legacy PI on `grid_target_w` — rollback only |

See the new §Exception in `docs/plan-ems-contract.md`.

## EV dispatch

Out of scope for this PR — `ev_dispatch` reads `SlotDirective.LoadpointEnergyWh` unconditionally and is orthogonal to the battery branch. A separate follow-up may be needed if forecast-overestimate causes the EV charger to import grid; call it out if observed in the field.

## Test plan

- [x] `go test ./...` — all green (including 6 new planner_self tests + 1 repurposed energy-dispatch test)
- [x] `make e2e` — green (27 s)
- [ ] Smoke on the Pi: flip mode to Smart self-consumption, watch `/api/status` + grid meter; confirm battery tracks live meter and never imports beyond baseline across a sunny slot + a cloudy slot.
- [ ] Confirm idle-gate behaviour: during a slot the DP picks to skip, battery should ramp to 0 and grid should export full PV surplus.

## Files

- `go/internal/control/dispatch.go` — new `planner_self` switch branch, `plannerSelfIdleGate` short-circuit
- `go/internal/control/control_test.go` — 6 new tests + 1 renamed
- `go/internal/mpc/mpc.go` — exported `IdleGateThresholdW` constant
- `go/internal/control/CLAUDE.md`, `go/internal/mpc/CLAUDE.md` — updated execution-path table + §What NOT to do
- `docs/plan-ems-contract.md` — §Exception: planner_self
- `docs/mpc-planner.md` — §Execution differs by strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)