### PR TITLE
fix(pvmodel): gate Predict at clearSky<50 to suppress night-time phantom output

### DIFF
--- a/go/internal/pvmodel/CLAUDE.md
+++ b/go/internal/pvmodel/CLAUDE.md
@@ -45,6 +45,12 @@ Output sanity envelope: if `y > 1.05 * rated` → return the physics prior
 instead (`model.go:140-143`). A wild RLS coefficient can't escape into the
 plan.
 
+Predict gate (`model.go:109-117`):
+
+- `clearSkyW < 50` → return 0. Physics: no sun → no PV. Mirrors the
+  Update-side gate; without this the intercept term (`x[0]=1`) projects
+  any non-zero `Beta[0]` into every night slot (issue #133).
+
 Input outlier rejection (`model.go:149-180`):
 
 - `clearSkyW < 50` → skip (night, no signal).

--- a/go/internal/pvmodel/model.go
+++ b/go/internal/pvmodel/model.go
@@ -107,6 +107,16 @@ func Features(clearSkyW, cloudPct float64, t time.Time) [NFeat]float64 {
 const WarmupSamples = 50
 
 func (m Model) Predict(clearSkyW, cloudPct float64, t time.Time) float64 {
+	// Physics gate: no sun above the horizon → no PV output. Mirrors the
+	// Update-side guard (`clearSkyW < 50` skips training), so prediction
+	// and training share one definition of "night". Without this gate the
+	// intercept term in Features (x[0]=1.0) projects Beta[0] into every
+	// night slot — and since RLS is free to pick a non-zero Beta[0] when
+	// that minimizes daytime residual, the model routinely emits
+	// 500-1500 W of phantom generation at 02:00. See issue #133.
+	if clearSkyW < 50 {
+		return 0
+	}
 	// Learned prediction.
 	x := Features(clearSkyW, cloudPct, t)
 	var learned float64

--- a/go/internal/pvmodel/model_test.go
+++ b/go/internal/pvmodel/model_test.go
@@ -176,3 +176,51 @@ func TestCapsAtDoubleRated(t *testing.T) {
 		t.Errorf("should cap at 1.3× rated, got %f", got)
 	}
 }
+
+// Night-time gate (issue #133). Any clear-sky below the Update-side
+// threshold must yield 0 W regardless of Beta drift. Covers the
+// operator-reported case where the planner showed −1.1 kW of PV at
+// 02:00 because Beta[0] (intercept) had drifted during daytime training.
+func TestPredictAtNightReturnsZero(t *testing.T) {
+	m := NewModel(10000)
+	// Force Beta[0] to a large positive value as if RLS had drifted
+	// the intercept during training. Without the gate, Predict at
+	// clearSky=0 would return this value.
+	m.Beta[0] = 1100
+	m.Samples = 100 // past warmup → full trust on learned model
+
+	t02 := time.Date(2026, 4, 20, 2, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name       string
+		clearSkyW  float64
+	}{
+		{"pitch-dark-midnight", 0},
+		{"astronomical-twilight", 10},
+		{"civil-twilight-just-below-gate", 49},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := m.Predict(c.clearSkyW, 50, t02)
+			if got != 0 {
+				t.Errorf("night (clearSky=%.0f, Beta[0]=%.0f) must return 0, got %.2f W",
+					c.clearSkyW, m.Beta[0], got)
+			}
+		})
+	}
+}
+
+// Sunrise transition: the moment clearSky crosses the gate threshold the
+// model is live again. Anchors the gate boundary so it doesn't silently
+// creep upward.
+func TestPredictAtGateThresholdBoundary(t *testing.T) {
+	m := NewModel(10000)
+	// Reasonable sunrise instant; exact time-of-day doesn't matter
+	// because we vary clearSky directly.
+	tt := time.Date(2026, 4, 20, 5, 0, 0, 0, time.UTC)
+	if got := m.Predict(49, 0, tt); got != 0 {
+		t.Errorf("clearSky=49 should be gated to 0, got %.2f", got)
+	}
+	if got := m.Predict(50, 0, tt); got <= 0 {
+		t.Errorf("clearSky=50 should be above the gate and produce nonzero, got %.2f", got)
+	}
+}


### PR DESCRIPTION
Closes #133.

## Summary

- Add a hard gate at the top of \`Model.Predict\`: when \`clearSkyW < 50\` return 0. Mirrors the Update-side gate (same threshold, same physical justification).
- Two regression tests: night-time prediction is 0 regardless of \`Beta[0]\` drift, and the gate boundary behaves as expected (49 → 0, 50 → nonzero).

## Why

Operator report (2026-04-19): planner UI showed −1.1 kW of PV at Mon 02:00 local. The feature vector's intercept term (\`x[0]=1\`) collapses the learned prediction to \`Beta[0]\` at night; RLS is free to pick a non-zero \`Beta[0]\` when that minimises daytime residual, and nothing stops the intercept from leaking into night slots.

Followed by the planner's \`selectPlannerPVW\` (\`mpc/service.go:832\`) — at night \`forecastPVW=0 < 200 W\` so it falls back unreserved to the twin's prediction — the twin's phantom 1.1 kW became the MPC's sole PV input.

Hard gate at the model layer is the right place: physics lives there, the planner trusts the model.

## Follow-up

#134 addresses the underlying intercept drift. This PR suppresses the night symptom; #134 will clean up the daytime bias.

## Test plan

- [x] \`go test ./internal/pvmodel\` — 8 tests green, including 2 new
- [x] \`make test\` + \`make e2e\` — green
- [ ] Smoke on Pi: refresh planner at night, confirm PV row reads 0 W for all post-midnight slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)