### PR TITLE
fix(control,pvmodel): address Codex review on #131 #136

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -959,3 +959,64 @@ func TestPlannerSelfWithoutPlanActsLikeManual(t *testing.T) {
 		t.Error("expected PlanStale=true when planner_self sees no directive")
 	}
 }
+
+// Codex P2 on PR #131: planner_cheap → planner_self → planner_cheap within
+// the same 15-minute slot must not let the energy path read stale
+// `slotDelivered` accumulated before the planner_self hop. If that leak
+// happens, the second cheap cycle computes `remainingWh` off the pre-hop
+// delivery number and over-commands battery for the rest of the slot.
+func TestPlannerSelfResetsEnergyBookkeepingOnEntry(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 800, 0.5}, // mid-charge so cheap path accumulates delivery
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	// 1. Run arbitrage — primes state.currentDirective / slotDelivered / lastTickTs.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.currentDirective.SlotStart.IsZero() {
+		t.Fatal("precondition: arbitrage cycle should have set currentDirective")
+	}
+
+	// 2. Operator flips to planner_self inside the same slot.
+	st.Mode = ModePlannerSelf
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	// After planner_self runs the energy-path bookkeeping must be
+	// cleared so a future cheap/arbitrage cycle can't read stale state.
+	if !st.currentDirective.SlotStart.IsZero() {
+		t.Errorf("currentDirective.SlotStart = %v after planner_self, want zero", st.currentDirective.SlotStart)
+	}
+	if st.slotDelivered != 0 {
+		t.Errorf("slotDelivered = %f after planner_self, want 0", st.slotDelivered)
+	}
+	if !st.lastTickTs.IsZero() {
+		t.Errorf("lastTickTs = %v after planner_self, want zero", st.lastTickTs)
+	}
+
+	// 3. Flip back to arbitrage — the SlotStart-equality branch should
+	// no longer match, so the code takes the rollover-reset path
+	// cleanly rather than accumulating off a frozen baseline.
+	st.Mode = ModePlannerArbitrage
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	// The re-primed directive should equal the fresh one exactly (reset
+	// branch fires), which implies slotDelivered starts from 0 again.
+	if !st.currentDirective.SlotStart.Equal(dir.SlotStart) {
+		t.Errorf("arbitrage cycle after planner_self didn't re-prime directive; SlotStart=%v want %v",
+			st.currentDirective.SlotStart, dir.SlotStart)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -233,6 +233,17 @@ func ComputeDispatch(
 	case state.Mode == ModePlannerSelf:
 		effectiveMode = ModeSelfConsumption
 		state.SetGridTarget(0)
+		// Reset the energy-allocation bookkeeping so a future switch to
+		// planner_cheap / planner_arbitrage within the same 15-minute
+		// slot can't read stale `slotDelivered` accumulated before the
+		// operator hopped through planner_self. Without this reset, the
+		// `SlotStart` comparison in the energy path would match (still
+		// the same clock-aligned slot) and skip its own rollover reset
+		// — reading the pre-hop delivered-Wh number and over-commanding
+		// charge/discharge for the rest of the slot. Codex P2 on PR #131.
+		state.currentDirective = SlotDirective{}
+		state.slotDelivered = 0
+		state.lastTickTs = time.Time{}
 		planFresh := false
 		if state.SlotDirective != nil {
 			if dir, ok := state.SlotDirective(time.Now()); ok {

--- a/go/internal/pvmodel/model.go
+++ b/go/internal/pvmodel/model.go
@@ -227,11 +227,19 @@ func (m *Model) Update(clearSkyW, cloudPct float64, t time.Time, actualPVW float
 	}
 
 	// P = (P − K·xᵀ·P) / λ
+	//
+	// Skip row/column 0 entirely: the intercept feature is hardcoded to 0
+	// (see Features() — a dead slot since #134), so no information flows
+	// into it. Letting the standard update run would still divide P[0][0]
+	// by λ every tick — growth ~1.005× per sample compounds to Inf after
+	// ~140k samples, after which Px[0] = Inf*0 = NaN poisons K, β, and
+	// all predictions. Freezing row/column 0 at zero keeps the
+	// dead-slot invariant numerically stable forever. Codex P1 on PR #136.
 	var newP [NFeat][NFeat]float64
-	for i := 0; i < NFeat; i++ {
-		for j := 0; j < NFeat; j++ {
+	for i := 1; i < NFeat; i++ {
+		for j := 1; j < NFeat; j++ {
 			var kxTP float64
-			for k := 0; k < NFeat; k++ {
+			for k := 1; k < NFeat; k++ {
 				kxTP += K[i] * x[k] * m.P[k][j]
 			}
 			newP[i][j] = (m.P[i][j] - kxTP) / m.Forgetting

--- a/go/internal/pvmodel/model_test.go
+++ b/go/internal/pvmodel/model_test.go
@@ -234,6 +234,55 @@ func TestInterceptDoesNotAffectDaytimePredict(t *testing.T) {
 	}
 }
 
+// Codex P1 on PR #136: with Features[0]=0 (dead slot), the standard
+// covariance update divides P[0][0] by λ every tick → ~1.005× growth
+// compounds to Inf after ~140k updates → Px[0] = Inf*0 = NaN poisons
+// K, β, and predictions. The Update() fix freezes row/column 0 of P.
+// This test runs enough Updates to catch any residual growth and asserts
+// the whole matrix + β stay finite.
+func TestUpdatePKeepsDeadInterceptFinite(t *testing.T) {
+	m := NewModel(10000)
+	base := time.Date(2026, 6, 1, 6, 0, 0, 0, time.UTC)
+	// 2000 Updates — well past the point where the old code would have
+	// started accelerating P[0][0] but not long enough to explode even
+	// the buggy version, so the assertion has to be tight, not loose.
+	for i := 0; i < 2000; i++ {
+		ts := base.Add(time.Duration(i) * time.Minute)
+		// Vary clearSky + cloud so the update actually fires (>50 gate)
+		// and doesn't get outlier-rejected.
+		cs := 400.0 + math.Mod(float64(i), 600)
+		cloud := math.Mod(float64(i), 100)
+		actual := 0.8 * cs * math.Pow(1-cloud/100, 1.5) * 10.0
+		_ = m.Update(cs, cloud, ts, actual)
+	}
+	// Every P cell finite.
+	for i := 0; i < NFeat; i++ {
+		for j := 0; j < NFeat; j++ {
+			if math.IsNaN(m.P[i][j]) || math.IsInf(m.P[i][j], 0) {
+				t.Fatalf("P[%d][%d] = %v — covariance went infinite", i, j, m.P[i][j])
+			}
+		}
+	}
+	// Row 0 and column 0 must stay at zero (or at least not wandering):
+	// the fix skips their update so whatever they started at (col 0 all
+	// 0, row 0 diagonal 1000) persists — but since row 0 and col 0
+	// never get written into, the `newP` zero-value clears them to 0.
+	for j := 1; j < NFeat; j++ {
+		if m.P[0][j] != 0 {
+			t.Errorf("P[0][%d] = %v, want 0 (row 0 is dead)", j, m.P[0][j])
+		}
+		if m.P[j][0] != 0 {
+			t.Errorf("P[%d][0] = %v, want 0 (col 0 is dead)", j, m.P[j][0])
+		}
+	}
+	// β stays finite.
+	for i := 0; i < NFeat; i++ {
+		if math.IsNaN(m.Beta[i]) || math.IsInf(m.Beta[i], 0) {
+			t.Fatalf("Beta[%d] = %v — coefficient went non-finite", i, m.Beta[i])
+		}
+	}
+}
+
 // Self-heal: Update zeros Beta[0] at the end of each RLS step so drifted
 // persisted models don't keep the stale intercept forever.
 func TestUpdateZeroesIntercept(t *testing.T) {


### PR DESCRIPTION
Two legit Codex findings on recently-merged PRs.

## Fix 1 — planner_self slot-energy reset (Codex P2 on #131)

\`ControlSwitch cheap → self → cheap\` within one slot would leak stale \`slotDelivered\` past the self hop, over-commanding battery for the rest of the slot. Reset the three energy-path fields when planner_self fires so a return to the energy path always takes its rollover-reset branch cleanly.

## Fix 2 — pvmodel covariance overflow on dead intercept (Codex P1 on #136)

With \`Features[0]=0\`, the standard RLS covariance update still grows \`P[0][0]\` by 1/λ each tick. ~140k successful Updates (months of daytime training) overflows to Inf → \`Px[0] = Inf*0 = NaN\` → poison cascades into β. Freeze row/column 0 in the update loop so the dead slot stays numerically dead.

## Tests

- \`TestPlannerSelfResetsEnergyBookkeepingOnEntry\` — full cheap→self→cheap mode-hop exercise.
- \`TestUpdatePKeepsDeadInterceptFinite\` — 2000 Updates, asserts every P cell + every β stays finite, row/col 0 stay at zero.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)