### PR TITLE
feat(selfupdate): let operators opt out of pre-update snapshot per-update

### DIFF
--- a/go/internal/api/api_selfupdate.go
+++ b/go/internal/api/api_selfupdate.go
@@ -71,23 +71,48 @@ func (s *Server) handleVersionUnskip(w http.ResponseWriter, r *http.Request) {
 // (state.db + config.yaml) into SnapshotDir. A failed snapshot aborts
 // the update — the whole point of offering "Update" is that the user
 // knows they can back out, and shipping without the safety net breaks
-// that promise. The one exception is an explicitly-disabled snapshot
-// dir, where the operator opted out at deploy time.
+// that promise. Two exceptions skip the snapshot:
+//
+//   - SnapshotDir is empty (operator opted out at deploy time).
+//   - The request body sets {"skip_snapshot": true} (operator opted
+//     out for this specific update via the UI checkbox, typically
+//     because the existing 5 retained snapshots already cover them).
+//
+// Both exceptions return \`snapshot_skipped: true\` in the response so
+// the UI can differentiate "no snapshot taken on purpose" from "no
+// snapshot field because the field was elided".
 func (s *Server) handleVersionUpdate(w http.ResponseWriter, r *http.Request) {
 	if s.deps.SelfUpdate == nil {
 		writeJSON(w, 503, map[string]string{"error": "self-update disabled"})
 		return
 	}
+
+	// Body is optional — empty body / null JSON yields the zero value
+	// (SkipSnapshot false), so pre-checkbox UIs keep getting the snapshot.
+	var body struct {
+		SkipSnapshot bool `json:"skip_snapshot,omitempty"`
+	}
+	// readJSON caps at 1 MB (api.go:153). Errors here include EOF on an
+	// empty body, which we treat as the operator using the legacy no-body
+	// path.
+	if r.ContentLength > 0 {
+		if err := readJSON(r, &body); err != nil {
+			writeJSON(w, 400, map[string]string{"error": "bad json: " + err.Error()})
+			return
+		}
+	}
+
 	info := s.deps.SelfUpdate.Info()
 
 	var snap SnapshotInfo
-	if s.deps.SnapshotDir != "" {
+	snapshotSkipped := body.SkipSnapshot || s.deps.SnapshotDir == ""
+	if !snapshotSkipped {
 		var err error
 		snap, err = s.createPreUpdateSnapshot("update", info.Current, info.Latest)
 		if err != nil {
 			writeJSON(w, 500, map[string]string{
 				"error":   "snapshot failed: " + err.Error(),
-				"hint":    "Update aborted so you keep a rollback point. Check SnapshotDir permissions or free space.",
+				"hint":    "Update aborted so you keep a rollback point. Check SnapshotDir permissions or free space — or re-submit with skip_snapshot=true if you accept the risk.",
 				"snapshot_dir": s.deps.SnapshotDir,
 			})
 			return
@@ -101,6 +126,9 @@ func (s *Server) handleVersionUpdate(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{"status": "started", "action": "update", "target": info.Latest}
 	if snap.ID != "" {
 		resp["snapshot"] = snap
+	}
+	if snapshotSkipped {
+		resp["snapshot_skipped"] = true
 	}
 	writeJSON(w, 202, resp)
 }

--- a/go/internal/api/api_selfupdate_test.go
+++ b/go/internal/api/api_selfupdate_test.go
@@ -195,6 +195,35 @@ func TestVersionUpdate_CreatesSnapshotBeforeTrigger(t *testing.T) {
 	snap.Close()
 }
 
+// Operator opt-out: POST {skip_snapshot: true} skips the snapshot
+// capture step and the handler proceeds to trigger the sidecar without
+// creating a rollback point. Used when the retained set already covers
+// the operator or when they consciously want to save the ~200 MB per
+// snapshot on a constrained SD card. Issue #149.
+func TestVersionUpdate_SkipSnapshotOptOut(t *testing.T) {
+	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
+	dir := t.TempDir()
+	st, _ := state.Open(filepath.Join(dir, "state.db"))
+	t.Cleanup(func() { st.Close() })
+	snapDir := filepath.Join(dir, "snapshots")
+	srv := New(&Deps{SelfUpdate: c, State: st, SnapshotDir: snapDir})
+
+	body := strings.NewReader(`{"skip_snapshot":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/version/update", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	// Sidecar trigger still fails (no socket), but the handler must
+	// first have honoured the skip — i.e. the snapshots dir stays empty.
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("want 502 from missing sidecar, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if entries, _ := os.ReadDir(snapDir); len(entries) != 0 {
+		t.Errorf("snapshots dir should be empty after skip_snapshot=true, found %d entries", len(entries))
+	}
+}
+
 // With ConfigPath set the snapshot must also copy config.yaml so a
 // rollback can restore the exact YAML the operator was running.
 func TestVersionUpdate_SnapshotIncludesConfigWhenPathSet(t *testing.T) {

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -27,6 +27,7 @@
       this._checkTimer = null;
       this._statusTimer = null;
       this._disabled = false;         // set true on 503 (feature gated off)
+      this._skipSnapshot = false;     // per-session opt-out toggle (#149)
       this._render();
     }
 
@@ -126,7 +127,14 @@
       this._render();
 
       const url = action === "restart" ? "/api/version/restart" : "/api/version/update";
-      this._postJSON(url, null)
+      // For /update we ship a body so the operator can opt out of the
+      // pre-update snapshot (retained set already covers them / tight
+      // on disk). Restart doesn't snapshot anyway, so keep its body nil.
+      let body = null;
+      if (action === "update" && this._skipSnapshot) {
+        body = { skip_snapshot: true };
+      }
+      this._postJSON(url, body)
         .then((resp) => {
           if (!resp.ok) {
             this._sidecarState = { state: "failed", action, message: (resp.body && resp.body.error) || "failed to start" };
@@ -242,11 +250,18 @@
         : (hasUpdate && notesLink ? `<p class="changelog-link">${notesLink}</p>` : "");
 
       // Reassure the operator that a rollback point will be captured
-      // before the update runs. Shown only when there's something to
-      // update to — no need to mention the snapshot on the "you're
-      // up to date" path.
+      // before the update runs — and let them opt out for this update
+      // via a checkbox (the retained 5 older snapshots usually cover
+      // them; power-users on small SD cards may not want another
+      // ~200 MB). Default unchecked (safety first).
       const snapshotHint = hasUpdate
-        ? `<p class="snapshot-hint">🛟 A snapshot of your data and config is saved before each update so you can roll back if needed.</p>`
+        ? `<div class="snapshot-hint">
+             <p>🛟 A snapshot of your data and config is saved before each update so you can roll back if needed.</p>
+             <label class="snapshot-skip">
+               <input type="checkbox" data-action="toggle-skip-snapshot" ${this._skipSnapshot ? "checked" : ""}>
+               Skip backup for this update
+             </label>
+           </div>`
         : "";
 
       return `
@@ -334,6 +349,11 @@
               break;
             case "reload":
               this._attemptReload();
+              break;
+            case "toggle-skip-snapshot":
+              // Don't re-render — the <input> element already reflects
+              // its own state and a full render would reset focus.
+              this._skipSnapshot = !!e.currentTarget.checked;
               break;
           }
         });
@@ -481,6 +501,21 @@
           color: var(--text-dim, #94a3b8);
           font-size: 0.78rem;
           line-height: 1.4;
+        }
+        .snapshot-hint p { margin: 0; }
+        .snapshot-skip {
+          display: flex;
+          align-items: center;
+          gap: 0.4rem;
+          margin-top: 0.4rem;
+          font-size: 0.76rem;
+          color: var(--text-dim, #94a3b8);
+          cursor: pointer;
+          user-select: none;
+        }
+        .snapshot-skip input[type="checkbox"] {
+          margin: 0;
+          cursor: pointer;
         }
         .err {
           margin-top: 0.75rem;


### PR DESCRIPTION
Small follow-up to #141.

## Summary

- Adds a checkbox under the snapshot hint in the update modal: *"Skip backup for this update"*. Default unchecked.
- When ticked the UI POSTs \`{"skip_snapshot": true}\` to \`/api/version/update\`; the handler bypasses the snapshot step and returns \`snapshot_skipped: true\` in the response.
- Default flow (checkbox left unchecked / no body / pre-checkbox UI) is unchanged — snapshot is created as before.

## Why

Per-update opt-out for two real cases:
1. The 5 retained snapshots already cover the likely rollback window.
2. Tight disk on a small SD card — ~200 MB per snapshot adds up.

Deploy-time opt-out (empty \`SnapshotDir\`) continues to work exactly the same.

## Test plan

- [x] \`TestVersionUpdate_SkipSnapshotOptOut\` — post with the flag, verify the snapshots directory stays empty.
- [x] Existing 8 version-update / snapshot tests green (default path untouched).
- [x] \`make test\` + \`make e2e\` green.
- [ ] Smoke on Pi when this ships: open modal → see checkbox under the 🛟 hint. Tick → click Update → verify \`/api/version/snapshots\` count doesn't grow on this run. Untick → click Update → count grows by 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)