### PR TITLE
feat(selfupdate): list + delete snapshots from the update modal

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -183,6 +183,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/version/restart", s.handleVersionRestart)
 	s.handle("GET  /api/version/update/status", s.handleVersionUpdateStatus)
 	s.handle("GET  /api/version/snapshots", s.handleVersionSnapshots)
+	s.handle("DELETE /api/version/snapshots/{id}", s.handleVersionSnapshotDelete)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.

--- a/go/internal/api/api_selfupdate_test.go
+++ b/go/internal/api/api_selfupdate_test.go
@@ -312,6 +312,64 @@ func TestSnapshotsPruneToKeepNewest(t *testing.T) {
 	}
 }
 
+// Delete by id removes the directory + returns 200. Guards #150's
+// operator-self-service promise: "I see these snapshots in the UI and
+// can reclaim disk from them without SSH."
+func TestVersionSnapshots_DeleteByID(t *testing.T) {
+	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
+	dir := t.TempDir()
+	st, _ := state.Open(filepath.Join(dir, "state.db"))
+	t.Cleanup(func() { st.Close() })
+	snapDir := filepath.Join(dir, "snapshots")
+	srv := New(&Deps{SelfUpdate: c, State: st, SnapshotDir: snapDir})
+	snap, err := srv.createPreUpdateSnapshot("update", "v0.0.0", "v0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/version/snapshots/"+snap.ID, nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("DELETE = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if _, err := os.Stat(snap.Path); !os.IsNotExist(err) {
+		t.Errorf("snapshot dir should be gone after DELETE, stat err = %v", err)
+	}
+}
+
+// Traversal + missing-id guards. A rogue client can't escape SnapshotDir
+// or delete arbitrary files via the endpoint.
+func TestVersionSnapshots_DeleteRejectsInvalidID(t *testing.T) {
+	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
+	dir := t.TempDir()
+	st, _ := state.Open(filepath.Join(dir, "state.db"))
+	t.Cleanup(func() { st.Close() })
+	snapDir := filepath.Join(dir, "snapshots")
+	srv := New(&Deps{SelfUpdate: c, State: st, SnapshotDir: snapDir})
+
+	// Non-existent id: handler hits the stat check, returns 404.
+	req := httptest.NewRequest(http.MethodDelete, "/api/version/snapshots/no-such-snapshot", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != 404 {
+		t.Errorf("missing snapshot: want 404, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+
+	// Traversal attempts: Go's ServeMux cleans paths and redirects
+	// anything containing `..`, so our handler is never reached — but
+	// that's the outcome we want (no delete, no 500, no information
+	// leak). Accept any non-200 outcome.
+	for _, evilID := range []string{"..", "../etc/passwd"} {
+		req := httptest.NewRequest(http.MethodDelete, "/api/version/snapshots/"+evilID, nil)
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		if rr.Code == 200 {
+			t.Errorf("DELETE %q returned 200 — traversal reached the handler", evilID)
+		}
+	}
+}
+
 func TestVersionSnapshots_ListsNewestFirst(t *testing.T) {
 	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
 	dir := t.TempDir()

--- a/go/internal/api/snapshots.go
+++ b/go/internal/api/snapshots.go
@@ -219,6 +219,57 @@ func pruneSnapshots(snapshotDir string, keep int) error {
 	return firstErr
 }
 
+// handleVersionSnapshotDelete removes one snapshot by ID. Used from the
+// UI's snapshot-management view when the operator wants to free disk
+// space manually (beyond the built-in last-5 retention). Validates the
+// ID is a snapshot-shaped filename and lives inside SnapshotDir so a
+// malicious caller can't traverse to sibling directories — only dirs
+// that listSnapshots would have surfaced are deletable.
+func (s *Server) handleVersionSnapshotDelete(w http.ResponseWriter, r *http.Request) {
+	if s.deps.SelfUpdate == nil {
+		writeJSON(w, 503, map[string]string{"error": "self-update disabled"})
+		return
+	}
+	if s.deps.SnapshotDir == "" {
+		writeJSON(w, 503, map[string]string{"error": "snapshots disabled (no SnapshotDir)"})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, 400, map[string]string{"error": "missing snapshot id"})
+		return
+	}
+	// Defense in depth: reject anything that isn't a simple directory
+	// name. No slashes, no "..". A well-formed snapshot id is produced
+	// by snapshotID() with only [A-Za-z0-9._-] characters.
+	if strings.ContainsAny(id, "/\\") || id == "." || id == ".." {
+		writeJSON(w, 400, map[string]string{"error": "invalid snapshot id"})
+		return
+	}
+	target := filepath.Join(s.deps.SnapshotDir, id)
+	// Must exist AND be inside SnapshotDir. filepath.Join can't escape
+	// SnapshotDir given the above ID guards, but verify by checking
+	// existence + type before deleting.
+	fi, err := os.Stat(target)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			writeJSON(w, 404, map[string]string{"error": "snapshot not found: " + id})
+			return
+		}
+		writeJSON(w, 500, map[string]string{"error": err.Error()})
+		return
+	}
+	if !fi.IsDir() {
+		writeJSON(w, 400, map[string]string{"error": "id does not refer to a snapshot directory"})
+		return
+	}
+	if err := os.RemoveAll(target); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "remove failed: " + err.Error()})
+		return
+	}
+	writeJSON(w, 200, map[string]any{"ok": true, "deleted": id})
+}
+
 // handleVersionSnapshots serves the list to the UI.
 func (s *Server) handleVersionSnapshots(w http.ResponseWriter, r *http.Request) {
 	if s.deps.SelfUpdate == nil {

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -28,6 +28,8 @@
       this._statusTimer = null;
       this._disabled = false;         // set true on 503 (feature gated off)
       this._skipSnapshot = false;     // per-session opt-out toggle (#149)
+      this._snapshots = null;         // last /api/version/snapshots payload (#150)
+      this._deletingSnapshot = null;  // id being deleted right now (#150)
       this._render();
     }
 
@@ -49,6 +51,34 @@
       this._phase = "dialog";
       this._render();
       this._refresh(false); // surface the freshest info when opened
+      this._refreshSnapshots(); // pull the list for the Snapshots accordion
+    }
+
+    // Fetch the snapshot list so the operator sees the retained set and
+    // can delete entries without SSH. Tolerates 503 (feature off) and
+    // 404s silently — the UI simply hides the section.
+    _refreshSnapshots() {
+      if (this._disabled) return;
+      fetch("/api/version/snapshots")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((body) => {
+          if (!body) return;
+          this._snapshots = body;
+          this._render();
+        })
+        .catch(() => { /* silent */ });
+    }
+
+    _deleteSnapshot(id) {
+      if (!id) return;
+      // Guard against rapid double-clicks while the request is pending.
+      if (this._deletingSnapshot) return;
+      this._deletingSnapshot = id;
+      fetch("/api/version/snapshots/" + encodeURIComponent(id), { method: "DELETE" })
+        .finally(() => {
+          this._deletingSnapshot = null;
+          this._refreshSnapshots();
+        });
     }
 
     // Permanently shut the element down: stop polling, clear shadow DOM, hide
@@ -280,11 +310,50 @@
             </dl>
             ${bodyHTML}
             ${snapshotHint}
+            ${this._snapshotsSectionHTML()}
             ${info.err ? `<p class="err">Last check failed: ${escapeHTML(info.err)}</p>` : ""}
           </div>
           <footer>${actions}</footer>
         </div>
       `;
+    }
+
+    _snapshotsSectionHTML() {
+      const payload = this._snapshots;
+      if (!payload || !payload.enabled) return "";
+      const snaps = Array.isArray(payload.snapshots) ? payload.snapshots : [];
+      if (!snaps.length) {
+        return `<details class="snapshots">
+                  <summary>Backup snapshots (0)</summary>
+                  <p class="dim snapshots-empty">No backups on disk yet. One is created before every update unless you opt out.</p>
+                </details>`;
+      }
+      const rows = snaps.map((s) => this._snapshotRowHTML(s)).join("");
+      return `<details class="snapshots">
+                <summary>Backup snapshots (${snaps.length})</summary>
+                <table class="snapshots-table">
+                  <thead>
+                    <tr><th>Created</th><th>From → To</th><th>Size</th><th></th></tr>
+                  </thead>
+                  <tbody>${rows}</tbody>
+                </table>
+              </details>`;
+    }
+
+    _snapshotRowHTML(s) {
+      const when = s.created_at ? new Date(s.created_at).toLocaleString() : "?";
+      const range = (s.from_version || "?") + " → " + (s.to_version || "?");
+      const sizeMB = s.size_bytes ? (s.size_bytes / (1024 * 1024)).toFixed(1) + " MB" : "?";
+      const deleting = this._deletingSnapshot === s.id;
+      const deleteBtn = deleting
+        ? `<span class="dim">deleting…</span>`
+        : `<button class="btn btn-ghost btn-small" data-action="delete-snapshot" data-id="${escapeHTML(s.id)}" title="Delete this backup">Delete</button>`;
+      return `<tr>
+                <td class="nowrap">${escapeHTML(when)}</td>
+                <td class="mono">${escapeHTML(range)}</td>
+                <td class="nowrap">${escapeHTML(sizeMB)}</td>
+                <td>${deleteBtn}</td>
+              </tr>`;
     }
 
     _updatingModalHTML() {
@@ -355,6 +424,17 @@
               // its own state and a full render would reset focus.
               this._skipSnapshot = !!e.currentTarget.checked;
               break;
+            case "delete-snapshot": {
+              const id = e.currentTarget.dataset.id;
+              // Simple confirm — this is a destructive operation but a
+              // recoverable one (the retention/prune logic will regenerate
+              // on future updates). Don't over-engineer the dialog.
+              if (id && window.confirm(`Delete snapshot ${id}? This can't be undone.`)) {
+                this._deleteSnapshot(id);
+                this._render(); // reflect the "deleting…" state immediately
+              }
+              break;
+            }
           }
         });
       });
@@ -516,6 +596,55 @@
         .snapshot-skip input[type="checkbox"] {
           margin: 0;
           cursor: pointer;
+        }
+        .snapshots {
+          margin-top: 0.75rem;
+          border: 1px solid var(--border, #334155);
+          border-radius: 4px;
+          background: rgba(255,255,255,0.02);
+        }
+        .snapshots > summary {
+          padding: 0.5rem 0.75rem;
+          cursor: pointer;
+          font-weight: 600;
+          font-size: 0.85rem;
+          color: var(--text-dim, #94a3b8);
+          list-style: none;
+        }
+        .snapshots > summary::-webkit-details-marker { display: none; }
+        .snapshots > summary::before {
+          content: "▸";
+          display: inline-block;
+          margin-right: 0.4rem;
+          transition: transform 0.15s;
+        }
+        .snapshots[open] > summary::before { transform: rotate(90deg); }
+        .snapshots-empty {
+          margin: 0.25rem 0.9rem 0.6rem;
+          font-size: 0.78rem;
+        }
+        .snapshots-table {
+          width: 100%;
+          border-collapse: collapse;
+          font-size: 0.78rem;
+          color: var(--text-dim, #94a3b8);
+        }
+        .snapshots-table th,
+        .snapshots-table td {
+          padding: 0.3rem 0.75rem;
+          text-align: left;
+          border-top: 1px solid var(--border, #334155);
+        }
+        .snapshots-table th {
+          font-weight: 600;
+          border-top: none;
+          color: var(--text, #e2e8f0);
+        }
+        .snapshots-table .nowrap { white-space: nowrap; }
+        .snapshots-table .mono { font-family: ui-monospace, monospace; }
+        .btn-small {
+          padding: 0.2rem 0.55rem;
+          font-size: 0.75rem;
         }
         .err {
           margin-top: 0.75rem;


### PR DESCRIPTION
Erik @xorath (field tester) asked for snapshot management in the UI:
*"en rollback funktion som listar alla snapshots, så man inte måste
ssh'a in, och möjlighet att radera gamla snapshots från samma lista"*.

This PR delivers the list + delete half. Rollback-to-snapshot comes next
in a focused follow-up (design sketch in #140 Phase 2 comment).

## Summary

- \`DELETE /api/version/snapshots/{id}\` — validates the id (no traversal, no dot-segments), checks the target exists inside SnapshotDir, \`os.RemoveAll\`.
- Update modal grows a collapsible "Backup snapshots (N)" table below the 🛟 hint. Columns: created-at, from→to version, size in MB, Delete button.
- Empty state + "deleting…" placeholder for rapid double-clicks.
- Auto-refreshes on modal open and after each delete.

## Test plan

- [x] Unit tests: \`TestVersionSnapshots_DeleteByID\` (happy path) + \`TestVersionSnapshots_DeleteRejectsInvalidID\` (traversal/missing).
- [x] \`make test\` + \`make e2e\` green.
- [ ] Smoke on Pi: open modal → expand Backup snapshots → see existing entries → Delete one → list shrinks without page reload.

## Follow-up

PR with rollback-to-snapshot comes next. Design in #140 Phase 2 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)