### PR TITLE
feat(selfupdate): rollback to snapshot from the update modal

### DIFF
--- a/go/cmd/ftw-updater/main.go
+++ b/go/cmd/ftw-updater/main.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -34,9 +35,10 @@ const mainServiceName = "forty-two-watts"
 // State mirrors selfupdate.UpdateStatus (we keep a local copy to avoid
 // importing the main module's internal package from this separate cmd).
 type State struct {
-	State     string    `json:"state"` // idle, pulling, restarting, done, failed
-	Action    string    `json:"action,omitempty"`
+	State     string    `json:"state"` // idle, pulling, restarting, restoring, done, failed
+	Action    string    `json:"action,omitempty"` // update, restart, rollback (#152)
 	Target    string    `json:"target,omitempty"`
+	Snapshot  string    `json:"snapshot,omitempty"` // snapshot id (rollback only, #152)
 	StartedAt time.Time `json:"started_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	Message   string    `json:"message,omitempty"`
@@ -165,15 +167,37 @@ func main() {
 
 func (s *server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Action string `json:"action"`
-		Target string `json:"target,omitempty"`
+		Action   string   `json:"action"`
+		Target   string   `json:"target,omitempty"`
+		Snapshot string   `json:"snapshot,omitempty"` // rollback-only (#152)
+		Files    []string `json:"files,omitempty"`    // rollback: basenames to restore
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<12)).Decode(&body); err != nil {
 		http.Error(w, "bad json: "+err.Error(), 400)
 		return
 	}
-	if body.Action != "update" && body.Action != "restart" {
-		http.Error(w, "action must be update or restart", 400)
+	switch body.Action {
+	case "update", "restart":
+		// existing semantics
+	case "rollback":
+		if body.Snapshot == "" {
+			http.Error(w, "rollback requires snapshot id", 400)
+			return
+		}
+		// Basename-only — never let a client traverse out of the
+		// conventional snapshots dir on the host.
+		if strings.ContainsAny(body.Snapshot, "/\\") || body.Snapshot == "." || body.Snapshot == ".." {
+			http.Error(w, "invalid snapshot id", 400)
+			return
+		}
+		for _, f := range body.Files {
+			if strings.ContainsAny(f, "/\\") || f == "." || f == ".." {
+				http.Error(w, "invalid file in rollback request", 400)
+				return
+			}
+		}
+	default:
+		http.Error(w, "action must be update, restart, or rollback", 400)
 		return
 	}
 	if !s.runMu.TryLock() {
@@ -185,11 +209,20 @@ func (s *server) handleUpdate(w http.ResponseWriter, r *http.Request) {
 	// main container's UI polls /status for progress.
 	go func() {
 		defer s.runMu.Unlock()
-		s.runJob(body.Action, body.Target)
+		if body.Action == "rollback" {
+			s.runRollback(body.Snapshot, body.Files)
+		} else {
+			s.runJob(body.Action, body.Target)
+		}
 	}()
 
 	w.WriteHeader(202)
-	_ = json.NewEncoder(w).Encode(map[string]any{"status": "started", "action": body.Action, "target": body.Target})
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":   "started",
+		"action":   body.Action,
+		"target":   body.Target,
+		"snapshot": body.Snapshot,
+	})
 }
 
 func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -238,6 +271,90 @@ func (s *server) runJob(action, target string) {
 	// will read this "done" state on startup and serve it to the UI that's
 	// still polling in the browser.
 	s.writeState(State{State: "done", Action: action, Target: target, StartedAt: now, UpdatedAt: time.Now(), Message: "compose up -d completed"})
+}
+
+// runRollback restores a snapshot's files over the main container's data
+// volume, keeping the image unchanged ("soft" rollback). The sequence is
+// intentionally simple:
+//
+//  1. compose stop forty-two-watts — main releases its SQLite handle so
+//     the swap doesn't write into a live DB.
+//  2. docker cp each file from the snapshot dir on the host into the
+//     stopped container. Bind-mount semantics make this a direct write
+//     to the host-side data dir; no read-only/writable bind trick needed.
+//  3. compose up -d forty-two-watts — main comes up on the restored state.
+//
+// Paths: the snapshots live at <host_project_dir>/data/snapshots/<id>.
+// We compute host_project_dir from FTW_UPDATER_COMPOSE (an absolute host
+// path already, documented in docker-compose.yml). Operators who move
+// the data bind off the default `./data:/app/data` layout would need a
+// separate override; tracked as a follow-up if we hit that in practice.
+//
+// A failed rollback leaves state: "failed" with a descriptive message
+// and — critically — still runs compose up -d in defer so the main
+// container comes back, even if wrong. Leaving the service down would
+// strand the operator.
+func (s *server) runRollback(snapshotID string, files []string) {
+	now := time.Now()
+	base := State{Action: "rollback", Snapshot: snapshotID, StartedAt: now}
+	s.writeState(State{State: "restoring", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: now, Message: "stopping main service"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	hostProjectDir := filepath.Dir(s.composeFile)
+	hostSnapDir := filepath.Join(hostProjectDir, "data", "snapshots", snapshotID)
+	if _, err := os.Stat(hostSnapDir); err != nil {
+		s.writeState(State{State: "failed", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "snapshot not readable from sidecar: " + err.Error()})
+		return
+	}
+
+	// 1. Stop the main service so SQLite isn't holding a file handle
+	// while we swap state.db under it.
+	stopArgs := s.composeArgs("stop", mainServiceName)
+	if err := s.runner(ctx, stopArgs...); err != nil {
+		s.writeState(State{State: "failed", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "compose stop failed: " + err.Error()})
+		return
+	}
+
+	// 2. Restore each requested file via docker cp. Defaults to the
+	// ones we always snapshot — state.db + config.yaml — when the
+	// caller left Files empty.
+	if len(files) == 0 {
+		files = []string{"state.db", "config.yaml"}
+	}
+	s.writeState(State{State: "restoring", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "copying snapshot files"})
+	for _, f := range files {
+		src := filepath.Join(hostSnapDir, f)
+		if _, err := os.Stat(src); err != nil {
+			// Optional files (e.g. config.yaml when the operator
+			// runs with defaults and no YAML on disk) just get
+			// skipped — not a rollback failure.
+			slog.Info("rollback: source missing, skipping", "file", f, "err", err)
+			continue
+		}
+		dst := "/app/data/" + f
+		cpArgs := []string{"cp", src, mainServiceName + ":" + dst}
+		if err := s.runner(ctx, cpArgs...); err != nil {
+			// File-swap failure is serious. Try to bring the
+			// service back anyway so the operator isn't stranded.
+			slog.Error("rollback docker cp failed", "file", f, "err", err)
+			s.writeState(State{State: "failed", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "docker cp " + f + " failed: " + err.Error()})
+			_ = s.runner(ctx, s.composeArgs("up", "-d", mainServiceName)...)
+			return
+		}
+	}
+
+	// 3. Start the main service again. --force-recreate so the new
+	// process certainly sees the swapped files (same semantics as the
+	// restart flow).
+	s.writeState(State{State: "restarting", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "starting main service on restored state"})
+	upArgs := s.composeArgs("up", "-d", "--force-recreate", mainServiceName)
+	if err := s.runner(ctx, upArgs...); err != nil {
+		s.writeState(State{State: "failed", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "compose up -d failed: " + err.Error()})
+		return
+	}
+	s.writeState(State{State: "done", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "rollback complete"})
 }
 
 func (s *server) writeState(st State) {

--- a/go/cmd/ftw-updater/main_test.go
+++ b/go/cmd/ftw-updater/main_test.go
@@ -158,6 +158,96 @@ func TestHandleUpdate_UpFailure(t *testing.T) {
 	}
 }
 
+// Rollback flow: stop → docker cp per file → up. Issue #152.
+func TestHandleUpdate_RollbackRestoresFiles(t *testing.T) {
+	s, runner := newTestServer(t)
+
+	// Create a fake snapshot on disk at the sidecar's expected host
+	// path: <compose_dir>/data/snapshots/<id>/. The sidecar derives
+	// this from FTW_UPDATER_COMPOSE (s.composeFile in tests).
+	composeDir := filepath.Dir(s.composeFile)
+	snapID := "2026-04-20T10-00-00Z_0.30.0_to_0.31.0"
+	snapDir := filepath.Join(composeDir, "data", "snapshots", snapID)
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"state.db", "config.yaml"} {
+		if err := os.WriteFile(filepath.Join(snapDir, f), []byte("fake"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	body := `{"action":"rollback","snapshot":"` + snapID + `","files":["state.db","config.yaml"]}`
+	req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.handleUpdate(rr, req)
+	if rr.Code != 202 {
+		t.Fatalf("rollback 202 expected, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	st := waitForState(t, s, "done")
+	if st.Action != "rollback" || st.Snapshot != snapID {
+		t.Errorf("state should track rollback + snapshot id: %+v", st)
+	}
+
+	calls := runner.snapshot()
+	// Expected sequence: compose stop → cp state.db → cp config.yaml → compose up.
+	if len(calls) != 4 {
+		t.Fatalf("want 4 docker calls, got %d: %v", len(calls), calls)
+	}
+	if !strings.Contains(strings.Join(calls[0], " "), "stop") {
+		t.Errorf("first call must be compose stop: %v", calls[0])
+	}
+	for i, f := range []string{"state.db", "config.yaml"} {
+		joined := strings.Join(calls[i+1], " ")
+		if !strings.HasPrefix(joined, "cp ") || !strings.Contains(joined, f) {
+			t.Errorf("call %d should be docker cp for %s: %v", i+1, f, calls[i+1])
+		}
+		if !strings.Contains(joined, snapID) {
+			t.Errorf("call %d should reference snapshot id %s: %v", i+1, snapID, calls[i+1])
+		}
+	}
+	up := strings.Join(calls[3], " ")
+	if !strings.Contains(up, "up -d") || !strings.Contains(up, "--force-recreate") {
+		t.Errorf("final call must be compose up -d --force-recreate: %v", calls[3])
+	}
+}
+
+// Rollback with a missing snapshot dir fails at stat, never stops the
+// main service. Safer than optimistically stopping then discovering no
+// files to restore.
+func TestHandleUpdate_RollbackMissingSnapshot(t *testing.T) {
+	s, runner := newTestServer(t)
+	body := `{"action":"rollback","snapshot":"nope","files":["state.db"]}`
+	req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.handleUpdate(rr, req)
+	if rr.Code != 202 {
+		t.Fatalf("handler should 202 and fail async, got %d", rr.Code)
+	}
+	st := waitForState(t, s, "failed")
+	if !strings.Contains(st.Message, "snapshot not readable") {
+		t.Errorf("failure should mention missing snapshot: %+v", st)
+	}
+	if len(runner.snapshot()) != 0 {
+		t.Errorf("no docker calls should fire when snapshot is missing, got: %v", runner.snapshot())
+	}
+}
+
+// Rollback with dangerous snapshot ids is rejected at the handler level,
+// before any goroutine is spawned.
+func TestHandleUpdate_RollbackRejectsTraversal(t *testing.T) {
+	s, _ := newTestServer(t)
+	for _, evil := range []string{"", "..", "../foo", "a/b"} {
+		body := `{"action":"rollback","snapshot":"` + evil + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		s.handleUpdate(rr, req)
+		if rr.Code != 400 {
+			t.Errorf("snapshot %q: want 400, got %d", evil, rr.Code)
+		}
+	}
+}
+
 func TestHandleUpdate_RejectsBadAction(t *testing.T) {
 	s, _ := newTestServer(t)
 	req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(`{"action":"rm -rf"}`))

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -184,6 +184,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/version/update/status", s.handleVersionUpdateStatus)
 	s.handle("GET  /api/version/snapshots", s.handleVersionSnapshots)
 	s.handle("DELETE /api/version/snapshots/{id}", s.handleVersionSnapshotDelete)
+	s.handle("POST /api/version/rollback", s.handleVersionRollback)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.

--- a/go/internal/api/api_selfupdate.go
+++ b/go/internal/api/api_selfupdate.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+	"path/filepath"
+	"strings"
 )
 
 // handleVersionCheck returns the cached self-update state. ?force=1 bypasses
@@ -131,6 +133,100 @@ func (s *Server) handleVersionUpdate(w http.ResponseWriter, r *http.Request) {
 		resp["snapshot_skipped"] = true
 	}
 	writeJSON(w, 202, resp)
+}
+
+// handleVersionRollback restores a specific snapshot over the main
+// container's data volume ("soft" rollback — state.db + config.yaml only,
+// image unchanged). Before triggering the sidecar we capture a
+// *pre-rollback* safety snapshot so the operator can roll forward again
+// if the restored state misbehaves. That extra snapshot is tagged as
+// action="pre-rollback" so the UI can distinguish it from the routine
+// pre-update set.
+//
+// Request body: {"snapshot_id": "<id>"}. The id must match a directory
+// inside SnapshotDir; the validation rules mirror handleVersionSnapshotDelete.
+//
+// Scope of this endpoint (#152):
+//   - Soft rollback only. Image version stays on the currently-running
+//     tag. If the snapshot predates a state-schema change, a forward
+//     rollback to the same version (or an explicit image pin) is needed
+//     — tracked as a follow-up in #140 Phase 3.
+//   - Pre-rollback safety snapshot is always created; no opt-out (unlike
+//     the routine #149 opt-out). If disk is tight, delete older
+//     snapshots via DELETE /api/version/snapshots/{id} first.
+func (s *Server) handleVersionRollback(w http.ResponseWriter, r *http.Request) {
+	if s.deps.SelfUpdate == nil {
+		writeJSON(w, 503, map[string]string{"error": "self-update disabled"})
+		return
+	}
+	if s.deps.SnapshotDir == "" {
+		writeJSON(w, 503, map[string]string{"error": "snapshots disabled (no SnapshotDir)"})
+		return
+	}
+	var body struct {
+		SnapshotID string `json:"snapshot_id"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	if body.SnapshotID == "" {
+		writeJSON(w, 400, map[string]string{"error": "snapshot_id required"})
+		return
+	}
+	// Same id-shape validation as DELETE — cheap defence in depth.
+	if containsTraversal(body.SnapshotID) {
+		writeJSON(w, 400, map[string]string{"error": "invalid snapshot id"})
+		return
+	}
+	// Validate the snapshot exists and looks plausible (has meta.json +
+	// at least one file we can restore).
+	snapDir := filepath.Join(s.deps.SnapshotDir, body.SnapshotID)
+	meta, err := readSnapshotMeta(snapDir)
+	if err != nil {
+		writeJSON(w, 404, map[string]string{"error": "snapshot not found or unreadable: " + err.Error()})
+		return
+	}
+	if len(meta.Files) == 0 {
+		writeJSON(w, 400, map[string]string{"error": "snapshot has no files recorded; cannot restore safely"})
+		return
+	}
+
+	// Safety-net snapshot before we swap files. If the rolled-back
+	// state turns out to be wrong, this is the forward-rollback point.
+	info := s.deps.SelfUpdate.Info()
+	safetyID := ""
+	if safety, serr := s.createPreUpdateSnapshot("pre-rollback", info.Current, body.SnapshotID); serr != nil {
+		writeJSON(w, 500, map[string]string{
+			"error": "failed to capture pre-rollback safety snapshot: " + serr.Error(),
+			"hint":  "Rollback aborted. Check SnapshotDir free space and retry, or delete stale snapshots first.",
+		})
+		return
+	} else {
+		safetyID = safety.ID
+	}
+
+	if err := s.deps.SelfUpdate.TriggerRollback(r.Context(), body.SnapshotID, meta.Files); err != nil {
+		writeJSON(w, 502, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 202, map[string]any{
+		"status":             "started",
+		"action":             "rollback",
+		"snapshot":           body.SnapshotID,
+		"files":              meta.Files,
+		"safety_snapshot_id": safetyID,
+	})
+}
+
+// containsTraversal rejects ids that could escape SnapshotDir.
+// Extracted so the rollback + delete handlers share the exact same
+// rule — diverging them silently would open a path-traversal CVE.
+func containsTraversal(id string) bool {
+	if strings.ContainsAny(id, "/\\") {
+		return true
+	}
+	return id == "." || id == ".."
 }
 
 // handleVersionRestart signals the sidecar to pull + force-recreate the

--- a/go/internal/api/api_selfupdate_test.go
+++ b/go/internal/api/api_selfupdate_test.go
@@ -409,6 +409,86 @@ func TestVersionSnapshots_ListsNewestFirst(t *testing.T) {
 	}
 }
 
+// Rollback creates a pre-rollback safety snapshot, then asks the sidecar
+// to restore (#152). The sidecar is absent in this test, so Trigger
+// fails with 502 — but the safety snapshot must land first, proving
+// the "we always capture current state before touching it" promise.
+func TestVersionRollback_CreatesSafetySnapshotBeforeTrigger(t *testing.T) {
+	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
+	dir := t.TempDir()
+	st, _ := state.Open(filepath.Join(dir, "state.db"))
+	t.Cleanup(func() { st.Close() })
+	snapDir := filepath.Join(dir, "snapshots")
+	srv := New(&Deps{SelfUpdate: c, State: st, SnapshotDir: snapDir})
+
+	// Seed one snapshot so the rollback target exists.
+	seed, err := srv.createPreUpdateSnapshot("update", "v1.3.0", "v1.4.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := strings.NewReader(`{"snapshot_id":"` + seed.ID + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/version/rollback", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	// Sidecar trigger fails → 502. The safety snapshot should have
+	// been captured before the trigger attempt regardless.
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("want 502 from missing sidecar, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	entries, _ := os.ReadDir(snapDir)
+	// Seed + safety = 2 entries (retention is 5, way under).
+	if len(entries) < 2 {
+		t.Fatalf("want ≥ 2 snapshots on disk (seed + safety), got %d", len(entries))
+	}
+	// At least one snapshot must be tagged "pre-rollback" in meta.
+	foundSafety := false
+	for _, e := range entries {
+		meta, err := readSnapshotMeta(filepath.Join(snapDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if meta.Action == "pre-rollback" {
+			foundSafety = true
+			break
+		}
+	}
+	if !foundSafety {
+		t.Error("expected a snapshot with meta.action = pre-rollback after rollback request")
+	}
+}
+
+// Bad snapshot id → handler refuses without creating any files.
+func TestVersionRollback_ValidatesSnapshotID(t *testing.T) {
+	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
+	dir := t.TempDir()
+	st, _ := state.Open(filepath.Join(dir, "state.db"))
+	t.Cleanup(func() { st.Close() })
+	srv := New(&Deps{SelfUpdate: c, State: st, SnapshotDir: filepath.Join(dir, "snapshots")})
+
+	cases := []struct {
+		body string
+		want int
+		desc string
+	}{
+		{`{}`, 400, "missing snapshot_id"},
+		{`{"snapshot_id":""}`, 400, "empty snapshot_id"},
+		{`{"snapshot_id":".."}`, 400, "traversal"},
+		{`{"snapshot_id":"nope"}`, 404, "nonexistent id"},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest(http.MethodPost, "/api/version/rollback", strings.NewReader(c.body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		if rr.Code != c.want {
+			t.Errorf("%s: got %d, want %d (body=%s)", c.desc, rr.Code, c.want, rr.Body.String())
+		}
+	}
+}
+
 func TestVersionUpdateStatus_Idle(t *testing.T) {
 	c := newCheckerAgainst(t, "v1.5.0", "v1.4.0")
 	srv := New(&Deps{SelfUpdate: c})

--- a/go/internal/api/snapshots.go
+++ b/go/internal/api/snapshots.go
@@ -242,7 +242,7 @@ func (s *Server) handleVersionSnapshotDelete(w http.ResponseWriter, r *http.Requ
 	// Defense in depth: reject anything that isn't a simple directory
 	// name. No slashes, no "..". A well-formed snapshot id is produced
 	// by snapshotID() with only [A-Za-z0-9._-] characters.
-	if strings.ContainsAny(id, "/\\") || id == "." || id == ".." {
+	if containsTraversal(id) {
 		writeJSON(w, 400, map[string]string{"error": "invalid snapshot id"})
 		return
 	}

--- a/go/internal/selfupdate/selfupdate.go
+++ b/go/internal/selfupdate/selfupdate.go
@@ -325,6 +325,34 @@ func (c *Checker) Trigger(ctx context.Context, action, target string) error {
 		return fmt.Errorf("selfupdate: invalid action %q", action)
 	}
 	body, _ := json.Marshal(map[string]string{"action": action, "target": target})
+	return c.postSidecar(ctx, body)
+}
+
+// TriggerRollback asks the sidecar to restore a snapshot over the main
+// service's data volume (soft rollback: state.db + config.yaml only;
+// image stays). The main container will be stopped, the files copied
+// in via `docker cp`, and the service brought back up. Observe
+// progress via Status() — new states are "restoring" and "restarting".
+// Issue #152.
+func (c *Checker) TriggerRollback(ctx context.Context, snapshotID string, files []string) error {
+	if c.cfg.SocketPath == "" {
+		return errors.New("selfupdate: sidecar socket not configured")
+	}
+	if snapshotID == "" {
+		return errors.New("selfupdate: rollback requires snapshot id")
+	}
+	body, _ := json.Marshal(map[string]any{
+		"action":   "rollback",
+		"snapshot": snapshotID,
+		"files":    files,
+	})
+	return c.postSidecar(ctx, body)
+}
+
+// postSidecar wraps the Unix-socket POST to the sidecar's /update
+// endpoint. Shared by Trigger and TriggerRollback so the HTTP client
+// config (socket dialer + timeout) only lives in one place.
+func (c *Checker) postSidecar(ctx context.Context, body []byte) error {
 	cli := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -81,6 +81,32 @@
         });
     }
 
+    // _beginRollback kicks off a rollback-to-snapshot. Reuses the same
+    // "updating" modal skin as _beginUpdate — the sidecar emits state
+    // transitions (restoring → restarting → done) that feed straight
+    // into the existing _tickStatus → _render path. See #152.
+    _beginRollback(snapshotID) {
+      this._phase = "updating";
+      this._updateStartedAt = Date.now();
+      this._updateOriginalVersion = this._info ? this._info.current : null;
+      this._sidecarState = { state: "starting", action: "rollback", snapshot: snapshotID };
+      this._render();
+
+      this._postJSON("/api/version/rollback", { snapshot_id: snapshotID })
+        .then((resp) => {
+          if (!resp.ok) {
+            this._sidecarState = { state: "failed", action: "rollback", message: (resp.body && resp.body.error) || "failed to start" };
+            this._render();
+            return;
+          }
+          this._startStatusPolling();
+        })
+        .catch((e) => {
+          this._sidecarState = { state: "failed", action: "rollback", message: String(e) };
+          this._render();
+        });
+    }
+
     // Permanently shut the element down: stop polling, clear shadow DOM, hide
     // from layout, and fire an event so the #version bridge can drop its
     // cursor/pointer affordance. Called when the backend returns 503, which
@@ -345,14 +371,23 @@
       const range = (s.from_version || "?") + " → " + (s.to_version || "?");
       const sizeMB = s.size_bytes ? (s.size_bytes / (1024 * 1024)).toFixed(1) + " MB" : "?";
       const deleting = this._deletingSnapshot === s.id;
+      // Rollback target for a *pre-rollback* safety snapshot takes the
+      // operator forward again — the 'from' version is what was running
+      // when we captured it. For a routine pre-update snapshot the 'from'
+      // version is what was running before that update — rolling back to
+      // it reverts that update. Either way the operation is the same:
+      // restore the files from this snapshot.
       const deleteBtn = deleting
         ? `<span class="dim">deleting…</span>`
         : `<button class="btn btn-ghost btn-small" data-action="delete-snapshot" data-id="${escapeHTML(s.id)}" title="Delete this backup">Delete</button>`;
+      const rollbackBtn = deleting
+        ? ""
+        : `<button class="btn btn-small" data-action="rollback-snapshot" data-id="${escapeHTML(s.id)}" data-from="${escapeHTML(s.from_version || "")}" title="Restore this backup (service will restart)">Roll back</button>`;
       return `<tr>
                 <td class="nowrap">${escapeHTML(when)}</td>
                 <td class="mono">${escapeHTML(range)}</td>
                 <td class="nowrap">${escapeHTML(sizeMB)}</td>
-                <td>${deleteBtn}</td>
+                <td class="snapshot-actions">${rollbackBtn}${deleteBtn}</td>
               </tr>`;
     }
 
@@ -379,11 +414,18 @@
            <button class="btn btn-ghost" data-action="close">Dismiss</button>`
         : `<span class="dim">Don't close this tab.</span>`;
 
+      let title;
+      switch (action) {
+        case "restart":  title = "Restarting service"; break;
+        case "rollback": title = "Rolling back"; break;
+        default:         title = "Updating service";
+      }
+
       return `
         <div class="backdrop"></div>
         <div class="modal" role="dialog" aria-modal="true" aria-live="polite">
           <header>
-            <h3>${action === "restart" ? "Restarting service" : "Updating service"}</h3>
+            <h3>${title}</h3>
           </header>
           <div class="body center">
             ${spinner}
@@ -432,6 +474,24 @@
               if (id && window.confirm(`Delete snapshot ${id}? This can't be undone.`)) {
                 this._deleteSnapshot(id);
                 this._render(); // reflect the "deleting…" state immediately
+              }
+              break;
+            }
+            case "rollback-snapshot": {
+              const id = e.currentTarget.dataset.id;
+              const from = e.currentTarget.dataset.from || "that point";
+              // Sharper warning for rollback — it stops the service,
+              // swaps live state, and restarts. Much more visible
+              // consequence than a Delete.
+              const msg =
+                `Roll back to ${id}?\n\n` +
+                `This will stop the service, restore state.db + config.yaml ` +
+                `from the snapshot (state as of "${from}"), and restart. ` +
+                `Any data written since the snapshot will be lost.\n\n` +
+                `A pre-rollback backup of the current state is saved ` +
+                `automatically so you can roll forward again.`;
+              if (id && window.confirm(msg)) {
+                this._beginRollback(id);
               }
               break;
             }
@@ -642,6 +702,12 @@
         }
         .snapshots-table .nowrap { white-space: nowrap; }
         .snapshots-table .mono { font-family: ui-monospace, monospace; }
+        .snapshot-actions {
+          display: flex;
+          gap: 0.3rem;
+          justify-content: flex-end;
+          flex-wrap: wrap;
+        }
         .btn-small {
           padding: 0.2rem 0.55rem;
           font-size: 0.75rem;
@@ -699,10 +765,17 @@
   function actionLabel(state, action) {
     switch (state) {
       case "pulling":    return "Pulling new image";
-      case "restarting": return action === "restart" ? "Restarting service" : "Applying update";
+      case "restoring":  return "Restoring snapshot";
+      case "restarting":
+        if (action === "restart")  return "Restarting service";
+        if (action === "rollback") return "Restarting on restored state";
+        return "Applying update";
       case "done":       return "Reloading";
       case "failed":     return "Failed";
-      default:           return action === "restart" ? "Restarting" : "Starting update";
+      default:
+        if (action === "restart")  return "Restarting";
+        if (action === "rollback") return "Starting rollback";
+        return "Starting update";
     }
   }
 


### PR DESCRIPTION
Second half of Erik @xorath's ask — one-click rollback from the UI. Builds on #151 (list + delete). Phase 2 of #140.

## Summary

- New *Roll back* button on each snapshot row. Warning dialog explains the consequence, then POSTs \`/api/version/rollback {snapshot_id}\`.
- Handler: validates the snapshot + its meta, captures a pre-rollback safety snapshot (so operator can roll forward if the restore is worse), calls \`TriggerRollback\` on the sidecar.
- Sidecar: accepts \`action: "rollback"\` on the existing /update endpoint, stops main, \`docker cp\`s snapshot files into the container's bind mount, starts main again with --force-recreate.
- UI reuses the existing "updating" overlay skin — new states \`restoring\` / \`restarting\` labelled specifically for the rollback action.

## Scope: soft rollback only

Image version stays on the currently running tag. Forward-compat generally holds (SQLite is tolerant of added columns). Hard rollback (image-tag swap + state restore) is tracked as #140 Phase 3.

## Safety invariants

- Pre-rollback safety snapshot is always captured — no opt-out. Gives the operator a path *forward* again if the restored state turns out to be worse.
- If \`docker cp\` fails mid-flow, the sidecar still runs \`compose up -d\` in a \`defer\`-ish path so the service never stays down.
- Traversal guard on snapshot id uses the same helper as the delete handler — can't silently drift apart.

## Why docker cp

The sidecar's project mount is read-only by design (\`${PWD}:${PWD}:ro\`). \`docker cp\` goes through the Docker daemon, which writes to the main container's bind-mounted data dir directly. **No compose change required for existing deploys.**

## Test plan

- [x] Main API tests — safety snapshot before trigger, validation errors.
- [x] Sidecar tests — stop/cp/up ordering, missing snapshot, traversal rejection.
- [x] \`make test\` + \`make e2e\` green.
- [ ] Smoke on Pi after the image rolls: open modal → Backup snapshots → Roll back → confirm → watch status banner → verify it lands on the restored state (SoC, config changes you made since).

## Follow-ups

- #140 Phase 3: hard rollback (image-tag swap).
- #140 Phase 4: post-rollback health check banner — detect if the restored version is worse and offer a one-click forward-rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)