### PR TITLE
fix(ferroamp): read per-phase grid current from iext not il

### DIFF
--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -164,7 +164,12 @@ function driver_poll()
         local pext     = extract_val(ehub_data, "pext")     -- per-phase grid power (W)
         local gridfreq = extract_val(ehub_data, "gridfreq") -- grid frequency (Hz)
         local ul       = extract_val(ehub_data, "ul")       -- per-phase voltage (V)
-        local il       = extract_val(ehub_data, "il")       -- per-phase current (A)
+        -- iext = per-phase GRID current at the service-entrance CTs, the
+        -- same source pext is derived from. NOT il (which is inverter AC
+        -- current and misses any load not routed through the Ferroamp
+        -- inverter, e.g. an EV charger on a separate breaker — that mix
+        -- made the fuse bars under-read by the EV share of total import).
+        local iext     = extract_val(ehub_data, "iext")     -- per-phase grid current (A)
         -- 3-phase energy totals in mJ
         local wextconsq3p = extract_val(ehub_data, "wextconsq3p") -- total import mJ
         local wextprodq3p = extract_val(ehub_data, "wextprodq3p") -- total export mJ
@@ -187,10 +192,12 @@ function driver_poll()
         meter.l2_v = phase_val(ul, "L2")
         meter.l3_v = phase_val(ul, "L3")
 
-        -- Per-phase current
-        meter.l1_a = phase_val(il, "L1")
-        meter.l2_a = phase_val(il, "L2")
-        meter.l3_a = phase_val(il, "L3")
+        -- Per-phase grid current (from service-entrance CTs, consistent
+        -- with pext above — previously read il by mistake, which is
+        -- inverter AC current).
+        meter.l1_a = phase_val(iext, "L1")
+        meter.l2_a = phase_val(iext, "L2")
+        meter.l3_a = phase_val(iext, "L3")
 
         -- Energy counters (mJ → Wh)
         if wextconsq3p then

--- a/go/cmd/sim-ferroamp/main.go
+++ b/go/cmd/sim-ferroamp/main.go
@@ -188,7 +188,17 @@ func publishEhub(server *mqttserver.Server, s ferroamp.Snapshot) {
 			"L2": fmt.Sprintf("%.1f", 230.0),
 			"L3": fmt.Sprintf("%.1f", 230.0),
 		},
-		// Per-phase current (derived: W/V)
+		// Per-phase grid current at the service-entrance CTs (the
+		// quantity pext measures). In the live protocol iext is what
+		// the driver reads for fuse bars + fuse_over_limit detection
+		// (#160); il is inverter AC current and is not what we need
+		// here. Populate both at W/V so the sim stays valid for any
+		// downstream that still peeks at il.
+		"iext": map[string]string{
+			"L1": fmt.Sprintf("%.2f", s.GridW/3/230.0),
+			"L2": fmt.Sprintf("%.2f", s.GridW/3/230.0),
+			"L3": fmt.Sprintf("%.2f", s.GridW/3/230.0),
+		},
 		"il": map[string]string{
 			"L1": fmt.Sprintf("%.2f", s.GridW/3/230.0),
 			"L2": fmt.Sprintf("%.2f", s.GridW/3/230.0),


### PR DESCRIPTION
Closes #160.

## Summary

- \`drivers/ferroamp.lua\` now reads \`iext\` (service-entrance CT current) for \`meter.l1_a\` / \`l2_a\` / \`l3_a\` instead of \`il\` (inverter AC current).
- Power (\`w\`) keeps reading \`pext\`; that was already correct. After the fix \`sum(l*_a) × V ≈ w\` for any load mix.
- \`go/cmd/sim-ferroamp\` emits both \`iext\` and \`il\` so the e2e harness stays valid for any downstream still peeking at \`il\`.

## Why

On a live Ferroamp install with CTs at the service entrance and an 11 kW EV charger on a separate breaker, the dashboard showed \`grid_w = 11 kW\` but fuse bars summed to \`≈ 874 W\` — a ~12× under-read. \`il\` only sees what flows through the Ferroamp inverter; the EV charger is invisible to it but visible to \`pext\` / \`iext\`. Same bug fed into the \`fuse_over_limit\` notification rule added in #159, so that would also miss EV-driven overloads.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [x] \`make e2e\` — full stack passes in 25 s (sim-ferroamp now emits both fields)
- [ ] Live validation on the reporting site: verify \`sum(l*_a) × 230 ≈ grid_w\` during a known EV-charging event

🤖 Generated with [Claude Code](https://claude.com/claude-code)