### PR TITLE
feat(control): BatteryCoversEV override — let battery discharge into the EV

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -155,6 +155,9 @@ func main() {
 			ctrl.SetGridTarget(f)
 		}
 	}
+	if v, ok := st.LoadConfig("battery_covers_ev"); ok {
+		ctrl.BatteryCoversEV = v == "true"
+	}
 
 	// ---- Driver capacities (site, for control + fuse guard) ----
 	// Loadpoint drivers are filtered out — their battery_capacity_wh
@@ -853,6 +856,14 @@ func main() {
 				defer ctrlMu.Unlock()
 				if active { ctrl.EVChargingW = w } else { ctrl.EVChargingW = 0 }
 				return nil
+			},
+			SetBatteryCoversEV: func(enabled bool) error {
+				ctrlMu.Lock()
+				ctrl.BatteryCoversEV = enabled
+				ctrlMu.Unlock()
+				val := "false"
+				if enabled { val = "true" }
+				return st.SaveConfig("battery_covers_ev", val)
 			},
 		}
 		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), cb)

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -152,6 +152,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/target", s.handleSetTarget)
 	s.handle("POST /api/peak_limit", s.handleSetPeakLimit)
 	s.handle("POST /api/ev_charging", s.handleSetEVCharging)
+	s.handle("POST /api/battery_covers_ev", s.handleSetBatteryCoversEV)
 	s.handle("GET  /api/drivers", s.handleDrivers)
 	s.handle("GET  /api/drivers/catalog", s.handleDriversCatalog)
 	s.handle("POST /api/drivers/{name}/restart", s.handleDriverRestart)
@@ -494,6 +495,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"grid_target_w":    ctrl.GridTargetW,
 		"peak_limit_w":     ctrl.PeakLimitW,
 		"ev_charging_w":    ctrl.EVChargingW,
+		"battery_covers_ev": ctrl.BatteryCoversEV,
 		// True when an EV charger password is persisted in state.db. The
 		// Settings UI uses this to show a "credentials saved" badge so the
 		// operator can tell apart "never entered" from "saved but masked".
@@ -718,6 +720,33 @@ func (s *Server) handleSetEVCharging(w http.ResponseWriter, r *http.Request) {
 	}
 	s.deps.CtrlMu.Unlock()
 	writeJSON(w, 200, map[string]any{"status": "ok", "ev_charging_w": req.PowerW})
+}
+
+// ---- /api/battery_covers_ev ----
+//
+// When enabled, dispatch skips its usual subtraction of EVChargingW from
+// the meter reading so batteries discharge into the EV. Default off
+// preserves the traditional "battery never feeds the car" behaviour.
+// See control.State.BatteryCoversEV for the full rationale.
+func (s *Server) handleSetBatteryCoversEV(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	s.deps.CtrlMu.Lock()
+	s.deps.Ctrl.BatteryCoversEV = req.Enabled
+	s.deps.CtrlMu.Unlock()
+	if s.deps.State != nil {
+		val := "false"
+		if req.Enabled {
+			val = "true"
+		}
+		_ = s.deps.State.SaveConfig("battery_covers_ev", val)
+	}
+	writeJSON(w, 200, map[string]any{"status": "ok", "battery_covers_ev": req.Enabled})
 }
 
 // ---- /api/drivers ----

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -484,6 +484,55 @@ func TestEVChargingSignalOverriddenByDerEVReading(t *testing.T) {
 	}
 }
 
+// TestBatteryCoversEV_OffExcludesEVFromGrid mirrors the existing
+// exclusion behaviour. Grid meter reads +3000 W, 2500 W is EV, so
+// the effective grid the controller sees should be 500 W — well
+// within the dead-band — and the battery should not try to cover
+// the whole 3000 W. Regression guard that the new flag's default
+// preserves current behaviour.
+func TestBatteryCoversEV_OffExcludesEVFromGrid(t *testing.T) {
+	store := seedStore(3000, []struct{ name string; currentW, soc float64 }{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.EVChargingW = 2500
+	st.BatteryCoversEV = false // explicit — this is the default
+	st.SlewRateW = 100000
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) > 0 && math.Abs(targets[0].TargetW) > 2000 {
+		t.Errorf("with flag off, battery must not try to cover 2500W EV draw; got target=%f", targets[0].TargetW)
+	}
+}
+
+// TestBatteryCoversEV_OnIncludesEVInGrid covers the opt-in scenario:
+// high grid prices now, cheap solar later → operator flips the
+// override and the battery discharges to cover full grid load
+// including EV. The dispatch should produce a target that actively
+// pulls the battery into discharge territory for the full 3000 W
+// import, not just the 500 W house portion.
+func TestBatteryCoversEV_OnIncludesEVInGrid(t *testing.T) {
+	store := seedStore(3000, []struct{ name string; currentW, soc float64 }{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.EVChargingW = 2500
+	st.BatteryCoversEV = true // opt in — battery covers everything
+	st.SlewRateW = 100000
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) == 0 {
+		t.Fatal("expected a dispatch target when grid is 3 kW over target, got none")
+	}
+	// With flag on, the full 3000 W import should drive battery toward
+	// discharge (negative target in site convention). Require at least
+	// half of the raw import as discharge command — conservative on the
+	// PI gain but clearly separates "covers EV too" from "house only".
+	if targets[0].TargetW > -1500 {
+		t.Errorf("with flag on, battery must drive toward discharge for full import; got target=%f (want <= -1500)", targets[0].TargetW)
+	}
+}
+
 func TestEVChargingManualPreservedWhenNoDriver(t *testing.T) {
 	// No DerEV reading. The manual slider value (1500W) must survive —
 	// we don't want an offline / stale driver to silently zero it out.

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -126,6 +126,16 @@ type State struct {
 	PeakLimitW float64
 	// EV charging signal — batteries won't try to cover this much of import
 	EVChargingW float64
+	// BatteryCoversEV overrides the default EV-exclusion behaviour. When
+	// false (default), EVChargingW is subtracted from the meter reading
+	// before the PI runs so batteries don't shuffle energy through the
+	// inverter to feed the EV on a normal day. When true, the subtraction
+	// is skipped and the battery is free to discharge into the EV up to
+	// its own SoC / power / fuse clamps — useful in price-arbitrage
+	// situations where the operator wants to drain the battery now and
+	// refill it later from cheap solar. Persisted in state.db via
+	// "battery_covers_ev"; toggled from HA and POST /api/battery_covers_ev.
+	BatteryCoversEV bool
 
 	// PI controller (outer, site-level)
 	PI *PIController
@@ -397,10 +407,22 @@ func ComputeDispatch(
 	if evSum > 0 {
 		state.EVChargingW = evSum
 	}
-	// EV signal: subtract EV load from grid so batteries don't try to cover it.
-	// EV is always a positive import at the meter; subtracting it makes the
-	// "effective grid" the controller works on the house-side portion only.
-	gridW := rawGridW - state.EVChargingW
+	// EV signal: subtract EV load from grid so batteries don't try to cover
+	// it. EV is always a positive import at the meter; subtracting it makes
+	// the "effective grid" the controller works on the house-side portion
+	// only — a sensible default that avoids shuffling energy through the
+	// inverter twice on a normal day.
+	//
+	// BatteryCoversEV (default false) flips this: the operator opts in to
+	// have the battery discharge into the EV. Useful when grid prices are
+	// high right now but expected to drop later (e.g. solar coming up), so
+	// it's cheaper to drain the battery now and refill it off-peak. All
+	// clamps (SoC, per-driver MaxDischargeW, fuse guard) still apply —
+	// exceeding battery capacity just means the residual comes from grid.
+	gridW := rawGridW
+	if !state.BatteryCoversEV {
+		gridW -= state.EVChargingW
+	}
 
 	// ---- planner_self idle-gate override (#153) ----
 	// The DP's decision to idle this slot assumed a forecasted surplus.

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -26,10 +26,11 @@ import (
 // CommandCallbacks is how the bridge hands received commands back to the
 // control loop. Caller provides these at construction time.
 type CommandCallbacks struct {
-	SetMode       func(string) error
-	SetGridTarget func(float64) error
-	SetPeakLimit  func(float64) error
-	SetEVCharging func(float64, bool) error
+	SetMode             func(string) error
+	SetGridTarget       func(float64) error
+	SetPeakLimit        func(float64) error
+	SetEVCharging       func(float64, bool) error
+	SetBatteryCoversEV  func(bool) error
 }
 
 // Bridge is an instance of the HA MQTT bridge.
@@ -216,6 +217,24 @@ func (b *Bridge) publishDiscovery() {
 	data, _ = json.Marshal(targetMsg)
 	b.publish(fmt.Sprintf("%s/number/%s/grid_target/config", b.discoPrefix, b.deviceID), data, true)
 
+	// ---- Battery-covers-EV as HA switch ----
+	// Operator-facing override: when ON, the control loop lets the battery
+	// discharge into the EV (price-arbitrage scenarios). Default OFF.
+	bceMsg := map[string]any{
+		"name":          "Battery Covers EV",
+		"unique_id":     b.deviceID + "_battery_covers_ev_cmd",
+		"state_topic":   b.stateTopic("battery_covers_ev"),
+		"command_topic": b.cmdTopic("battery_covers_ev"),
+		"payload_on":    "ON",
+		"payload_off":   "OFF",
+		"state_on":      "ON",
+		"state_off":     "OFF",
+		"icon":          "mdi:car-battery",
+		"device":        dev,
+	}
+	data, _ = json.Marshal(bceMsg)
+	b.publish(fmt.Sprintf("%s/switch/%s/battery_covers_ev/config", b.discoPrefix, b.deviceID), data, true)
+
 	// ---- Per-driver sensors ----
 	for _, name := range b.driverNames {
 		for _, s := range []struct{ id, label, unit, class string }{
@@ -275,6 +294,12 @@ func (b *Bridge) subscribeCommands() {
 			_ = b.cb.SetEVCharging(f, f > 0)
 		}
 	})
+	b.client.Subscribe(b.cmdTopic("battery_covers_ev"), 0, func(_ paho.Client, m paho.Message) {
+		on := string(m.Payload()) == "ON"
+		if b.cb.SetBatteryCoversEV != nil {
+			_ = b.cb.SetBatteryCoversEV(on)
+		}
+	})
 }
 
 // ---- State publish loop ----
@@ -306,6 +331,7 @@ func (b *Bridge) publishState() {
 	siteMeter := b.ctrl.SiteMeterDriver
 	mode := string(b.ctrl.Mode)
 	gridTarget := b.ctrl.GridTargetW
+	batteryCoversEV := b.ctrl.BatteryCoversEV
 	b.ctrlMu.Unlock()
 
 	gridW := 0.0
@@ -334,6 +360,11 @@ func (b *Bridge) publishState() {
 	b.publishValue("bat_soc_pct", avgSoC*100)
 	b.publishValue("grid_target_w", gridTarget)
 	b.publishString("mode", mode)
+	bceState := "OFF"
+	if batteryCoversEV {
+		bceState = "ON"
+	}
+	b.publishString("battery_covers_ev", bceState)
 
 	// Per-driver
 	for _, name := range b.driverNames {

--- a/web/index.html
+++ b/web/index.html
@@ -233,6 +233,20 @@
       <!-- EV charging slider removed — ev_charging_w is now set
            automatically by the Easee Cloud driver (or any DerEV driver).
            The manual /api/ev_charging endpoint stays as a debug override. -->
+
+      <!-- Battery-covers-EV toggle. When ON, self-consumption lets the
+           home battery discharge into the EV — useful when grid prices
+           are high now and cheap PV/off-peak is expected later. OFF
+           (default) keeps the battery from draining to feed the car. -->
+      <div class="card control-card">
+        <div class="card-label">Let battery cover EV</div>
+        <label class="ftw-toggle">
+          <input type="checkbox" id="battery-covers-ev-toggle">
+          <span class="ftw-toggle-slider"></span>
+          <span class="ftw-toggle-label" id="battery-covers-ev-label">Off</span>
+        </label>
+        <div class="card-sub card-hint">On = home battery discharges into the EV (e.g. expensive grid now, cheap solar later). Off = battery stays out of EV charging.</div>
+      </div>
     </section>
 
     <!-- Live power + plan side-by-side -->

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -141,6 +141,8 @@
   const evSlider = $("ev-slider");
   const evValue = $("ev-value");
   const evSend = $("ev-send");
+  const bceToggle = $("battery-covers-ev-toggle");
+  const bceLabel = $("battery-covers-ev-label");
   const fuseUse = $("fuse-use");
   const fuseFill = $("fuse-fill");
   const fusePhases = $("fuse-phases");
@@ -411,6 +413,13 @@
     if (evSlider && document.activeElement !== evSlider && data.ev_charging_w != null) {
       evSlider.value = data.ev_charging_w;
       evValue.textContent = formatW(data.ev_charging_w);
+    }
+    // Battery-covers-EV toggle — only update DOM when not mid-click,
+    // otherwise the user's change would get overwritten by the next
+    // status poll before the POST round-trip settles.
+    if (bceToggle && document.activeElement !== bceToggle && data.battery_covers_ev != null) {
+      bceToggle.checked = !!data.battery_covers_ev;
+      if (bceLabel) bceLabel.textContent = data.battery_covers_ev ? "On" : "Off";
     }
 
     // Energy today
@@ -1424,6 +1433,10 @@
     postJson("/api/ev_charging", { power_w: w, active: w > 0 }).catch(function () {});
   }
 
+  function setBatteryCoversEV(enabled) {
+    postJson("/api/battery_covers_ev", { enabled: !!enabled }).catch(function () {});
+  }
+
   function postJson(url, body) {
     return fetch(url, {
       method: "POST",
@@ -1494,6 +1507,13 @@
   peakLimitSend.addEventListener("click", function () {
     setPeakLimit(Number(peakLimitSlider.value));
   });
+
+  if (bceToggle) {
+    bceToggle.addEventListener("change", function () {
+      if (bceLabel) bceLabel.textContent = bceToggle.checked ? "On" : "Off";
+      setBatteryCoversEV(bceToggle.checked);
+    });
+  }
 
   // EV detail modal — <ftw-modal> handles ESC / backdrop / close button;
   // we only drive open()/close() and refresh the body on a timer. Opened

--- a/web/next.css
+++ b/web/next.css
@@ -510,6 +510,54 @@ body.ftw-next .control-card .card-label {
   text-transform: uppercase;
   margin-bottom: 10px;
 }
+/* ftw-toggle: compact switch used inside control-cards for boolean
+   opt-ins (e.g. "Let battery cover EV"). Hides the native checkbox
+   and renders a pill + dot that slides on check. */
+body.ftw-next .ftw-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+body.ftw-next .ftw-toggle input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+body.ftw-next .ftw-toggle-slider {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: oklch(0.20 0.015 250);
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  transition: background .15s, border-color .15s;
+}
+body.ftw-next .ftw-toggle-slider::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--fg-dim);
+  border-radius: 50%;
+  transition: transform .18s ease, background .15s;
+}
+body.ftw-next .ftw-toggle input:checked + .ftw-toggle-slider {
+  background: oklch(0.55 0.12 155);
+  border-color: oklch(0.60 0.13 155);
+}
+body.ftw-next .ftw-toggle input:checked + .ftw-toggle-slider::after {
+  transform: translateX(18px);
+  background: oklch(0.98 0 0);
+}
+body.ftw-next .ftw-toggle-label {
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--fg-dim);
+}
 body.ftw-next .mode-buttons {
   gap: 6px;
 }


### PR DESCRIPTION
Closes #162.

## Summary

- New \`control.State.BatteryCoversEV\` flag (default **off** — preserves current behaviour). When **on**, dispatch stops subtracting \`EVChargingW\` from the grid reading, so the battery sees the full site load and discharges into whatever's there — EV included.
- Persisted in state.db (\`battery_covers_ev\` key), restored on startup.
- \`POST /api/battery_covers_ev\` + value in \`/api/status\`.
- HA MQTT switch via autodiscovery (appears as \`switch.forty_two_watts_battery_covers_ev\`).
- Dashboard toggle (\`ftw-toggle\` CSS component) wired to the endpoint.

## Scenario

Grid prices are high right now. Operator knows PV + cheap prices are coming later today. They want:

1. EV charging at full power **now** (not waiting for cheap hours)
2. Home battery discharging to cover it — so import is minimised
3. Battery refills in the afternoon from free solar

Flip the toggle ON → battery drains into the EV → grid imports only the residual the battery can't cover (SoC, \`MaxDischargeW\`, fuse guard all still apply).

When normal operation resumes (or prices rebalance), flip OFF → battery is protected from the EV load again, existing "don't shuffle energy through the inverter twice" behaviour is back.

## Why a body flag, not a new mode

\`self_consumption\` already does the right thing once the subtraction is gone. Adding a separate \`self_consumption_with_ev\` mode would duplicate all the mode machinery for a one-line behavioural change. The flag is orthogonal: it works with any mode that uses the EV-subtraction path, is trivially defaulted to the old behaviour for anyone who doesn't touch it, and the UI surface is a single switch — clearer than a mode-picker variant.

## Test plan

- [x] \`TestBatteryCoversEV_OffExcludesEVFromGrid\` — regression guard that default preserves today's behaviour
- [x] \`TestBatteryCoversEV_OnIncludesEVInGrid\` — flag on → battery drives toward discharge for full import, not just house share
- [x] \`go test ./...\` — all 35 packages still pass
- [x] \`make e2e\` — full stack in 25 s
- [ ] Live run on reporter site: flip ON mid-EV-charge, verify grid import drops to \`max(0, total_load − battery_discharge_max)\` within ~2–3 control cycles
- [ ] Live run: flip OFF, verify grid import returns to full EV power, battery returns to idle/PV-absorption

🤖 Generated with [Claude Code](https://claude.com/claude-code)