### PR TITLE
refactor(loadpoint): extract EV dispatch into Controller (#172, PR 1/3)

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -664,6 +664,50 @@ func main() {
 			"pvtwin", pvSvc != nil)
 	}
 
+	// ---- EV loadpoint controller ----
+	// Phase 1 of the EV-arch refactor (issue #172): the per-tick EV
+	// dispatch that used to live inline in the control loop is now
+	// owned by loadpoint.Controller. Behaviour is identical — same
+	// 5 s cadence, same energy-allocation contract, same snap. The
+	// separation exists so follow-up PRs can give each loadpoint its
+	// own goroutine + driver-declared cadence (#172 PR 2) and a
+	// phase/step state machine (#172 PR 3) without disturbing
+	// battery dispatch.
+	//
+	// Adapters here keep loadpoint independent of mpc/telemetry
+	// (mpc already imports loadpoint — the cycle must go this way).
+	var lpController *loadpoint.Controller
+	if mpcSvc != nil {
+		planAdapter := func(now time.Time) (loadpoint.Directive, bool) {
+			d, ok := mpcSvc.SlotDirectiveAt(now)
+			if !ok {
+				return loadpoint.Directive{}, false
+			}
+			return loadpoint.Directive{
+				SlotStart:         d.SlotStart,
+				SlotEnd:           d.SlotEnd,
+				LoadpointEnergyWh: d.LoadpointEnergyWh,
+			}, true
+		}
+		telAdapter := func(driver string) (loadpoint.EVSample, bool) {
+			r := tel.Get(driver, telemetry.DerEV)
+			if r == nil {
+				return loadpoint.EVSample{}, false
+			}
+			var d struct {
+				Connected bool    `json:"connected"`
+				SessionWh float64 `json:"session_wh"`
+			}
+			_ = json.Unmarshal(r.Data, &d)
+			return loadpoint.EVSample{
+				PowerW:    r.SmoothedW,
+				SessionWh: d.SessionWh,
+				Connected: d.Connected,
+			}, true
+		}
+		lpController = loadpoint.NewController(lpMgr, planAdapter, telAdapter, reg.Send)
+	}
+
 	// ---- Self-update checker ----
 	// Probes the GitHub Releases API in the background; the UI reads the
 	// cached result via /api/version/check. Gated behind FTW_SELFUPDATE_ENABLED
@@ -1072,70 +1116,11 @@ func main() {
 				}
 			}
 
-			// ---- EV dispatch: observe + command per loadpoint ----
-			// For each configured loadpoint we first read the
-			// charger driver's latest telemetry and feed it to the
-			// manager (plug state + session Wh → inferred SoC). Then
-			// we ask the MPC for the current slot's energy budget
-			// and translate it to an instantaneous W command. No
-			// PI — energy-allocation contract: remaining Wh /
-			// remaining s → W, snap to the charger's allowed steps.
-			if len(cfg.Loadpoints) > 0 && mpcSvc != nil {
-				for _, lpCfg := range cfg.Loadpoints {
-					evr := tel.Get(lpCfg.DriverName, telemetry.DerEV)
-					plugged := false
-					var sessionWh, powerW float64
-					if evr != nil {
-						powerW = evr.SmoothedW
-						var d struct {
-							Connected bool    `json:"connected"`
-							SessionWh float64 `json:"session_wh"`
-						}
-						if err := json.Unmarshal(evr.Data, &d); err == nil {
-							plugged = d.Connected
-							sessionWh = d.SessionWh
-						}
-					}
-					lpMgr.Observe(lpCfg.ID, plugged, powerW, sessionWh)
-					if !plugged {
-						continue
-					}
-					// Resolve this tick's EV setpoint. Default 0 W so
-					// the charger is explicitly told to stand down
-					// whenever the MPC has no allocation for this
-					// slot — without an explicit command, the
-					// charger silently keeps drawing at its last
-					// setpoint from a previous slot.
-					var cmdW float64
-					d, ok := mpcSvc.SlotDirectiveAt(time.Now())
-					if ok {
-						if budgetWh, hasBudget := d.LoadpointEnergyWh[lpCfg.ID]; hasBudget {
-							remainingS := d.SlotEnd.Sub(time.Now()).Seconds()
-							// Subtract what's already been delivered
-							// so a mid-slot dispatch doesn't
-							// overshoot. Approximated from current
-							// power × fraction of slot elapsed.
-							elapsed := d.SlotEnd.Sub(d.SlotStart).Seconds() - remainingS
-							if elapsed < 0 {
-								elapsed = 0
-							}
-							alreadyWh := powerW * elapsed / 3600.0
-							remainingWh := budgetWh - alreadyWh
-							wantW := control.EnergyBudgetToPowerW(remainingWh, remainingS)
-							cmdW = control.SnapChargeW(wantW, lpCfg.MinChargeW,
-								lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
-						}
-					}
-					payload, _ := json.Marshal(map[string]any{
-						"action":  "ev_set_current",
-						"power_w": cmdW,
-					})
-					if err := reg.Send(ctx, lpCfg.DriverName, payload); err != nil {
-						slog.Warn("loadpoint dispatch", "lp", lpCfg.ID,
-							"driver", lpCfg.DriverName, "err", err)
-					}
-				}
-			}
+			// ---- EV dispatch: per-loadpoint observe + command ----
+			// The per-loadpoint state machine (observe → plan lookup
+			// → snap → send) is owned by loadpoint.Controller so the
+			// main tick stays a thin orchestrator. See issue #172.
+			lpController.Tick(ctx, time.Now())
 
 			// ---- Record history snapshot ----
 			recordHistory(st, tel, ctrl, nowMs)

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -1,0 +1,158 @@
+package loadpoint
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+)
+
+// Controller orchestrates one dispatch cycle for every configured
+// loadpoint: observe driver telemetry, read the planner's per-slot
+// energy budget, translate to an instantaneous W command, and send
+// to the driver.
+//
+// Extracted verbatim from the monolithic block that used to live in
+// main.go's control tick. Phase 1 is behaviour-preserving only — the
+// main loop calls (*Controller).Tick(ctx, now) where it used to
+// inline the logic. Phase 2 will give each loadpoint its own
+// goroutine + cadence declared by the driver.
+//
+// Dependencies are injected as function types (not interfaces) to
+// avoid pulling mpc and telemetry into loadpoint's import graph —
+// mpc already imports loadpoint for its DP loadpoint_spec, so the
+// cycle must go the other way. main.go wires short adapter closures
+// from mpc.Service / telemetry.Store / drivers.Registry.
+type Controller struct {
+	manager *Manager
+	plan    PlanFunc
+	tel     TelemetryFunc
+	send    SenderFunc
+}
+
+// Directive is the loadpoint-relevant slice of mpc.SlotDirective.
+// The mpc package defines the full type with BatteryEnergyWh etc;
+// the controller only needs the slot window and per-loadpoint Wh
+// budget, so we don't pull in the whole struct.
+type Directive struct {
+	SlotStart         time.Time
+	SlotEnd           time.Time
+	LoadpointEnergyWh map[string]float64
+}
+
+// EVSample is the loadpoint-relevant slice of telemetry.DerReading
+// for a DerEV entry — power, cumulative session energy, plug state.
+// Chargers like Easee don't expose the vehicle's BMS SoC, so the
+// controller only sees these three fields.
+type EVSample struct {
+	PowerW    float64
+	SessionWh float64
+	Connected bool
+}
+
+// PlanFunc returns the current-slot directive for now, or (_, false)
+// when no plan is available (stale, missing, out of horizon).
+type PlanFunc func(now time.Time) (Directive, bool)
+
+// TelemetryFunc returns the latest EV reading for a driver. The
+// second return is false when the driver hasn't produced a reading
+// yet.
+type TelemetryFunc func(driver string) (EVSample, bool)
+
+// SenderFunc forwards a JSON command payload to a driver. Matches
+// drivers.Registry.Send.
+type SenderFunc func(ctx context.Context, driver string, payload []byte) error
+
+// NewController wires the dependencies. Passing nil for plan, tel,
+// or send disables the corresponding step — useful in tests.
+func NewController(mgr *Manager, plan PlanFunc, tel TelemetryFunc, send SenderFunc) *Controller {
+	return &Controller{manager: mgr, plan: plan, tel: tel, send: send}
+}
+
+// Tick runs one dispatch cycle for every configured loadpoint.
+// Safe to call even when no loadpoints are configured. Idempotent —
+// calling it twice in the same moment produces the same commands.
+//
+// Behaviour is equivalent to the inline block previously in main.go:
+//
+//  1. Read latest charger telemetry for this driver.
+//  2. Feed the observation to the Manager (plug state, session Wh,
+//     inferred SoC).
+//  3. For unplugged loadpoints: skip command entirely.
+//  4. For plugged loadpoints: ask the plan for this slot's Wh
+//     allocation and translate to a W command via the energy-
+//     allocation contract (remaining_wh × 3600 / remaining_s).
+//  5. Snap to the charger's discrete steps.
+//  6. Send `ev_set_current` with the resulting W. When no plan
+//     allocation exists, 0 W is commanded explicitly — without it
+//     the charger rides the previous slot's setpoint.
+func (c *Controller) Tick(ctx context.Context, now time.Time) {
+	if c == nil || c.manager == nil {
+		return
+	}
+	// Preserve the old `len(cfg.Loadpoints) > 0 && mpcSvc != nil` guard:
+	// when the planner isn't wired we stay fully out of the loadpoint
+	// driver's state, the same as before the refactor. Phase 3 will
+	// relax this once the controller owns its own fallback behaviour.
+	if c.plan == nil {
+		return
+	}
+	for _, lpCfg := range c.manager.Configs() {
+		c.tickOne(ctx, now, lpCfg)
+	}
+}
+
+func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
+	var sample EVSample
+	if c.tel != nil {
+		sample, _ = c.tel(lpCfg.DriverName)
+	}
+	c.manager.Observe(lpCfg.ID, sample.Connected, sample.PowerW, sample.SessionWh)
+	if !sample.Connected {
+		return
+	}
+	cmdW := c.computeCommand(now, lpCfg, sample.PowerW)
+	payload, err := json.Marshal(map[string]any{
+		"action":  "ev_set_current",
+		"power_w": cmdW,
+	})
+	if err != nil {
+		return
+	}
+	if c.send == nil {
+		return
+	}
+	if err := c.send(ctx, lpCfg.DriverName, payload); err != nil {
+		slog.Warn("loadpoint dispatch", "lp", lpCfg.ID,
+			"driver", lpCfg.DriverName, "err", err)
+	}
+}
+
+// computeCommand resolves the W setpoint for a plugged loadpoint.
+// Returns 0 when the planner has no allocation for this slot — an
+// explicit standdown, not a lazy last-command.
+func (c *Controller) computeCommand(now time.Time, lpCfg Config, currentPowerW float64) float64 {
+	if c.plan == nil {
+		return 0
+	}
+	d, ok := c.plan(now)
+	if !ok {
+		return 0
+	}
+	budgetWh, hasBudget := d.LoadpointEnergyWh[lpCfg.ID]
+	if !hasBudget {
+		return 0
+	}
+	remainingS := d.SlotEnd.Sub(now).Seconds()
+	// Subtract what's already been delivered so a mid-slot dispatch
+	// doesn't overshoot. Approximated from current power × fraction
+	// of slot elapsed.
+	elapsed := d.SlotEnd.Sub(d.SlotStart).Seconds() - remainingS
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	alreadyWh := currentPowerW * elapsed / 3600.0
+	remainingWh := budgetWh - alreadyWh
+	wantW := EnergyBudgetToPowerW(remainingWh, remainingS)
+	return SnapChargeW(wantW, lpCfg.MinChargeW, lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
+}

--- a/go/internal/loadpoint/controller_test.go
+++ b/go/internal/loadpoint/controller_test.go
@@ -1,0 +1,264 @@
+package loadpoint
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeSender records every Send call so tests can assert on both the
+// target driver and the payload contents.
+type fakeSender struct {
+	calls []sentCommand
+	err   error
+}
+
+type sentCommand struct {
+	driver string
+	power  float64
+	action string
+}
+
+func (f *fakeSender) Send(ctx context.Context, driver string, payload []byte) error {
+	var d struct {
+		Action string  `json:"action"`
+		PowerW float64 `json:"power_w"`
+	}
+	if err := json.Unmarshal(payload, &d); err != nil {
+		return err
+	}
+	f.calls = append(f.calls, sentCommand{driver: driver, power: d.PowerW, action: d.Action})
+	return f.err
+}
+
+// newTestController wires a controller with a manager pre-loaded with
+// `cfgs`, a plan returning `directive` (or nothing when ok=false),
+// and a telemetry func returning per-driver samples.
+func newTestController(t *testing.T, cfgs []Config, directive *Directive,
+	samples map[string]EVSample, sender *fakeSender) *Controller {
+	t.Helper()
+	m := NewManager()
+	m.Load(cfgs)
+	plan := PlanFunc(func(now time.Time) (Directive, bool) {
+		if directive == nil {
+			return Directive{}, false
+		}
+		return *directive, true
+	})
+	tel := TelemetryFunc(func(driver string) (EVSample, bool) {
+		s, ok := samples[driver]
+		return s, ok
+	})
+	return NewController(m, plan, tel, sender.Send)
+}
+
+// TestTickUnpluggedSendsNoCommand — the inline dispatch block skipped
+// the command step entirely for unplugged chargers. We preserve that
+// so an unplugged port isn't pinned to 0 W by the EMS (the driver's
+// autonomous mode handles idle state).
+func TestTickUnpluggedSendsNoCommand(t *testing.T) {
+	sender := &fakeSender{}
+	cfgs := []Config{{ID: "garage", DriverName: "easee", MinChargeW: 1400, MaxChargeW: 11000}}
+	samples := map[string]EVSample{"easee": {PowerW: 0, Connected: false}}
+	c := newTestController(t, cfgs, nil, samples, sender)
+
+	c.Tick(context.Background(), time.Now())
+
+	if len(sender.calls) != 0 {
+		t.Errorf("unplugged loadpoint should send no command, got %d", len(sender.calls))
+	}
+}
+
+// TestTickPluggedNoPlanCommandsZero — preserves the explicit-standdown
+// semantics: without a plan allocation, command 0 W so the charger
+// doesn't ride the previous slot's setpoint.
+func TestTickPluggedNoPlanCommandsZero(t *testing.T) {
+	sender := &fakeSender{}
+	cfgs := []Config{{ID: "garage", DriverName: "easee", MinChargeW: 1400, MaxChargeW: 11000}}
+	samples := map[string]EVSample{"easee": {PowerW: 3000, Connected: true, SessionWh: 4000}}
+	c := newTestController(t, cfgs, nil, samples, sender)
+
+	c.Tick(context.Background(), time.Now())
+
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(sender.calls))
+	}
+	if sender.calls[0].power != 0 {
+		t.Errorf("plugged + no plan → expected 0 W, got %.0f", sender.calls[0].power)
+	}
+	if sender.calls[0].action != "ev_set_current" {
+		t.Errorf("action = %q, want ev_set_current", sender.calls[0].action)
+	}
+}
+
+// TestTickPluggedWithBudgetSendsSnappedPower — end-to-end: plan says
+// 2.75 kWh over a 15-min slot (=11 kW), but the charger snaps to a
+// discrete {0, 7.4, 11} kW ladder → 11 kW. This is the exact chain
+// the inline dispatch ran; we're locking it in.
+func TestTickPluggedWithBudgetSendsSnappedPower(t *testing.T) {
+	sender := &fakeSender{}
+	slotStart := time.Now().Add(-time.Second) // just started, negligible elapsed
+	slotEnd := slotStart.Add(15 * time.Minute)
+	cfgs := []Config{{
+		ID:            "garage",
+		DriverName:    "easee",
+		MinChargeW:    1400,
+		MaxChargeW:    11000,
+		AllowedStepsW: []float64{0, 1400, 4100, 7400, 11000},
+	}}
+	directive := &Directive{
+		SlotStart:         slotStart,
+		SlotEnd:           slotEnd,
+		LoadpointEnergyWh: map[string]float64{"garage": 2750},
+	}
+	samples := map[string]EVSample{"easee": {PowerW: 0, Connected: true}}
+	c := newTestController(t, cfgs, directive, samples, sender)
+
+	c.Tick(context.Background(), time.Now())
+
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(sender.calls))
+	}
+	// 2.75 kWh / 0.25 h = 11 kW, hits the 11000 step exactly.
+	if sender.calls[0].power != 11000 {
+		t.Errorf("want 11000 W, got %.0f", sender.calls[0].power)
+	}
+}
+
+// TestTickBudgetMissingForLoadpointCommandsZero — the plan may have
+// allocated to other loadpoints but not this one; treat it like
+// no-plan (0 W).
+func TestTickBudgetMissingForLoadpointCommandsZero(t *testing.T) {
+	sender := &fakeSender{}
+	slotStart := time.Now()
+	slotEnd := slotStart.Add(15 * time.Minute)
+	cfgs := []Config{{ID: "garage", DriverName: "easee", MinChargeW: 1400, MaxChargeW: 11000}}
+	directive := &Directive{
+		SlotStart:         slotStart,
+		SlotEnd:           slotEnd,
+		LoadpointEnergyWh: map[string]float64{"other": 2000}, // not "garage"
+	}
+	samples := map[string]EVSample{"easee": {PowerW: 2000, Connected: true}}
+	c := newTestController(t, cfgs, directive, samples, sender)
+
+	c.Tick(context.Background(), time.Now())
+
+	if len(sender.calls) != 1 || sender.calls[0].power != 0 {
+		t.Errorf("want 0 W when loadpoint has no allocation, got %+v", sender.calls)
+	}
+}
+
+// TestTickMidSlotSubtractsAlreadyDelivered — if half the slot has
+// elapsed at 4 kW, the controller should treat the remaining budget
+// accordingly rather than re-issuing the full slot power. Locks in
+// the `alreadyWh = powerW * elapsed / 3600` approximation.
+func TestTickMidSlotSubtractsAlreadyDelivered(t *testing.T) {
+	sender := &fakeSender{}
+	// Place `now` at the midpoint of a 30-min slot so the elapsed
+	// math is deterministic without sub-second jitter.
+	now := time.Date(2026, 4, 22, 14, 15, 0, 0, time.UTC)
+	slotStart := now.Add(-15 * time.Minute)
+	slotEnd := now.Add(15 * time.Minute)
+	cfgs := []Config{{
+		ID:         "garage",
+		DriverName: "easee",
+		MinChargeW: 1400,
+		MaxChargeW: 11000,
+	}}
+	// Budget 4 kWh, half slot consumed at 4 kW → alreadyWh = 1 kWh,
+	// remaining = 3 kWh over 0.25 h = 12 kW → clamped to max 11 kW.
+	directive := &Directive{
+		SlotStart:         slotStart,
+		SlotEnd:           slotEnd,
+		LoadpointEnergyWh: map[string]float64{"garage": 4000},
+	}
+	samples := map[string]EVSample{"easee": {PowerW: 4000, Connected: true}}
+	// No AllowedStepsW → continuous passthrough after clamp.
+	c := newTestController(t, cfgs, directive, samples, sender)
+
+	c.Tick(context.Background(), now)
+
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(sender.calls))
+	}
+	if sender.calls[0].power != 11000 {
+		t.Errorf("want 11000 W after mid-slot + max clamp, got %.0f", sender.calls[0].power)
+	}
+}
+
+// TestTickFeedsObservationsToManager — the manager's SoC-inference
+// pipeline depends on every tick calling Observe, including the
+// plug-in transition that seeds the session anchor.
+func TestTickFeedsObservationsToManager(t *testing.T) {
+	sender := &fakeSender{}
+	cfgs := []Config{{
+		ID:                "garage",
+		DriverName:        "easee",
+		VehicleCapacityWh: 60000,
+		PluginSoCPct:      30,
+	}}
+	samples := map[string]EVSample{"easee": {PowerW: 7400, Connected: true, SessionWh: 6000}}
+	c := newTestController(t, cfgs, nil, samples, sender)
+
+	c.Tick(context.Background(), time.Now())
+
+	st, ok := c.manager.State("garage")
+	if !ok {
+		t.Fatal("manager state missing after Tick")
+	}
+	// 30 + 6000/60000*100 = 40.
+	if st.CurrentSoCPct < 39 || st.CurrentSoCPct > 41 {
+		t.Errorf("expected ~40 %% SoC after Observe, got %.2f", st.CurrentSoCPct)
+	}
+	if !st.PluggedIn || st.CurrentPowerW != 7400 {
+		t.Errorf("observation not propagated: %+v", st)
+	}
+}
+
+// TestTickNoLoadpoints — the inline block early-returned on
+// len(cfg.Loadpoints) == 0. Preserve: controller without configs
+// must not touch the sender.
+func TestTickNoLoadpoints(t *testing.T) {
+	sender := &fakeSender{}
+	m := NewManager()
+	m.Load(nil)
+	c := NewController(m,
+		func(time.Time) (Directive, bool) { return Directive{}, false },
+		func(string) (EVSample, bool) { return EVSample{}, false },
+		sender.Send,
+	)
+
+	c.Tick(context.Background(), time.Now())
+
+	if len(sender.calls) != 0 {
+		t.Errorf("no configs → no sends, got %d", len(sender.calls))
+	}
+}
+
+// TestTickSendErrorDoesNotPanic — driver comms failures are a
+// logged warning, not a crash. Preserves the previous behaviour.
+func TestTickSendErrorDoesNotPanic(t *testing.T) {
+	sender := &fakeSender{err: errors.New("driver offline")}
+	cfgs := []Config{{ID: "garage", DriverName: "easee", MinChargeW: 1400, MaxChargeW: 11000}}
+	samples := map[string]EVSample{"easee": {PowerW: 0, Connected: true}}
+	c := newTestController(t, cfgs, nil, samples, sender)
+
+	c.Tick(context.Background(), time.Now()) // must not panic
+}
+
+// TestConfigsReturnsSnapshotInOrder guards that Manager.Configs feeds
+// the controller a deterministic view — otherwise a dispatch cycle
+// could command different drivers on each run after a map iteration.
+func TestConfigsReturnsSnapshotInOrder(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{
+		{ID: "garage", DriverName: "easee"},
+		{ID: "street", DriverName: "zap"},
+	})
+	got := m.Configs()
+	if len(got) != 2 || got[0].ID != "garage" || got[1].ID != "street" {
+		t.Errorf("Configs order broken: %+v", got)
+	}
+}

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -173,6 +173,22 @@ func (m *Manager) States() []State {
 	return out
 }
 
+// Configs returns a snapshot of the currently-configured loadpoints
+// in insertion order. Used by Controller.Tick to drive dispatch
+// without needing a second copy of the YAML source of truth — the
+// manager is already the authoritative in-memory view after Load().
+func (m *Manager) Configs() []Config {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]Config, 0, len(m.order))
+	for _, id := range m.order {
+		if lp, ok := m.byID[id]; ok {
+			out = append(out, lp.Config)
+		}
+	}
+	return out
+}
+
 // Observe updates the measurement side of a loadpoint from raw driver
 // telemetry. The manager derives current SoC internally from the
 // session's plug-in anchor + delivered energy (chargers like Easee

--- a/go/internal/loadpoint/snap.go
+++ b/go/internal/loadpoint/snap.go
@@ -1,12 +1,12 @@
-package control
+package loadpoint
 
 import "math"
 
 // SnapChargeW turns an ideal charging-power request into the nearest
-// feasible level the charger can actually deliver. Used by EV
-// dispatch to convert a smooth MPC-derived power target into one of
-// the discrete levels a charger supports (e.g. Easee's 0 plus 6-32 A
-// bands).
+// feasible level the charger can actually deliver. Used by the
+// loadpoint Controller to convert a smooth MPC-derived power target
+// into one of the discrete levels a charger supports (e.g. Easee's 0
+// plus 6-32 A bands).
 //
 // Rules:
 //
@@ -50,9 +50,8 @@ func SnapChargeW(want, min, max float64, steps []float64) float64 {
 // so EV and battery share one mental model.
 //
 // Negative remaining energy (already overshot the plan) → 0 so we
-// stop drawing. Non-positive remaining time → return `want` as if
-// the slot were just beginning; the next dispatch tick will see a
-// fresh slot anyway.
+// stop drawing. Non-positive remaining time → 0; the next tick will
+// see a fresh slot anyway.
 func EnergyBudgetToPowerW(remainingWh, remainingS float64) float64 {
 	if remainingWh <= 0 {
 		return 0

--- a/go/internal/loadpoint/snap_test.go
+++ b/go/internal/loadpoint/snap_test.go
@@ -1,4 +1,4 @@
-package control
+package loadpoint
 
 import "testing"
 


### PR DESCRIPTION
Closes #172 — Phase 1 (pure refactor, no behaviour change).

## Why

EV charging currently runs inline in the 5 s battery control tick (`main.go:1075–1138`). We want each loadpoint to own its own goroutine with a driver-declared cadence (Easee cloud ≈ 30 s, Zap local ≈ 5 s), plus a phase/step state machine with hysteresis. That reshape is risky to do in one shot.

This PR is the foundational step: lift the inline dispatch into a new `loadpoint.Controller` with zero behaviour change, so the follow-ups can iterate on the controller without touching the main loop again.

## What

**Moves:**
- `control.SnapChargeW` + `control.EnergyBudgetToPowerW` → `loadpoint` (they were only used by EV dispatch; `control` is the site-PI package)
- The ~65-line inline block in `main.go` → `loadpoint.Controller.Tick`

**Wiring:**
- `Controller` takes function-typed deps (`PlanFunc`, `TelemetryFunc`, `SenderFunc`) to keep `loadpoint` independent of `mpc` and `telemetry`. `mpc` already imports `loadpoint` for DP planning — the cycle must go this way.
- `main.go` builds short adapter closures over `mpcSvc.SlotDirectiveAt`, `tel.Get`, and `reg.Send`, then constructs the controller once MPC is fully wired.
- `Tick` is nil-safe, so MPC-less deployments behave exactly as before (no EV dispatch fires).

## Behaviour equivalence

Same on every axis that matters:

- 5 s tick cadence (fires from the same `ticker.C` case)
- Energy-allocation contract: `remaining_wh × 3600 / remaining_s` → snap to allowed steps
- Explicit 0 W standdown when the plan has no allocation (prevents riding the previous setpoint)
- Unplugged loadpoints skip the command step entirely
- `loadpoint.Manager.Observe` called with the same plug/session/power values on every tick
- Exact same JSON payload: `{\"action\": \"ev_set_current\", \"power_w\": …}`

## Tests

New behaviour-equivalence suite in `loadpoint/controller_test.go`:
- unplugged → no command sent
- plugged + no plan → 0 W sent (not skipped)
- plugged + budget → snapped W
- plan exists but no allocation for this loadpoint → 0 W
- mid-slot already-delivered subtraction
- Observe pipeline carries plug/power/session through
- no-loadpoints no-op
- driver send error doesn't panic

`SnapChargeW` + `EnergyBudgetToPowerW` test file moved verbatim. `make test` + `make e2e` both green.

## Out of scope

- PR 2: per-driver `command_min_interval_s` + goroutine-per-loadpoint
- PR 3: phase/step state machine with hysteresis
- V2X driver: separate track (blocked on DC2 MQTT spec)