### PR TITLE
feat(settings): add EV tab with charge plans (loadpoints)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -99,6 +99,7 @@
         <button data-tab="planner">Planner</button>
         <button data-tab="ha">Home Assistant</button>
         <button data-tab="notifications">Notifications</button>
+        <button data-tab="ev">EV</button>
         <button data-tab="system">System</button>
       </div>
       <div class="modal-body" id="settings-body">
@@ -443,7 +444,7 @@
   <script src="/settings/tabs/planner.js?v=tabsplit1"></script>
   <script src="/settings/tabs/ha.js?v=tabsplit1"></script>
   <script src="/settings/tabs/notifications.js?v=tabsplit1"></script>
-  <script src="/settings/tabs/ev.js?v=tabsplit1"></script>
+  <script src="/settings/tabs/ev.js?v=loadpoints2"></script>
   <script src="/settings/tabs/system.js?v=tabsplit1"></script>
   <script src="/models.js?v=diag1"></script>
   <script src="/plan.js?v=diag1"></script>

--- a/web/settings/tabs/ev.js
+++ b/web/settings/tabs/ev.js
@@ -1,7 +1,243 @@
-// Settings → EV tab: cloud EV charger credentials + live status.
+// Settings → EV tab: cloud EV charger credentials + charge plans (loadpoints) + live status.
 (function () {
   var S = (window.FTWSettings = window.FTWSettings || { tabs: {} });
   S.tabs = S.tabs || {};
+
+  function driverOptionsHTML(ctx, selected) {
+    var drivers = (ctx.config.drivers || []).map(function (d) { return d.name; }).filter(Boolean);
+    // Keep the current value even if it no longer matches a driver, so
+    // stale config still round-trips cleanly.
+    if (selected && drivers.indexOf(selected) === -1) drivers.unshift(selected);
+    var opts = '<option value=""' + (selected ? '' : ' selected') + '>— select driver —</option>';
+    drivers.forEach(function (n) {
+      opts += '<option value="' + ctx.escHtml(n) + '"' + (n === selected ? ' selected' : '') + '>' + ctx.escHtml(n) + '</option>';
+    });
+    return opts;
+  }
+
+  function renderLoadpoints(ctx) {
+    var config = ctx.config, field = ctx.field, escHtml = ctx.escHtml, help = ctx.help, getByPath = ctx.getByPath;
+    if (!Array.isArray(config.loadpoints)) config.loadpoints = [];
+    var html = '<fieldset><legend>Charge Plans</legend>' +
+      '<div id="lp-live" class="lp-live" style="margin-bottom:12px">' +
+        '<div class="lp-live-placeholder" style="color:var(--text-dim);font-size:0.85rem">Loading live state…</div>' +
+      '</div>';
+    if (config.loadpoints.length === 0) {
+      html += '<p style="color:var(--text-dim);font-size:0.85rem;margin:0 0 8px 0">No charge plans configured. Click "Add charge plan" to create one.</p>';
+    }
+    config.loadpoints.forEach(function (lp, i) {
+      var base = "loadpoints." + i + ".";
+      var currentDriver = getByPath(config, base + "driver_name", "") || "";
+      html +=
+        '<div class="lp-entry" style="border:1px solid var(--border);padding:10px;margin-bottom:10px;border-radius:4px">' +
+          '<div class="field-row"><div>' +
+            field("ID", base + "id", "text", "",
+              "Stable identifier for this charge plan (e.g. 'garage', 'street').") +
+          '</div><div>' +
+            '<label>Driver ' + help("Which configured driver controls the charger for this loadpoint.") + '</label>' +
+            '<select data-path="' + base + 'driver_name">' + driverOptionsHTML(ctx, currentDriver) + '</select>' +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+            field("Min charge (W)", base + "min_charge_w", "number", "",
+              "Lower bound the planner is allowed to command. 0 = no minimum.") +
+          '</div><div>' +
+            field("Max charge (W)", base + "max_charge_w", "number", "",
+              "Upper bound the planner is allowed to command.") +
+          '</div></div>' +
+          '<div class="field-row"><div>' +
+            field("Vehicle capacity (Wh)", base + "vehicle_capacity_wh", "number", "",
+              "Battery capacity in Wh. 0 defaults to 60 kWh.") +
+          '</div><div>' +
+            field("Plug-in SoC (%)", base + "plugin_soc_pct", "number", "",
+              "Assumed vehicle SoC at plug-in. 0 defaults to 20%.") +
+          '</div></div>' +
+          '<label>Allowed steps (W, comma-separated) ' + help("Discrete power levels the charger supports. Leave blank for continuous. E.g. '0,1380,2760,4140'.") + '</label>' +
+          '<input type="text" class="lp-steps-input" data-lp-index="' + i + '" value="' +
+            escHtml((lp.allowed_steps_w || []).join(",")) + '">' +
+          '<div style="text-align:right;margin-top:6px">' +
+            '<button type="button" class="btn-remove-lp" data-lp-index="' + i + '" style="background:transparent;border:1px solid var(--border);color:#e57373;padding:4px 10px;border-radius:4px;cursor:pointer">Remove</button>' +
+          '</div>' +
+        '</div>';
+    });
+    html += '<button type="button" id="btn-add-lp" style="background:transparent;border:1px solid var(--border);color:var(--text);padding:6px 12px;border-radius:4px;cursor:pointer">+ Add charge plan</button>';
+    html += '</fieldset>';
+    return html;
+  }
+
+  function msToLocalInput(ms) {
+    if (!ms || ms <= 0) return "";
+    var d = new Date(ms);
+    if (isNaN(d.getTime())) return "";
+    var pad = function (n) { return n < 10 ? "0" + n : "" + n; };
+    return d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" + pad(d.getDate()) +
+      "T" + pad(d.getHours()) + ":" + pad(d.getMinutes());
+  }
+
+  function parseTargetTimeMs(state) {
+    if (!state || !state.target_time) return 0;
+    if (state.target_time.indexOf("0001-") === 0) return 0;
+    var d = new Date(state.target_time);
+    var ms = d.getTime();
+    return (isNaN(ms) || ms <= 0) ? 0 : ms;
+  }
+
+  function buildLiveCard(ctx, id) {
+    var card = document.createElement("div");
+    card.className = "lp-live-card";
+    card.dataset.lpStateId = id;
+    card.style.cssText = "border:1px solid var(--border);padding:10px;margin-bottom:8px;border-radius:4px";
+    card.innerHTML =
+      '<div class="lp-live-summary" style="margin-bottom:4px"></div>' +
+      '<div class="lp-live-target" style="color:var(--text-dim);font-size:0.85rem;margin-bottom:8px"></div>' +
+      '<div class="field-row">' +
+        '<div><label>Target SoC (%)</label><input type="number" class="lp-target-soc" min="0" max="100" step="1"></div>' +
+        '<div><label>By (local time, optional)</label><input type="datetime-local" class="lp-target-time"></div>' +
+      '</div>' +
+      '<div style="text-align:right;margin-top:6px">' +
+        '<button type="button" class="lp-target-apply" style="background:transparent;border:1px solid var(--border);color:var(--text);padding:4px 12px;border-radius:4px;cursor:pointer">Apply target</button>' +
+        '<span class="lp-target-status" style="margin-left:8px;font-size:0.85rem"></span>' +
+      '</div>';
+
+    card.querySelector(".lp-target-apply").addEventListener("click", function () {
+      var socInp = card.querySelector(".lp-target-soc");
+      var timeInp = card.querySelector(".lp-target-time");
+      var status = card.querySelector(".lp-target-status");
+      var soc = parseFloat(socInp.value);
+      if (isNaN(soc) || soc < 0 || soc > 100) {
+        status.textContent = "SoC must be 0–100";
+        status.style.color = "#e57373";
+        return;
+      }
+      var tMs = 0;
+      if (timeInp.value) {
+        var d = new Date(timeInp.value);
+        if (!isNaN(d.getTime())) tMs = d.getTime();
+      }
+      status.textContent = "Applying…";
+      status.style.color = "";
+      fetch("/api/loadpoints/" + encodeURIComponent(id) + "/target", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ soc_pct: soc, target_time_ms: tMs }),
+      }).then(function (r) {
+        if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || ("HTTP " + r.status)); });
+        return r.json();
+      }).then(function () {
+        status.textContent = "✓ applied";
+        status.style.color = "#6ec26e";
+        setTimeout(function () { status.textContent = ""; }, 2000);
+      }).catch(function (e) {
+        status.textContent = "Failed: " + e.message;
+        status.style.color = "#e57373";
+      });
+    });
+
+    return card;
+  }
+
+  function updateLiveCard(ctx, card, s) {
+    var summary = card.querySelector(".lp-live-summary");
+    var target = card.querySelector(".lp-live-target");
+    var socInp = card.querySelector(".lp-target-soc");
+    var timeInp = card.querySelector(".lp-target-time");
+
+    var soc = (s.current_soc_pct || 0).toFixed(0);
+    var pw = (s.current_power_w || 0).toFixed(0);
+    var tag = s.plugged_in ? "● plugged in" : "○ unplugged";
+    summary.innerHTML = '<strong>' + ctx.escHtml(s.id || "(no id)") + '</strong> &mdash; ' +
+      tag + ' · SoC ' + soc + '% · ' + pw + ' W';
+
+    var tMs = parseTargetTimeMs(s);
+    if (s.target_soc_pct && s.target_soc_pct > 0) {
+      var when = tMs > 0 ? " by " + new Date(tMs).toLocaleString() : " (no deadline)";
+      target.textContent = "Current target: " + s.target_soc_pct.toFixed(0) + "%" + when;
+    } else {
+      target.textContent = "No target set.";
+    }
+
+    // Seed the inputs once so user sees the current target and can tweak.
+    // Don't overwrite once the user has typed something (focus-tracked).
+    if (!card.dataset.lpSeeded) {
+      socInp.value = (s.target_soc_pct && s.target_soc_pct > 0) ? s.target_soc_pct.toFixed(0) : "";
+      timeInp.value = msToLocalInput(tMs);
+      card.dataset.lpSeeded = "1";
+    }
+  }
+
+  function wireLoadpoints(ctx) {
+    var bodyEl = ctx.bodyEl, config = ctx.config;
+
+    // Comma-separated allowed_steps_w → float[] on input.
+    bodyEl.querySelectorAll(".lp-steps-input").forEach(function (inp) {
+      inp.addEventListener("input", function () {
+        var idx = parseInt(inp.dataset.lpIndex, 10);
+        if (!config.loadpoints || !config.loadpoints[idx]) return;
+        var parts = inp.value.split(",").map(function (s) { return parseFloat(s.trim()); }).filter(function (n) { return !isNaN(n); });
+        config.loadpoints[idx].allowed_steps_w = parts.length ? parts : undefined;
+      });
+    });
+
+    bodyEl.querySelectorAll(".btn-remove-lp").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var idx = parseInt(btn.dataset.lpIndex, 10);
+        ctx.captureCurrentTab();
+        config.loadpoints.splice(idx, 1);
+        ctx.renderTab("ev");
+      });
+    });
+
+    var addBtn = bodyEl.querySelector("#btn-add-lp");
+    if (addBtn) {
+      addBtn.addEventListener("click", function () {
+        ctx.captureCurrentTab();
+        if (!Array.isArray(config.loadpoints)) config.loadpoints = [];
+        config.loadpoints.push({ id: "", driver_name: "" });
+        ctx.renderTab("ev");
+      });
+    }
+
+    var liveEl = bodyEl.querySelector("#lp-live");
+    if (!liveEl) return;
+    function refreshLive() {
+      fetch("/api/loadpoints").then(function (r) { return r.json(); }).then(function (d) {
+        var placeholder = liveEl.querySelector(".lp-live-placeholder");
+        if (placeholder) placeholder.remove();
+        if (!d.enabled) {
+          liveEl.innerHTML = '<div style="color:var(--text-dim);font-size:0.85rem">Loadpoints not active (none configured).</div>';
+          return;
+        }
+        var states = d.loadpoints || [];
+        if (states.length === 0) {
+          liveEl.innerHTML = '<div style="color:var(--text-dim);font-size:0.85rem">No active loadpoints.</div>';
+          return;
+        }
+        // Strip any stale non-card message.
+        Array.from(liveEl.children).forEach(function (child) {
+          if (!child.dataset.lpStateId) child.remove();
+        });
+        var seen = {};
+        states.forEach(function (s) {
+          if (!s.id) return;
+          seen[s.id] = true;
+          var sel = '[data-lp-state-id="' + s.id.replace(/"/g, '\\"') + '"]';
+          var card = liveEl.querySelector(sel);
+          if (!card) {
+            card = buildLiveCard(ctx, s.id);
+            liveEl.appendChild(card);
+          }
+          updateLiveCard(ctx, card, s);
+        });
+        Array.from(liveEl.querySelectorAll("[data-lp-state-id]")).forEach(function (card) {
+          if (!seen[card.dataset.lpStateId]) card.remove();
+        });
+      }).catch(function () {
+        liveEl.innerHTML = '<div style="color:var(--text-dim);font-size:0.85rem">Loadpoint status endpoint unreachable.</div>';
+      });
+    }
+    refreshLive();
+    if (window._lpStatusTimer) clearInterval(window._lpStatusTimer);
+    window._lpStatusTimer = setInterval(refreshLive, 5000);
+  }
 
   S.tabs.ev = {
     render: function (ctx) {
@@ -42,7 +278,8 @@
         '<p style="color:var(--text-dim);font-size:0.8rem;margin-top:8px">' +
         'Credentials are used to authenticate with the Easee Cloud API. ' +
         'The charger serial is optional — if left empty the driver will use the first charger found on your account.' +
-        '</p>';
+        '</p>' +
+        renderLoadpoints(ctx);
     },
     after: function (ctx) {
       var bodyEl = ctx.bodyEl;
@@ -54,6 +291,7 @@
           if (!pwInput.value && evHasPassword) pwInput.placeholder = "••••••••";
         });
       }
+      wireLoadpoints(ctx);
       var el = document.getElementById("ev-status-indicator");
       if (!el) return;
       function refresh() {


### PR DESCRIPTION
## Summary

Wires up the previously-orphaned EV settings tab (the script was loaded but had no button in the tab bar) and extends it with a **Charge Plans** section for managing loadpoints.

## Changes

**`web/index.html`**
- Adds the missing `<button data-tab="ev">EV</button>` to the settings modal tab bar.
- Bumps the `ev.js` cache-buster.

**`web/settings/tabs/ev.js`**
- Keeps the existing Easee cloud credentials section + live charger status.
- Adds a **Charge Plans** section:
  - Editable cards for each `config.loadpoints[i]` — ID, driver (dropdown populated from `config.drivers[].name`), min/max charge W, vehicle capacity, plug-in SoC, and `allowed_steps_w` as a comma-separated list.
  - Add/remove controls; persistence goes through the existing `/api/config` POST flow — no backend changes.
  - Live-state cards polled from `/api/loadpoints` every 5 s with runtime **target SoC** + **deadline** inputs that POST to `/api/loadpoints/{id}/target`. Inputs are seeded once from current state; polling only refreshes the readouts so user input isn't clobbered.

## Architectural notes

Target SoC + deadline are *runtime intent*, not config — they live in `loadpoint.State`, not `config.Loadpoint`, and set via `POST /api/loadpoints/{id}/target`. So the target controls live in the live-state cards, not in the YAML-persisted config editor. If we ever want persistent target defaults (e.g. "always aim for 80% by 7am"), that's a separate change: new fields on the Go `Loadpoint` struct + backend logic to seed state on plug-in.

## Testing

Syntax-checked `ev.js` locally. Haven't run `make dev` — @frahlg will verify the UI in the browser.