### PR TITLE
install.sh: fix docker group check on fresh installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,8 +122,10 @@ curl -fsSL "$COMPOSE_URL" -o "$INSTALL_DIR/docker-compose.yml"
 # Run docker as the invoking user, not via sudo. If they were just added
 # to the docker group in step 2, their current shell hasn't picked it up
 # yet — `sg docker -c ...` executes under the new primary group without
-# requiring a re-login.
-if [ "$(id -u)" -eq 0 ] || id -nG "$USER" 2>/dev/null | grep -qw docker; then
+# requiring a re-login. NEED_RELOGIN from step 2 is authoritative here:
+# `id -nG "$USER"` reads /etc/group (already updated by usermod), not the
+# current process's credentials, so it can't answer this question.
+if [ "$(id -u)" -eq 0 ] || [ "$NEED_RELOGIN" = "0" ]; then
   run_docker() { docker "$@"; }
 else
   run_docker() { sg docker -c "docker $*"; }


### PR DESCRIPTION
## Problem

On a fresh install (user not previously in the docker group), step 5 fails with:

```
unable to get image 'ghcr.io/frahlg/forty-two-watts-updater:latest': permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

## Cause

`scripts/install.sh:126` used `id -nG "$USER" | grep -qw docker` to decide whether the current shell could call docker directly or needed `sg docker -c …`. But `id -nG` with a username argument reads `/etc/group` — which `usermod -aG docker` in step 2 has already updated. The check evaluated true even though the running shell's process credentials still lacked the docker group, so the script skipped the `sg docker` wrapper and hit the socket unprivileged.

## Fix

Reuse `NEED_RELOGIN` from step 2 — it's the authoritative signal for "does the current shell still need `sg docker`?".