### PR TITLE
feat(zap): opt-out PV aggregation via disable_pv config flag

### DIFF
--- a/drivers/zap.lua
+++ b/drivers/zap.lua
@@ -71,6 +71,10 @@ local pv_serials = {}     -- list of inverter serials that carry an enabled pv D
 local discovered   = false  -- true once discover_devices has succeeded
                              -- (even with zero PV). Prevents re-hitting
                              -- /api/devices every poll on meter-only sites.
+local disable_pv   = false  -- operator opt-out: when a site has a second
+                             -- Zap used for metering only, set `disable_pv:
+                             -- true` in config to skip PV discovery + emit.
+                             -- The primary Zap keeps owning PV aggregation.
 
 -- Backoff state for *discovery* (/api/devices) failures. Separate from
 -- data-fetch failures: discovery backoff must NOT gate the site meter
@@ -191,6 +195,10 @@ function driver_init(config)
         host.set_sn(p1_serial)
         host.log("info", "Zap: using pinned P1 serial " .. p1_serial)
     end
+    if config and config.disable_pv then
+        disable_pv = true
+        host.log("info", "Zap: PV aggregation disabled via config")
+    end
 
     host.log("info", "Zap: driver initialized (host=" .. zap_host .. ")")
 end
@@ -217,12 +225,17 @@ function driver_poll()
             host.set_sn(p1_serial)
             host.log("info", "Zap: discovered P1 meter " .. p1_serial)
         end
-        pv_serials = pvs
-        if #pv_serials > 0 then
-            host.log("info", "Zap: discovered " .. #pv_serials
-                .. " PV inverter(s): " .. table.concat(pv_serials, ","))
+        if disable_pv then
+            pv_serials = {}
+            host.log("info", "Zap: PV inverters ignored (disable_pv=true)")
         else
-            host.log("info", "Zap: no PV inverters found")
+            pv_serials = pvs
+            if #pv_serials > 0 then
+                host.log("info", "Zap: discovered " .. #pv_serials
+                    .. " PV inverter(s): " .. table.concat(pv_serials, ","))
+            else
+                host.log("info", "Zap: no PV inverters found")
+            end
         end
         discovered = true
         clear_backoff()

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -80,10 +80,22 @@
         var isCloudDriver = cap.http != null && !hasHostField && (hasAuthField || Object.keys(dcfg).length === 0);
         if (isLocalHTTP) {
           var lcfg = d.config || {};
+          // Zap is today the only HTTP driver that aggregates both meter
+          // and PV; the checkbox lets operators point a second gateway
+          // at P1-only duty without a separate driver file.
+          var isZap = /(^|\/)zap\.lua$/.test(d.lua || '');
           html += '<fieldset><legend>HTTP</legend>' +
             '<label>Host / IP ' + help('Hostname (e.g. zap.local) or IP address of the device. mDNS names work when your OS resolver supports them; otherwise use the LAN IP.') + '</label>' +
-            '<input type="text" data-path="drivers.' + idx + '.config.host" value="' + escHtml(lcfg.host || '') + '" placeholder="zap.local">' +
-            '</fieldset>';
+            '<input type="text" data-path="drivers.' + idx + '.config.host" value="' + escHtml(lcfg.host || '') + '" placeholder="zap.local">';
+          if (isZap) {
+            html += '<label style="margin-top:8px;display:flex;align-items:center;gap:6px;font-weight:normal">' +
+              '<input type="checkbox" data-checkbox-path="drivers.' + idx + '.config.disable_pv"' +
+              (lcfg.disable_pv ? ' checked' : '') + '>' +
+              'Disable PV readings ' +
+              help('Use this gateway for the P1 meter only. A second Zap at a metering-only site, or a setup where another driver already owns PV, should enable this so the two drivers don\'t double-count generation.') +
+              '</label>';
+          }
+          html += '</fieldset>';
         }
         if (isCloudDriver) {
           var cfg = d.config || {};

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -80,22 +80,22 @@
         var isCloudDriver = cap.http != null && !hasHostField && (hasAuthField || Object.keys(dcfg).length === 0);
         if (isLocalHTTP) {
           var lcfg = d.config || {};
-          // Zap is today the only HTTP driver that aggregates both meter
-          // and PV; the checkbox lets operators point a second gateway
-          // at P1-only duty without a separate driver file.
-          var isZap = /(^|\/)zap\.lua$/.test(d.lua || '');
+          // Render the Disable-PV checkbox for every HTTP driver; the
+          // post-fetch pass in `after` hides it for drivers whose
+          // catalog doesn't advertise BOTH meter + pv capabilities
+          // (only those can double-count generation). Hiding via a
+          // post-render DOM edit mirrors the site-meter pattern above
+          // and avoids a re-render race with the async catalog fetch.
           html += '<fieldset><legend>HTTP</legend>' +
             '<label>Host / IP ' + help('Hostname (e.g. zap.local) or IP address of the device. mDNS names work when your OS resolver supports them; otherwise use the LAN IP.') + '</label>' +
-            '<input type="text" data-path="drivers.' + idx + '.config.host" value="' + escHtml(lcfg.host || '') + '" placeholder="zap.local">';
-          if (isZap) {
-            html += '<label style="margin-top:8px;display:flex;align-items:center;gap:6px;font-weight:normal">' +
+            '<input type="text" data-path="drivers.' + idx + '.config.host" value="' + escHtml(lcfg.host || '') + '" placeholder="zap.local">' +
+            '<label class="drv-disable-pv" data-drv-lua="' + escHtml(d.lua || '') + '" style="margin-top:8px;display:none;align-items:center;gap:6px;font-weight:normal">' +
               '<input type="checkbox" data-checkbox-path="drivers.' + idx + '.config.disable_pv"' +
               (lcfg.disable_pv ? ' checked' : '') + '>' +
               'Disable PV readings ' +
-              help('Use this gateway for the P1 meter only. A second Zap at a metering-only site, or a setup where another driver already owns PV, should enable this so the two drivers don\'t double-count generation.') +
-              '</label>';
-          }
-          html += '</fieldset>';
+              help('Use this gateway for the P1 meter only. When another driver already owns PV aggregation, set this so the two drivers don\'t double-count generation.') +
+            '</label>' +
+            '</fieldset>';
         }
         if (isCloudDriver) {
           var cfg = d.config || {};
@@ -139,10 +139,26 @@
 
       // Driver catalog picker — fetch async, render into select.
       fetch("/api/drivers/catalog").then(function (r) { return r.json(); }).then(function (data) {
+        var entries = (data && data.entries) || [];
+        // Capability-driven reveal: show the Disable-PV checkbox only
+        // on drivers whose catalog entry advertises BOTH meter and pv.
+        // Other drivers can't double-count generation, so the toggle
+        // would be meaningless. Looking up by `d.lua` ties the UI to
+        // what the driver itself declares, not a hard-coded list.
+        var byLua = {};
+        entries.forEach(function (e) { if (e && e.path) byLua[e.path] = e; });
+        bodyEl.querySelectorAll(".drv-disable-pv").forEach(function (lbl) {
+          var lua = lbl.getAttribute("data-drv-lua");
+          var entry = lua && byLua[lua];
+          if (!entry) return;
+          var caps = entry.capabilities || [];
+          if (caps.indexOf("meter") >= 0 && caps.indexOf("pv") >= 0) {
+            lbl.style.display = "flex";
+          }
+        });
         var sel = document.getElementById("driver-catalog-picker");
         if (!sel) return;
         sel.innerHTML = "";
-        var entries = (data && data.entries) || [];
         if (entries.length === 0) {
           sel.innerHTML = "<option value=''>(no drivers found in drivers/)</option>";
           return;


### PR DESCRIPTION
## Summary

- Lets a secondary Sourceful Zap act as a P1-only meter by setting `disable_pv: true` under the driver's `config:` block. Skips `/api/devices` PV-inverter enumeration and Phase 3 aggregation; P1 meter polling is untouched.
- Settings → Devices shows a "Disable PV readings" checkbox on any `zap.lua` driver, bound via `data-checkbox-path` so the generic settings saver round-trips it as a boolean.
- No impact on single-gateway deployments (flag defaults false). Primary Zap keeps owning PV aggregation as before.

## Why

Sites running two Sourceful Zaps — one with inverters, one as a spare P1 gateway on a different circuit — had both drivers walk `/api/devices` and sum every inverter they saw, double-counting generation in site PV. Decided against forking the driver file; a config flag keeps a single driver, with opt-in semantics.

## Test plan

- [ ] Add a second Zap driver in Settings → Devices, tick "Disable PV readings", Save.
- [ ] Verify the config.yaml round-trip: `config.disable_pv: true` under that driver, no changes to the primary Zap's config block.
- [ ] Confirm logs: secondary driver prints `Zap: PV aggregation disabled via config` at init and `Zap: PV inverters ignored (disable_pv=true)` after discovery; no `pv` emissions appear in telemetry for that driver.
- [ ] Site PV reading matches the primary Zap alone (not doubled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)