### PR TITLE
docs(setup-guide): use bare `fortytwo` hostname (no .local) in all languages

### DIFF
--- a/docs/setup-guide/de.md
+++ b/docs/setup-guide/de.md
@@ -60,7 +60,7 @@ Klicke auf **Next**. Das Programm fragt, ob du die Einstellungen anpassen möcht
 
 Trage ein:
 
-- **Hostname:** `fortytwo.local`
+- **Hostname:** `fortytwo`
 - **Localization:** wähle dein Land
 - **Benutzername:** z.B. `pi`
 - **Passwort:** wähle eins, das du dir merken kannst — aber nicht "1234"
@@ -131,7 +131,7 @@ Gib dein Passwort noch einmal ein. Jetzt wird alles installiert. Das dauert ein 
 Öffne den Browser auf deinem normalen Computer und rufe die Web-Oberfläche auf:
 
 ```
-http://fortytwo.local:8080/
+http://fortytwo:8080/
 ```
 
 Wenn diese Adresse nicht funktioniert — probiere die IP-Adresse, die du aufgeschrieben hast, z.B. `http://192.168.1.123:8080/`.

--- a/docs/setup-guide/en.md
+++ b/docs/setup-guide/en.md
@@ -60,7 +60,7 @@ Click **Next**. The program asks whether you want to customize settings — say 
 
 Fill in:
 
-- **Hostname:** `fortytwo.local`
+- **Hostname:** `fortytwo`
 - **Localization:** choose your country
 - **Username:** e.g. `pi`
 - **Password:** pick something you'll remember — but not "1234"
@@ -131,7 +131,7 @@ Type your password one more time. Everything installs now. It takes a few minute
 Open the browser on your regular computer and go to the web interface:
 
 ```
-http://fortytwo.local:8080/
+http://fortytwo:8080/
 ```
 
 If that address doesn't work — try the IP address you wrote down, e.g. `http://192.168.1.123:8080/`.

--- a/docs/setup-guide/es.md
+++ b/docs/setup-guide/es.md
@@ -60,7 +60,7 @@ Haz clic en **Next**. El programa pregunta si quieres personalizar los ajustes �
 
 Rellena:
 
-- **Hostname:** `fortytwo.local`
+- **Hostname:** `fortytwo`
 - **Localization:** elige tu país
 - **Usuario:** p. ej. `pi`
 - **Contraseña:** elige una que recuerdes — pero no "1234"
@@ -131,7 +131,7 @@ Escribe tu contraseña una vez más. Ahora se instala todo. Tarda unos minutos. 
 Abre el navegador en tu ordenador normal y ve a la interfaz web:
 
 ```
-http://fortytwo.local:8080/
+http://fortytwo:8080/
 ```
 
 Si esa dirección no funciona — prueba con la dirección IP que apuntaste, p. ej. `http://192.168.1.123:8080/`.

--- a/docs/setup-guide/fr.md
+++ b/docs/setup-guide/fr.md
@@ -60,7 +60,7 @@ Cliquez sur **Next**. Le programme demande si vous voulez personnaliser les rég
 
 Remplissez :
 
-- **Hostname :** `fortytwo.local`
+- **Hostname :** `fortytwo`
 - **Localization :** choisissez votre pays
 - **Nom d'utilisateur :** p. ex. `pi`
 - **Mot de passe :** choisissez-en un que vous retiendrez — mais pas "1234"
@@ -131,7 +131,7 @@ Tapez votre mot de passe une dernière fois. Tout s'installe maintenant. Cela pr
 Ouvrez le navigateur sur votre ordinateur habituel et allez à l'interface web :
 
 ```
-http://fortytwo.local:8080/
+http://fortytwo:8080/
 ```
 
 Si cette adresse ne fonctionne pas — essayez l'adresse IP que vous avez notée, p. ex. `http://192.168.1.123:8080/`.

--- a/docs/setup-guide/sv.md
+++ b/docs/setup-guide/sv.md
@@ -60,7 +60,7 @@ Klicka på **Next**. Programmet frågar om du vill anpassa inställningar — sv
 
 Fyll i så här:
 
-- **Hostname:** `fortytwo.local`
+- **Hostname:** `fortytwo`
 - **Localization:** **Sweden / SE**
 - **Användarnamn:** t.ex. `pi`
 - **Lösenord:** välj något du kommer ihåg, men inte "1234"
@@ -131,7 +131,7 @@ Skriv in ditt lösenord en gång till. Nu installeras allt. Det tar några minut
 Öppna webbläsaren på din vanliga dator och gå till webb-gränssnittet:
 
 ```
-http://fortytwo.local:8080/
+http://fortytwo:8080/
 ```
 
 Fungerar inte den adressen — prova IP-adressen du skrev ner, t.ex. `http://192.168.1.123:8080/`.


### PR DESCRIPTION
## Summary
- Raspberry Pi Imager's **Hostname** field takes the short name only — the `.local` suffix is added by mDNS and isn't valid there.
- Updated all five language versions of the setup guide (en, de, fr, es, sv) so the imager hostname and the post-install browser URL both use `fortytwo`.

## Test plan
- [ ] Visual scan of each language file for consistent hostname
- [ ] Verify `http://fortytwo:8080/` resolves on a fresh install (mDNS or router DNS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)