### PR TITLE
feat(rpi-image): trim image by skipping stage2 + minimal Docker install

### DIFF
--- a/deploy/pi-gen/build.sh
+++ b/deploy/pi-gen/build.sh
@@ -57,20 +57,16 @@ rm -rf "${PI_GEN_DIR}/stage-42w"
 cp -R "${SCRIPT_DIR}/stage-42w" "${PI_GEN_DIR}/stage-42w"
 cp    "${SCRIPT_DIR}/config"    "${PI_GEN_DIR}/config"
 
-# Skip the desktop stages entirely — we only want Lite as the base
-# for stage-42w to layer on top of. pi-gen honours SKIP files
-# dropped into each stage's directory.
-for stage in stage3 stage4 stage5; do
+# Skip stage2 (Lite "comfort" CLI tooling) and stage3-5 (desktop +
+# NOOBS) entirely — the only stages we run are stage0 + stage1 +
+# stage-42w. Stage-42w explicitly installs the few stage2 packages
+# we actually need (avahi-daemon, network-manager). pi-gen honours
+# SKIP files dropped into each stage's directory; SKIP prevents the
+# stage from running, SKIP_IMAGES prevents an .img export.
+for stage in stage2 stage3 stage4 stage5; do
     touch "${PI_GEN_DIR}/${stage}/SKIP" \
           "${PI_GEN_DIR}/${stage}/SKIP_IMAGES" 2>/dev/null || true
 done
-
-# Stage2 must still RUN (it's the base rootfs for stage-42w), but
-# we don't want pi-gen to also export a separate `…-lite.img.xz`
-# from it. Without this, `deploy/` ends up with two images and a
-# naive `ls deploy/*.img.xz | head -n1` picks the wrong one
-# alphabetically (the -lite variant sorts ahead of ours).
-touch "${PI_GEN_DIR}/stage2/SKIP_IMAGES" 2>/dev/null || true
 
 cd "${PI_GEN_DIR}"
 

--- a/deploy/pi-gen/config
+++ b/deploy/pi-gen/config
@@ -15,9 +15,14 @@ KEYBOARD_KEYMAP="us"
 KEYBOARD_LAYOUT="English (US)"
 TIMEZONE_DEFAULT="UTC"
 
-# The Lite stages stop after stage2; our stage-42w bakes on top.
-# stage3-5 (desktop + NOOBS) are skipped via SKIP files in build.sh.
-STAGE_LIST="stage0 stage1 stage2 stage-42w"
+# Skip stage2 (Pi OS Lite "comfort" packages: vim, less, raspi-config,
+# build-essential, python3-pip, network-manager-gnome, etc.) — none of
+# its additions are needed for "boot → docker compose up". Stage-42w
+# explicitly pulls the bits we DO need (avahi-daemon for mDNS,
+# network-manager for wifi-connect) so we don't lose mDNS or WiFi
+# onboarding by dropping stage2. Stage3-5 (desktop + NOOBS) are
+# skipped separately via SKIP files in build.sh.
+STAGE_LIST="stage0 stage1 stage-42w"
 
 # First-login creds. Users who flash with Raspberry Pi Imager will
 # override these via Imager's advanced-options panel (which writes to

--- a/deploy/pi-gen/stage-42w/00-install-packages/00-packages
+++ b/deploy/pi-gen/stage-42w/00-install-packages/00-packages
@@ -2,3 +2,5 @@ avahi-daemon
 ca-certificates
 curl
 jq
+network-manager
+raspberrypi-sys-mods

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
@@ -5,20 +5,45 @@
 # *-run-chroot.sh scripts are piped to on_chroot as stdin and
 # therefore can't read the files/ directory, hence the split.
 
-# Docker via the official convenience script — same path as
-# scripts/install.sh so bare-metal and image installs converge on
-# the same engine version. Runs inside the chroot so the installed
-# service units end up in the image rootfs.
+# Docker — explicit apt repo + minimal package set. Replaces
+# `curl get.docker.com | sh` which pulls docker-ce-rootless-extras +
+# docker-buildx-plugin + docker-model-plugin (~300 MB combined). We
+# don't run rootless, don't build images on the Pi, and have no AI
+# workloads — so those stay out. The bare four packages below are
+# what `docker compose up -d` against a pulled image actually needs.
+# Same Docker apt repo URL and pinning approach the convenience
+# script uses, so we stay on the same engine version stream.
 on_chroot << 'EOF'
-curl -fsSL https://get.docker.com | sh
+set -e
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+    > /etc/apt/sources.list.d/docker.list
+apt-get -qq update
+DEBIAN_FRONTEND=noninteractive apt-get -y -qq install --no-install-recommends \
+    docker-ce docker-ce-cli containerd.io docker-compose-plugin
 systemctl enable docker.service
 systemctl enable avahi-daemon.service
+systemctl enable NetworkManager.service
 # /etc/hosts entry prevents sudo's "unable to resolve host 42w"
 # warning on first boot. pi-gen writes /etc/hostname from
 # TARGET_HOSTNAME but leaves /etc/hosts at the stock Raspberry Pi
 # OS template (which hard-codes `raspberrypi`).
 sed -i 's/^127\.0\.1\.1.*/127.0.1.1\t42w/' /etc/hosts
 EOF
+
+# init=firstboot on first boot — without stage2, nobody else injects
+# this into cmdline.txt. The firstboot script ships with
+# raspberrypi-sys-mods and handles partition resize, ssh enable, and
+# userconf-pi processing on the very first boot, then removes itself
+# from cmdline.txt and reboots. Mirrors what pi-gen's
+# stage2/01-sys-tweaks/01-run.sh does on a stock Lite build.
+# Idempotent — re-running the build won't double-inject.
+CMDLINE="${ROOTFS_DIR}/boot/firmware/cmdline.txt"
+if [ -f "${CMDLINE}" ] && ! grep -q "raspberrypi-sys-mods/firstboot" "${CMDLINE}"; then
+    sed -i 's| rootwait| init=/usr/lib/raspberrypi-sys-mods/firstboot rootwait|' "${CMDLINE}"
+fi
 
 # Deploy directory: docker-compose.yml lives here and
 # `docker compose up -d` runs from it on first boot.


### PR DESCRIPTION
## Why

Stock pi-gen output for our use case carries ~1 GB of rootfs the dashboard never touches. We boot, run docker-compose, serve a web UI — none of stage2's \"comfort\" CLI tooling (\`vim\`, \`less\`, \`raspi-config\`, \`build-essential\`, \`python3-pip\`, \`network-manager-gnome\`, \`fonts-*\`, \`htop\`) is on the critical path. The Docker convenience script also pulls \`docker-ce-rootless-extras\`, \`docker-buildx-plugin\`, and \`docker-model-plugin\` (~300 MB combined) that we have no use for.

Stacked on **#186**. Merge target: \`183-rpi-sd-image\` (so the trim sits on top of the three earlier image-pipeline fixes).

## What

Three coordinated changes:

1. **Drop stage2 from STAGE_LIST.** pi-gen now runs only \`stage0 + stage1 + stage-42w\`. SKIP + SKIP_IMAGES files dropped on stage2-5 in \`build.sh\`.

2. **Pull the stage2 packages we actually need into stage-42w.** Added to \`00-install-packages/00-packages\`:
   - \`network-manager\` — wifi-connect depends on it; we already mask dhcpcd in 02-wifi-onboarding.
   - \`raspberrypi-sys-mods\` — provides \`/usr/lib/raspberrypi-sys-mods/firstboot\` which handles partition-resize + ssh-enable on first boot, the same job stage2/01-sys-tweaks did.

3. **Replace \`curl get.docker.com | sh\` with explicit Docker apt repo + minimal package list:** \`docker-ce\`, \`docker-ce-cli\`, \`containerd.io\`, \`docker-compose-plugin\`. Same Docker apt URL the convenience script uses, just without the bloat we don't run.

\`01-ftw-setup/00-run.sh\` also explicitly enables \`NetworkManager.service\` + injects \`init=/usr/lib/raspberrypi-sys-mods/firstboot\` into \`cmdline.txt\` so the first-boot resize still happens — both jobs stage2 used to do.

## Expected impact

Image: **3.0 GB → ~2.0 GB uncompressed**, **561 MB → ~350 MB compressed**.

## Test plan

- [x] CI build: confirms the trimmed STAGE_LIST + minimal Docker install completes successfully.
- [ ] Real-hardware boot: download artifact, flash to SD, boot. Verify:
  - mDNS resolves \`42w.local\` (avahi-daemon up).
  - Partition resize happened (\`df -h /\` shows full SD card).
  - \`docker --version\` works, \`ftw-firstboot\` pulls + brings up the stack.
  - \`http://42w.local:8080/\` redirects to /setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)