### PR TITLE
feat(ci): attach rpi-image PR builds as draft preview releases

### DIFF
--- a/.github/workflows/rpi-image-build.yml
+++ b/.github/workflows/rpi-image-build.yml
@@ -33,7 +33,12 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  # `contents: write` lets the "Attach to PR-preview release" step
+  # below upsert a tag + release with the .img.xz attached. Without
+  # this, gh-release can't create or update the preview release.
+  # Read access is enough for everything else (checkout, build).
+  contents: write
+  pull-requests: read
 
 jobs:
   build:
@@ -120,3 +125,42 @@ jobs:
           # across a normal review cycle.
           retention-days: 14
           if-no-files-found: error
+
+      # ---- PR-preview release ----
+      # GitHub auto-wraps every workflow artifact in a .zip, which
+      # Raspberry Pi Imager and balenaEtcher refuse to accept (they
+      # expect raw .img / .img.xz). Testers had to manually unzip the
+      # wrapper before flashing — clunky and surprising.
+      #
+      # For pull_request events from the same repo (forks get
+      # restricted GITHUB_TOKEN scopes and can't write releases), we
+      # also attach the .img.xz to a per-PR pre-release tagged
+      # `pr-<N>-image-preview`. The release is marked draft so it
+      # doesn't pollute the public Releases page; collaborators can
+      # still grab the asset from the Releases tab → Drafts. Each
+      # rebuild upserts the same tag, so a PR has at most one
+      # preview release at any time.
+      #
+      # Tagged production releases still flow through release.yml
+      # untouched.
+      - name: Attach to PR-preview release
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: pr-${{ github.event.pull_request.number }}-image-preview
+          name: PR #${{ github.event.pull_request.number }} — image preview
+          body: |
+            Auto-built `.img.xz` for PR #${{ github.event.pull_request.number }}
+            (commit `${{ github.event.pull_request.head.sha }}`).
+
+            **Download the asset below directly** — no zip wrapper, ready
+            to flash with Raspberry Pi Imager / Etcher / `dd`. This
+            release is automatically replaced on each new push to the PR
+            and deleted when the PR closes.
+
+            For tagged production releases see the main Releases page.
+          files: ${{ steps.artifact.outputs.path }}
+          draft: true
+          prerelease: true

--- a/.github/workflows/rpi-preview-cleanup.yml
+++ b/.github/workflows/rpi-preview-cleanup.yml
@@ -1,0 +1,42 @@
+name: rpi-image preview cleanup
+
+# Deletes the per-PR draft preview release + tag created by
+# rpi-image-build.yml when the PR closes (merged or rejected).
+# Without this, draft releases pile up indefinitely under the
+# Releases → Drafts tab.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: rpi-preview-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview release + tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: pr-${{ github.event.pull_request.number }}-image-preview
+          REPO: ${{ github.repository }}
+        run: |
+          # Both calls are best-effort: a PR that never had a preview
+          # build (no image-affecting paths touched) will simply 404
+          # on both. We swallow exit codes so the cleanup workflow
+          # itself never goes red and noisily for what is a no-op.
+          set +e
+          echo "Attempting to delete preview release ${TAG}..."
+          gh release delete "${TAG}" --repo "${REPO}" --yes --cleanup-tag 2>&1 || \
+            echo "  (no release with that tag — fine, nothing to delete)"
+          # --cleanup-tag in newer gh versions removes the underlying
+          # ref automatically; older versions need an explicit delete.
+          # Belt-and-suspenders so the tag is gone either way.
+          gh api "repos/${REPO}/git/refs/tags/${TAG}" -X DELETE 2>&1 || \
+            echo "  (no dangling tag — fine)"
+          exit 0


### PR DESCRIPTION
Re-targeting against master now that #186 + #195 are merged.

## Why

GitHub Actions auto-wraps every workflow artifact in a \`.zip\`, which Raspberry Pi Imager and balenaEtcher refuse to handle (they expect raw \`.img\` / \`.img.xz\`). Testers had to manually unzip the wrapper before flashing — clunky enough that it bit us during the first real-hardware test.

## What

Two coordinated workflow changes:

1. **\`rpi-image-build.yml\` gains a release-attach step.** On \`pull_request\` from the same repo, it attaches the \`.img.xz\` to a draft pre-release tagged \`pr-<N>-image-preview\`. Asset is downloadable directly (no zip wrapper), draft so it stays out of the public Releases page, upserted on each push.

2. **New \`rpi-preview-cleanup.yml\`** fires on PR close and deletes the matching tag + draft release.

Forks skipped (their GITHUB_TOKEN doesn't have contents:write). Production tagged releases continue through release.yml unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)