### PR TITLE
Map port 80 -> 8080 on RPi image + Documentation reshuffle (#199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A pre-built `42w-rpi4-arm64-vX.Y.Z.img.xz` ships with every release.
 Flash it to an SD card with [Raspberry Pi Imager](https://www.raspberrypi.com/software/)
 or [balenaEtcher](https://etcher.balena.io/) (both handle `.img.xz`
 natively — no need to decompress first), boot the Pi, and open
-`http://42w.local:8080/`. No terminal work required.
+`http://42w.local/`. No terminal work required.
 
 If you don't pre-configure WiFi in Imager's advanced options, the Pi
 exposes a `42w-setup` captive portal for phone-based onboarding.
@@ -146,6 +146,34 @@ config.yaml
 
 No cloud dependency for core operation. Everything runs locally on the Pi. Weather forecasts (met.no) and electricity prices (Elpriset Just Nu / ENTSO-E) are fetched periodically but the system degrades gracefully without them.
 
+## Documentation
+
+**Get started**
+- [SD-card image walkthrough](docs/rpi-image.md) — flash, boot, WiFi onboarding, troubleshoot
+- [Setup guide](docs/setup-guide/) — first-time wizard explained step by step
+- [Configuration reference](docs/configuration.md) — every YAML key, with examples
+- [Driver catalog](docs/driver-catalog.md) — supported devices and their config blocks
+
+**Run it**
+- [Operations](docs/operations.md) — deploy, backup, upgrade, logs
+- [In-app updates](docs/self-update.md) — how the `ftw-updater` sidecar works
+- [Home Assistant integration](docs/ha-integration.md) — MQTT autodiscovery setup
+- [Safety model](docs/safety.md) — watchdog, clamps, fuse guard, stale-meter guard
+
+**Understand it**
+- [Architecture overview](docs/architecture.md) — layers, data flow, why each piece exists
+- [Site sign convention](docs/site-convention.md) — must-read before touching power-math code
+- [ML models](docs/ml-models.md) — PV / load / price twins
+- [MPC planner](docs/mpc-planner.md) — DP strategy details
+- [Battery models](docs/battery-models.md) — ARX(1), RLS, cascade, self-tune
+- [API reference](docs/api.md) — HTTP endpoints
+
+**Build with it**
+- [Writing a Lua driver](docs/writing-a-driver.md) — full walkthrough
+- [Using Claude Code](docs/writing-a-driver-with-claude-code.md) — AI-assisted driver generation
+- [Testing drivers live](docs/testing-drivers-live.md) — sim + Pi workflow
+- [Lua host API](docs/host-api.md) — every `host.*` capability the Lua side can call
+
 ## Development
 
 ```bash
@@ -155,10 +183,7 @@ make dev          # live dev with hot-reload
 make build-arm64  # cross-compile for Pi
 ```
 
-Driver development:
-- [Writing a Lua driver](docs/writing-a-driver.md) — full walkthrough
-- [Using Claude Code](docs/writing-a-driver-with-claude-code.md) — AI-assisted driver generation
-- [Testing drivers live](docs/testing-drivers-live.md) — sim + Pi workflow
+See [docs/development.md](docs/development.md) and [docs/testing.md](docs/testing.md) for the full dev loop, sim setup, and e2e recipes.
 
 ## Community
 

--- a/deploy/pi-gen/stage-42w/03-port-redirect/00-packages
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/00-packages
@@ -1,0 +1,1 @@
+nftables

--- a/deploy/pi-gen/stage-42w/03-port-redirect/01-run.sh
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/01-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+# Install the nftables rules file + the systemd oneshot that loads
+# it at boot. See files/42w-port-redirect.nft for why this exists
+# (compose stack uses host networking, so docker port mapping isn't
+# available; redirecting at the kernel keeps the app on 8080 and
+# makes 80 reachable for free).
+
+install -m 0644 files/42w-port-redirect.nft       "${ROOTFS_DIR}/etc/42w-port-redirect.nft"
+install -m 0644 files/42w-port-redirect.service   "${ROOTFS_DIR}/etc/systemd/system/42w-port-redirect.service"
+
+on_chroot << 'EOF'
+systemctl enable 42w-port-redirect.service
+EOF

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
@@ -1,0 +1,23 @@
+#!/usr/sbin/nft -f
+# Redirect TCP port 80 to 8080 so the dashboard is reachable at the
+# bare hostname (http://42w.local/) without users having to remember
+# the :8080 suffix.
+#
+# We can't use Docker's port mapping (80:8080) because docker-compose.yml
+# runs the stack with network_mode: host — required for Modbus TCP
+# discovery, LAN MQTT brokers, and mDNS-based drivers like Sourceful
+# Zap. The Go app binds 8080 directly on the host's network namespace.
+#
+# Own table (`42w_redirect`) to stay isolated from any other nftables
+# config a future image stage might add. `flush table` at the top
+# makes the load idempotent: re-running `nft -f` doesn't stack
+# duplicate rules.
+table ip 42w_redirect
+flush table ip 42w_redirect
+
+table ip 42w_redirect {
+    chain prerouting {
+        type nat hook prerouting priority dstnat; policy accept;
+        tcp dport 80 redirect to :8080
+    }
+}

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=42w port 80 -> 8080 redirect (nftables)
+Documentation=https://github.com/frahlg/forty-two-watts/blob/master/docs/rpi-image.md
+# Land before the network is generally available so the redirect is
+# in place when Docker brings the dashboard up. After local-fs so
+# /etc/42w-port-redirect.nft exists.
+After=local-fs.target
+Before=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/nft -f /etc/42w-port-redirect.nft
+# Idempotent — the rules file flushes the 42w_redirect table at the
+# top before re-installing, so a manual `systemctl restart` doesn't
+# stack duplicates.
+ExecReload=/usr/sbin/nft -f /etc/42w-port-redirect.nft
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/rpi-image.md
+++ b/docs/rpi-image.md
@@ -3,7 +3,7 @@
 A pre-built `.img.xz` ships with every release. Flash it to an SD
 card, drop the card into a Raspberry Pi 4, plug in power + Ethernet
 (or follow the WiFi-onboarding flow below), and the dashboard is at
-`http://42w.local:8080/` within ~90 s of first boot. No terminal, no
+`http://42w.local/` within ~90 s of first boot. No terminal, no
 manual install.
 
 This is the recommended path for new users.
@@ -15,7 +15,7 @@ This is the recommended path for new users.
 1. Download `42w-rpi4-arm64-vX.Y.Z.img.xz` from [Releases](https://github.com/frahlg/forty-two-watts/releases/latest).
 2. Flash to an SD card with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended) or [balenaEtcher](https://etcher.balena.io/). Both handle `.img.xz` natively — no need to decompress first.
 3. Insert SD card → power on the Pi → wait ~90 s.
-4. Open `http://42w.local:8080/` in any browser on the same network.
+4. Open `http://42w.local/` in any browser on the same network. (`:8080` also works — the image runs an nftables redirect from 80 to 8080 so the bare hostname is enough.)
 
 If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
 
@@ -31,6 +31,7 @@ If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
 | Container engine | Docker CE + compose plugin (from Docker's official apt repo) |
 | Network | NetworkManager + Avahi (mDNS) |
 | WiFi onboarding | [`wifi-connect`](https://github.com/balena-os/wifi-connect) captive portal |
+| Port redirect | nftables maps 80 -> 8080 so `http://42w.local/` works without `:8080` |
 | Stack | `forty-two-watts`, `mosquitto`, `ftw-updater` (pulled from GHCR on first boot) |
 
 Image size: ~410 MB compressed, ~2.4 GB written to SD card. Any 8 GB
@@ -159,7 +160,7 @@ From a phone or laptop:
    `http://192.168.42.1/` in a browser.
 3. Pick your home network → enter the password → submit.
 4. The Pi joins the network, the AP disappears, the dashboard comes
-   up at `http://42w.local:8080/` within 30–60 s.
+   up at `http://42w.local/` within 30–60 s.
 
 iOS 17 and later occasionally suppress captive-portal popups —
 manually open Safari to any `http://` (not `https://`) URL like
@@ -170,8 +171,11 @@ manually open Safari to any `http://` (not `https://`) URL like
 ## Open the dashboard
 
 ```
-http://42w.local:8080/
+http://42w.local/
 ```
+
+(`http://42w.local:8080/` also works — the image runs an nftables
+redirect at boot so port 80 lands on the same dashboard.)
 
 First time you visit, you land in the setup wizard at `/setup`. Walk
 through: location (for solar forecast), price zone, drivers (your
@@ -180,7 +184,7 @@ over once you click "Finish".
 
 If `42w.local` doesn't resolve (some routers block mDNS, especially
 mesh systems): find the Pi in your router's client list and use the
-IP directly — `http://192.168.x.y:8080/`.
+IP directly — `http://192.168.x.y/` (or `:8080`).
 
 ---
 
@@ -201,7 +205,7 @@ when you flash for real use.
 
 ## Troubleshooting
 
-### Dashboard doesn't load at `42w.local:8080`
+### Dashboard doesn't load at `42w.local`
 
 SSH in:
 


### PR DESCRIPTION
## Summary

- Adds `stage-42w/03-port-redirect/` to the pi-gen image: a tiny nftables rule + systemd oneshot that maps TCP 80 to 8080 at boot. Users can now open `http://42w.local/` directly instead of `http://42w.local:8080/`. The compose stack uses `network_mode: host` (Modbus TCP, mDNS, local MQTT broker), so docker port mapping isn't an option — kernel-level redirect is the cleanest path. Both URLs continue to work.
- README gets a `## Documentation` section that groups existing docs by audience (Get started / Run it / Understand it / Build with it). Surfaces `operations.md`, `safety.md`, `architecture.md`, the configuration reference, and the driver catalog that weren't previously linked from README.
- `docs/rpi-image.md` switches the bare hostname URL everywhere it referenced `:8080`, plus a row in the "What's on the image" table for the redirect.

Confirmed working end-to-end: field tester flashed the merged #186 image with balenaEtcher, booted, and the dashboard came up. This PR layers port 80 + the docs polish on top.

Closes #199. Follow-up to #183.

## Test plan

- [ ] `rpi-image-build` workflow goes green on this PR
- [ ] Flash on RPi4 → `http://42w.local/` responds
- [ ] `http://42w.local:8080/` still responds (no breakage)
- [ ] `nft list ruleset` on the booted Pi shows the `42w_redirect` table
- [ ] `systemctl status 42w-port-redirect` reports active

🤖 Generated with [Claude Code](https://claude.com/claude-code)