### PR TITLE
feat(savings): web UI — Savings tab (PR 3/3)

### DIFF
--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -20,18 +20,25 @@
   const tabs = document.getElementById('app-tabs');
   const viewLive = document.getElementById('view-live');
   const viewDiag = document.getElementById('view-diagnose');
+  const viewSavings = document.getElementById('view-savings');
+
+  // Allow-list for top-level views the router knows about. Anything else
+  // falls back to "live" (matches the historical behaviour). Add a new
+  // entry here when introducing another <main id="view-X"> block.
+  const KNOWN_VIEWS = new Set(['live', 'savings', 'diagnose']);
 
   function applyHash() {
     const h = (location.hash || '#live').replace(/^#/, '');
     const parts = h.split('/');
-    const view = parts[0] === 'diagnose' ? 'diagnose' : 'live';
+    const view = KNOWN_VIEWS.has(parts[0]) ? parts[0] : 'live';
     viewLive.classList.toggle('hidden', view !== 'live');
     viewDiag.classList.toggle('hidden', view !== 'diagnose');
+    if (viewSavings) viewSavings.classList.toggle('hidden', view !== 'savings');
     // Sync active state across both the top-row .tab-btn cluster AND
     // the drawer-nav-btn duplicates inside the mobile header-right
     // drawer. Query the whole document so both get the active pill.
     document.querySelectorAll('.tab-btn[data-view], .drawer-nav-btn[data-view]').forEach(b => {
-      if (b.dataset.view === 'live' || b.dataset.view === 'diagnose') {
+      if (KNOWN_VIEWS.has(b.dataset.view)) {
         b.classList.toggle('active', b.dataset.view === view);
       }
     });
@@ -54,7 +61,8 @@
     tabs.addEventListener('click', (e) => {
       const b = e.target.closest('.tab-btn');
       if (!b) return;
-      location.hash = b.dataset.view === 'diagnose' ? '#diagnose' : '#live';
+      const v = KNOWN_VIEWS.has(b.dataset.view) ? b.dataset.view : 'live';
+      location.hash = '#' + v;
     });
   }
   // Drawer navigation duplicates (mobile). Same behavior as the
@@ -63,7 +71,7 @@
   document.addEventListener('click', (e) => {
     const b = e.target.closest('.drawer-nav-btn[data-view]');
     if (!b) return;
-    if (b.dataset.view !== 'live' && b.dataset.view !== 'diagnose') return;
+    if (!KNOWN_VIEWS.has(b.dataset.view)) return;
     location.hash = '#' + b.dataset.view;
     const hdr = document.querySelector('body.ftw-next > header');
     if (hdr) {

--- a/web/index.html
+++ b/web/index.html
@@ -59,6 +59,7 @@
     <img src="/logo.jpg" alt="42W" class="header-logo"><h1>42W</h1>
     <nav class="app-tabs" id="app-tabs" role="tablist">
       <button data-view="live" class="tab-btn active" role="tab">Live</button>
+      <button data-view="savings" class="tab-btn" role="tab" title="How much money the EMS has saved you, day by day">Savings</button>
       <button data-view="diagnose" class="tab-btn" role="tab" title="Time-travel through past planner decisions">Diagnose</button>
     </nav>
     <!-- Hamburger — visible only on narrow viewports. Opens the header
@@ -71,6 +72,7 @@
            router in diagnose.js treats them the same as the top-row
            tabs. Added so the mobile hamburger menu exposes Diagnose. -->
       <button data-view="live" class="drawer-nav-btn" data-menu-label="Live view">&#9654;</button>
+      <button data-view="savings" class="drawer-nav-btn" data-menu-label="Savings">&#128181;</button>
       <button data-view="diagnose" class="drawer-nav-btn" data-menu-label="Diagnose">&#9202;</button>
       <button id="hero-toggle" class="icon-btn" data-menu-label="Hero / tiles" title="Switch between hero diagram and numeric tiles">&#9638;</button>
       <button id="theme-toggle" class="icon-btn" data-menu-label="Dark mode" title="Toggle light / dark theme">&#9790;</button>
@@ -368,6 +370,51 @@
     </section>
   </main>
 
+  <!-- Savings view — historical savings ledger (per-day vs no-battery
+       baseline, with drill-down). Backend endpoints live in
+       go/internal/api/api_savings.go. Wiring + rendering in savings.js. -->
+  <main id="view-savings" class="hidden">
+    <section class="savings-header">
+      <div class="savings-title">
+        <h2>Savings</h2>
+        <span class="plan-summary">How much the EMS has saved you vs running with no battery — using the same cost model the live planner shows on the Plan card.</span>
+      </div>
+    </section>
+
+    <section class="savings-kpi-row" id="savings-kpis">
+      <!-- Filled by savings.js: today / 7 d / 30 d totals as cards. -->
+    </section>
+
+    <section class="savings-chart-section">
+      <div class="chart-header">
+        <h2 style="font-size:0.95rem">Daily savings</h2>
+        <div class="range-buttons" id="savings-range">
+          <button type="button" data-days="7">7 d</button>
+          <button type="button" data-days="30" class="active">30 d</button>
+          <button type="button" data-days="90">90 d</button>
+        </div>
+      </div>
+      <p class="plan-help">
+        Each day shows two stacked bars: red (lighter) is what the day
+        would have cost with no battery, green (solid) is what it
+        actually cost. The gap between them is the saved money. Click
+        a day to drill into per-slot detail.
+      </p>
+      <div class="chart-container">
+        <canvas id="savings-chart" width="800" height="220"></canvas>
+      </div>
+      <div class="chart-legend">
+        <span class="legend-item" title="What the day would have cost with no battery — load + PV at the meter, priced with the same import + export model the planner uses"><span class="legend-color" style="background:rgba(239,68,68,0.5)"></span> No-battery cost</span>
+        <span class="legend-item" title="What the day actually cost — measured grid flows priced the same way"><span class="legend-color" style="background:rgba(34,197,94,0.78)"></span> Actual cost</span>
+      </div>
+    </section>
+
+    <section class="savings-drill">
+      <div class="savings-drill-head" id="savings-drill-head">Click a day to inspect it</div>
+      <div class="savings-drill-body" id="savings-drill-body"></div>
+    </section>
+  </main>
+
   <!-- Diagnose view — time-travel through persisted planner snapshots -->
   <main id="view-diagnose" class="hidden">
     <section class="diagnose-header">
@@ -457,6 +504,7 @@
   <script src="/plan.js?v=diag1"></script>
   <script src="/twins.js?v=diag1"></script>
   <script src="/diagnose.js?v=diag1"></script>
+  <script src="/savings.js?v=savings1"></script>
   <script src="/update-badge.js?v=modal1" defer></script>
   <script>
     // Bridge: clicking the plain-text version span opens the update modal

--- a/web/next.css
+++ b/web/next.css
@@ -833,6 +833,140 @@ body.ftw-next .saving-badge.saving-pos { border-color: rgba(34,197,94,0.45); col
 body.ftw-next .saving-badge.saving-neg { border-color: rgba(239,68,68,0.45); color: #f87171; }
 body.ftw-next .plan-actions { gap: 10px; display: flex; align-items: center; }
 
+/* ---- Savings view ---- */
+body.ftw-next #view-savings {
+  max-width: 1560px;
+  margin: 0 auto;
+  padding: 20px 28px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+body.ftw-next .savings-header h2 {
+  font-family: var(--sans);
+  font-size: 17px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+body.ftw-next .savings-header .plan-summary {
+  color: var(--fg-muted);
+  font-size: 12px;
+  display: block;
+  max-width: 80ch;
+}
+body.ftw-next .savings-kpi-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+body.ftw-next .savings-kpi { padding: 14px 16px; }
+body.ftw-next .savings-kpi .card-value {
+  font-family: var(--mono);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+body.ftw-next .savings-kpi .card-value.saving-pos { color: #4ade80; }
+body.ftw-next .savings-kpi .card-value.saving-neg { color: #f87171; }
+body.ftw-next .savings-empty {
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-style: italic;
+  padding: 12px;
+}
+body.ftw-next .savings-chart-section {
+  background: var(--ink-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+body.ftw-next .savings-chart-section .chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+body.ftw-next #savings-range button.active {
+  background: var(--accent, #60a5fa);
+  color: #0b1220;
+  border-color: transparent;
+}
+body.ftw-next .savings-drill {
+  background: var(--ink-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+}
+body.ftw-next .savings-drill-head {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+}
+body.ftw-next .savings-drill-head .drill-day {
+  font-weight: 700;
+  color: var(--fg);
+  font-size: 13px;
+}
+body.ftw-next .savings-drill-head .drill-stat b { color: var(--fg); }
+body.ftw-next .savings-drill-head .drill-warn { color: #f59e0b; }
+body.ftw-next .savings-table {
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 11px;
+  border-collapse: collapse;
+}
+body.ftw-next .savings-table thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--fg-muted);
+  border-bottom: 1px solid var(--line);
+  padding: 6px 8px;
+  position: sticky;
+  top: 0;
+  background: var(--ink-raised);
+}
+body.ftw-next .savings-table tbody td {
+  padding: 5px 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  color: var(--fg);
+}
+body.ftw-next .savings-table td.num { text-align: right; }
+body.ftw-next .savings-table td.drill-dim { color: var(--fg-muted); }
+body.ftw-next .savings-table td.saving-pos { color: #4ade80; }
+body.ftw-next .savings-table td.saving-neg { color: #f87171; }
+body.ftw-next .savings-table .flow-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  max-width: 320px;
+}
+body.ftw-next .flow-tag {
+  font-size: 10px;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 1px 5px;
+  white-space: nowrap;
+  opacity: 0.95;
+}
+body.ftw-next .savings-tip {
+  position: fixed;
+  background: rgba(15,23,42,0.96);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg);
+  pointer-events: none;
+  z-index: 100;
+}
+body.ftw-next .savings-tip .tip-day { font-weight: 700; margin-bottom: 3px; }
+body.ftw-next .savings-tip .tip-warn { color: #f59e0b; margin-top: 3px; }
+
 /* ---- ML twins / drivers / calibration sections ---- */
 body.ftw-next .section-header h2,
 body.ftw-next #twins-section h2,

--- a/web/savings.js
+++ b/web/savings.js
@@ -1,0 +1,426 @@
+// savings.js — historical savings ledger.
+//
+// Shows three things:
+//   1. KPI row (today / 7 d / 30 d total saved vs no-battery baseline)
+//   2. Daily bar chart — one bar per day, height = savings_ore. Click a
+//      bar to drill in.
+//   3. Drill-down panel — per-slot table for the selected day, including
+//      flow decomposition (where each kWh came from / went to) and the
+//      predicted-vs-actual overlay from planner_diagnostics.
+//
+// Backed by:
+//   GET /api/savings/summary    → KPI numbers
+//   GET /api/savings/daily?days → bar chart
+//   GET /api/savings/intraday?date → drill-down rows
+
+(function () {
+  'use strict';
+
+  const REFRESH_MS = 60 * 1000;
+
+  const state = {
+    summary: null,
+    daily: [],
+    selectedDate: null,
+    intraday: null,
+    range: 30, // days shown on the bar chart
+  };
+
+  const fmtSEK = (ore) => (ore / 100).toFixed(2) + ' SEK';
+  const fmtSEKShort = (ore) => {
+    const sek = ore / 100;
+    if (Math.abs(sek) >= 1000) return (sek / 1000).toFixed(1) + ' k';
+    if (Math.abs(sek) >= 100) return sek.toFixed(0);
+    return sek.toFixed(1);
+  };
+  const fmtSEKSigned = (ore) => (ore >= 0 ? '+' : '−') + fmtSEK(Math.abs(ore));
+  const fmtKWh = (kwh) => kwh.toFixed(2) + ' kWh';
+  const fmtPct = (p) => (p * 100).toFixed(0) + ' %';
+
+  async function fetchAll() {
+    try {
+      const [summary, daily] = await Promise.all([
+        fetch('/api/savings/summary').then(r => r.json()).catch(() => ({})),
+        fetch('/api/savings/daily?days=' + state.range).then(r => r.json()).catch(() => ({})),
+      ]);
+      state.summary = summary || null;
+      state.daily = (daily && daily.days) || [];
+      // Keep the selected date if it still appears in the new range,
+      // otherwise default to the most recent day.
+      const seen = new Set(state.daily.map(d => d.day));
+      if (!state.selectedDate || !seen.has(state.selectedDate)) {
+        state.selectedDate = state.daily.length > 0 ? state.daily[state.daily.length - 1].day : null;
+      }
+      if (state.selectedDate) {
+        await loadIntraday(state.selectedDate);
+      } else {
+        state.intraday = null;
+      }
+    } catch (e) {
+      // Silent — UI shows empty state on its own.
+    }
+    render();
+  }
+
+  async function loadIntraday(date) {
+    try {
+      const r = await fetch('/api/savings/intraday?date=' + encodeURIComponent(date));
+      state.intraday = await r.json();
+    } catch (e) {
+      state.intraday = null;
+    }
+  }
+
+  function setRange(days) {
+    state.range = days;
+    fetchAll();
+  }
+
+  // ---- Renderers ----
+
+  function renderKPIs() {
+    const el = document.getElementById('savings-kpis');
+    if (!el) return;
+    const s = state.summary;
+    if (!s || !s.enabled) {
+      const reason = (s && s.reason) || 'savings not available — configure spot prices first';
+      el.innerHTML = `<div class="savings-empty">${reason}</div>`;
+      return;
+    }
+    const cls = (v) => v >= 0 ? 'saving-pos' : 'saving-neg';
+    const card = (label, ore, hint) =>
+      `<div class="card savings-kpi" title="${hint}">` +
+      `  <div class="card-label">${label}</div>` +
+      `  <div class="card-value ${cls(ore)}">${fmtSEKSigned(ore)}</div>` +
+      `</div>`;
+    el.innerHTML =
+      card('Today', s.today_ore || 0,
+        'Savings so far today vs running with no battery — recomputed on every page load.') +
+      card('Last 7 days', s.last_7_days_ore || 0,
+        'Sum of daily savings over the last 7 days (today included).') +
+      card('Last 30 days', s.last_30_days_ore || 0,
+        'Sum of daily savings over the last 30 days (today included).');
+  }
+
+  function renderRangeButtons() {
+    const wrap = document.getElementById('savings-range');
+    if (!wrap) return;
+    wrap.querySelectorAll('button').forEach(b => {
+      b.classList.toggle('active', Number(b.dataset.days) === state.range);
+    });
+  }
+
+  // Daily bar chart. Two stacked rectangles per day:
+  //   bottom (light) = no-battery cost
+  //   on top (dark)  = actual cost
+  // Saved area is the gap. Hovering / clicking selects the day.
+  function renderDailyChart() {
+    const canvas = document.getElementById('savings-chart');
+    if (!canvas) return;
+    const cssW = canvas.clientWidth || 800;
+    const cssH = 220;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = cssW * dpr;
+    canvas.height = cssH * dpr;
+    canvas.style.height = cssH + 'px';
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const pad = { l: 50, r: 12, t: 12, b: 28 };
+    const plotW = cssW - pad.l - pad.r;
+    const plotH = cssH - pad.t - pad.b;
+
+    if (state.daily.length === 0) {
+      ctx.fillStyle = 'rgba(255,255,255,0.45)';
+      ctx.font = '12px var(--mono, monospace)';
+      ctx.textAlign = 'center';
+      ctx.fillText('No priced days yet — savings appear once spot prices have been fetched.',
+        cssW / 2, cssH / 2);
+      state.barBounds = [];
+      return;
+    }
+
+    // y-scale: max of (no_battery_ore, actual_ore) across days.
+    let yMax = 0;
+    for (const d of state.daily) {
+      yMax = Math.max(yMax, d.no_battery_ore || 0, d.actual_ore || 0);
+    }
+    if (yMax <= 0) yMax = 1;
+
+    // Headroom + nice round step for ticks
+    const niceMax = Math.ceil(yMax / 100) * 100;
+    const yScale = (v) => pad.t + plotH - (v / niceMax) * plotH;
+
+    // Y-axis
+    ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+    ctx.fillStyle = 'rgba(255,255,255,0.45)';
+    ctx.font = '10px var(--mono, monospace)';
+    ctx.textAlign = 'right';
+    const ticks = 4;
+    for (let i = 0; i <= ticks; i++) {
+      const v = (niceMax / ticks) * i;
+      const y = yScale(v);
+      ctx.beginPath();
+      ctx.moveTo(pad.l, y);
+      ctx.lineTo(cssW - pad.r, y);
+      ctx.stroke();
+      ctx.fillText(fmtSEKShort(v), pad.l - 4, y + 3);
+    }
+
+    const n = state.daily.length;
+    const barSlot = plotW / n;
+    const barW = Math.max(2, Math.min(20, barSlot * 0.7));
+    const bounds = [];
+    for (let i = 0; i < n; i++) {
+      const d = state.daily[i];
+      const cx = pad.l + barSlot * i + barSlot / 2;
+      const x0 = cx - barW / 2;
+      const yNoBat = yScale(d.no_battery_ore || 0);
+      const yActual = yScale(d.actual_ore || 0);
+      const y0 = Math.min(yNoBat, yActual);
+      const yBase = pad.t + plotH;
+
+      // No-battery rectangle (full height)
+      ctx.fillStyle = 'rgba(239,68,68,0.32)';
+      ctx.fillRect(x0, yNoBat, barW, yBase - yNoBat);
+      // Actual rectangle (smaller — overlays the bottom of the no-bat)
+      ctx.fillStyle = 'rgba(34,197,94,0.78)';
+      ctx.fillRect(x0, yActual, barW, yBase - yActual);
+
+      // Selection highlight
+      if (d.day === state.selectedDate) {
+        ctx.strokeStyle = '#60a5fa';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x0 - 1, pad.t - 2, barW + 2, plotH + 4);
+        ctx.lineWidth = 1;
+      }
+
+      bounds.push({ x0, x1: x0 + barW, day: d.day, data: d });
+
+      // Date tick on every Nth bar so labels don't collide
+      const everyN = Math.max(1, Math.ceil(n / 10));
+      if (i % everyN === 0 || i === n - 1) {
+        ctx.fillStyle = 'rgba(255,255,255,0.5)';
+        ctx.textAlign = 'center';
+        ctx.fillText(d.day.slice(5), cx, cssH - pad.b + 14);
+      }
+    }
+    state.barBounds = bounds;
+  }
+
+  function renderDrillDown() {
+    const head = document.getElementById('savings-drill-head');
+    const body = document.getElementById('savings-drill-body');
+    if (!head || !body) return;
+
+    const i = state.intraday;
+    if (!state.selectedDate) {
+      head.textContent = 'Click a day to inspect it';
+      body.innerHTML = '';
+      return;
+    }
+    if (!i || !i.enabled) {
+      head.textContent = state.selectedDate;
+      body.innerHTML = '<div class="savings-empty">No data for this day yet.</div>';
+      return;
+    }
+
+    const slots = i.slots || [];
+    const sek = (ore) => (ore / 100).toFixed(2);
+
+    const headParts = [
+      `<span class="drill-day">${i.day}</span>`,
+      `<span class="drill-stat">Saved <b>${fmtSEKSigned(i.savings_ore)}</b></span>`,
+      `<span class="drill-stat">Actual <b>${sek(i.actual_ore)} SEK</b></span>`,
+      `<span class="drill-stat">No battery <b>${sek(i.no_battery_ore)} SEK</b></span>`,
+    ];
+    if (typeof i.coverage_pct === 'number' && i.coverage_pct < 0.95) {
+      headParts.push(`<span class="drill-stat drill-warn" title="Less than 95% of the day's slot-time had data — slots with gaps are excluded from totals">Coverage ${fmtPct(i.coverage_pct)}</span>`);
+    }
+    head.innerHTML = headParts.join(' · ');
+
+    if (slots.length === 0) {
+      body.innerHTML = '<div class="savings-empty">No priced slots for this day.</div>';
+      return;
+    }
+
+    const rows = slots.map(s => {
+      const t = new Date(s.start_ms);
+      const hh = t.getHours().toString().padStart(2, '0') + ':' +
+                 t.getMinutes().toString().padStart(2, '0');
+      const cls = s.savings_ore >= 0 ? 'saving-pos' : 'saving-neg';
+      const flows = s.flows || {};
+      // Compact flow tags: only show non-zero contributions, ordered by magnitude.
+      const tags = [];
+      const push = (label, kwh, color) => {
+        if (Math.abs(kwh) < 0.01) return;
+        tags.push({ label, kwh, color });
+      };
+      push('self', flows.self_consumption_kwh, '#22c55e');
+      push('PV→bat', flows.pv_to_bat_kwh, '#86efac');
+      push('bat→home', flows.bat_to_home_kwh, '#8b5cf6');
+      push('grid→bat', flows.grid_to_bat_kwh, '#f59e0b');
+      push('bat→grid', flows.bat_to_grid_kwh, '#a78bfa');
+      push('export', flows.direct_export_kwh, '#34d399');
+      push('grid→home', flows.grid_to_home_kwh, '#ef4444');
+      tags.sort((a, b) => b.kwh - a.kwh);
+      const tagsHtml = tags.map(t =>
+        `<span class="flow-tag" style="border-color:${t.color}33;color:${t.color}" title="${t.label} ${t.kwh.toFixed(2)} kWh">` +
+        `${t.label} ${t.kwh.toFixed(2)}</span>`
+      ).join('');
+
+      let predictedCell = '';
+      if (typeof s.predicted_ore === 'number') {
+        const errCls = Math.abs(s.prediction_error_ore) < 1 ? '' :
+          (s.prediction_error_ore > 0 ? 'saving-neg' : 'saving-pos');
+        predictedCell = `<td class="num">${sek(s.predicted_ore)}</td>` +
+          `<td class="num ${errCls}" title="actual − predicted (öre)">${sek(s.prediction_error_ore)}</td>`;
+      } else {
+        predictedCell = '<td class="num drill-dim">—</td><td class="num drill-dim">—</td>';
+      }
+
+      return `<tr>
+        <td>${hh}</td>
+        <td class="num">${(s.price_ore || 0).toFixed(0)}</td>
+        <td class="num">${(s.load_kwh || 0).toFixed(2)}</td>
+        <td class="num">${(s.pv_kwh || 0).toFixed(2)}</td>
+        <td class="num">${(s.grid_import_kwh || 0).toFixed(2)}</td>
+        <td class="num">${(s.grid_export_kwh || 0).toFixed(2)}</td>
+        <td class="num">${(s.bat_charged_kwh || 0).toFixed(2)}</td>
+        <td class="num">${(s.bat_discharged_kwh || 0).toFixed(2)}</td>
+        <td class="num">${sek(s.actual_ore)}</td>
+        <td class="num">${sek(s.no_battery_ore)}</td>
+        <td class="num ${cls}"><b>${fmtSEKSigned(s.savings_ore)}</b></td>
+        ${predictedCell}
+        <td class="flow-cell">${tagsHtml}</td>
+      </tr>`;
+    });
+
+    body.innerHTML = `
+      <table class="savings-table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>öre/kWh</th>
+            <th>Load</th>
+            <th>PV</th>
+            <th>Grid in</th>
+            <th>Grid out</th>
+            <th>Bat ch</th>
+            <th>Bat dis</th>
+            <th>Actual</th>
+            <th>No bat</th>
+            <th>Saved</th>
+            <th title="Cost the MPC plan predicted for this slot at the time it ran">MPC said</th>
+            <th title="Actual − predicted; positive = paid more than the plan expected">Δ</th>
+            <th>Flows (kWh)</th>
+          </tr>
+        </thead>
+        <tbody>${rows.join('')}</tbody>
+      </table>`;
+  }
+
+  function render() {
+    renderKPIs();
+    renderRangeButtons();
+    renderDailyChart();
+    renderDrillDown();
+  }
+
+  // ---- Wiring ----
+
+  function setupChartHover() {
+    const canvas = document.getElementById('savings-chart');
+    if (!canvas) return;
+    let tip = document.getElementById('savings-tip');
+    if (!tip) {
+      tip = document.createElement('div');
+      tip.id = 'savings-tip';
+      tip.className = 'savings-tip';
+      tip.style.display = 'none';
+      document.body.appendChild(tip);
+    }
+    canvas.addEventListener('mousemove', (e) => {
+      if (!state.barBounds || state.barBounds.length === 0) {
+        tip.style.display = 'none';
+        return;
+      }
+      const rect = canvas.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      let found = null;
+      for (const b of state.barBounds) {
+        if (cx >= b.x0 && cx <= b.x1) { found = b; break; }
+      }
+      if (!found) { tip.style.display = 'none'; return; }
+      const d = found.data;
+      tip.innerHTML =
+        `<div class="tip-day">${d.day}</div>` +
+        `<div>Saved: <b>${fmtSEKSigned(d.savings_ore)}</b></div>` +
+        `<div>Actual: ${fmtSEK(d.actual_ore)}</div>` +
+        `<div>No battery: ${fmtSEK(d.no_battery_ore)}</div>` +
+        (d.coverage_pct < 0.95 ? `<div class="tip-warn">Coverage ${fmtPct(d.coverage_pct)}</div>` : '');
+      tip.style.display = 'block';
+      tip.style.left = (e.clientX + 12) + 'px';
+      tip.style.top = (e.clientY + 12) + 'px';
+    });
+    canvas.addEventListener('mouseleave', () => { tip.style.display = 'none'; });
+    canvas.addEventListener('click', (e) => {
+      if (!state.barBounds) return;
+      const rect = canvas.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      for (const b of state.barBounds) {
+        if (cx >= b.x0 && cx <= b.x1) {
+          state.selectedDate = b.day;
+          loadIntraday(b.day).then(render);
+          return;
+        }
+      }
+    });
+  }
+
+  function setupRangeButtons() {
+    const wrap = document.getElementById('savings-range');
+    if (!wrap) return;
+    wrap.addEventListener('click', (e) => {
+      const b = e.target.closest('button[data-days]');
+      if (!b) return;
+      setRange(Number(b.dataset.days));
+    });
+  }
+
+  // ---- Lifecycle ----
+
+  let timer = null;
+  let started = false;
+
+  function start() {
+    if (started) return;
+    const view = document.getElementById('view-savings');
+    if (!view) return;
+    started = true;
+    setupChartHover();
+    setupRangeButtons();
+    fetchAll();
+    timer = setInterval(() => {
+      // Only refresh if the view is actually visible — saves cycles +
+      // avoids a request burst on slow links when the operator never
+      // opens the tab.
+      if (view.classList.contains('hidden')) return;
+      fetchAll();
+    }, REFRESH_MS);
+  }
+
+  // Boot when the savings view becomes visible (or on hash arrival).
+  function maybeStart() {
+    const view = document.getElementById('view-savings');
+    if (view && !view.classList.contains('hidden')) start();
+  }
+  window.addEventListener('hashchange', maybeStart);
+  document.addEventListener('DOMContentLoaded', maybeStart);
+  // If the document is already parsed when this script runs (the
+  // common case — we're loaded at the bottom of <body>), check once
+  // synchronously so navigating directly to #savings works on first
+  // load without a hash event.
+  if (document.readyState !== 'loading') maybeStart();
+})();


### PR DESCRIPTION
Stacked on #201.

## Summary

PR 3 of 3 in the **historical savings** feature track. New top-level
"Savings" tab in the dashboard, between Live and Diagnose. Backed by
the endpoints shipped in #201; this is the visible end of the
feature.

## What it shows

1. **KPI row** — Today / Last 7 days / Last 30 days, in SEK,
   coloured green when positive, red when negative.

2. **Daily bar chart** — One stacked bar per day:
   - Red (lighter) rectangle is what the day **would have cost**
     with no battery at all.
   - Green (solid) rectangle is what the day **actually cost**.
   - The gap between them is the saved money.

   Hover for the day's full numbers. Click to drill in.

3. **Drill-down table** — Per-slot rows with measured kWh per
   channel (load / PV / grid in / grid out / battery charge / battery
   discharge), actual vs no-battery öre, the planner's
   predicted cost from `planner_diagnostics` for that slot (when
   available), and a flow-tag chip cloud so the operator can see
   HOW the savings happened — `self 0.42`, `bat→home 0.31`,
   `grid→bat 1.20`, etc.

4. **Coverage warning** when less than 95 % of the day's slot-time
   had history data — slots with gaps are excluded from totals so
   an outage doesn't silently inflate either side.

## Routing change

Extended `diagnose.js` to consult a `KNOWN_VIEWS` set instead of
hard-coding the live/diagnose binary. Adding a fourth tab in the
future is now one constant entry plus a `<main id="view-X">` block;
no per-route branches. Behaviour for `#live` and `#diagnose`
unchanged — verified by inspection of the served `index.html` (tab
buttons, drawer buttons, and main view containers all present at
the expected positions).

## Test plan

- [x] **`go test ./...`** — full suite green (no Go changes in this
  PR, just sanity).
- [x] **JS syntax** — `node -c web/savings.js` and `node -c
  web/diagnose.js` both parse clean.
- [x] **Static-asset smoke test** — booted a backend on a private
  port with a stub config (no drivers, prices=elprisetjustnu,
  zone=SE3) and confirmed:
  - `GET /api/savings/summary` → `{enabled: true, ...}` once prices
    arrive
  - `GET /api/savings/daily?days=3` → enabled, day rows with zero
    cost (no history seeded yet)
  - `GET /savings.js` and `GET /` → expected payloads, all
    `data-view="savings"` / `view-savings` / `savings.js` markup
    present in the served HTML.
- [ ] **In-browser visual** — out of scope for this PR. We'll let
  the field testers (`@erikarenhill` et al.) put real data through
  the page and report back; the math has unit + integration tests
  behind it from #198 and #201.