### PR TITLE
fix(mpc): price imports + exports separately in FlatAvg baseline

### DIFF
--- a/go/internal/mpc/baselines.go
+++ b/go/internal/mpc/baselines.go
@@ -16,11 +16,19 @@ package mpc
 //     computed by the DP's own per-slot loop, so it's directly
 //     comparable to plan.TotalCostOre.
 //
-//   - FlatAvgOre: total net consumption × the horizon's mean import
-//     price. Shows the value of *when* energy is moved — if the
-//     optimizer saves more vs FlatAvg than vs NoBattery, most of the
-//     win is timing (shifting load into cheap hours) rather than PV
+//   - FlatAvgOre: no-battery import volume × horizon mean import price,
+//     minus no-battery export volume × horizon mean export revenue.
+//     Shows the value of *when* energy is moved — if the optimizer
+//     saves more vs FlatAvg than vs NoBattery, most of the win is
+//     timing (shifting load into cheap hours) rather than PV
 //     self-consumption. A diagnostic, not an operational baseline.
+//
+//     Import and export are priced separately (and at their respective
+//     means) because the consumer total PriceOre includes grid tariffs
+//     that aren't earned on export. Netting energy at a single mean
+//     would credit each exported kWh at the import-tariff price — and
+//     so any horizon with even partial export would show an artificially
+//     low FlatAvg, hiding timing value behind the asymmetry.
 //
 // Cheap to call — the SC re-optimize is one extra Optimize pass
 // (~10ms for the default 193 slots × 51 SoC × 21 actions).
@@ -31,26 +39,38 @@ func ComputeBaselines(slots []Slot, p Params) Baselines {
 	}
 
 	// ---- No-battery baseline + flat-average inputs ----
-	// Both can be computed in one pass over the slots.
-	var netKWh float64
-	var priceWtMin float64
+	// One pass: integrate no-battery grid flow per slot, bucket into
+	// import / export volumes, and accumulate time-weighted means of
+	// the import price and the export revenue (using the same per-slot
+	// formula SlotGridCostOre uses). FlatAvgOre then re-scores the
+	// no-battery flows at those flat means.
+	var importKWh, exportKWh float64
+	var importPriceWtMin, exportPriceWtMin float64
 	var lenMinSum float64
 	for _, s := range slots {
 		dt := float64(s.LenMin) / 60.0
 		gridKWh := (s.LoadW + s.PVW) * dt / 1000.0
 		b.NoBatteryOre += SlotGridCostOre(s, gridKWh, p)
-		netKWh += gridKWh
-		priceWtMin += s.PriceOre * float64(s.LenMin)
-		lenMinSum += float64(s.LenMin)
+		if gridKWh > 0 {
+			importKWh += gridKWh
+		} else {
+			exportKWh += -gridKWh
+		}
+		lm := float64(s.LenMin)
+		importPriceWtMin += s.PriceOre * lm
+		exportPriceWtMin += SlotExportPriceOre(s, p) * lm
+		lenMinSum += lm
 	}
+	var avgImportOre, avgExportOre float64
 	if lenMinSum > 0 {
-		b.AvgPriceOre = priceWtMin / lenMinSum
+		avgImportOre = importPriceWtMin / lenMinSum
+		avgExportOre = exportPriceWtMin / lenMinSum
 	}
-	b.NetKWh = netKWh
-	// Flat-avg: charge the net consumption at the mean price. If net is
-	// negative (export-dominated horizon), the sign is kept — consistent
-	// with the NoBattery cost model where export shows up as negative.
-	b.FlatAvgOre = netKWh * b.AvgPriceOre
+	// AvgPriceOre keeps its meaning as the horizon's mean import price —
+	// that's what the planner UI's "vs flat avg" tooltip references.
+	b.AvgPriceOre = avgImportOre
+	b.NetKWh = importKWh - exportKWh
+	b.FlatAvgOre = importKWh*avgImportOre - exportKWh*avgExportOre
 
 	// ---- Self-consumption baseline ----
 	// Re-run Optimize with the SC policy. Drop the loadpoint from the

--- a/go/internal/mpc/baselines_test.go
+++ b/go/internal/mpc/baselines_test.go
@@ -98,3 +98,70 @@ func TestBaselinesEmpty(t *testing.T) {
 		t.Errorf("expected zero Baselines for empty slots, got %+v", b)
 	}
 }
+
+// FlatAvg must price imports and exports separately. The consumer total
+// PriceOre includes grid tariffs that are not earned on export, so
+// netting energy at one mean would credit each exported kWh at the
+// import-tariff price and silently shrink the apparent timing value.
+//
+// Setup: 4 slots, 60 min each, SpotOre = PriceOre/2 (export earns half
+// of consumer price, no bonus/fee). Load = 0 in slots 0..1, PV = -2 kW
+// in slots 0..1; load = 2 kW in slots 2..3, no PV. So the no-battery
+// flows are exactly: slot 0,1 export 2 kWh each; slot 2,3 import 2 kWh
+// each. Symmetric volumes, asymmetric prices.
+func TestBaselinesFlatAvgPricesImportExportSeparately(t *testing.T) {
+	prices := []float64{100, 200, 300, 400} // consumer total, öre/kWh
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: prices[0], SpotOre: prices[0] / 2, LoadW: 0, PVW: -2000},
+		{StartMs: 3_600_000, LenMin: 60, PriceOre: prices[1], SpotOre: prices[1] / 2, LoadW: 0, PVW: -2000},
+		{StartMs: 7_200_000, LenMin: 60, PriceOre: prices[2], SpotOre: prices[2] / 2, LoadW: 2000, PVW: 0},
+		{StartMs: 10_800_000, LenMin: 60, PriceOre: prices[3], SpotOre: prices[3] / 2, LoadW: 2000, PVW: 0},
+	}
+	p := baseParams(ModeArbitrage)
+
+	b := ComputeBaselines(slots, p)
+
+	// AvgPriceOre is the mean *import* price (consumer total).
+	wantAvgImport := (100.0 + 200 + 300 + 400) / 4.0 // 250
+	if math.Abs(b.AvgPriceOre-wantAvgImport) > 1e-6 {
+		t.Errorf("avg import price: got %.3f, want %.3f", b.AvgPriceOre, wantAvgImport)
+	}
+	// NetKWh is import minus export. Both are 4 kWh ⇒ 0.
+	if math.Abs(b.NetKWh) > 1e-9 {
+		t.Errorf("net kWh: got %.6f, want 0 (4 in, 4 out)", b.NetKWh)
+	}
+	// FlatAvg priced separately: 4 kWh × 250 import − 4 kWh × 125 export
+	// = 1000 − 500 = 500 öre. The old (buggy) implementation returned
+	// netKWh × avgImport = 0 × 250 = 0 — i.e., it would tell the user
+	// timing was worth nothing, which is exactly the case Erik flagged.
+	wantFlat := 4.0*250.0 - 4.0*125.0
+	if math.Abs(b.FlatAvgOre-wantFlat) > 1e-6 {
+		t.Errorf("flat-avg cost: got %.3f, want %.3f", b.FlatAvgOre, wantFlat)
+	}
+	// Sanity: NoBattery on the same flows uses the same per-slot model,
+	// just with the actual per-slot prices. Imports cost slot.PriceOre,
+	// exports earn slot.SpotOre (no flat fee/bonus in baseParams).
+	wantNoBat := 2.0*300.0 + 2.0*400.0 - 2.0*50.0 - 2.0*100.0 // 1400 − 300 = 1100
+	if math.Abs(b.NoBatteryOre-wantNoBat) > 1e-6 {
+		t.Errorf("no-battery cost: got %.3f, want %.3f", b.NoBatteryOre, wantNoBat)
+	}
+}
+
+// Honor a flat ExportOrePerKWh feed-in tariff: every exported kWh in
+// FlatAvgOre is credited at exactly that rate, regardless of slot spot.
+func TestBaselinesFlatAvgHonorsFlatExportTariff(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 200, SpotOre: 50, LoadW: 0, PVW: -1000},
+		{StartMs: 3_600_000, LenMin: 60, PriceOre: 200, SpotOre: 50, LoadW: 1000, PVW: 0},
+	}
+	p := baseParams(ModeArbitrage)
+	p.ExportOrePerKWh = 60 // flat feed-in beats spot=50
+
+	b := ComputeBaselines(slots, p)
+
+	// Import: 1 kWh × 200 = 200. Export: 1 kWh × 60 = 60. FlatAvg = 140.
+	wantFlat := 1.0*200.0 - 1.0*60.0
+	if math.Abs(b.FlatAvgOre-wantFlat) > 1e-6 {
+		t.Errorf("flat-avg with flat export tariff: got %.3f, want %.3f", b.FlatAvgOre, wantFlat)
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -178,10 +178,12 @@ type Action struct {
 // load + pv each slot, priced with the same import/export model the DP
 // uses). SelfConsumptionOre comes from re-running Optimize with
 // ModeSelfConsumption — so it uses the real efficiency, power, and SoC
-// constraints, not a simplified simulation. FlatAvgOre is net
-// consumption priced at the horizon's mean — shows the value of
-// *timing* (shifting load to cheap hours), separate from the value of
-// having a battery.
+// constraints, not a simplified simulation. FlatAvgOre re-prices the
+// no-battery flows at horizon-mean prices (import and export each at
+// their own mean) — shows the value of *timing* (shifting load to
+// cheap hours), separate from the value of having a battery.
+// AvgPriceOre is the time-weighted mean import price over the horizon;
+// NetKWh is import minus export volume.
 type Baselines struct {
 	NoBatteryOre       float64 `json:"no_battery_ore"`
 	SelfConsumptionOre float64 `json:"self_consumption_ore"`
@@ -216,14 +218,23 @@ func SlotGridCostOre(slot Slot, gridKWh float64, p Params) float64 {
 	if gridKWh > 0 {
 		return slot.PriceOre * gridKWh
 	}
-	rawExport := p.ExportOrePerKWh
-	if rawExport <= 0 {
-		rawExport = slot.SpotOre + p.ExportBonusOreKwh - p.ExportFeeOreKwh
-		if rawExport < 0 {
-			rawExport = 0
-		}
+	return -SlotExportPriceOre(slot, p) * (-gridKWh)
+}
+
+// SlotExportPriceOre returns the öre/kWh a slot's export earns, using the
+// same model SlotGridCostOre uses on the export side: a flat
+// ExportOrePerKWh wins if set, otherwise spot + bonus − fee clamped at
+// zero. Exported here so baseline / reconstruction code can apply the
+// export side of the cost model without duplicating the formula.
+func SlotExportPriceOre(slot Slot, p Params) float64 {
+	if p.ExportOrePerKWh > 0 {
+		return p.ExportOrePerKWh
 	}
-	return -rawExport * (-gridKWh)
+	v := slot.SpotOre + p.ExportBonusOreKwh - p.ExportFeeOreKwh
+	if v < 0 {
+		v = 0
+	}
+	return v
 }
 
 // Optimize runs DP and returns the cost-minimizing plan.

--- a/web/plan.js
+++ b/web/plan.js
@@ -518,7 +518,7 @@
           badge(
             'vs flat avg price',
             savedFlat, sekFlat,
-            `Net consumption (${b.net_kwh.toFixed(1)} kWh) × horizon mean price (${b.avg_price_ore.toFixed(1)} öre/kWh). Captures the value of *timing* — shifting consumption into cheap hours — independently of battery.`
+            `No-battery imports priced at the horizon mean import price (${b.avg_price_ore.toFixed(1)} öre/kWh) and exports at the horizon mean export revenue, separately. Net no-battery flow is ${b.net_kwh.toFixed(1)} kWh. Captures the value of *timing* — shifting consumption into cheap hours — independently of battery.`
           ),
         ].join('');
       }


### PR DESCRIPTION
## Summary

- `ComputeBaselines.FlatAvgOre` used `netKWh × meanImportPrice`, which credited every exported kWh at the consumer total (spot + grid tariff + VAT) — money the homeowner doesn't earn when selling.
- Any horizon with partial export shrank the FlatAvg cost, hiding the planner's timing value behind the import/export price asymmetry.
- Fix: walk slots once, bucket no-battery flow into import vs export volumes, and re-score each at its own horizon-mean price. Export uses the same formula `SlotGridCostOre` uses (extracted to `SlotExportPriceOre` so the two stay in sync).

`AvgPriceOre` keeps its meaning — the horizon's mean import price. `NetKWh` is now `import − export` (still signed). The planner UI's "vs flat avg price" tooltip is updated to spell out that imports and exports are priced separately.

Reported by @erikarenhill on a system with a configured grid tariff.

## Test plan

- [x] New `TestBaselinesFlatAvgPricesImportExportSeparately` — symmetric 4 kWh in / 4 kWh out, asymmetric prices: pre-fix returned 0 (netKWh × mean = 0), post-fix returns the correct timing value.
- [x] New `TestBaselinesFlatAvgHonorsFlatExportTariff` — `Params.ExportOrePerKWh` overrides per-slot export revenue.
- [x] Existing baseline tests still pass (all-import horizons unchanged).
- [x] `make test` green (unit + e2e).
- [ ] Spot-check the "vs flat avg price" badge on a system with PV export and a grid tariff configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)