### PR TITLE
fix(mpc/baselines): flat-avg uses spot price for exported kWh

### DIFF
--- a/go/internal/mpc/baselines.go
+++ b/go/internal/mpc/baselines.go
@@ -7,7 +7,8 @@ package mpc
 //
 //   - NoBatteryOre: each slot's grid flow = load + pv (pretend the
 //     battery doesn't exist). Costed with the same import/export model
-//     the DP uses.
+//     the DP uses (consumer-total price for imports, spot + bonus − fee
+//     for exports).
 //
 //   - SelfConsumptionOre: re-runs Optimize with Mode=SelfConsumption
 //     over the same slots and params. Using the optimizer itself (vs a
@@ -16,41 +17,75 @@ package mpc
 //     computed by the DP's own per-slot loop, so it's directly
 //     comparable to plan.TotalCostOre.
 //
-//   - FlatAvgOre: total net consumption × the horizon's mean import
-//     price. Shows the value of *when* energy is moved — if the
-//     optimizer saves more vs FlatAvg than vs NoBattery, most of the
-//     win is timing (shifting load into cheap hours) rather than PV
-//     self-consumption. A diagnostic, not an operational baseline.
+//   - FlatAvgOre: same physical flows as NoBatteryOre, but priced at
+//     horizon-average rates instead of each slot's real price. Isolates
+//     the *timing* component of savings from the *quantity* component
+//     — if `plan_cost − flat_avg` ≫ `plan_cost − no_battery`, most of
+//     the win is timing (shifting load into cheap hours and/or exporting
+//     at expensive ones), not the existence of price variation per se.
+//
+//     FlatAvg uses an ASYMMETRIC price model that mirrors
+//     SlotGridCostOre: imported kWh × the horizon's mean consumer-total
+//     price MINUS exported kWh × the horizon's mean export price (mean
+//     spot + ExportBonus − ExportFee, clamped ≥ 0; or ExportOrePerKWh
+//     if the flat rate is set). Treating both directions with the
+//     consumer-total average — as the previous implementation did —
+//     overstated export revenue by the grid tariff + VAT, materially
+//     distorting the savings panel on PV-export-heavy days.
 //
 // Cheap to call — the SC re-optimize is one extra Optimize pass
-// (~10ms for the default 193 slots × 51 SoC × 21 actions).
+// (~10 ms for the default 193 slots × 51 SoC × 21 actions).
 func ComputeBaselines(slots []Slot, p Params) Baselines {
 	b := Baselines{}
 	if len(slots) == 0 {
 		return b
 	}
 
-	// ---- No-battery baseline + flat-average inputs ----
-	// Both can be computed in one pass over the slots.
-	var netKWh float64
-	var priceWtMin float64
-	var lenMinSum float64
+	// ---- No-battery cost + horizon-mean inputs ----
+	// One pass populates everything except the SC baseline.
+	var (
+		netKWh     float64
+		importKWh  float64 // total imported (positive)
+		exportKWh  float64 // total exported (positive magnitude)
+		priceWtMin float64 // time-weighted Σ for consumer-total mean
+		spotWtMin  float64 // time-weighted Σ for spot mean
+		lenMinSum  float64
+	)
 	for _, s := range slots {
 		dt := float64(s.LenMin) / 60.0
 		gridKWh := (s.LoadW + s.PVW) * dt / 1000.0
 		b.NoBatteryOre += SlotGridCostOre(s, gridKWh, p)
 		netKWh += gridKWh
+		switch {
+		case gridKWh > 0:
+			importKWh += gridKWh
+		case gridKWh < 0:
+			exportKWh += -gridKWh
+		}
 		priceWtMin += s.PriceOre * float64(s.LenMin)
+		spotWtMin += s.SpotOre * float64(s.LenMin)
 		lenMinSum += float64(s.LenMin)
 	}
 	if lenMinSum > 0 {
 		b.AvgPriceOre = priceWtMin / lenMinSum
+		b.AvgSpotOre = spotWtMin / lenMinSum
 	}
 	b.NetKWh = netKWh
-	// Flat-avg: charge the net consumption at the mean price. If net is
-	// negative (export-dominated horizon), the sign is kept — consistent
-	// with the NoBattery cost model where export shows up as negative.
-	b.FlatAvgOre = netKWh * b.AvgPriceOre
+
+	// Effective per-direction prices for the flat-avg baseline. Imports
+	// pay the consumer-total mean. Exports earn the spot mean adjusted
+	// by the operator's flat bonus/fee (clamped to non-negative so the
+	// model never rewards "not exporting"), or the operator's flat
+	// export rate when configured.
+	avgExportRevenue := p.ExportOrePerKWh
+	if avgExportRevenue <= 0 {
+		avgExportRevenue = b.AvgSpotOre + p.ExportBonusOreKwh - p.ExportFeeOreKwh
+		if avgExportRevenue < 0 {
+			avgExportRevenue = 0
+		}
+	}
+	b.AvgExportPriceOre = avgExportRevenue
+	b.FlatAvgOre = importKWh*b.AvgPriceOre - exportKWh*avgExportRevenue
 
 	// ---- Self-consumption baseline ----
 	// Re-run Optimize with the SC policy. Drop the loadpoint from the

--- a/go/internal/mpc/baselines_test.go
+++ b/go/internal/mpc/baselines_test.go
@@ -98,3 +98,116 @@ func TestBaselinesEmpty(t *testing.T) {
 		t.Errorf("expected zero Baselines for empty slots, got %+v", b)
 	}
 }
+
+// FlatAvg on an export-heavy horizon must price the exported kWh at
+// the spot mean (with bonus/fee), NOT the consumer-total mean. This
+// is the regression test for the asymmetric-price bug: previously
+// `flat_avg = netKWh × AvgPriceOre` overstated export revenue by the
+// grid tariff + VAT on every PV-export-heavy day.
+func TestFlatAvgUsesSpotForExports(t *testing.T) {
+	// 4 hourly slots, all exporting 2 kW. Consumer total 250 öre/kWh
+	// (e.g. 100 spot + 100 grid tariff + 50 VAT), spot 100 öre/kWh.
+	// PVW dominates LoadW so gridKWh is negative every slot.
+	prices := []float64{250, 250, 250, 250}
+	spots := []float64{100, 100, 100, 100}
+	slots := flatLoadSlots(prices) // load=1000W, no PV
+	for i := range slots {
+		slots[i].PVW = -3000 // 3 kW PV → net -2 kW per slot
+		slots[i].SpotOre = spots[i]
+	}
+	p := baseParams(ModeArbitrage)
+	b := ComputeBaselines(slots, p)
+
+	// 4 slots × 2 kW × 1 h = 8 kWh exported.
+	if b.NetKWh > -7.99 || b.NetKWh < -8.01 {
+		t.Fatalf("net kWh = %.3f, want -8.0", b.NetKWh)
+	}
+	// AvgPriceOre stays at the consumer total (used elsewhere in the
+	// UI). AvgSpotOre and AvgExportPriceOre are the new fields.
+	if b.AvgPriceOre != 250 {
+		t.Errorf("avg consumer-total price = %.1f, want 250", b.AvgPriceOre)
+	}
+	if b.AvgSpotOre != 100 {
+		t.Errorf("avg spot = %.1f, want 100", b.AvgSpotOre)
+	}
+	if b.AvgExportPriceOre != 100 {
+		t.Errorf("avg export price = %.1f, want 100 (spot, no bonus/fee)",
+			b.AvgExportPriceOre)
+	}
+	// FlatAvg = imports × consumerTotal − exports × spot
+	//        = 0 × 250 − 8 × 100
+	//        = −800 öre  (revenue of 8 SEK)
+	// The pre-fix bug would have given −8 × 250 = −2000 öre, which is
+	// 2.5× more revenue than the operator can actually earn.
+	if b.FlatAvgOre > -799.99 || b.FlatAvgOre < -800.01 {
+		t.Errorf("flat-avg = %.2f, want -800 (8 kWh × 100 öre/kWh spot)", b.FlatAvgOre)
+	}
+}
+
+// On a mixed horizon (some import slots, some export slots), the
+// flat-avg breaks net into both directions and prices each at its own
+// horizon mean.
+func TestFlatAvgMixedDirectionHorizon(t *testing.T) {
+	// 4 hourly slots: two importing at 1 kW, two exporting at 1 kW.
+	// Consumer total 200 öre, spot 80 öre.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 200, SpotOre: 80, LoadW: 1000, PVW: 0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 200, SpotOre: 80, LoadW: 1000, PVW: 0},
+		{StartMs: 7200_000, LenMin: 60, PriceOre: 200, SpotOre: 80, LoadW: 0, PVW: -1000},
+		{StartMs: 10800_000, LenMin: 60, PriceOre: 200, SpotOre: 80, LoadW: 0, PVW: -1000},
+	}
+	p := baseParams(ModeArbitrage)
+	b := ComputeBaselines(slots, p)
+
+	// 2 kWh imported, 2 kWh exported, net 0.
+	if math.Abs(b.NetKWh) > 1e-9 {
+		t.Fatalf("net kWh = %.6f, want 0", b.NetKWh)
+	}
+	// FlatAvg = 2 × 200 − 2 × 80 = 400 − 160 = 240 öre.
+	want := 240.0
+	if math.Abs(b.FlatAvgOre-want) > 1e-6 {
+		t.Errorf("flat-avg = %.3f, want %.3f", b.FlatAvgOre, want)
+	}
+}
+
+// Operator-configured flat ExportOrePerKWh wins over spot-derived
+// pricing — same precedence as SlotGridCostOre.
+func TestFlatAvgFlatExportRateOverridesSpot(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 250, SpotOre: 100, LoadW: 0, PVW: -2000},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 250, SpotOre: 100, LoadW: 0, PVW: -2000},
+	}
+	p := baseParams(ModeArbitrage)
+	p.ExportOrePerKWh = 60 // operator's contracted feed-in rate
+	b := ComputeBaselines(slots, p)
+
+	if b.AvgExportPriceOre != 60 {
+		t.Errorf("avg export price = %.1f, want 60 (flat rate)", b.AvgExportPriceOre)
+	}
+	// 4 kWh exported × 60 öre = 240 öre revenue → -240 in flat_avg.
+	if math.Abs(b.FlatAvgOre+240) > 1e-6 {
+		t.Errorf("flat-avg = %.3f, want -240 (4 kWh × 60 öre flat)", b.FlatAvgOre)
+	}
+}
+
+// Negative effective export revenue (fee > spot + bonus) clamps to 0
+// — same defensive guard as SlotGridCostOre. Without it the model
+// would "reward" not exporting, which can break baseline comparisons.
+func TestFlatAvgClampsNegativeExportRevenue(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 250, SpotOre: 10, LoadW: 0, PVW: -1000},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 250, SpotOre: 10, LoadW: 0, PVW: -1000},
+	}
+	p := baseParams(ModeArbitrage)
+	p.ExportFeeOreKwh = 50 // fee far exceeds spot
+	b := ComputeBaselines(slots, p)
+
+	// avg spot 10 + bonus 0 - fee 50 = -40 → clamped to 0.
+	if b.AvgExportPriceOre != 0 {
+		t.Errorf("clamped export price = %.1f, want 0", b.AvgExportPriceOre)
+	}
+	// 2 kWh exported × 0 = 0 export revenue. No imports.
+	if b.FlatAvgOre != 0 {
+		t.Errorf("flat-avg = %.3f, want 0 (export revenue clamped)", b.FlatAvgOre)
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -178,16 +178,29 @@ type Action struct {
 // load + pv each slot, priced with the same import/export model the DP
 // uses). SelfConsumptionOre comes from re-running Optimize with
 // ModeSelfConsumption — so it uses the real efficiency, power, and SoC
-// constraints, not a simplified simulation. FlatAvgOre is net
-// consumption priced at the horizon's mean — shows the value of
-// *timing* (shifting load to cheap hours), separate from the value of
-// having a battery.
+// constraints, not a simplified simulation. FlatAvgOre prices the
+// no-battery flows at horizon-mean rates (asymmetric: imports at
+// AvgPriceOre, exports at AvgExportPriceOre) — shows the value of
+// *timing* separate from the value of having a battery.
 type Baselines struct {
 	NoBatteryOre       float64 `json:"no_battery_ore"`
 	SelfConsumptionOre float64 `json:"self_consumption_ore"`
 	FlatAvgOre         float64 `json:"flat_avg_ore"`
-	AvgPriceOre        float64 `json:"avg_price_ore"`
-	NetKWh             float64 `json:"net_kwh"`
+	// AvgPriceOre is the time-weighted mean consumer-total price across
+	// the horizon — what an imported kWh costs on average. Used as the
+	// import side of FlatAvgOre.
+	AvgPriceOre float64 `json:"avg_price_ore"`
+	// AvgSpotOre is the time-weighted mean raw spot price across the
+	// horizon, before ExportBonus / ExportFee. Surfaced for the UI's
+	// "what does an exported kWh actually pay" explanation.
+	AvgSpotOre float64 `json:"avg_spot_ore"`
+	// AvgExportPriceOre is the effective per-kWh export revenue at the
+	// horizon-mean spot price, adjusted by the operator's flat
+	// ExportBonus / ExportFee (clamped ≥ 0) — or ExportOrePerKWh when
+	// the flat rate is configured. This is what FlatAvgOre uses on the
+	// export side, mirroring SlotGridCostOre's per-slot model.
+	AvgExportPriceOre float64 `json:"avg_export_price_ore"`
+	NetKWh            float64 `json:"net_kwh"`
 }
 
 // Plan is the output.


### PR DESCRIPTION
## Summary

`ComputeBaselines.FlatAvgOre` priced exported kWh at the **consumer-total** average (spot + grid tariff + VAT). That's only valid for imports — exports earn spot price ± export bonus/fee, not the grid tariff or VAT. On PV-export-heavy days the bug materially overstates export revenue and distorts the savings panel.

## Before

```go
b.FlatAvgOre = netKWh * b.AvgPriceOre
```

`netKWh` is signed (negative on net-export horizons), `AvgPriceOre` is the consumer-total mean. Multiplying together silently applies grid tariff + VAT to exported kWh.

**On the user's site today** (`net_kwh = -31.86 kWh`, consumer-total avg `247.76 öre/kWh`): the formula produces `-7894 öre` of "revenue" that the operator can never actually earn — the real spot-priced number is closer to `-3000 öre` depending on the horizon's spot/total ratio.

## After

```go
flat_avg = imports × avg_consumer_total
         − exports × max(0, avg_spot + bonus − fee)
```

Mirrors `SlotGridCostOre`'s asymmetric model exactly: imports pay the consumer-total mean, exports earn the operator's effective per-kWh export rate at the horizon-mean spot (clamped to non-negative; or `ExportOrePerKWh` when a flat feed-in contract is configured).

## Schema additions on `Baselines`

| Field | Meaning |
|---|---|
| `AvgPriceOre` | (unchanged) time-weighted mean **consumer-total** price — used for the import side of `FlatAvgOre` and as the UI's "average import price" label |
| `AvgSpotOre` | new — time-weighted mean **raw spot** price, before bonus/fee. Surfaced so the UI can explain "what an exported kWh actually pays" |
| `AvgExportPriceOre` | new — effective per-kWh export revenue at horizon-mean spot, after the operator's flat bonus/fee (clamped ≥ 0), or `ExportOrePerKWh` when configured. This is what `FlatAvgOre` uses on the export side |

## Tests

- `TestFlatAvgUsesSpotForExports` — 8 kWh exported at spot 100 öre must yield `FlatAvgOre = -800 öre` (was `-2000 öre` under the bug).
- `TestFlatAvgMixedDirectionHorizon` — 2 kWh import + 2 kWh export at split prices must combine asymmetrically.
- `TestFlatAvgFlatExportRateOverridesSpot` — same precedence as `SlotGridCostOre` when `ExportOrePerKWh` is configured.
- `TestFlatAvgClampsNegativeExportRevenue` — fee > spot + bonus clamps to 0 instead of becoming "negative cost".

`go test ./...` green incl. `test/e2e`.

## Notes

- Existing tests on net-import horizons still pass — without exports, the new formula reduces to the old one.
- `web/plan.js` will need a small companion change to surface the new `AvgExportPriceOre` field in the savings explainer (out of scope for this fix; the JSON shape is additive so the UI keeps working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)