### PR TITLE
feat(control): reactive fuse-saver — battery always discharges to protect fuse

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -202,6 +202,58 @@ planner's idle slot, and `gridW` exceeded `fuseSafeMaxW` until the
 operator stopped the test. The reactive fuse-saver eliminates that
 class of incident at the dispatch level.
 
+### 3b. Per-phase clamp (PR #208 follow-up)
+
+The aggregate fuse-guard above (sections 3 + 3a) protects against
+total grid power exceeding the breaker's combined rating. It does
+**not** see per-phase imbalance: a 16 A 3Φ fuse has each phase trip
+at 16 A, and a single phase can blow even when the three-phase
+aggregate is well below `fuseMaxW`. This was the failure mode the
+operator hit in PR #208's hardware test — the EV was at ~16 A 3Φ
+balanced (3.6 kW per phase), but a single-phase Pixii battery
+charging at 4.4 kW on L1 pushed that one phase past 16 A while the
+aggregate stayed under fuse.
+
+Both `applyFuseGuard` and `forceFuseDischarge` consult an additional
+`perPhaseImportOverageW(store, state)` helper:
+
+```go
+// go/internal/control/dispatch.go
+func perPhaseImportOverageW(store *telemetry.Store, state *State) float64
+```
+
+Reads `l1_a` / `l2_a` / `l3_a` from the meter driver's
+`DerReading.Data` (Pixii, Ferroamp, Sungrow all emit these). Returns
+the wattage by which the worst single phase exceeds
+`state.SiteFuseAmps`, or 0 when within limits / data unavailable /
+clamp disabled.
+
+The dispatch logic then takes the larger of:
+
+- aggregate overage = `predicted_grid − fuseMaxW`
+- per-phase overage = `worst_phase_watts × 3` (balanced-3Φ assumption
+  for the battery — total reduction needed to bring the worst phase
+  back, accepting over-correction on the other phases)
+
+…and uses that as the reduction/discharge target. The existing
+charge-scaling and force-discharge code paths do not change; only
+the input number is now per-phase aware.
+
+**Configuration.** `state.SiteFuseAmps` and `state.SiteFuseVoltage`
+are wired from `cfg.Fuse.MaxAmps` + `cfg.Fuse.Voltage` in `main.go`.
+`SiteFuseAmps == 0` disables the per-phase clamp (back-compat for
+sites without per-phase meter data and the test suite).
+
+**Conservatism for 1Φ batteries.** A balanced 3Φ battery reduces
+each phase by 1/3 of its total output, so `× 3` is exact. A
+single-phase battery (Pixii Home, OCPP single-phase) on the
+overloaded phase reduces it 1:1 — `× 3` over-corrects 3×, but that
+direction is safe (less import on the overloaded phase, slight
+over-export elsewhere that the aggregate guard catches next cycle).
+A single-phase battery on a *different* phase from the overload
+cannot help; this is a real limitation. Per-battery `phase`
+configuration is a follow-up.
+
 ## 4. Dispatch min interval
 
 `cfg.Site.MinDispatchIntervalS` (default **5s**, set in

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -141,6 +141,67 @@ Sungrow and Ferroamp both emit per-phase data into
 JSON blob. The aggregate three-phase guard is the floor; per-phase
 logic is opt-in on top.
 
+### 3a. Reactive fuse-saver (PR #208)
+
+`applyFuseGuard` only scales POSITIVE (charge) targets DOWN — it
+prevents the EMS from making an existing overflow worse, but doesn't
+help in the common "battery idle, surprise load" case because there's
+no charge to shrink.
+
+The reactive fuse-saver (`forceFuseDischarge`) closes that gap:
+
+```go
+// go/internal/control/dispatch.go
+func forceFuseDischarge(
+    targets []DispatchTarget,
+    store *telemetry.Store,
+    state *State,
+    capacities map[string]float64,
+    fuseMaxW float64,
+) []DispatchTarget
+```
+
+Runs **after** `applyFuseGuard` on every dispatch cycle, in **every**
+mode (idle, self_consumption, planner_*, holdoff window). Behaviour:
+
+1. Recompute `predicted = currentGrid − currentBat + sumTarget` against
+   the post-`applyFuseGuard` targets. `currentGrid` is the live meter
+   and reflects ALL loads — planned, off-plan, manual_hold-injected,
+   and unplanned spikes.
+2. If `predicted > fuseMaxW`, allocate `overage = predicted − fuseMaxW`
+   of additional discharge across online batteries proportionally to
+   each battery's remaining headroom (`MaxDischargeW − current target
+   magnitude`, gated on `SoC ≥ 5 %`).
+3. Mark every modified target `Clamped = true` so the dispatch trace
+   shows the fuse-saver fired.
+
+Coverage extends to every code path that would normally short-circuit
+`ComputeDispatch` to `nil`:
+
+- **`ModeIdle`**: zeros are generated for every online battery, run
+  through `forceFuseDischarge`. Idle mode + grid spike → battery is
+  overridden to discharge.
+- **Holdoff window**: same — fuse-saver overrides the 5 s holdoff
+  because overflow can't wait.
+
+Edge cases:
+
+- All batteries empty (SoC < 5 %) → fuse-saver returns targets
+  unchanged. Hardware breaker remains the next layer.
+- All batteries already at `MaxDischargeW` → fuse-saver no-op (already
+  doing all it can).
+- `fuseMaxW = 0` → disabled (matches `applyFuseGuard`'s convention).
+
+The 5 s control-tick is the floor. Sub-tick spikes (an oven turning
+on between ticks) still rely on the hardware fuse for protection;
+going faster requires pushing the dispatch loop down to ~1 s.
+
+Surfaced by the manual_hold ramp test in PR #206's session: the EV
+was pinned at ~5.5 kW while the home battery sat at 0 W per the
+planner's idle slot, and `gridW` exceeded `fuseSafeMaxW` until the
+operator stopped the test. The reactive fuse-saver eliminates that
+class of incident at the dispatch level.
+
 ## 4. Dispatch min interval
 
 `cfg.Site.MinDispatchIntervalS` (default **5s**, set in

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -166,6 +166,11 @@ func main() {
 	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
 	ctrl.InverterGroups = inverterGroupsFrom(cfg.Drivers)
 	ctrl.DriverLimits = driverLimitsFrom(cfg.Drivers)
+	// Per-phase fuse params for the per-phase clamp inside applyFuseGuard
+	// + forceFuseDischarge. Reads l1_a/l2_a/l3_a from the meter driver
+	// when SiteFuseAmps > 0; otherwise the per-phase clamp is disabled.
+	ctrl.SiteFuseAmps = cfg.Fuse.MaxAmps
+	ctrl.SiteFuseVoltage = cfg.Fuse.Voltage
 	// Restore persisted mode + target if present. The planner variants
 	// have to be listed too — without them the strategy the user picked in
 	// the UI (planner_self / planner_cheap / planner_arbitrage) is silently

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -286,7 +286,8 @@ func TestFuseGuardScalesDischargeWhenExportExceedsFuse(t *testing.T) {
 	s.DriverHealthMut("a").RecordSuccess()
 	targets := []DispatchTarget{{Driver: "a", TargetW: -6000}} // add 6 kW discharge on top
 	// Predicted grid = -8000 - 0 + (-6000) = -14000 (exporting). Fuse 11040.
-	scaled := applyFuseGuard(targets, s, "meter", 11040)
+	st := NewState(0, 50, "meter")
+	scaled := applyFuseGuard(targets, s, st, 11040)
 	if !scaled[0].Clamped {
 		t.Error("expected clamped=true")
 	}
@@ -304,7 +305,8 @@ func TestFuseGuardPassesThroughWhenWithinFuse(t *testing.T) {
 	s.Update("a", telemetry.DerBattery, 0, nil, nil)
 	s.DriverHealthMut("a").RecordSuccess()
 	targets := []DispatchTarget{{Driver: "a", TargetW: 3000}}
-	scaled := applyFuseGuard(targets, s, "meter", 11040)
+	st := NewState(0, 50, "meter")
+	scaled := applyFuseGuard(targets, s, st, 11040)
 	if scaled[0].TargetW != 3000 || scaled[0].Clamped {
 		t.Errorf("within fuse: got %f clamped=%v, want 3000 false", scaled[0].TargetW, scaled[0].Clamped)
 	}
@@ -328,7 +330,8 @@ func TestFuseGuardScalesChargingWhenImportExceedsFuse(t *testing.T) {
 	}
 	// Predicted = 8000 - 0 + 10000 = 18000 W. Fuse 11040.
 	// Overage = 6960. Total charge = 10000. New total = 3040. Scale = 0.304.
-	scaled := applyFuseGuard(targets, s, "meter", 11040)
+	st := NewState(0, 50, "meter")
+	scaled := applyFuseGuard(targets, s, st, 11040)
 	var totalCharge float64
 	for _, tgt := range scaled {
 		if tgt.TargetW > 0 {
@@ -353,7 +356,8 @@ func TestFuseGuardNoOpWithoutMeterReading(t *testing.T) {
 	s := telemetry.NewStore()
 	targets := []DispatchTarget{{Driver: "a", TargetW: 5000}}
 	// No meter reading → currentGrid defaults to 0 → predicted = 5000 which is fine.
-	scaled := applyFuseGuard(targets, s, "does-not-exist", 11040)
+	st := NewState(0, 50, "does-not-exist")
+	scaled := applyFuseGuard(targets, s, st, 11040)
 	if scaled[0].TargetW != 5000 || scaled[0].Clamped {
 		t.Errorf("absent meter → no prediction-based clamp, got %f clamped=%v",
 			scaled[0].TargetW, scaled[0].Clamped)

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -368,13 +368,22 @@ func ComputeDispatch(
 	// ---- Idle + Charge short-circuits ----
 	switch effectiveMode {
 	case ModeIdle:
-		state.LastTargets = nil
 		// Even in idle, the reactive fuse-saver runs: an unplanned
 		// load (manual_hold injecting EV power, oven turning on,
 		// neighbour's pool pump on the same fuse) can push grid
 		// import past the fuse with the battery sitting at 0 W. The
 		// fuse-saver overrides idle and forces discharge.
-		return fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
+		out := fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
+		// LastTargets reflects what we actually issued: nil when
+		// the fuse-saver no-op'd, the discharge targets when it
+		// fired. /api/status, the history snapshot, and the RLS
+		// model loop all depend on this being accurate.
+		state.LastTargets = out
+		if out != nil {
+			now := time.Now()
+			state.LastDispatch = &now
+		}
+		return out
 	case ModeCharge:
 		targets := chargeAll(store, driverCapacities, state.DriverLimits)
 		state.LastTargets = targets
@@ -388,7 +397,16 @@ func ComputeDispatch(
 			// Holdoff suppresses normal re-dispatch, but the
 			// fuse-saver overrides — an overflow can't wait 5 s for
 			// the next eligible tick.
-			return fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
+			out := fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
+			if out != nil {
+				// Same bookkeeping as the idle path so downstream
+				// consumers (status/history/learner) see the
+				// commanded discharge.
+				state.LastTargets = out
+				now := time.Now()
+				state.LastDispatch = &now
+			}
+			return out
 		}
 	}
 
@@ -653,6 +671,13 @@ func ComputeDispatch(
 
 	// ---- Fuse guard (bidirectional, #145) ----
 	raw = applyFuseGuard(raw, store, state.SiteMeterDriver, fuseMaxW)
+	// forceFuseDischarge runs LAST, deliberately AFTER the slew loop
+	// at line 625. A fuse overflow can demand a battery target that's
+	// far beyond what slew would normally allow in a single 5 s tick
+	// (e.g. 0 W → −3 kW), and slew-limiting that would leave the
+	// fuse violated for multiple ticks. The fuse is the
+	// non-negotiable ceiling — it bypasses slew. Regression-guarded
+	// by TestFuseSaverBypassesSlew.
 	raw = forceFuseDischarge(raw, store, state, driverCapacities, fuseMaxW)
 
 	// Update state
@@ -967,21 +992,34 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 // Called from ComputeDispatch branches that would otherwise return nil
 // (idle mode, holdoff window) so the safety primary still gets a chance
 // to fire before we walk away from the cycle. Builds zero-W targets for
-// every online battery and runs them through forceFuseDischarge; if no
+// every battery that is BOTH online (per DriverHealth) AND has a current
+// DerBattery reading, then runs them through forceFuseDischarge; if no
 // overflow is predicted, the result is nil (caller sees the same
-// empty-dispatch behaviour as before).
+// empty-dispatch behaviour as before). Filtering to online+telemetry
+// matches ComputeDispatch's main path and avoids commanding offline
+// batteries via the fuse-saver back door.
 func fuseSaverFromZero(
 	store *telemetry.Store,
 	state *State,
 	driverCapacities map[string]float64,
 	fuseMaxW float64,
 ) []DispatchTarget {
-	if fuseMaxW <= 0 || len(driverCapacities) == 0 {
+	if fuseMaxW <= 0 || len(driverCapacities) == 0 || store == nil {
 		return nil
 	}
 	zeros := make([]DispatchTarget, 0, len(driverCapacities))
 	for name := range driverCapacities {
+		h := store.DriverHealth(name)
+		if h == nil || !h.IsOnline() {
+			continue
+		}
+		if r := store.Get(name, telemetry.DerBattery); r == nil {
+			continue
+		}
 		zeros = append(zeros, DispatchTarget{Driver: name, TargetW: 0})
+	}
+	if len(zeros) == 0 {
+		return nil
 	}
 	out := forceFuseDischarge(zeros, store, state, driverCapacities, fuseMaxW)
 	for _, t := range out {
@@ -1043,9 +1081,20 @@ func forceFuseDischarge(
 	if fuseMaxW <= 0 || len(targets) == 0 || state == nil {
 		return targets
 	}
+	// Sum currentBat only across the batteries we're about to control
+	// — uncontrolled or offline batteries' current draw is captured in
+	// the live grid reading already; counting them again would
+	// double-subtract their contribution and mispredict.
+	seenBat := make(map[string]struct{}, len(targets))
 	var currentBat float64
-	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
-		currentBat += r.SmoothedW
+	for _, t := range targets {
+		if _, seen := seenBat[t.Driver]; seen {
+			continue
+		}
+		seenBat[t.Driver] = struct{}{}
+		if r := store.Get(t.Driver, telemetry.DerBattery); r != nil {
+			currentBat += r.SmoothedW
+		}
 	}
 	var currentGrid float64
 	if state.SiteMeterDriver != "" {
@@ -1115,11 +1164,18 @@ func forceFuseDischarge(
 	copy(out, targets)
 	for _, s := range slots {
 		share := allocate * (s.headroom / totalHeadroom)
-		if out[s.idx].TargetW > 0 {
-			out[s.idx].TargetW = -share
-		} else {
-			out[s.idx].TargetW -= share
-		}
+		// Subtract `share` from the existing target — that gives the
+		// algorithm one consistent rule across all signs:
+		//   +3000 - 2960 = +40   (still charging, but reduced)
+		//    0    - 2960 = -2960 (idle → discharge)
+		//   -1000 - 960  = -1960 (already discharging → more)
+		// The net change to sumTarget is exactly `share`, so the
+		// post-dispatch predicted gridW lands at fuseMaxW. Setting
+		// TargetW = -share when positive (the prior implementation)
+		// over-corrected by the original charge magnitude — letting
+		// out`predicted` undershoot the fuse and discharging more
+		// than necessary.
+		out[s.idx].TargetW -= share
 		out[s.idx].Clamped = true
 	}
 	return out

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"encoding/json"
 	"log/slog"
 	"math"
 	"time"
@@ -106,6 +107,19 @@ type State struct {
 	GridTargetW    float64
 	GridToleranceW float64
 	SiteMeterDriver string
+
+	// SiteFuseAmps is the per-phase trip current of the site's main
+	// breaker (cfg.Fuse.MaxAmps). Used by the per-phase clamp inside
+	// applyFuseGuard / forceFuseDischarge: when the meter reports
+	// per-phase amps via DerReading.Data (l1_a / l2_a / l3_a, emitted
+	// by Pixii / Ferroamp / Sungrow), any single phase exceeding
+	// SiteFuseAmps is treated as additional aggregate overage so the
+	// existing scaling+discharge logic responds.
+	//
+	// Zero disables the per-phase clamp (back-compat for tests and
+	// sites without per-phase meter data).
+	SiteFuseAmps    float64
+	SiteFuseVoltage float64
 
 	// For Priority mode
 	PriorityOrder []string
@@ -670,7 +684,7 @@ func ComputeDispatch(
 	}
 
 	// ---- Fuse guard (bidirectional, #145) ----
-	raw = applyFuseGuard(raw, store, state.SiteMeterDriver, fuseMaxW)
+	raw = applyFuseGuard(raw, store, state, fuseMaxW)
 	// forceFuseDischarge runs LAST, deliberately AFTER the slew loop
 	// at line 625. A fuse overflow can demand a battery target that's
 	// far beyond what slew would normally allow in a single 5 s tick
@@ -904,10 +918,11 @@ func clampWithSoC(target float64, b batteryInfo) (float64, bool) {
 // can't push aggregate imports past the fuse. The new path also uses
 // live load inference so the discharge side no longer over-scales
 // during high-load hours.
-func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter string, fuseMaxW float64) []DispatchTarget {
-	if fuseMaxW <= 0 {
+func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *State, fuseMaxW float64) []DispatchTarget {
+	if fuseMaxW <= 0 || state == nil {
 		return targets
 	}
+	siteMeter := state.SiteMeterDriver
 	// Aggregate live battery power so we can hold load+pv constant.
 	var currentBat float64
 	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
@@ -925,7 +940,22 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 	}
 	predicted := currentGrid - currentBat + sumTarget
 
-	if math.Abs(predicted) <= fuseMaxW {
+	// Per-phase import overage: the worst single-phase amperage above
+	// the fuse, expressed as the AGGREGATE battery reduction needed
+	// to bring it back. Assumes a 3Φ balanced battery — each unit of
+	// total battery action contributes 1/3 to each phase, so a worst-
+	// phase overage of N watts requires 3 × N watts of total battery
+	// action to bring it under. Conservative for 1Φ batteries (e.g.
+	// Pixii Home) — they over-correct on the other phases, which
+	// means LESS import on those, still safe. See PR #208 follow-up
+	// in `docs/safety.md` §3a.
+	perPhaseImport := perPhaseImportOverageW(store, state) * 3.0
+	importOverage := predicted - fuseMaxW
+	if perPhaseImport > importOverage {
+		importOverage = perPhaseImport
+	}
+
+	if importOverage <= 0 && math.Abs(predicted) <= fuseMaxW {
 		return targets
 	}
 
@@ -933,9 +963,8 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 	copy(out, targets)
 
 	switch {
-	case predicted > fuseMaxW:
-		// Too much import → shrink charging.
-		overage := predicted - fuseMaxW
+	case importOverage > 0:
+		// Too much import (aggregate or per-phase) → shrink charging.
 		var totalCharge float64
 		for _, t := range out {
 			if t.TargetW > 0 {
@@ -945,10 +974,11 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 		if totalCharge <= 0 {
 			// No charge commands to pull back — the overage is load-driven
 			// and nothing this layer can do. Leave targets untouched;
-			// operator/BMS/load shedding is the next lever.
+			// the reactive fuse-saver below (forceFuseDischarge) can
+			// still flip idle batteries to discharge.
 			return out
 		}
-		newTotal := totalCharge - overage
+		newTotal := totalCharge - importOverage
 		if newTotal < 0 {
 			newTotal = 0
 		}
@@ -959,7 +989,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 				out[i].Clamped = true
 			}
 		}
-	default: // predicted < -fuseMaxW
+	case predicted < -fuseMaxW:
 		overage := -fuseMaxW - predicted // positive magnitude over export fuse
 		var totalDischarge float64
 		for _, t := range out {
@@ -986,6 +1016,44 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 		}
 	}
 	return out
+}
+
+// perPhaseImportOverageW returns the wattage by which the worst single
+// phase exceeds the per-phase fuse amperage. 0 when within limits, when
+// per-phase data isn't available, or when the per-phase clamp is
+// disabled (state.SiteFuseAmps == 0). The meter driver must emit
+// l1_a / l2_a / l3_a in DerReading.Data — Pixii, Ferroamp, and Sungrow
+// all do this today.
+func perPhaseImportOverageW(store *telemetry.Store, state *State) float64 {
+	if state == nil || state.SiteFuseAmps <= 0 || state.SiteMeterDriver == "" {
+		return 0
+	}
+	r := store.Get(state.SiteMeterDriver, telemetry.DerMeter)
+	if r == nil || len(r.Data) == 0 {
+		return 0
+	}
+	var d struct {
+		L1A *float64 `json:"l1_a"`
+		L2A *float64 `json:"l2_a"`
+		L3A *float64 `json:"l3_a"`
+	}
+	if err := json.Unmarshal(r.Data, &d); err != nil {
+		return 0
+	}
+	maxA := 0.0
+	for _, p := range []*float64{d.L1A, d.L2A, d.L3A} {
+		if p != nil && *p > maxA {
+			maxA = *p
+		}
+	}
+	if maxA <= state.SiteFuseAmps {
+		return 0
+	}
+	v := state.SiteFuseVoltage
+	if v <= 0 {
+		v = 230 // sensible default; main wires the actual config voltage
+	}
+	return (maxA - state.SiteFuseAmps) * v
 }
 
 // fuseSaverFromZero is the early-return entry point for the fuse-saver.
@@ -1108,10 +1176,17 @@ func forceFuseDischarge(
 	}
 	predicted := currentGrid - currentBat + sumTarget
 
-	if predicted <= fuseMaxW {
+	// Per-phase overage trumps aggregate when bigger. Same balanced-3Φ
+	// assumption as applyFuseGuard (× 3 multiplier on the worst-phase
+	// W to get the equivalent total-battery W needed).
+	perPhaseOverage := perPhaseImportOverageW(store, state) * 3.0
+	overage := predicted - fuseMaxW
+	if perPhaseOverage > overage {
+		overage = perPhaseOverage
+	}
+	if overage <= 0 {
 		return targets
 	}
-	overage := predicted - fuseMaxW
 
 	type slot struct {
 		idx      int

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -369,7 +369,12 @@ func ComputeDispatch(
 	switch effectiveMode {
 	case ModeIdle:
 		state.LastTargets = nil
-		return nil
+		// Even in idle, the reactive fuse-saver runs: an unplanned
+		// load (manual_hold injecting EV power, oven turning on,
+		// neighbour's pool pump on the same fuse) can push grid
+		// import past the fuse with the battery sitting at 0 W. The
+		// fuse-saver overrides idle and forces discharge.
+		return fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
 	case ModeCharge:
 		targets := chargeAll(store, driverCapacities, state.DriverLimits)
 		state.LastTargets = targets
@@ -380,7 +385,10 @@ func ComputeDispatch(
 	if state.LastDispatch != nil {
 		elapsed := time.Since(*state.LastDispatch).Seconds()
 		if elapsed < float64(state.MinDispatchIntervalS) {
-			return nil
+			// Holdoff suppresses normal re-dispatch, but the
+			// fuse-saver overrides — an overflow can't wait 5 s for
+			// the next eligible tick.
+			return fuseSaverFromZero(store, state, driverCapacities, fuseMaxW)
 		}
 	}
 
@@ -645,6 +653,7 @@ func ComputeDispatch(
 
 	// ---- Fuse guard (bidirectional, #145) ----
 	raw = applyFuseGuard(raw, store, state.SiteMeterDriver, fuseMaxW)
+	raw = forceFuseDischarge(raw, store, state, driverCapacities, fuseMaxW)
 
 	// Update state
 	now := time.Now()
@@ -950,6 +959,168 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, siteMeter 
 				out[i].Clamped = true
 			}
 		}
+	}
+	return out
+}
+
+// fuseSaverFromZero is the early-return entry point for the fuse-saver.
+// Called from ComputeDispatch branches that would otherwise return nil
+// (idle mode, holdoff window) so the safety primary still gets a chance
+// to fire before we walk away from the cycle. Builds zero-W targets for
+// every online battery and runs them through forceFuseDischarge; if no
+// overflow is predicted, the result is nil (caller sees the same
+// empty-dispatch behaviour as before).
+func fuseSaverFromZero(
+	store *telemetry.Store,
+	state *State,
+	driverCapacities map[string]float64,
+	fuseMaxW float64,
+) []DispatchTarget {
+	if fuseMaxW <= 0 || len(driverCapacities) == 0 {
+		return nil
+	}
+	zeros := make([]DispatchTarget, 0, len(driverCapacities))
+	for name := range driverCapacities {
+		zeros = append(zeros, DispatchTarget{Driver: name, TargetW: 0})
+	}
+	out := forceFuseDischarge(zeros, store, state, driverCapacities, fuseMaxW)
+	for _, t := range out {
+		if t.TargetW != 0 || t.Clamped {
+			return out
+		}
+	}
+	return nil
+}
+
+// forceFuseDischarge is the reactive fuse-saver primary. It runs AFTER
+// applyFuseGuard and unconditionally drains the home battery whenever
+// predicted grid import would exceed the fuse, regardless of mode,
+// regardless of operator intent (BatteryCoversEV toggle, planner
+// allocation, manual_hold injecting unplanned EV draw, an oven
+// turning on, or any other off-plan load).
+//
+// The contract: under no software-controllable circumstance should
+// the operator's hardware fuse trip because the EMS sat idle while
+// the meter was over the limit. The hardware breaker remains the
+// final cutoff for sub-tick spikes; this layer eliminates
+// steady-state overflow at the 5 s control-tick rate.
+//
+// Why this exists separately from applyFuseGuard:
+//
+//	applyFuseGuard scales POSITIVE (charge) targets DOWN to 0 when
+//	import is over fuse. That helps when the planner asked for a
+//	charge — it prevents the EMS from making the overflow worse —
+//	but cannot help in the common "battery idle, surprise load" case
+//	because there's no charge to shrink. The PR #206 manual_hold
+//	ramp test surfaced this: the EV was pinned at ~5.5 kW while the
+//	home battery sat at 0 W per the planner's idle slot, and gridW
+//	went over fuseSafeMaxW until the operator stopped the test.
+//
+// Algorithm:
+//
+//  1. Recompute predicted gridW after applyFuseGuard's scaling
+//     (currentGrid − currentBat + sumTarget). currentGrid is the
+//     live meter reading and reflects ALL loads including off-plan
+//     EV draw / manual_hold / unplanned spikes.
+//  2. If predicted ≤ fuseMaxW: nothing to do.
+//  3. Otherwise allocate `overage = predicted − fuseMaxW` of
+//     additional discharge, distributed proportionally to each
+//     online battery's remaining discharge headroom (per-battery
+//     MaxDischargeW − current target magnitude, gated on SoC ≥ 5 %).
+//  4. Mark every modified target Clamped so the dispatch trace
+//     shows the fuse-saver fired.
+//
+// Out of scope: sub-tick reactivity. A 5 s tick is the floor here;
+// going faster requires pushing the dispatch loop down to ~1 s.
+// Hardware fuse trips remain the only protection for sub-tick spikes.
+func forceFuseDischarge(
+	targets []DispatchTarget,
+	store *telemetry.Store,
+	state *State,
+	driverCapacities map[string]float64,
+	fuseMaxW float64,
+) []DispatchTarget {
+	if fuseMaxW <= 0 || len(targets) == 0 || state == nil {
+		return targets
+	}
+	var currentBat float64
+	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
+		currentBat += r.SmoothedW
+	}
+	var currentGrid float64
+	if state.SiteMeterDriver != "" {
+		if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
+			currentGrid = r.SmoothedW
+		}
+	}
+	var sumTarget float64
+	for _, t := range targets {
+		sumTarget += t.TargetW
+	}
+	predicted := currentGrid - currentBat + sumTarget
+
+	if predicted <= fuseMaxW {
+		return targets
+	}
+	overage := predicted - fuseMaxW
+
+	type slot struct {
+		idx      int
+		headroom float64
+	}
+	slots := make([]slot, 0, len(targets))
+	var totalHeadroom float64
+	for i, t := range targets {
+		cap, ok := driverCapacities[t.Driver]
+		if !ok || cap <= 0 {
+			continue
+		}
+		r := store.Get(t.Driver, telemetry.DerBattery)
+		if r == nil {
+			continue
+		}
+		soc := 0.1
+		if r.SoC != nil {
+			soc = *r.SoC
+		}
+		if soc < 0.05 {
+			continue // empty pack — can't draw on it
+		}
+		lim := state.DriverLimits[t.Driver]
+		dCap := lim.MaxDischargeW
+		if dCap <= 0 {
+			dCap = MaxCommandW
+		}
+		var alreadyDischarging float64
+		if t.TargetW < 0 {
+			alreadyDischarging = -t.TargetW
+		}
+		room := dCap - alreadyDischarging
+		if room <= 0 {
+			continue
+		}
+		slots = append(slots, slot{idx: i, headroom: room})
+		totalHeadroom += room
+	}
+	if totalHeadroom <= 0 {
+		return targets
+	}
+
+	allocate := overage
+	if allocate > totalHeadroom {
+		allocate = totalHeadroom
+	}
+
+	out := make([]DispatchTarget, len(targets))
+	copy(out, targets)
+	for _, s := range slots {
+		share := allocate * (s.headroom / totalHeadroom)
+		if out[s.idx].TargetW > 0 {
+			out[s.idx].TargetW = -share
+		} else {
+			out[s.idx].TargetW -= share
+		}
+		out[s.idx].Clamped = true
 	}
 	return out
 }

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -52,24 +52,43 @@ func TestFuseSaverForcesDischargeFromIdle(t *testing.T) {
 	}
 }
 
-// Planner commanded the battery to CHARGE (off-peak hours, planner
-// arbitrage). Grid is already at the fuse from external loads. The
-// fuse-saver flips the charge command to discharge regardless of plan.
-func TestFuseSaverFlipsChargeToDischargeWhenOverFuse(t *testing.T) {
-	// Live grid at fuse limit; planner asked to charge 3 kW; current
-	// battery doing nothing (target hasn't propagated yet).
+// In production the call chain is applyFuseGuard THEN
+// forceFuseDischarge. When the planner asks for charge while the grid
+// is already at the fuse, applyFuseGuard scales the charge down toward
+// 0; forceFuseDischarge then sees a small (or zero) target and either
+// no-ops or adds a tiny extra discharge to close the residual gap.
+// The standalone-flip-to-discharge behaviour the previous version of
+// this test asserted doesn't happen on the real path — applyFuseGuard
+// would never let a +3 kW charge reach forceFuseDischarge with grid
+// already at the fuse.
+func TestFuseSaverAfterFuseGuardKeepsScaledCharge(t *testing.T) {
+	// Live grid near the fuse limit; planner asked to charge 3 kW;
+	// battery currently idle.
 	store, state, caps := setupFuseSaver(11000, 0, 0.6, 10000)
 	targets := []DispatchTarget{{Driver: "bat", TargetW: 3000}}
-	// Predicted = 11000 - 0 + 3000 = 14000. Over fuse by 2960.
-	out := forceFuseDischarge(targets, store, state, caps, 11040)
-	if out[0].TargetW >= 0 {
-		t.Errorf("expected discharge override, got TargetW=%.0f", out[0].TargetW)
+
+	// Step 1: applyFuseGuard scales charging down because predicted
+	// import (11000 + 3000 = 14000) exceeds the fuse.
+	guarded := applyFuseGuard(targets, store, "meter", 11040)
+	if guarded[0].TargetW < 0 {
+		t.Fatalf("applyFuseGuard should NOT flip charge to discharge — "+
+			"got %.0f W", guarded[0].TargetW)
 	}
-	// 14000 - 11040 = 2960 overage → full discharge of 2960 W
-	// (charge zeroed first, then negative magnitude added).
-	expected := -2960.0
-	if math.Abs(out[0].TargetW-expected) > 1 {
-		t.Errorf("target = %.0f, want ≈ %.0f", out[0].TargetW, expected)
+	if guarded[0].TargetW > 100 {
+		t.Fatalf("applyFuseGuard should have scaled charge down toward 0, "+
+			"got %.0f W (charge surviving the fuse guard is a regression)",
+			guarded[0].TargetW)
+	}
+
+	// Step 2: forceFuseDischarge runs on the post-guard targets. With
+	// charge already at ~0 the predicted gridW after the guard is at
+	// the fuse limit; forceFuseDischarge no-ops or adds a small
+	// residual discharge. Either way it must NOT take the target
+	// further negative than -2960 W (the original overage).
+	out := forceFuseDischarge(guarded, store, state, caps, 11040)
+	if out[0].TargetW < -2960.001 {
+		t.Errorf("post-guard discharge over-correction: target = %.0f W, "+
+			"original overage was 2960 W", out[0].TargetW)
 	}
 }
 
@@ -172,6 +191,31 @@ func TestFuseSaverDisabledWhenFuseMaxZero(t *testing.T) {
 	if out[0].TargetW != 1000 || out[0].Clamped {
 		t.Errorf("fuse_max=0 should disable: got %.0f clamped=%v",
 			out[0].TargetW, out[0].Clamped)
+	}
+}
+
+// Slew bypass — the fuse is the non-negotiable ceiling, slew rate
+// must NOT limit the fuse-saver. End-to-end test: battery at rest
+// (anchor SmoothedW = 0), aggressive 500 W/cycle slew, sudden grid
+// import 14 kW (over 11 kW fuse). Expected: target ≈ -3 kW
+// regardless of the slew rate, because forceFuseDischarge runs
+// AFTER the slew loop in ComputeDispatch.
+func TestFuseSaverBypassesSlew(t *testing.T) {
+	store, state, caps := setupFuseSaver(14000, 0, 0.6, 10000)
+	state.Mode = ModeIdle
+	state.SlewRateW = 500 // tight slew that would otherwise cap the response
+	out := ComputeDispatch(store, state, caps, 11040)
+	if len(out) == 0 {
+		t.Fatalf("idle + over-fuse: expected fuse-saver discharge, got empty")
+	}
+	// Predicted overage = 14000 − 11040 = 2960 W. With 10 kW headroom
+	// the fuse-saver should command the full overage as discharge —
+	// well beyond the 500 W/cycle slew. If we see −500 W instead of
+	// ≈ −2960 W, slew is incorrectly clamping the safety primary.
+	expected := -2960.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f W, want %.0f W (slew must NOT clamp the fuse-saver)",
+			out[0].TargetW, expected)
 	}
 }
 

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -69,7 +70,7 @@ func TestFuseSaverAfterFuseGuardKeepsScaledCharge(t *testing.T) {
 
 	// Step 1: applyFuseGuard scales charging down because predicted
 	// import (11000 + 3000 = 14000) exceeds the fuse.
-	guarded := applyFuseGuard(targets, store, "meter", 11040)
+	guarded := applyFuseGuard(targets, store, state, 11040)
 	if guarded[0].TargetW < 0 {
 		t.Fatalf("applyFuseGuard should NOT flip charge to discharge — "+
 			"got %.0f W", guarded[0].TargetW)
@@ -215,6 +216,117 @@ func TestFuseSaverBypassesSlew(t *testing.T) {
 	expected := -2960.0
 	if math.Abs(out[0].TargetW-expected) > 1 {
 		t.Errorf("target = %.0f W, want %.0f W (slew must NOT clamp the fuse-saver)",
+			out[0].TargetW, expected)
+	}
+}
+
+// ---- Per-phase clamp ----
+
+// setupPerPhase wires a meter that emits l1_a/l2_a/l3_a in
+// DerReading.Data and a single battery. Aggregate gridW stays
+// deliberately under the fuse to prove the per-phase clamp fires
+// independently of the aggregate guard.
+func setupPerPhase(aggGridW float64, l1A, l2A, l3A float64, batSoC float64, maxDischargeW float64) (*telemetry.Store, *State, map[string]float64) {
+	s := telemetry.NewStore()
+	data, _ := json.Marshal(map[string]any{
+		"l1_a": l1A,
+		"l2_a": l2A,
+		"l3_a": l3A,
+	})
+	s.Update("meter", telemetry.DerMeter, aggGridW, nil, data)
+	s.DriverHealthMut("meter").RecordSuccess()
+	soc := batSoC
+	s.Update("bat", telemetry.DerBattery, 0, &soc, nil)
+	s.DriverHealthMut("bat").RecordSuccess()
+	st := NewState(0, 50, "meter")
+	st.SiteFuseAmps = 16
+	st.SiteFuseVoltage = 230
+	st.DriverLimits = map[string]PowerLimits{
+		"bat": {MaxChargeW: 10000, MaxDischargeW: maxDischargeW},
+	}
+	return s, st, map[string]float64{"bat": 15200}
+}
+
+// Single-phase imbalance: aggregate is under fuse but L1 is over.
+// applyFuseGuard must scale charging down to bring the worst phase
+// back. (Pixii single-phase battery on L1 is the real-world case.)
+func TestPerPhaseClampScalesChargingOnImbalance(t *testing.T) {
+	// Isolate the per-phase case: aggregate predicted (7000 + 4000 =
+	// 11000 W) is under the 11040 W fuse, so the legacy aggregate
+	// branch wouldn't fire. But L1 alone is at 18 A × 230 V = 4140 W
+	// (over the 16 A fuse on that phase) — only the per-phase clamp
+	// can catch it.
+	store, state, _ := setupPerPhase(7000, 18, 12, 8, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 4000}}
+	guarded := applyFuseGuard(targets, store, state, 11040)
+	if !guarded[0].Clamped {
+		t.Errorf("Clamped flag must mark per-phase response")
+	}
+	// Per-phase overage = (18 − 16) × 230 = 460 W on the worst phase.
+	// Balanced-3Φ assumption ⇒ 460 × 3 = 1380 W of total battery
+	// reduction needed. Charge 4000 → 4000 − 1380 = 2620 W.
+	expected := 2620.0
+	if math.Abs(guarded[0].TargetW-expected) > 1 {
+		t.Errorf("charge after per-phase clamp = %.0f W, want %.0f W",
+			guarded[0].TargetW, expected)
+	}
+}
+
+// Per-phase overage with no charge to scale → fuse-saver forces
+// discharge. Reproduces the test-day failure: battery idle, EV pinned
+// at 16 A 3Φ, one phase pushed over by house imbalance, aggregate
+// stays under fuse so applyFuseGuard wouldn't fire — but the per-phase
+// path now does.
+func TestPerPhaseClampFiresFuseSaverFromIdle(t *testing.T) {
+	store, state, caps := setupPerPhase(9000, 18, 12, 8, 0.6, 10000)
+	out := fuseSaverFromZero(store, state, caps, 11040)
+	if out == nil {
+		t.Fatalf("per-phase overload from idle must trigger fuse-saver")
+	}
+	if out[0].TargetW >= 0 {
+		t.Errorf("expected discharge target, got %.0f W", out[0].TargetW)
+	}
+	// Same math as the charging test: 460 W × 3 = 1380 W. From idle
+	// (target 0), full discharge of 1380 W.
+	expected := -1380.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("forced discharge = %.0f W, want %.0f W", out[0].TargetW, expected)
+	}
+}
+
+// All phases under the fuse → per-phase clamp doesn't fire.
+func TestPerPhaseClampNoOpWhenAllPhasesSafe(t *testing.T) {
+	store, state, caps := setupPerPhase(8000, 14, 12, 10, 0.6, 10000)
+	out := fuseSaverFromZero(store, state, caps, 11040)
+	if out != nil {
+		t.Errorf("all phases under fuse: expected nil, got %v", out)
+	}
+}
+
+// Per-phase clamp gated on SiteFuseAmps > 0. Sites without per-phase
+// configuration get the legacy aggregate-only behaviour.
+func TestPerPhaseClampDisabledWhenSiteFuseAmpsZero(t *testing.T) {
+	store, state, caps := setupPerPhase(9000, 18, 12, 8, 0.6, 10000)
+	state.SiteFuseAmps = 0 // disable per-phase clamp
+	out := fuseSaverFromZero(store, state, caps, 11040)
+	if out != nil {
+		t.Errorf("per-phase clamp disabled but still fired: %v", out)
+	}
+}
+
+// Aggregate AND per-phase both over: take the larger overage. With a
+// huge imbalance, per-phase × 3 dominates.
+func TestPerPhaseClampDominatesAggregateWhenLarger(t *testing.T) {
+	// Aggregate over by 500 W (predicted = 11540 vs 11040). But L1 is
+	// at 22 A → over by 6 A × 230 = 1380 W per-phase × 3 = 4140 W.
+	store, state, caps := setupPerPhase(11540, 22, 14, 8, 0.6, 10000)
+	out := fuseSaverFromZero(store, state, caps, 11040)
+	if out == nil {
+		t.Fatalf("expected discharge, got nil")
+	}
+	expected := -4140.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("forced discharge = %.0f W, want %.0f W (per-phase × 3)",
 			out[0].TargetW, expected)
 	}
 }

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -1,0 +1,193 @@
+package control
+
+import (
+	"math"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// Reactive fuse-saver tests. These guard the contract: under no
+// software-controllable circumstance should the operator's hardware
+// fuse trip because the EMS sat idle while the meter went over the
+// limit. The PR description has the full background — surfaced by
+// the manual_hold ramp test where the EV was pinned at high amps
+// while the home battery was idle per the planner's slot.
+
+func setupFuseSaver(gridW, batW float64, batSoC float64, maxDischargeW float64) (*telemetry.Store, *State, map[string]float64) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, gridW, nil, nil)
+	s.DriverHealthMut("meter").RecordSuccess()
+	soc := batSoC
+	s.Update("bat", telemetry.DerBattery, batW, &soc, nil)
+	s.DriverHealthMut("bat").RecordSuccess()
+	st := NewState(0, 50, "meter")
+	st.DriverLimits = map[string]PowerLimits{
+		"bat": {MaxChargeW: 10000, MaxDischargeW: maxDischargeW},
+	}
+	return s, st, map[string]float64{"bat": 15200}
+}
+
+// Idle battery + grid surge over fuse → battery is forced to discharge
+// to bring grid back under the fuse. This is the manual_hold-ramp
+// scenario from the PR description.
+func TestFuseSaverForcesDischargeFromIdle(t *testing.T) {
+	// Grid importing 14 kW (e.g. EV pinned at 11 kW + house 3 kW),
+	// fuse 11.04 kW. Battery currently idle.
+	store, state, caps := setupFuseSaver(14000, 0, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 0}}
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(out))
+	}
+	// Predicted = 14000 - 0 + 0 = 14000. Overage = 14000 - 11040 = 2960.
+	// Battery has 10 kW of discharge headroom → absorb full overage.
+	expected := -2960.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f, want %.0f (full overage absorbed by idle battery)",
+			out[0].TargetW, expected)
+	}
+	if !out[0].Clamped {
+		t.Errorf("Clamped flag must mark fuse-saver activation")
+	}
+}
+
+// Planner commanded the battery to CHARGE (off-peak hours, planner
+// arbitrage). Grid is already at the fuse from external loads. The
+// fuse-saver flips the charge command to discharge regardless of plan.
+func TestFuseSaverFlipsChargeToDischargeWhenOverFuse(t *testing.T) {
+	// Live grid at fuse limit; planner asked to charge 3 kW; current
+	// battery doing nothing (target hasn't propagated yet).
+	store, state, caps := setupFuseSaver(11000, 0, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 3000}}
+	// Predicted = 11000 - 0 + 3000 = 14000. Over fuse by 2960.
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	if out[0].TargetW >= 0 {
+		t.Errorf("expected discharge override, got TargetW=%.0f", out[0].TargetW)
+	}
+	// 14000 - 11040 = 2960 overage → full discharge of 2960 W
+	// (charge zeroed first, then negative magnitude added).
+	expected := -2960.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f, want ≈ %.0f", out[0].TargetW, expected)
+	}
+}
+
+// Battery already commanded to discharge a bit; fuse-saver TOPS UP the
+// discharge instead of starting from scratch.
+func TestFuseSaverAddsToExistingDischarge(t *testing.T) {
+	store, state, caps := setupFuseSaver(13000, 0, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: -1000}}
+	// Predicted = 13000 - 0 + (-1000) = 12000. Over fuse by 960.
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	expected := -1960.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f, want %.0f (existing discharge plus overage)",
+			out[0].TargetW, expected)
+	}
+}
+
+// Empty pack (SoC < 5%) → can't be drained. Function returns the
+// targets unchanged. Hardware fuse is the next layer.
+func TestFuseSaverRespectsEmptyBattery(t *testing.T) {
+	store, state, caps := setupFuseSaver(14000, 0, 0.02, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 0}}
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	if out[0].TargetW != 0 || out[0].Clamped {
+		t.Errorf("empty battery should not be drained: got %.0f clamped=%v",
+			out[0].TargetW, out[0].Clamped)
+	}
+}
+
+// MaxDischargeW caps the fuse-saver — never command more discharge
+// than the battery can physically deliver, even if the fuse would
+// otherwise be violated by even more.
+func TestFuseSaverRespectsMaxDischarge(t *testing.T) {
+	// Massive overage (10 kW), but battery can only discharge 4 kW.
+	store, state, caps := setupFuseSaver(20000, 0, 0.6, 4000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 0}}
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	if out[0].TargetW < -4000.001 {
+		t.Errorf("target = %.0f, exceeds MaxDischargeW=4000",
+			out[0].TargetW)
+	}
+}
+
+// Within fuse → no-op. The fuse-saver doesn't touch dispatch when
+// predicted gridW is already safe.
+func TestFuseSaverNoOpWhenWithinFuse(t *testing.T) {
+	store, state, caps := setupFuseSaver(5000, 0, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 1000}}
+	out := forceFuseDischarge(targets, store, state, caps, 11040)
+	if out[0].TargetW != 1000 || out[0].Clamped {
+		t.Errorf("within fuse: got %.0f clamped=%v, want 1000 false",
+			out[0].TargetW, out[0].Clamped)
+	}
+}
+
+// Multi-battery: distribute the forced discharge proportionally to
+// each battery's remaining headroom.
+func TestFuseSaverDistributesAcrossBatteries(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, 14000, nil, nil)
+	s.DriverHealthMut("meter").RecordSuccess()
+	soc := 0.6
+	s.Update("a", telemetry.DerBattery, 0, &soc, nil)
+	s.DriverHealthMut("a").RecordSuccess()
+	s.Update("b", telemetry.DerBattery, 0, &soc, nil)
+	s.DriverHealthMut("b").RecordSuccess()
+	state := NewState(0, 50, "meter")
+	state.DriverLimits = map[string]PowerLimits{
+		"a": {MaxChargeW: 10000, MaxDischargeW: 6000},
+		"b": {MaxChargeW: 10000, MaxDischargeW: 4000},
+	}
+	caps := map[string]float64{"a": 10000, "b": 5000}
+	targets := []DispatchTarget{
+		{Driver: "a", TargetW: 0},
+		{Driver: "b", TargetW: 0},
+	}
+	// Overage 14000 - 11040 = 2960. Distributed by headroom (6:4):
+	// a gets 2960*0.6 = 1776, b gets 2960*0.4 = 1184.
+	out := forceFuseDischarge(targets, s, state, caps, 11040)
+	if math.Abs(out[0].TargetW-(-1776)) > 1 {
+		t.Errorf("battery a: %.0f, want -1776", out[0].TargetW)
+	}
+	if math.Abs(out[1].TargetW-(-1184)) > 1 {
+		t.Errorf("battery b: %.0f, want -1184", out[1].TargetW)
+	}
+	var sum float64
+	for _, t := range out {
+		sum += t.TargetW
+	}
+	if math.Abs(sum-(-2960)) > 1 {
+		t.Errorf("total forced discharge = %.0f, want -2960", sum)
+	}
+}
+
+// fuseMaxW=0 → disabled. No-op.
+func TestFuseSaverDisabledWhenFuseMaxZero(t *testing.T) {
+	store, state, caps := setupFuseSaver(20000, 0, 0.6, 10000)
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 1000}}
+	out := forceFuseDischarge(targets, store, state, caps, 0)
+	if out[0].TargetW != 1000 || out[0].Clamped {
+		t.Errorf("fuse_max=0 should disable: got %.0f clamped=%v",
+			out[0].TargetW, out[0].Clamped)
+	}
+}
+
+// End-to-end via ComputeDispatch: idle mode + grid surge → returns
+// non-empty discharge targets. Idle mode would normally return [].
+func TestFuseSaverFiresInIdleMode(t *testing.T) {
+	store, state, caps := setupFuseSaver(14000, 0, 0.6, 10000)
+	state.Mode = ModeIdle
+	out := ComputeDispatch(store, state, caps, 11040)
+	if len(out) == 0 {
+		t.Fatalf("idle mode + over-fuse import: expected fuse-saver discharge, got empty")
+	}
+	if out[0].TargetW >= 0 {
+		t.Errorf("expected discharge target, got %.0f", out[0].TargetW)
+	}
+	if !out[0].Clamped {
+		t.Errorf("Clamped flag must mark fuse-saver activation")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `forceFuseDischarge` — a dispatch-level safety primary that **unconditionally drains the home battery whenever predicted grid import exceeds the fuse**. Runs in every mode (idle, self_consumption, planner_*, holdoff window) and overrides every operator intent (BatteryCoversEV toggle, planner allocation, manual_hold injection).

## What incident this addresses

In PR #206's session, the manual_hold ramp test pinned the EV at ~5.5 kW while the home battery sat at 0 W per the planner's idle slot. `gridW` exceeded `fuseSafeMaxW` until the operator stopped the test by hand. The user's safety requirement: **the battery should in ALL situations discharge to prevent fuse overload, react in real time for unplanned loads.**

## Why a new primitive (existing `applyFuseGuard` isn't enough)

`applyFuseGuard` only scales POSITIVE (charge) targets DOWN to 0 when import is over fuse. That helps when the planner asked for a charge — it prevents the EMS from making the overflow worse — but cannot help in the common \"battery idle, surprise load\" case because there's no charge to shrink. `forceFuseDischarge` closes that gap.

## Behaviour

1. Recompute `predicted = currentGrid − currentBat + sumTarget` after `applyFuseGuard`'s scaling. `currentGrid` is the live meter and reflects ALL loads — planned, off-plan, manual_hold-injected, neighbour's pool pump on the same fuse.
2. If `predicted > fuseMaxW`, allocate `overage = predicted − fuseMaxW` of additional discharge across online batteries proportionally to each battery's remaining headroom (`MaxDischargeW − current target magnitude`), gated on `SoC ≥ 5 %`.
3. Mark every modified target `Clamped = true` so the dispatch trace shows the fuse-saver fired.

## Coverage

- **Idle mode** routes through `fuseSaverFromZero` — generates zero-W targets for every online battery and runs them through `forceFuseDischarge`. If no overflow is predicted, returns nil (same as today).
- **Holdoff window** does the same — overflow can't wait 5 s for the next eligible tick.
- **Empty pack** (SoC < 5 %) → fuse-saver returns targets unchanged. Hardware fuse becomes the next layer.
- **All batteries at MaxDischargeW** → no-op (already doing all the EMS can).
- **`fuseMaxW = 0`** → disabled (matches `applyFuseGuard`'s convention).

## What this DOES NOT do

- **Sub-tick reactivity.** The 5 s control-tick is the floor. Sub-tick spikes (an oven turning on between ticks) still rely on the hardware fuse. Going faster requires pushing the dispatch loop down to ~1 s — separate change.
- **Per-phase imbalance.** This is the aggregate three-phase guard. Per-phase logic (e.g. a 16 A fuse where one phase is the EV and another the oven) would need driver-level data and is a follow-up.

## Tests

9 new tests in `go/internal/control/fuse_saver_test.go`:

| Test | Verifies |
|---|---|
| `TestFuseSaverForcesDischargeFromIdle` | Battery at 0 W + grid 14 kW + fuse 11.04 kW → battery commanded to −2960 W |
| `TestFuseSaverFlipsChargeToDischargeWhenOverFuse` | Planner asks for +3 kW charge but grid already at fuse → battery flips to discharge |
| `TestFuseSaverAddsToExistingDischarge` | Battery already discharging 1 kW, grid still over → tops up |
| `TestFuseSaverRespectsEmptyBattery` | SoC = 2 % → no-op, hardware fuse takes over |
| `TestFuseSaverRespectsMaxDischarge` | Massive overage but battery cap = 4 kW → discharge clamped at MaxDischargeW |
| `TestFuseSaverNoOpWhenWithinFuse` | Healthy grid → leave dispatch alone |
| `TestFuseSaverDistributesAcrossBatteries` | Two batteries with 6:4 headroom split → forced discharge weighted accordingly |
| `TestFuseSaverDisabledWhenFuseMaxZero` | `fuseMaxW = 0` → no-op |
| `TestFuseSaverFiresInIdleMode` | End-to-end via `ComputeDispatch` — idle mode + grid spike yields non-empty dispatch |

`go test ./...` all green incl. `test/e2e`. No regressions in existing fuse-guard tests.

## Docs

`docs/safety.md` gets section 3a documenting the new primary alongside the existing `applyFuseGuard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)