### PR TITLE
fix(history): record per-driver ev_w so live chart can plot EV power

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1601,6 +1601,14 @@ func recordHistory(st *state.Store, tel *telemetry.Store, ctrl *control.State, n
 		if r := tel.Get(name, telemetry.DerMeter); r != nil {
 			row["meter_w"] = r.SmoothedW
 		}
+		// EV charge power: required for the live chart's EV series
+		// (web/next-app.js reads `d.ev_w` per driver from /api/history).
+		// Without it the chart's EV trace is always zero — the in-memory
+		// /api/status DOES carry ev_w, but history rows never did until
+		// this row was added.
+		if r := tel.Get(name, telemetry.DerEV); r != nil {
+			row["ev_w"] = r.SmoothedW
+		}
 		_ = h
 		perDriver[name] = row
 	}


### PR DESCRIPTION
## Summary

The live chart's EV trace was always zero. `recordHistory()` in `main.go` was packing per-driver `bat_w` / `pv_w` / `meter_w` into the history JSON column but **not** `ev_w` — so the chart's per-driver lookup (\`d.ev_w\` in \`web/next-app.js:1866\`) returned undefined and the trace plotted as zero.

The in-memory \`/api/status\` path was unaffected (it always emitted \`ev_w\` from the easee-cloud driver), which is why operators saw the correct number on the dashboard cards but a flat-zero chart.

## Fix

Pull \`DerEV.SmoothedW\` into the per-driver history row alongside the existing types. Three lines.

```go
if r := tel.Get(name, telemetry.DerEV); r != nil {
    row[\"ev_w\"] = r.SmoothedW
}
```

## Verification

5-step 3Φ ramp at 6/7/8/9/10 A on a real Easee charger:

| Step | Requested W | Observed ev_w |
|---|---:|---:|
| 6A 3Φ | 4140 | 0 (awaiting start) |
| 7A 3Φ | 4830 | 4774 |
| 8A 3Φ | 5520 | 5470 |
| 9A 3Φ | 6210 | 6108 |
| 10A 3Φ | 6900 | 6793 |

`/api/history` history points now show the same values inside the per-driver `easee-cloud` map, and the live chart renders the stair-step trace as expected.

## Why no test

The fix is a single-pass-through line in `recordHistory` and is verified end-to-end against real hardware. Adding a `cmd/forty-two-watts` unit test would require lifting `recordHistory` into a testable package — appropriate for a follow-up refactor, not this minimal bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)