### PR TITLE
fix(easee): always start sessions at 6 A to avoid 16 A inrush

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -420,6 +420,22 @@ function driver_init(config)
         host.log("warn", "Easee: could not read firmware settings: " .. serr)
     end
 
+    -- Force a 6 A resting setpoint so any session that starts before our
+    -- first ev_set_current tick lands begins at the hardware minimum, not
+    -- at maxChargerCurrent. Easee resets dynamicChargerCurrent → max on
+    -- phase changes and on some session-start paths; without this, a
+    -- freshly plugged-in EV pulls 16 A for 5–10 s before the controller's
+    -- first dispatch tick claws it back, which the operator sees as a
+    -- visible inrush at the meter.
+    local pre_err = write_setting(charger_serial, {dynamicChargerCurrent = EASEE_MIN_A})
+    if pre_err == nil then
+        last_amps_set = EASEE_MIN_A
+        host.log("info", "Easee: dynamicChargerCurrent primed to " .. tostring(EASEE_MIN_A) .. " A at init")
+    else
+        host.log("warn", "Easee: init prime to " .. tostring(EASEE_MIN_A) .. " A failed: " ..
+            redact_http_err(pre_err))
+    end
+
     host.log("info", "Easee: driver initialized for " .. charger_serial)
 end
 
@@ -540,6 +556,19 @@ function driver_command(action, power_w, cmd)
     if not charger_serial or not ensure_auth(email, password) then return false end
 
     if action == "ev_start" then
+        -- Floor the dynamic setpoint to 6 A *before* asking the charger to
+        -- start. Without this, Easee energises the cable at whatever
+        -- dynamicChargerCurrent is currently cached server-side — which
+        -- after a phaseMode reset is maxChargerCurrent (16 A). Starting at
+        -- the minimum lets the controller ramp up on its own schedule
+        -- instead of the EV briefly pulling fuse-rated current.
+        local floor_err = write_setting(charger_serial, {dynamicChargerCurrent = EASEE_MIN_A})
+        if floor_err == nil then
+            last_amps_set = EASEE_MIN_A
+        else
+            host.log("warn", "Easee: pre-start floor write failed (continuing): " ..
+                redact_http_err(floor_err))
+        end
         return post_command("/commands/start_charging")
     elseif action == "ev_pause" then
         return post_command("/commands/pause_charging")


### PR DESCRIPTION
## Summary

- Easee's cloud caches `dynamicChargerCurrent` and resets it to `maxChargerCurrent` (typically 16 A) on phaseMode changes and some session-start paths. A freshly plugged-in EV therefore pulls fuse-rated current for 5–10 s before the controller's first dispatch tick claws it back — visible at the meter as a power surge.
- This PR floors the cached server-side setpoint to the Easee hardware minimum (6 A) in two places so every session starts at 6 A and ramps up from there.

## Changes

`drivers/easee_cloud.lua`:

- **`driver_init`** — primes `dynamicChargerCurrent = 6` once auth + serial are resolved, so the very first session a user starts begins at 6 A regardless of what was cached server-side.
- **`ev_start`** — re-floors to 6 A immediately before `POST /commands/start_charging`, so the cable energises at the minimum even when a phaseMode reset just bumped the cached value back to `maxChargerCurrent`.

Both writes update `last_amps_set` so the post-phaseMode resend logic (`pending_amp_resend`) doesn't race the floor back up. The controller's 5 s `ev_set_current` tick ramps from 6 A toward the dispatched target on its own schedule — no behaviour change above the driver layer.

## Not addressed (separate concern)

The phaseMode-change reset window (~5–10 s where Easee pins `dynamicChargerCurrent = maxChargerCurrent` regardless of what we write) is unchanged. Capping that window at 6 A would require a temporary `maxChargerCurrent = 6` write around phase flips, which is more invasive — worth its own PR if the operator still sees a flip-time surge.

## Test plan

- [ ] Plug in EV with charger fresh-booted: meter should show ramp from ~1.4 kW (6 A × 230 V) up to dispatched target, not a 3.7 kW spike.
- [ ] Restart the forty-two-watts service mid-session: log line `Easee: dynamicChargerCurrent primed to 6 A at init` should appear.
- [ ] Trigger an `ev_start` via the dispatch path: cable should energise at 6 A before the next 5 s controller tick raises it.
- [ ] Verify firmware-locked `phaseMode` installs aren't broken (init prime write should succeed even when phaseMode writes are silently rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)