### PR TITLE
Tesla BLE driver + vehicle SoC + joint fuse-budget allocator + EV bubble

### DIFF
--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -1,0 +1,215 @@
+-- Tesla Vehicle Driver (read-only, via TeslaBLEProxy or Tesla API)
+-- Emits: Vehicle (DerVehicle)
+-- Protocol: HTTPS / HTTP (Tesla Owner API shape — vehicle_data endpoint)
+--
+-- Fetches the vehicle's own SoC and charge_limit so forty-two-watts can
+-- show the real "24 / 50 %" in the EV bubble and let the loadpoint
+-- manager prefer the truth over its delivered-Wh inference. This
+-- driver is transparent to the transport — it speaks plain HTTP/JSON
+-- against anything that implements Tesla's vehicle_data shape. In the
+-- typical deployment that's TeslaBLEProxy running on the same LAN
+-- (https://github.com/wimaha/TeslaBleHttpProxy) which translates to
+-- BLE under the hood — forty-two-watts never sees BLE.
+--
+-- Config example:
+--   drivers:
+--     - name: tesla-garage
+--       lua: drivers/tesla_vehicle.lua
+--       capabilities:
+--         http:
+--           allowed_hosts: ["192.168.1.50"]
+--       config:
+--         base_url: "http://192.168.1.50:8080"
+--         vehicle_id: "1234567890"      # id or VIN, per proxy
+--         access_token: ""              # optional Bearer token
+--         poll_interval_s: 60           # default 60
+--         stale_after_s: 900            # default 900 (15 min)
+
+DRIVER = {
+  id           = "tesla-vehicle",
+  name         = "Tesla Vehicle (BLE Proxy)",
+  manufacturer = "Tesla",
+  version      = "0.1.0",
+  protocols    = { "http" },
+  capabilities = { "vehicle" },
+  description  = "Read-only vehicle SoC + charge limit via Tesla API-compatible HTTP endpoint (e.g. TeslaBLEProxy).",
+  homepage     = "https://github.com/wimaha/TeslaBleHttpProxy",
+  authors      = { "forty-two-watts contributors" },
+  tested_models = { "Model Y", "Model 3" },
+  verification_status = "beta",
+}
+
+PROTOCOL = "http"
+
+-- Runtime state
+local base_url = nil
+local vehicle_id = nil
+local access_token = nil
+local poll_interval_ms = 60000
+local stale_after_ms = 900000
+
+-- Cached last-known reading so we can keep publishing a value while
+-- the vehicle is asleep. Tesla returns 408 "vehicle unavailable" when
+-- the car is in deep sleep; we treat that as "use last-known" until
+-- stale_after_ms elapses.
+local last = {
+  ts_ms          = 0,
+  soc            = nil,
+  charge_limit   = nil,
+  charging_state = nil,
+  time_to_full   = nil,
+}
+
+local function auth_headers()
+  if access_token and access_token ~= "" then
+    return { ["Authorization"] = "Bearer " .. access_token,
+             ["Accept"] = "application/json" }
+  end
+  return { ["Accept"] = "application/json" }
+end
+
+local function safe_http_err(err)
+  if err == nil then return "ok" end
+  return tostring(err):match("^(HTTP %d+)") or "request failed"
+end
+
+function driver_init(config)
+  if not config then
+    host.log("error", "tesla: config required")
+    return
+  end
+  base_url = config.base_url
+  vehicle_id = config.vehicle_id or config.vin
+  access_token = config.access_token
+
+  if not base_url or base_url == "" then
+    host.log("error", "tesla: base_url required")
+    return
+  end
+  if not vehicle_id or vehicle_id == "" then
+    host.log("error", "tesla: vehicle_id (or vin) required")
+    return
+  end
+
+  if tonumber(config.poll_interval_s) then
+    poll_interval_ms = math.max(15, math.floor(tonumber(config.poll_interval_s))) * 1000
+  end
+  if tonumber(config.stale_after_s) then
+    stale_after_ms = math.max(60, math.floor(tonumber(config.stale_after_s))) * 1000
+  end
+
+  host.set_make("Tesla")
+  host.set_sn(tostring(vehicle_id))
+  host.log("info", "tesla: driver initialized for " .. tostring(vehicle_id))
+end
+
+-- emit_last sends the cached reading with a stale flag computed from
+-- the cached timestamp. Called when the HTTP poll fails or the
+-- vehicle is asleep, so the UI keeps showing a number instead of a
+-- blank.
+local function emit_last()
+  if last.soc == nil then
+    return
+  end
+  local age = host.millis() - last.ts_ms
+  local stale = age > stale_after_ms
+  host.emit("vehicle", {
+    soc              = last.soc,
+    charge_limit_pct = last.charge_limit,
+    charging_state   = last.charging_state,
+    time_to_full_min = last.time_to_full,
+    stale            = stale,
+  })
+end
+
+function driver_poll()
+  if not base_url or not vehicle_id then
+    return 10000
+  end
+
+  local url = base_url .. "/api/1/vehicles/" .. vehicle_id .. "/vehicle_data"
+  local resp, err = host.http_get(url, auth_headers())
+  if err ~= nil then
+    -- Tesla proxies return 408 for "vehicle asleep" — treat as
+    -- "cached data still valid" rather than a hard error.
+    host.log("debug", "tesla: poll error: " .. safe_http_err(err))
+    emit_last()
+    return poll_interval_ms
+  end
+
+  local body = resp and resp.body
+  if not body or body == "" then
+    emit_last()
+    return poll_interval_ms
+  end
+
+  local decoded, derr = host.json_decode(body)
+  if derr or not decoded then
+    host.log("warn", "tesla: json decode failed")
+    emit_last()
+    return poll_interval_ms
+  end
+
+  -- Tesla shape: { response: { charge_state: {...}, ... } } for Owner API.
+  -- Some proxies omit the envelope and return charge_state at top level —
+  -- handle both.
+  local charge_state = nil
+  if type(decoded) == "table" then
+    if decoded.response and type(decoded.response) == "table" and
+       decoded.response.charge_state then
+      charge_state = decoded.response.charge_state
+    elseif decoded.charge_state then
+      charge_state = decoded.charge_state
+    end
+  end
+  if not charge_state then
+    host.log("debug", "tesla: no charge_state in response")
+    emit_last()
+    return poll_interval_ms
+  end
+
+  local soc = tonumber(charge_state.battery_level)
+  local limit = tonumber(charge_state.charge_limit_soc)
+  local ttf = tonumber(charge_state.time_to_full_charge)
+  local cs = charge_state.charging_state
+  if type(cs) ~= "string" then cs = nil end
+
+  if soc ~= nil then
+    last.soc            = soc
+    last.charge_limit   = limit
+    last.charging_state = cs
+    -- Tesla API returns time_to_full_charge in hours (decimal); convert to minutes.
+    last.time_to_full   = ttf and math.floor(ttf * 60 + 0.5) or nil
+    last.ts_ms          = host.millis()
+
+    host.emit("vehicle", {
+      soc              = soc,
+      charge_limit_pct = limit,
+      charging_state   = cs,
+      time_to_full_min = last.time_to_full,
+      stale            = false,
+    })
+  else
+    -- Malformed response (no battery_level) → keep last-known.
+    emit_last()
+  end
+
+  return poll_interval_ms
+end
+
+function driver_command(action, _, _)
+  -- Read-only driver. Commands are intentionally not supported —
+  -- forty-two-watts does not try to wake / set_charge_limit /
+  -- start_charging the vehicle. Operators manage that via their
+  -- Tesla app or the proxy's own UI.
+  host.log("debug", "tesla: command ignored: " .. tostring(action))
+  return false
+end
+
+function driver_default_mode()
+  -- Nothing to do — there's no output state to reset.
+end
+
+function driver_cleanup()
+  last.soc = nil
+end

--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -1,29 +1,27 @@
--- Tesla Vehicle Driver (read-only, via TeslaBLEProxy or Tesla API)
+-- Tesla Vehicle Driver (read-only, via TeslaBLEProxy on local LAN)
 -- Emits: Vehicle (DerVehicle)
--- Protocol: HTTPS / HTTP (Tesla Owner API shape — vehicle_data endpoint)
+-- Protocol: HTTP (Tesla Owner API shape — /api/1/vehicles/{VIN}/vehicle_data)
 --
 -- Fetches the vehicle's own SoC and charge_limit so forty-two-watts can
 -- show the real "24 / 50 %" in the EV bubble and let the loadpoint
--- manager prefer the truth over its delivered-Wh inference. This
--- driver is transparent to the transport — it speaks plain HTTP/JSON
--- against anything that implements Tesla's vehicle_data shape. In the
--- typical deployment that's TeslaBLEProxy running on the same LAN
--- (https://github.com/wimaha/TeslaBleHttpProxy) which translates to
--- BLE under the hood — forty-two-watts never sees BLE.
+-- manager prefer the truth over its delivered-Wh inference. Designed
+-- to talk to TeslaBLEProxy running on the same LAN
+-- (https://github.com/wimaha/TeslaBleHttpProxy), which translates
+-- HTTP/JSON to BLE under the hood. No Tesla cloud credentials, no
+-- OAuth token, no internet round-trip — the proxy IS the key to the
+-- vehicle.
 --
--- Config example:
+-- Config: two fields, that's it.
+--
 --   drivers:
 --     - name: tesla-garage
 --       lua: drivers/tesla_vehicle.lua
 --       capabilities:
 --         http:
---           allowed_hosts: ["192.168.1.50"]
+--           allowed_hosts: ["192.168.1.50"]   # IP of the proxy
 --       config:
---         base_url: "http://192.168.1.50:8080"
---         vehicle_id: "1234567890"      # id or VIN, per proxy
---         access_token: ""              # optional Bearer token
---         poll_interval_s: 60           # default 60
---         stale_after_s: 900            # default 900 (15 min)
+--         ip:  "192.168.1.50"
+--         vin: "5YJ3E1EA1KF000000"
 
 DRIVER = {
   id           = "tesla-vehicle",
@@ -41,30 +39,35 @@ DRIVER = {
 
 PROTOCOL = "http"
 
--- Runtime state
+-- Runtime state. base_url is built from the `ip` config field.
+-- TeslaBLEProxy listens on :8080 by default — hardcoded since that's
+-- what the project ships. Poll + staleness are tuned in-driver;
+-- operators touch only `ip` + `vin` in YAML.
+local PROXY_PORT        = 8080
+local POLL_INTERVAL_MS  = 60000
+local STALE_AFTER_MS    = 900000
+
 local base_url = nil
-local vehicle_id = nil
-local access_token = nil
-local poll_interval_ms = 60000
-local stale_after_ms = 900000
+local vin = nil
 
 -- Cached last-known reading so we can keep publishing a value while
 -- the vehicle is asleep. Tesla returns 408 "vehicle unavailable" when
 -- the car is in deep sleep; we treat that as "use last-known" until
--- stale_after_ms elapses.
+-- STALE_AFTER_MS elapses.
 local last = {
-  ts_ms          = 0,
-  soc            = nil,
-  charge_limit   = nil,
-  charging_state = nil,
-  time_to_full   = nil,
+  ts_ms                   = 0,
+  soc                     = nil,
+  charge_limit            = nil,
+  charging_state          = nil,
+  time_to_full            = nil,
+  charge_amps             = nil,
+  charger_actual_current  = nil,
 }
 
 local function auth_headers()
-  if access_token and access_token ~= "" then
-    return { ["Authorization"] = "Bearer " .. access_token,
-             ["Accept"] = "application/json" }
-  end
+  -- TeslaBLEProxy on the LAN doesn't require a bearer token; it
+  -- authenticates against the car via BLE itself. Plain JSON Accept
+  -- header is all we need.
   return { ["Accept"] = "application/json" }
 end
 
@@ -75,32 +78,49 @@ end
 
 function driver_init(config)
   if not config then
-    host.log("error", "tesla: config required")
+    host.log("error", "tesla: config required (ip + vin)")
     return
   end
-  base_url = config.base_url
-  vehicle_id = config.vehicle_id or config.vin
-  access_token = config.access_token
+  local ip = config.ip
+  vin = config.vin
 
-  if not base_url or base_url == "" then
-    host.log("error", "tesla: base_url required")
+  if not ip or ip == "" then
+    host.log("error", "tesla: `ip` required (LAN address of TeslaBLEProxy)")
     return
   end
-  if not vehicle_id or vehicle_id == "" then
-    host.log("error", "tesla: vehicle_id (or vin) required")
+  if not vin or vin == "" then
+    host.log("error", "tesla: `vin` required (vehicle VIN the proxy is paired to)")
     return
   end
 
-  if tonumber(config.poll_interval_s) then
-    poll_interval_ms = math.max(15, math.floor(tonumber(config.poll_interval_s))) * 1000
-  end
-  if tonumber(config.stale_after_s) then
-    stale_after_ms = math.max(60, math.floor(tonumber(config.stale_after_s))) * 1000
+  -- Accept bare IP (uses PROXY_PORT default) or host:port. We split
+  -- on the LAST colon so IPv6-in-brackets-plus-port works too, though
+  -- the typical config is "192.168.1.50" or "192.168.1.50:1234".
+  local host_part, port_part = ip:match("^(.*):(%d+)$")
+  if host_part and port_part then
+    base_url = "http://" .. host_part .. ":" .. port_part
+  else
+    base_url = "http://" .. ip .. ":" .. tostring(PROXY_PORT)
   end
 
   host.set_make("Tesla")
-  host.set_sn(tostring(vehicle_id))
-  host.log("info", "tesla: driver initialized for " .. tostring(vehicle_id))
+  host.set_sn(tostring(vin))
+  -- Two-phase poll cadence:
+  --  1. Init pumps the interval down to 500 ms so the registry's
+  --     initial timer fires almost immediately. The first poll
+  --     thus runs ≤ 1 s after startup / restart / hot-reload —
+  --     no 60-second blank window where the dashboard says
+  --     "no vehicle data".
+  --  2. driver_poll bumps the interval back up to POLL_INTERVAL_MS
+  --     (60 s) before returning, so steady-state polling is
+  --     conservative on BLE wake-ups + Tesla cloud rate.
+  -- The registry re-reads PollInterval() on every iteration, so the
+  -- mid-flight change takes effect immediately.
+  host.set_poll_interval(500)
+  host.log("info", "tesla: driver initialized vin=" .. tostring(vin) ..
+                   " proxy=" .. base_url ..
+                   " poll_s=" .. tostring(POLL_INTERVAL_MS / 1000) ..
+                   " (first poll within 1s)")
 end
 
 -- emit_last sends the cached reading with a stale flag computed from
@@ -112,89 +132,151 @@ local function emit_last()
     return
   end
   local age = host.millis() - last.ts_ms
-  local stale = age > stale_after_ms
+  local stale = age > STALE_AFTER_MS
   host.emit("vehicle", {
-    soc              = last.soc,
-    charge_limit_pct = last.charge_limit,
-    charging_state   = last.charging_state,
-    time_to_full_min = last.time_to_full,
-    stale            = stale,
+    soc                    = last.soc,
+    charge_limit_pct       = last.charge_limit,
+    charging_state         = last.charging_state,
+    time_to_full_min       = last.time_to_full,
+    charge_amps            = last.charge_amps,
+    charger_actual_current = last.charger_actual_current,
+    stale                  = stale,
   })
 end
 
 function driver_poll()
-  if not base_url or not vehicle_id then
+  if not base_url or not vin then
     return 10000
   end
 
-  local url = base_url .. "/api/1/vehicles/" .. vehicle_id .. "/vehicle_data"
-  local resp, err = host.http_get(url, auth_headers())
-  if err ~= nil then
-    -- Tesla proxies return 408 for "vehicle asleep" — treat as
-    -- "cached data still valid" rather than a hard error.
-    host.log("debug", "tesla: poll error: " .. safe_http_err(err))
-    emit_last()
-    return poll_interval_ms
-  end
+  -- Bump the steady-state interval back to 60 s after the (deliberately
+  -- short) init interval that gets us our first reading inside a
+  -- second of startup. Idempotent — running set_poll_interval with the
+  -- same value every poll is a no-op cost-wise.
+  host.set_poll_interval(POLL_INTERVAL_MS)
 
-  local body = resp and resp.body
-  if not body or body == "" then
+  -- endpoints=charge_state narrows the response to just what we
+  -- care about (SoC + limit + charging_state + time_to_full).
+  --
+  -- wakeup=true is intentionally OMITTED. The proxy returns
+  -- cached data from its own background sync (typically ≤ 5 s
+  -- fresh, fine for our 60 s poll cadence + pokes). Forcing a
+  -- BLE wake on every poll caused HTTP 503 "Command Disallowed"
+  -- storms when the driver was poked alongside regular polls —
+  -- BLE radio can only service one command at a time and our
+  -- poke-on-plug-in + poke-on-charging-start stacked queries
+  -- faster than the proxy could complete them.
+  local url = base_url .. "/api/1/vehicles/" .. vin ..
+              "/vehicle_data?endpoints=charge_state"
+  -- host.http_get returns (body_string, nil) or (nil, error_string) —
+  -- first return is the body directly, NOT a table with .body. The
+  -- earlier tesla_vehicle iterations treated it as a table and got
+  -- length 0 on every poll, which silently emit_last()'d the driver.
+  local body, err = host.http_get(url, auth_headers())
+  if err ~= nil then
+    -- 503 "Command Disallowed" means the proxy's BLE radio is
+    -- busy (usually because we just poked or the car just started
+    -- charging and the radio negotiation hasn't cleared). Log at
+    -- debug to avoid noise — the next poll will succeed.
+    local es = tostring(err)
+    if es:match("HTTP 503") then
+      host.log("debug", "tesla: proxy busy (BLE busy) — will retry")
+    else
+      host.log("warn", "tesla: poll HTTP error: " .. es)
+    end
     emit_last()
-    return poll_interval_ms
+    return POLL_INTERVAL_MS
+  end
+  if not body or body == "" then
+    host.log("warn", "tesla: empty body from proxy")
+    emit_last()
+    return POLL_INTERVAL_MS
   end
 
   local decoded, derr = host.json_decode(body)
   if derr or not decoded then
-    host.log("warn", "tesla: json decode failed")
+    host.log("warn", "tesla: json decode failed: " .. tostring(derr))
     emit_last()
-    return poll_interval_ms
+    return POLL_INTERVAL_MS
   end
 
-  -- Tesla shape: { response: { charge_state: {...}, ... } } for Owner API.
-  -- Some proxies omit the envelope and return charge_state at top level —
-  -- handle both.
+  -- Response shapes (in the wild):
+  --   1. TeslaBLEProxy double-wrapped:
+  --        { response = { response = { charge_state = {...} } } }
+  --   2. Tesla Owner API envelope:
+  --        { response = { charge_state = {...} } }
+  --   3. Bare: { charge_state = {...} }
   local charge_state = nil
   if type(decoded) == "table" then
-    if decoded.response and type(decoded.response) == "table" and
-       decoded.response.charge_state then
-      charge_state = decoded.response.charge_state
-    elseif decoded.charge_state then
+    if type(decoded.response) == "table" then
+      if type(decoded.response.response) == "table" and
+         decoded.response.response.charge_state then
+        charge_state = decoded.response.response.charge_state
+      elseif decoded.response.charge_state then
+        charge_state = decoded.response.charge_state
+      end
+    end
+    if not charge_state and decoded.charge_state then
       charge_state = decoded.charge_state
     end
   end
   if not charge_state then
     host.log("debug", "tesla: no charge_state in response")
     emit_last()
-    return poll_interval_ms
+    return POLL_INTERVAL_MS
   end
 
   local soc = tonumber(charge_state.battery_level)
   local limit = tonumber(charge_state.charge_limit_soc)
-  local ttf = tonumber(charge_state.time_to_full_charge)
+  -- Per-vehicle in-app current limit. The car negotiates DOWN to
+  -- this amperage regardless of what the wallbox offers; surface it
+  -- so operators can see "wallbox commands 16A but car capped to 5A"
+  -- mismatches without digging into the raw proxy response.
+  local charge_amps = tonumber(charge_state.charge_amps)
+  local charger_actual_current = tonumber(charge_state.charger_actual_current)
+  -- Field name depends on source:
+  --   - TeslaBLEProxy emits `minutes_to_full_charge` (integer minutes).
+  --   - Tesla Owner API emits `time_to_full_charge` (fractional hours).
+  local ttf_min = tonumber(charge_state.minutes_to_full_charge)
+  if ttf_min == nil then
+    local ttf_h = tonumber(charge_state.time_to_full_charge)
+    if ttf_h ~= nil then ttf_min = math.floor(ttf_h * 60 + 0.5) end
+  end
   local cs = charge_state.charging_state
   if type(cs) ~= "string" then cs = nil end
 
   if soc ~= nil then
-    last.soc            = soc
-    last.charge_limit   = limit
-    last.charging_state = cs
-    -- Tesla API returns time_to_full_charge in hours (decimal); convert to minutes.
-    last.time_to_full   = ttf and math.floor(ttf * 60 + 0.5) or nil
-    last.ts_ms          = host.millis()
+    last.soc                    = soc
+    last.charge_limit           = limit
+    last.charging_state         = cs
+    last.time_to_full           = ttf_min
+    last.charge_amps            = charge_amps
+    last.charger_actual_current = charger_actual_current
+    last.ts_ms                  = host.millis()
 
-    host.emit("vehicle", {
-      soc              = soc,
-      charge_limit_pct = limit,
-      charging_state   = cs,
-      time_to_full_min = last.time_to_full,
-      stale            = false,
+    host.log("info", "tesla: emit soc=" .. tostring(soc) ..
+                     " limit=" .. tostring(limit) ..
+                     " state=" .. tostring(cs) ..
+                     " amps=" .. tostring(charge_amps) ..
+                     "/" .. tostring(charger_actual_current))
+    local emit_err = host.emit("vehicle", {
+      soc                     = soc,
+      charge_limit_pct        = limit,
+      charging_state          = cs,
+      time_to_full_min        = ttf_min,
+      charge_amps             = charge_amps,
+      charger_actual_current  = charger_actual_current,
+      stale                   = false,
     })
+    if emit_err then
+      host.log("warn", "tesla: emit returned error: " .. tostring(emit_err))
+    end
   else
     -- Malformed response (no battery_level) → keep last-known.
     emit_last()
   end
 
-  return poll_interval_ms
+  return POLL_INTERVAL_MS
 end
 
 function driver_command(action, _, _)

--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -173,14 +173,21 @@ function driver_poll()
   --
   -- BUT once every WAKEUP_INTERVAL_MS (30 min) we DO request a
   -- wakeup so cached data can't drift forever while the car sleeps.
+  -- last_wakeup_ms == 0 is the "never woken since process start" sentinel
+  -- so the FIRST poll after startup always forces a wakeup. The car may
+  -- have been asleep for hours while forty-two-watts was down — we want
+  -- ground-truth SoC on the dashboard immediately, not the proxy's stale
+  -- cache from the previous run. After this initial wake, the 30-min
+  -- cadence takes over.
   local now = host.millis()
-  local do_wakeup = (now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS
+  local do_wakeup = (last_wakeup_ms == 0) or ((now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS)
   local url = base_url .. "/api/1/vehicles/" .. vin ..
               "/vehicle_data?endpoints=charge_state"
   if do_wakeup then
     url = url .. "&wakeup=true"
+    local reason = (last_wakeup_ms == 0) and "startup" or "30-min cadence"
     last_wakeup_ms = now
-    host.log("info", "tesla: forcing BLE wakeup on this poll (30-min cadence)")
+    host.log("info", "tesla: forcing BLE wakeup on this poll (" .. reason .. ")")
   end
   -- host.http_get returns (body_string, nil) or (nil, error_string) —
   -- first return is the body directly, NOT a table with .body. The

--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -46,9 +46,16 @@ PROTOCOL = "http"
 local PROXY_PORT        = 8080
 local POLL_INTERVAL_MS  = 60000
 local STALE_AFTER_MS    = 900000
+-- Every WAKEUP_INTERVAL_MS we attach `wakeup=true` to ONE poll so the
+-- proxy forces a BLE wake. Without this the proxy serves cached data
+-- indefinitely while the car sleeps and our SoC slowly drifts from
+-- reality. 30 min is a balance between freshness and not draining the
+-- 12 V battery from constant BLE wakes.
+local WAKEUP_INTERVAL_MS = 1800000
 
 local base_url = nil
 local vin = nil
+local last_wakeup_ms = 0
 
 -- Cached last-known reading so we can keep publishing a value while
 -- the vehicle is asleep. Tesla returns 408 "vehicle unavailable" when
@@ -158,16 +165,23 @@ function driver_poll()
   -- endpoints=charge_state narrows the response to just what we
   -- care about (SoC + limit + charging_state + time_to_full).
   --
-  -- wakeup=true is intentionally OMITTED. The proxy returns
+  -- wakeup=true is OFF on the steady-state poll. The proxy returns
   -- cached data from its own background sync (typically ≤ 5 s
-  -- fresh, fine for our 60 s poll cadence + pokes). Forcing a
-  -- BLE wake on every poll caused HTTP 503 "Command Disallowed"
-  -- storms when the driver was poked alongside regular polls —
-  -- BLE radio can only service one command at a time and our
-  -- poke-on-plug-in + poke-on-charging-start stacked queries
-  -- faster than the proxy could complete them.
+  -- fresh, fine for our 60 s poll cadence + pokes). Forcing a BLE
+  -- wake on every poll caused HTTP 503 "Command Disallowed" storms
+  -- when the driver was poked alongside regular polls.
+  --
+  -- BUT once every WAKEUP_INTERVAL_MS (30 min) we DO request a
+  -- wakeup so cached data can't drift forever while the car sleeps.
+  local now = host.millis()
+  local do_wakeup = (now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS
   local url = base_url .. "/api/1/vehicles/" .. vin ..
               "/vehicle_data?endpoints=charge_state"
+  if do_wakeup then
+    url = url .. "&wakeup=true"
+    last_wakeup_ms = now
+    host.log("info", "tesla: forcing BLE wakeup on this poll (30-min cadence)")
+  end
   -- host.http_get returns (body_string, nil) or (nil, error_string) —
   -- first return is the body directly, NOT a table with .body. The
   -- earlier tesla_vehicle iterations treated it as a table and got

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -535,6 +535,10 @@ func main() {
 	// ---- Start MPC planner (optional) ----
 	mpcSvc = buildMPC(cfg, st, tel, capacities)
 	if mpcSvc != nil {
+		// Plumb the site fuse so the DP joint-plans battery + EV under
+		// the fuse from the start (instead of producing plans that
+		// dispatch later has to scale via the joint allocator).
+		mpcSvc.FuseMaxW = cfg.Fuse.MaxPowerW()
 		if pvSvc != nil {
 			mpcSvc.PV = pvSvc.Predict
 		}
@@ -557,6 +561,51 @@ func main() {
 						break
 					}
 				}
+				// Prefer live DerVehicle SoC over the loadpoint manager's
+				// inferred plugin-anchor + delivered-Wh estimate. The
+				// inference is blind to BMS truth (Easee can't see the
+				// car); when a vehicle driver such as TeslaBLEProxy is
+				// online, its SoC reading is ground truth.
+				//
+				// Multi-vehicle case: one charger may be paired with N
+				// vehicle drivers (a household with 2 Teslas sharing one
+				// wallbox). Pick the one most likely to be the car
+				// physically connected right now: rank by charging_state
+				// (Charging > NoPower/Starting > Stopped/Complete >
+				// Disconnected/unknown), tiebreak by freshness. Falls
+				// back to inferred SoC when nothing online matches.
+				initSoC := st.CurrentSoCPct
+				socSource := "inferred"
+				var bestRank = -1
+				var bestUpdated time.Time
+				for _, vr := range tel.ReadingsByType(telemetry.DerVehicle) {
+					if vr.SoC == nil {
+						continue
+					}
+					if h := tel.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
+						continue
+					}
+					var meta struct {
+						ChargingState string `json:"charging_state"`
+					}
+					if len(vr.Data) > 0 {
+						_ = json.Unmarshal(vr.Data, &meta)
+					}
+					rank := vehicleConnectedRank(meta.ChargingState)
+					if rank < 0 {
+						continue // explicitly disconnected — not this car
+					}
+					if rank < bestRank {
+						continue
+					}
+					if rank == bestRank && !vr.UpdatedAt.After(bestUpdated) {
+						continue
+					}
+					bestRank = rank
+					bestUpdated = vr.UpdatedAt
+					initSoC = *vr.SoC
+					socSource = "vehicle:" + vr.Driver
+				}
 				// Map target time → slot index using the DP's
 				// actual slot length (hour-of-prices vs. 15-min
 				// quarters vary by market). Anything past horizon
@@ -572,13 +621,16 @@ func main() {
 						targetSlot = int(delta / (time.Duration(slotLenMin) * time.Minute))
 					}
 				}
+				slog.Debug("mpc: loadpoint spec",
+					"id", st.ID, "soc_pct", initSoC, "soc_source", socSource,
+					"target_pct", st.TargetSoCPct, "target_slot", targetSlot)
 				return &mpc.LoadpointSpec{
 					ID:              st.ID,
 					CapacityWh:      capWh,
 					Levels:          11,
 					MinPct:          0,
 					MaxPct:          100,
-					InitialSoCPct:   st.CurrentSoCPct,
+					InitialSoCPct:   initSoC,
 					PluggedIn:       true,
 					TargetSoCPct:    st.TargetSoCPct,
 					TargetSlotIdx:   targetSlot,
@@ -718,6 +770,18 @@ func main() {
 			MaxAmps:  cfg.Fuse.MaxAmps,
 			Voltage:  cfg.Fuse.Voltage,
 			PhaseCnt: cfg.Fuse.Phases,
+		})
+		// Wire the joint fuse-budget allocator: when battery + EV would
+		// together bust the fuse, dispatch publishes a cap on EV W; the
+		// loadpoint controller honours it so battery and EV cooperatively
+		// share the budget instead of oscillating against the fuse guard.
+		lpController.SetFuseEVMax(func() (float64, bool) {
+			ctrlMu.Lock()
+			defer ctrlMu.Unlock()
+			if !ctrl.FuseSaturated {
+				return 0, false
+			}
+			return ctrl.FuseEVMaxW, true
 		})
 	}
 
@@ -1028,6 +1092,13 @@ func main() {
 	ticker := time.NewTicker(controlInterval)
 	defer ticker.Stop()
 	var saveCount uint64
+	// Track FuseSaturated edge so we replan once when the joint allocator
+	// kicks in — the plan was made without knowledge of the live overage,
+	// and a replan with current EV/PV/load state usually finds a feasible
+	// schedule that doesn't fight the fuse.
+	var prevFuseSaturated bool
+	var lastFuseReplan time.Time
+	const fuseReplanCooldown = 60 * time.Second
 	for {
 		select {
 		case <-sigc:
@@ -1140,6 +1211,22 @@ func main() {
 			// → snap → send) is owned by loadpoint.Controller so the
 			// main tick stays a thin orchestrator. See issue #172.
 			lpController.Tick(ctx, time.Now())
+
+			// ---- Trigger MPC replan on fuse-saturation rising edge ----
+			// The joint allocator (control.dispatch) just throttled
+			// battery and EV to fit under the fuse. The plan was built
+			// without seeing this overage, so let MPC redraw with current
+			// state — usually it finds a slot allocation that doesn't
+			// require both battery charge and full-bore EV simultaneously.
+			ctrlMu.Lock()
+			fuseSatNow := ctrl.FuseSaturated
+			ctrlMu.Unlock()
+			if mpcSvc != nil && fuseSatNow && !prevFuseSaturated && time.Since(lastFuseReplan) > fuseReplanCooldown {
+				lastFuseReplan = time.Now()
+				go mpcSvc.Replan(ctx)
+				slog.Info("fuse-saturated → MPC replan triggered")
+			}
+			prevFuseSaturated = fuseSatNow
 
 			// ---- Record history snapshot ----
 			recordHistory(st, tel, ctrl, nowMs)
@@ -1563,6 +1650,26 @@ func isConfigMissing(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "no such file")
+}
+
+// vehicleConnectedRank scores how likely a DerVehicle driver is to be the
+// one physically plugged into the loadpoint right now, based on Tesla
+// Owner-API charging_state semantics (other vendors use the same
+// vocabulary). Higher rank = more likely connected. Negative = explicitly
+// not connected; caller should skip.
+func vehicleConnectedRank(chargingState string) int {
+	switch chargingState {
+	case "Charging", "Starting":
+		return 3 // actively pulling power — definitely this car
+	case "NoPower":
+		return 2 // plugged but wallbox not delivering yet
+	case "Stopped", "Complete":
+		return 1 // plugged + idle (charge limit reached, paused, etc.)
+	case "Disconnected":
+		return -1 // explicitly unplugged — never pick this one
+	default:
+		return 0 // unknown/missing — usable but de-prioritised
+	}
 }
 
 func recordHistory(st *state.Store, tel *telemetry.Store, ctrl *control.State, nowMs int64) {

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1464,10 +1464,12 @@ func isLikelyEVDriver(luaPath string) bool {
 	}
 	base = strings.TrimSuffix(base, ".lua")
 	for _, p := range []string{
-		"easee",       // easee_cloud.lua, easee.lua
-		"ocpp",        // ocpp_cp.lua, ocpp_csms.lua
-		"ctek",        // ctek.lua, ctek_mqtt.lua, ctek_v2.lua
-		"chargestorm", // CTEK Chargestorm variants
+		"easee",         // easee_cloud.lua, easee.lua
+		"ocpp",          // ocpp_cp.lua, ocpp_csms.lua
+		"ctek",          // ctek.lua, ctek_mqtt.lua, ctek_v2.lua
+		"chargestorm",   // CTEK Chargestorm variants
+		"tesla_vehicle", // tesla_vehicle.lua — DerVehicle emitter (BLE proxy)
+		"vehicle",       // generic vehicle drivers — anything emitting DerVehicle should NOT be counted as a stationary battery
 	} {
 		if strings.HasPrefix(base, p) {
 			return true

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -719,6 +719,15 @@ func main() {
 			"horizon", mpcSvc.Horizon,
 			"interval", mpcSvc.Interval,
 			"pvtwin", pvSvc != nil)
+		// Startup replan: the scheduled tick is up to mpcSvc.Interval
+		// (15 min) away. Don't make the operator wait — fire one
+		// immediately so /api/mpc/plan is populated as soon as
+		// telemetry, prices, and forecasts have settled.
+		go func() {
+			time.Sleep(2 * time.Second) // give drivers a moment to seed SoC
+			_ = mpcSvc.Replan(ctx)
+			slog.Info("mpc: startup replan completed")
+		}()
 	}
 
 	// ---- EV loadpoint controller ----
@@ -1099,6 +1108,11 @@ func main() {
 	var prevFuseSaturated bool
 	var lastFuseReplan time.Time
 	const fuseReplanCooldown = 60 * time.Second
+	// One-shot replan when the FIRST DerVehicle reading arrives. The
+	// startup replan ran with whatever fallback SoC was available; once
+	// the Tesla / vehicle driver gets ground truth from the car, the
+	// plan should incorporate it (especially for EV target deadlines).
+	var vehicleReplanFired bool
 	for {
 		select {
 		case <-sigc:
@@ -1227,6 +1241,26 @@ func main() {
 				slog.Info("fuse-saturated → MPC replan triggered")
 			}
 			prevFuseSaturated = fuseSatNow
+
+			// First-vehicle-SoC replan trigger: as soon as any
+			// DerVehicle driver is online and reporting SoC, redo the
+			// plan once with measured-truth instead of the pluginSoC
+			// estimate the startup replan used.
+			if mpcSvc != nil && !vehicleReplanFired {
+				for _, vr := range tel.ReadingsByType(telemetry.DerVehicle) {
+					if vr.SoC == nil {
+						continue
+					}
+					if h := tel.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
+						continue
+					}
+					vehicleReplanFired = true
+					go mpcSvc.Replan(ctx)
+					slog.Info("first vehicle SoC seen → MPC replan triggered",
+						"driver", vr.Driver, "soc", *vr.SoC)
+					break
+				}
+			}
 
 			// ---- Record history snapshot ----
 			recordHistory(st, tel, ctrl, nowMs)

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -553,6 +553,18 @@ func main() {
 				if !st.PluggedIn {
 					continue
 				}
+				// Schedule gate: only extend the DP with an EV-SoC
+				// dimension when the operator has set BOTH a target SoC
+				// and a future deadline. Without a schedule the DP
+				// previously planned EV charging speculatively across
+				// the full 48 h horizon — drawing battery + grid budget
+				// against a target the operator never asked for. With
+				// no schedule, EV is left to the loadpoint controller's
+				// reactive surplus-only behaviour.
+				if st.TargetSoCPct <= 0 || st.TargetTime.IsZero() ||
+					!st.TargetTime.After(time.Now()) {
+					continue
+				}
 				// Pull capacity off the configured loadpoint.
 				var capWh float64 = 60000 // 60 kWh fallback
 				for _, c := range cfg.Loadpoints {
@@ -576,6 +588,7 @@ func main() {
 				// back to inferred SoC when nothing online matches.
 				initSoC := st.CurrentSoCPct
 				socSource := "inferred"
+				var vehicleChargeLimit float64 // 0 = unknown
 				var bestRank = -1
 				var bestUpdated time.Time
 				for _, vr := range tel.ReadingsByType(telemetry.DerVehicle) {
@@ -586,7 +599,8 @@ func main() {
 						continue
 					}
 					var meta struct {
-						ChargingState string `json:"charging_state"`
+						ChargingState  string  `json:"charging_state"`
+						ChargeLimitPct float64 `json:"charge_limit_pct"`
 					}
 					if len(vr.Data) > 0 {
 						_ = json.Unmarshal(vr.Data, &meta)
@@ -605,6 +619,7 @@ func main() {
 					bestUpdated = vr.UpdatedAt
 					initSoC = *vr.SoC
 					socSource = "vehicle:" + vr.Driver
+					vehicleChargeLimit = meta.ChargeLimitPct
 				}
 				// Map target time → slot index using the DP's
 				// actual slot length (hour-of-prices vs. 15-min
@@ -621,15 +636,33 @@ func main() {
 						targetSlot = int(delta / (time.Duration(slotLenMin) * time.Minute))
 					}
 				}
+				// Operational ceiling: the lower of the user's target
+				// and the vehicle-configured charge limit. The car
+				// won't accept current beyond charge_limit_pct anyway,
+				// so planning past it is wasted DP grid space. When
+				// the limit is unknown, fall back to the deadline
+				// target itself; never plan beyond what was requested.
+				maxPct := st.TargetSoCPct
+				if vehicleChargeLimit > 0 && vehicleChargeLimit < maxPct {
+					maxPct = vehicleChargeLimit
+				}
+				// Guard against degenerate grids: if current SoC > maxPct
+				// (already over target), grow the ceiling to current so
+				// the DP can at least represent it (no charging will be
+				// scheduled). The deadline penalty handles the rest.
+				if initSoC > maxPct {
+					maxPct = initSoC
+				}
 				slog.Debug("mpc: loadpoint spec",
 					"id", st.ID, "soc_pct", initSoC, "soc_source", socSource,
-					"target_pct", st.TargetSoCPct, "target_slot", targetSlot)
+					"target_pct", st.TargetSoCPct, "target_slot", targetSlot,
+					"max_pct", maxPct, "vehicle_limit_pct", vehicleChargeLimit)
 				return &mpc.LoadpointSpec{
 					ID:              st.ID,
 					CapacityWh:      capWh,
 					Levels:          11,
 					MinPct:          0,
-					MaxPct:          100,
+					MaxPct:          maxPct,
 					InitialSoCPct:   initSoC,
 					PluggedIn:       true,
 					TargetSoCPct:    st.TargetSoCPct,

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1786,16 +1786,115 @@ func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
 }
 
 // GET /api/loadpoints returns the configured EV loadpoints with their
-// current observable state.
+// current observable state. When a DerVehicle driver is online (e.g.
+// tesla_vehicle.lua against TeslaBLEProxy), its real BMS SoC is
+// overlaid onto the response and SoCSource flips from "inferred" to
+// "vehicle" so the UI can render measured-vs-estimated honestly.
+// Multi-vehicle households (one wallbox, multiple Teslas) are picked
+// among by charging_state ranking — see decorateWithVehicle.
 func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
 	if s.deps.Loadpoints == nil {
 		writeJSON(w, 200, map[string]any{"enabled": false, "loadpoints": []any{}})
 		return
 	}
+	states := s.deps.Loadpoints.States()
+	if s.deps.Tel != nil {
+		decorateLoadpointsWithVehicle(states, s.deps.Tel)
+	}
 	writeJSON(w, 200, map[string]any{
 		"enabled":    true,
-		"loadpoints": s.deps.Loadpoints.States(),
+		"loadpoints": states,
 	})
+}
+
+// decorateLoadpointsWithVehicle overlays the best-matching DerVehicle
+// reading onto each plugged-in loadpoint state. Mutates the input
+// slice in place. The "best" reading is the one most likely to be the
+// car physically connected: rank by charging_state, tiebreak by
+// freshness; an explicit "Disconnected" is skipped entirely.
+func decorateLoadpointsWithVehicle(states []loadpoint.State, tel *telemetry.Store) {
+	readings := tel.ReadingsByType(telemetry.DerVehicle)
+	if len(readings) == 0 {
+		// No vehicle drivers — mark every plugged-in lp as inferred.
+		for i := range states {
+			if states[i].PluggedIn {
+				states[i].SoCSource = "inferred"
+			}
+		}
+		return
+	}
+	// Pick the single best vehicle reading across all DerVehicle drivers.
+	// Multi-vehicle ranking lives close to where it matters: this is the
+	// only place that needs to interpret charging_state today.
+	type vehicleData struct {
+		ChargingState  string  `json:"charging_state"`
+		ChargeLimitPct float64 `json:"charge_limit_pct"`
+		Stale          bool    `json:"stale"`
+	}
+	rankFn := func(s string) int {
+		switch s {
+		case "Charging", "Starting":
+			return 3
+		case "NoPower":
+			return 2
+		case "Stopped", "Complete":
+			return 1
+		case "Disconnected":
+			return -1
+		default:
+			return 0
+		}
+	}
+	var bestRank = -1
+	var bestUpdated time.Time
+	var bestSoC, bestLimit float64
+	var bestState, bestDriver string
+	var bestStale bool
+	for _, vr := range readings {
+		if vr.SoC == nil {
+			continue
+		}
+		if h := tel.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
+			continue
+		}
+		var meta vehicleData
+		if len(vr.Data) > 0 {
+			_ = json.Unmarshal(vr.Data, &meta)
+		}
+		rank := rankFn(meta.ChargingState)
+		if rank < 0 {
+			continue
+		}
+		if rank < bestRank || (rank == bestRank && !vr.UpdatedAt.After(bestUpdated)) {
+			continue
+		}
+		bestRank = rank
+		bestUpdated = vr.UpdatedAt
+		bestSoC = *vr.SoC
+		bestLimit = meta.ChargeLimitPct
+		bestState = meta.ChargingState
+		bestStale = meta.Stale
+		bestDriver = vr.Driver
+	}
+	for i := range states {
+		if !states[i].PluggedIn {
+			continue
+		}
+		if bestDriver == "" {
+			states[i].SoCSource = "inferred"
+			continue
+		}
+		states[i].VehicleDriver = bestDriver
+		states[i].VehicleSoCPct = bestSoC
+		states[i].VehicleChargeLimitPct = bestLimit
+		states[i].VehicleChargingState = bestState
+		states[i].VehicleStale = bestStale
+		// Override CurrentSoCPct with measured value. The loadpoint
+		// manager's inferred value is preserved internally — this is
+		// purely a presentation overlay so the dashboard shows truth.
+		states[i].CurrentSoCPct = bestSoC
+		states[i].SoCSource = "vehicle"
+	}
 }
 
 // POST /api/loadpoints/{id}/target sets user intent for an EV

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -165,6 +165,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/system/info", s.handleSysInfo)
 	s.handle("GET  /api/config", s.handleGetConfig)
 	s.handle("POST /api/config", s.handlePostConfig)
+	s.handle("POST /api/drivers/verify_tesla", s.handleVerifyTesla)
 	s.handle("GET  /api/mode", s.handleGetMode)
 	s.handle("POST /api/mode", s.handleSetMode)
 	s.handle("POST /api/target", s.handleSetTarget)
@@ -369,6 +370,44 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 			d["bat_w"] = r.SmoothedW
 			if r.SoC != nil {
 				d["bat_soc"] = *r.SoC
+			}
+		}
+		// Vehicle (DerVehicle) — read-only BMS readings emitted by
+		// drivers like tesla_vehicle.lua. Surfaced so the per-driver
+		// card can render SoC + charge_limit + charging_state. RawW
+		// is always 0 for vehicle readings (no power channel).
+		if r := s.deps.Tel.Get(name, telemetry.DerVehicle); r != nil {
+			var v struct {
+				SoC                  *float64 `json:"soc"`
+				ChargeLimitPct       *float64 `json:"charge_limit_pct"`
+				ChargingState        *string  `json:"charging_state"`
+				TimeToFullMin        *int     `json:"time_to_full_min"`
+				ChargeAmps           *float64 `json:"charge_amps"`
+				ChargerActualCurrent *float64 `json:"charger_actual_current"`
+				Stale                *bool    `json:"stale"`
+			}
+			if r.Data != nil && json.Unmarshal(r.Data, &v) == nil {
+				if v.SoC != nil {
+					d["vehicle_soc"] = *v.SoC
+				}
+				if v.ChargeLimitPct != nil {
+					d["vehicle_charge_limit_pct"] = *v.ChargeLimitPct
+				}
+				if v.ChargingState != nil {
+					d["vehicle_charging_state"] = *v.ChargingState
+				}
+				if v.TimeToFullMin != nil {
+					d["vehicle_time_to_full_min"] = *v.TimeToFullMin
+				}
+				if v.ChargeAmps != nil {
+					d["vehicle_charge_amps"] = *v.ChargeAmps
+				}
+				if v.ChargerActualCurrent != nil {
+					d["vehicle_charger_actual_current"] = *v.ChargerActualCurrent
+				}
+				if v.Stale != nil {
+					d["vehicle_stale"] = *v.Stale
+				}
 			}
 		}
 		if r := s.deps.Tel.Get(name, telemetry.DerEV); r != nil {

--- a/go/internal/api/api_tesla_verify.go
+++ b/go/internal/api/api_tesla_verify.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// POST /api/drivers/verify_tesla — operator-facing "Verify connection"
+// button for the Tesla vehicle driver config form. Accepts {ip, vin}
+// exactly matching the driver's own config fields, issues a single
+// GET to the proxy's vehicle_data endpoint from the backend (avoids
+// browser CORS), and returns a summary the UI can render inline.
+//
+// Hardened against SSRF: the `ip` param is constrained to RFC1918
+// private space (10/8, 172.16/12, 192.168/16), link-local is rejected,
+// loopback is rejected, ports are restricted to 80/443/8080, VIN is
+// regex-validated to the standard 17-char pattern, redirects are
+// refused, and the upstream body is never reflected back to the caller.
+// See PR #184 review S1.
+type verifyTeslaRequest struct {
+	IP  string `json:"ip"`
+	VIN string `json:"vin"`
+}
+
+type verifyTeslaResponse struct {
+	OK             bool    `json:"ok"`
+	Error          string  `json:"error,omitempty"`
+	URL            string  `json:"url,omitempty"`
+	Status         int     `json:"status,omitempty"`
+	SoCPct         float64 `json:"soc_pct,omitempty"`
+	ChargeLimitPct float64 `json:"charge_limit_pct,omitempty"`
+	ChargingState  string  `json:"charging_state,omitempty"`
+}
+
+// validVINRe is the standard 17-character VIN charset: A-HJ-NPR-Z0-9
+// (excludes I, O, Q to avoid confusion with 0/1). Applied even though
+// Teslas pattern-match narrower because an attacker could try to abuse
+// a relaxed validation to smuggle `/` or `?` into the URL path.
+var validVINRe = regexp.MustCompile(`^[A-HJ-NPR-Z0-9]{17}$`)
+
+// allowedVerifyPorts is the tiny set of ports we'll probe on the
+// supposed proxy host. TeslaBLEProxy defaults to 8080 in every
+// deployment we've seen; 80/443 are included for completeness in case
+// someone fronted it with a reverse proxy. Locked down to these three
+// so the endpoint can't be used to scan arbitrary LAN services.
+var allowedVerifyPorts = map[int]bool{80: true, 443: true, 8080: true}
+
+// errRedirectsForbidden ends a redirect chain before the backend follows
+// a Location header to an unintended target (another SSRF vector).
+var errRedirectsForbidden = errors.New("redirects disabled")
+
+// maxVerifyBody caps how much of the proxy response we read. Tesla
+// vehicle_data responses are typically 5-15 KB; 1 MB is pessimistic
+// headroom. Prevents a malicious proxy from stalling the handler.
+const maxVerifyBody = 1 << 20
+
+// validateProxyIP accepts "host" or "host:port" where host is an IPv4
+// literal in RFC1918 space. Hostnames are rejected — we want no DNS
+// step between parse and connect, because a DNS rebind can change the
+// answer between verification and connection.
+func validateProxyIP(s string) (string, int, error) {
+	host, port := splitHostPort(s, 8080)
+	if !allowedVerifyPorts[port] {
+		return "", 0, fmt.Errorf("port %d not permitted (allowed: 80, 443, 8080)", port)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "", 0, fmt.Errorf("invalid IP literal %q (hostnames not allowed)", host)
+	}
+	if ip.To4() == nil {
+		return "", 0, fmt.Errorf("IPv6 not supported")
+	}
+	if ip.IsLoopback() {
+		return "", 0, fmt.Errorf("loopback address not permitted")
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return "", 0, fmt.Errorf("link-local address not permitted")
+	}
+	if !isPrivateIPv4(ip) {
+		return "", 0, fmt.Errorf("public IP not permitted (RFC1918 only)")
+	}
+	return ip.String(), port, nil
+}
+
+// isPrivateIPv4 matches 10/8, 172.16/12, 192.168/16. Intentionally
+// does NOT match 169.254/16 (link-local — caller blocks separately),
+// 100.64/10 (carrier-grade NAT), or RFC6598 space.
+func isPrivateIPv4(ip net.IP) bool {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	switch {
+	case ip4[0] == 10:
+		return true
+	case ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31:
+		return true
+	case ip4[0] == 192 && ip4[1] == 168:
+		return true
+	}
+	return false
+}
+
+// handleVerifyTesla runs a one-off vehicle_data fetch against the
+// configured TeslaBLEProxy. Mirrors exactly what the driver does on
+// each poll, minus the emit. Errors are surfaced verbatim so the
+// operator can distinguish "proxy unreachable" from "vehicle asleep"
+// from "VIN not paired".
+func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
+	var req verifyTeslaRequest
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, verifyTeslaResponse{Error: "invalid body: " + err.Error()})
+		return
+	}
+	ipRaw := strings.TrimSpace(req.IP)
+	vin := strings.ToUpper(strings.TrimSpace(req.VIN))
+	if ipRaw == "" || vin == "" {
+		writeJSON(w, 400, verifyTeslaResponse{Error: "both `ip` and `vin` are required"})
+		return
+	}
+	if !validVINRe.MatchString(vin) {
+		writeJSON(w, 400, verifyTeslaResponse{Error: "invalid VIN (must be 17 chars, A-HJ-NPR-Z and 0-9)"})
+		return
+	}
+
+	host, port, err := validateProxyIP(ipRaw)
+	if err != nil {
+		writeJSON(w, 400, verifyTeslaResponse{Error: "invalid proxy ip: " + err.Error()})
+		return
+	}
+
+	url := fmt.Sprintf("http://%s:%d/api/1/vehicles/%s/vehicle_data?endpoints=charge_state&wakeup=true",
+		host, port, vin)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		writeJSON(w, 500, verifyTeslaResponse{Error: "build request: " + err.Error(), URL: url})
+		return
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	// Client configured for SSRF resistance: no redirects (a compromised
+	// proxy could send a 302 to a metadata endpoint), context-bound
+	// timeout, no arbitrary transport sharing.
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errRedirectsForbidden
+		},
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		writeJSON(w, 200, verifyTeslaResponse{Error: "request failed: " + err.Error(), URL: url})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusRequestTimeout { // 408: car asleep
+		writeJSON(w, 200, verifyTeslaResponse{
+			Error:  "vehicle asleep (408) — the proxy reached your car but it did not wake in time. Try again in a few seconds.",
+			URL:    url,
+			Status: resp.StatusCode,
+		})
+		return
+	}
+	if resp.StatusCode >= 400 {
+		// Do NOT reflect the upstream body — even the status number on
+		// its own is already a port-scan oracle, but the body can carry
+		// metadata-service tokens on a successful SSRF hop. Fixed message.
+		writeJSON(w, 200, verifyTeslaResponse{
+			Error:  fmt.Sprintf("HTTP %d from proxy", resp.StatusCode),
+			URL:    url,
+			Status: resp.StatusCode,
+		})
+		return
+	}
+
+	// Three response shapes in the wild:
+	//
+	//   1. TeslaBLEProxy: { response: { response: { charge_state: {…} } } }
+	//      — the proxy wraps the upstream body once more. THIS is
+	//      what the real-world deployment emits (tested locally).
+	//   2. Tesla Owner API:  { response: { charge_state: {…} } }
+	//   3. Bare:             { charge_state: {…} }
+	//
+	// We try all three and pick whichever yielded non-zero fields.
+	type chargeState struct {
+		BatteryLevel        float64 `json:"battery_level"`
+		ChargeLimitSoC      float64 `json:"charge_limit_soc"`
+		ChargingState       string  `json:"charging_state"`
+		MinutesToFullCharge float64 `json:"minutes_to_full_charge"`
+		TimeToFullCharge    float64 `json:"time_to_full_charge"`
+	}
+	var parsed struct {
+		Response struct {
+			Response struct {
+				ChargeState chargeState `json:"charge_state"`
+			} `json:"response"`
+			ChargeState chargeState `json:"charge_state"`
+		} `json:"response"`
+		ChargeState chargeState `json:"charge_state"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxVerifyBody)).Decode(&parsed); err != nil {
+		writeJSON(w, 200, verifyTeslaResponse{
+			Error: "decode failed (upstream response not recognizable JSON)", URL: url, Status: resp.StatusCode,
+		})
+		return
+	}
+	cs := parsed.Response.Response.ChargeState
+	if cs.BatteryLevel == 0 && cs.ChargeLimitSoC == 0 && cs.ChargingState == "" {
+		cs = parsed.Response.ChargeState
+	}
+	if cs.BatteryLevel == 0 && cs.ChargeLimitSoC == 0 && cs.ChargingState == "" {
+		cs = parsed.ChargeState
+	}
+	if cs.BatteryLevel == 0 && cs.ChargeLimitSoC == 0 && cs.ChargingState == "" {
+		writeJSON(w, 200, verifyTeslaResponse{
+			Error: "proxy returned 200 but no charge_state fields — VIN may not be paired",
+			URL:   url, Status: resp.StatusCode,
+		})
+		return
+	}
+	writeJSON(w, 200, verifyTeslaResponse{
+		OK:             true,
+		URL:            url,
+		Status:         resp.StatusCode,
+		SoCPct:         cs.BatteryLevel,
+		ChargeLimitPct: cs.ChargeLimitSoC,
+		ChargingState:  cs.ChargingState,
+	})
+}
+
+// splitHostPort parses "host" or "host:port" and returns the port
+// defaulting to `def` when absent. Copes with IPv4 and bracketed
+// IPv6 (though brackets aren't expected in the typical config).
+func splitHostPort(s string, def int) (string, int) {
+	// Only split on the LAST colon that's followed by digits — avoids
+	// eating a port out of an IPv6 without brackets. Good enough for
+	// the LAN-only case this endpoint serves.
+	i := strings.LastIndex(s, ":")
+	if i < 0 {
+		return s, def
+	}
+	host := s[:i]
+	portStr := s[i+1:]
+	var port int
+	for _, r := range portStr {
+		if r < '0' || r > '9' {
+			return s, def
+		}
+		port = port*10 + int(r-'0')
+	}
+	if port == 0 {
+		return s, def
+	}
+	return host, port
+}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -702,6 +702,208 @@ func TestEnergyDispatchDoesNotAbsorbPVSurprise(t *testing.T) {
 	}
 }
 
+// Regression: BatteryCoversEV=false must hold on the energy-allocation
+// path too. Operator report 2026-04-27: "I have 'let battery cover ev'
+// disabled now, even though it discharges into the EV." Cause: the
+// energy-dispatch branch consulted neither BatteryCoversEV nor the
+// EV draw, blindly executing the plan's BatteryEnergyWh directive.
+//
+// Scenario: EV pulling 4 kW, house side importing 200 W, plan wants
+// to discharge ~1 kWh this slot (≈ 4 kW). Toggle says battery shall
+// not feed the EV. Expected: battery discharges only as much as the
+// house alone needs (~200 W), NOT the planner's 4 kW.
+func TestEnergyDispatchHonorsBatteryCoversEVOff(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -1000, // plan: discharge 1 kWh this slot (~ -4 kW)
+		Strategy:        "arbitrage",
+	}
+	// rawGridW = 4200 W (200 W house + 4000 W EV importing). Battery 0.
+	store := seedStore(4200, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 4000     // manual injection — no EV driver in store
+	st.BatteryCoversEV = false // explicit; the contended toggle
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Allowed: discharge up to ~ house import (200 W). Forbidden:
+	// discharge of EV magnitude (~ -4000 W).
+	if got < -500 {
+		t.Errorf("TargetW = %f W — battery is discharging into the EV despite BatteryCoversEV=false. "+
+			"Expected at most ~ -200 W (house side only).", got)
+	}
+}
+
+// Counter-test: with BatteryCoversEV=true, the energy path stays unchanged —
+// plan's full discharge is honored.
+func TestEnergyDispatchBatteryCoversEVOnLetsPlanRun(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -1000,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(4200, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 4000
+	st.BatteryCoversEV = true // opt-in: planner runs as-is
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Plan wanted ~ -4000 W. Tolerate slew/clamp drift but expect heavy discharge.
+	if got > -1500 {
+		t.Errorf("TargetW = %f W — plan wanted ~ -4000 W, but battery is barely discharging. "+
+			"BatteryCoversEV=true should let the planner's directive run.", got)
+	}
+}
+
+// Joint fuse-budget allocator: when EV draw + plan's battery charge would
+// exceed the fuse, both should be scaled proportionally — battery charge
+// reduced AND state.FuseEVMaxW published so the loadpoint controller can
+// curtail the EV. Operator report: oscillation loop where plan ramps
+// battery, fuse guard cuts it, plan ramps again.
+//
+// Scenario: house 200 W, EV at 8 kW, plan wants battery +5 kW, fuse 11 kW.
+// Naive: total grid = 200+8000+5000 = 13.2 kW → fuse busts.
+// Joint allocator: scale = (11000-200-0)/(5000+8000) ≈ 0.831.
+//   battery charge → ~4150 W
+//   FuseEVMaxW    → ~6650 W
+//   sum + house    ≈ 11.0 kW. Fuse respected.
+func TestJointFuseAllocatorScalesBothBatteryAndEV(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1250, // ~5 kW for 15 min
+		Strategy:        "arbitrage",
+	}
+	// rawGridW = 13.2 kW (importing — house 200 + EV 8000 + plan-imminent
+	// battery 5000, but battery currentW=0 means it's not yet charging,
+	// so right now grid is 200+8000=8200. Plan WANTS battery to add 5kW.
+	// Use 8200 to model the live state at the start of the tick.)
+	store := seedStore(8200, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 8000
+	st.BatteryCoversEV = true // not the toggle under test; let plan run
+
+	const fuseMaxW = 11000
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), fuseMaxW)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Allocator contract: FuseEVMaxW published so loadpoint can throttle.
+	// In *this* tick, EV is still at 8 kW (hasn't seen the cap yet), so the
+	// existing fuse guard further clamps battery to ~2800 W (= 11000 −
+	// 8200). Within 1 follow-up tick (after EV throttles to ~6650 W),
+	// battery climbs to ~4150 W. Joint stable point: 4150 + 6650 = 10800
+	// + 200 house = 11 kW = fuse.
+	if got > 4500 {
+		t.Errorf("TargetW = %.0f W — battery charge not cut by joint allocator (want ≤ 4500)", got)
+	}
+	if got < 0 {
+		t.Errorf("TargetW = %.0f W — battery shouldn't be discharging here", got)
+	}
+	if !st.FuseSaturated {
+		t.Errorf("FuseSaturated = false; want true after joint scaling")
+	}
+	// EV cap is the allocator's verdict (independent of fuse guard's
+	// in-tick safety net): scale × current EV ≈ 0.831 × 8000 ≈ 6650.
+	if st.FuseEVMaxW < 6000 || st.FuseEVMaxW > 7200 {
+		t.Errorf("FuseEVMaxW = %.0f — want ~6650 (scaled EV cap)", st.FuseEVMaxW)
+	}
+	// Sanity: post-dispatch projected grid stays at or below fuse.
+	projected := 8200.0 + got
+	if projected > fuseMaxW+50 {
+		t.Errorf("projected grid %.0f W > fuse %.0f after dispatch", projected, float64(fuseMaxW))
+	}
+}
+
+// Counter-test: when battery wants to discharge, no scaling — discharge
+// helps the fuse rather than competing with the EV.
+func TestJointFuseAllocatorIgnoresDischarge(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -1000, // discharge
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(8200, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 8000
+	st.BatteryCoversEV = true // discharge into EV explicitly OK
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11000)
+	got := targets[0].TargetW
+	// Plan wanted ~ -4000 W discharge. Should run roughly as planned —
+	// discharge counts AGAINST grid, so doesn't fight EV.
+	if got > -1500 {
+		t.Errorf("TargetW = %.0f W — discharge unexpectedly cut", got)
+	}
+	if st.FuseSaturated {
+		t.Errorf("FuseSaturated = true; want false (discharge helps fuse, no joint scaling needed)")
+	}
+}
+
+// No EV competition: plan wants battery charge, no EV active. Allocator
+// must not interfere even if rawGridW is high (fuse guard handles that).
+func TestJointFuseAllocatorNoOpWithoutEV(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1250,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(200, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 0
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11000)
+	got := targets[0].TargetW
+	if got < 4500 || got > 5500 {
+		t.Errorf("TargetW = %.0f — no EV present, plan should run as-is (~5000 W)", got)
+	}
+	if st.FuseSaturated {
+		t.Errorf("FuseSaturated = true with no EV — should be false")
+	}
+}
+
 // Slot rollover: when SlotDirective returns a new SlotStart, the delivered
 // accumulator must reset so the next slot starts from zero.
 func TestEnergyDispatchResetsOnSlotRollover(t *testing.T) {

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -195,6 +195,18 @@ type State struct {
 	// preserves the capacity-proportional default. Issue #143.
 	InverterGroups map[string]string
 
+	// FuseEVMaxW is the joint allocator's verdict for the EV's allowed
+	// wattage this tick. Only meaningful when FuseSaturated is true.
+	// Read by the loadpoint controller (via a hook) to curtail the EV
+	// command so battery and EV cooperatively share the fuse budget.
+	// Recomputed every dispatch tick.
+	FuseEVMaxW float64
+	// FuseSaturated signals that the joint allocator had to scale battery
+	// and/or EV demand to fit under the fuse this tick. Used to gate the
+	// loadpoint controller's read of FuseEVMaxW and as the trigger for
+	// an MPC reactive replan from main.go.
+	FuseSaturated bool
+
 	// DriverLimits maps driver name → per-battery charge/discharge cap.
 	// Missing entries (or zero fields) fall through to the global
 	// MaxCommandW default. Consulted in every clamp step — per-battery
@@ -549,6 +561,23 @@ func ComputeDispatch(
 		// GridTargetW, producing wrong corrections.
 		state.SetGridTarget(0)
 		state.PI.Reset()
+
+		// BatteryCoversEV=false safety net: the energy path executes the
+		// plan's BatteryEnergyWh directive blindly, but the MPC may have
+		// planned battery→EV transfers (it joint-optimises both). Cap any
+		// commanded discharge to the level the reactive path would target
+		// — i.e. enough to zero the *house* side, not to feed the EV.
+		// Charging is left untouched. Mirrors the dispatch.go:453 rule on
+		// the legacy path. The MPC also gets a NoBatteryToEV constraint
+		// so the plan stops prescribing what dispatch then has to censor.
+		if !state.BatteryCoversEV && state.EVChargingW > 0 && targetTotalW < 0 {
+			houseGridW := rawGridW - state.EVChargingW
+			reactiveTotal := currentTotal - houseGridW
+			if targetTotalW < reactiveTotal {
+				targetTotalW = reactiveTotal
+			}
+		}
+
 		totalCorrection = targetTotalW - currentTotal
 	default:
 		// Legacy PI-on-grid-target path. Used by:
@@ -591,6 +620,51 @@ func ComputeDispatch(
 		}
 		out := state.PI.Update(piMeasurement)
 		totalCorrection = out.Output
+	}
+
+	// ---- Joint fuse-budget allocator ----
+	// When EV draw + commanded battery charge would exceed the site fuse,
+	// scale BOTH proportionally so they share the budget rather than
+	// oscillating against each other (battery ramps up per plan → fuse
+	// guard cuts it → plan ramps again next tick — operator report
+	// 2026-04-27). The battery side is mutated here; the EV side is
+	// published via state.FuseEVMaxW + FuseSaturated for the loadpoint
+	// controller to read on its next Tick.
+	//
+	// Math (site sign, + = import):
+	//   targetTotal = currentTotal + totalCorrection
+	//   B  = max(0, targetTotal)        battery charge component (≥0)
+	//   Bn = min(0, targetTotal)        battery discharge component (≤0)
+	//   E  = state.EVChargingW          EV draw (≥0)
+	//   H  = rawGridW − currentTotal − E   "house" net (load + PV)
+	//   newGrid' = H + (Bn + B*scale) + E*scale
+	//   solve newGrid' ≤ fuseMaxW  ⇒  scale ≤ (fuseMaxW − H − Bn) / (B + E)
+	//
+	// Discharge alone never trips this — Bn is negative, so it lifts the
+	// numerator (more headroom). Only positive battery demand competes
+	// with EV.
+	state.FuseEVMaxW = 0
+	state.FuseSaturated = false
+	if fuseMaxW > 0 && state.EVChargingW > 0 {
+		targetTotal := currentTotal + totalCorrection
+		B := math.Max(0, targetTotal)
+		Bn := math.Min(0, targetTotal)
+		E := state.EVChargingW
+		H := rawGridW - currentTotal - E
+		projectedGrid := H + targetTotal + E
+		if projectedGrid > fuseMaxW && (B+E) > 0 {
+			scale := (fuseMaxW - H - Bn) / (B + E)
+			if scale < 0 {
+				scale = 0
+			}
+			if scale > 1 {
+				scale = 1
+			}
+			newBattery := Bn + B*scale
+			totalCorrection = newBattery - currentTotal
+			state.FuseEVMaxW = E * scale
+			state.FuseSaturated = true
+		}
 	}
 
 	// ---- Per-group PV surplus for DC-local charge routing (#143) ----

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -53,6 +53,14 @@ type HostEnv struct {
 	MQTT       MQTTCap    // nil → mqtt_* calls return ErrNoCapability
 	Modbus     ModbusCap  // nil → modbus_* calls return ErrNoCapability
 	HTTP       bool       // false → http_* calls return ErrNoCapability
+	// HTTPAllowedHosts, when non-empty, restricts which hosts this
+	// driver can reach via host.http_get / host.http_post. Each entry
+	// is matched case-insensitively against the URL's host component
+	// (not the port) — so "192.168.1.50" matches both port 80 and 8080
+	// on that host. Empty list (nil or len==0) = any host allowed, for
+	// backward compat with existing drivers that didn't declare a list.
+	// Populated from driver config `capabilities.http.allowed_hosts`.
+	HTTPAllowedHosts []string
 	Start      time.Time  // monotonic start; host.millis() computed from here
 
 	mu sync.Mutex
@@ -88,6 +96,13 @@ func (h *HostEnv) WithModbus(m ModbusCap) *HostEnv { h.Modbus = m; return h }
 
 // WithHTTP enables the HTTP capability.
 func (h *HostEnv) WithHTTP() *HostEnv { h.HTTP = true; return h }
+
+// WithHTTPAllowedHosts installs an allowlist. An empty / nil slice
+// means "any host" (backward compatible). Matched against URL host.
+func (h *HostEnv) WithHTTPAllowedHosts(hosts []string) *HostEnv {
+	h.HTTPAllowedHosts = hosts
+	return h
+}
 
 // millis returns monotonic milliseconds since host startup.
 func (h *HostEnv) millis() int64 {

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -183,7 +183,7 @@ func registerHost(L *lua.LState, env *HostEnv) {
 		return 0
 	}))
 
-	// host.emit("meter"|"pv"|"battery"|"ev", { w=…, soc=…, connected=…, charging=… })
+	// host.emit("meter"|"pv"|"battery"|"ev"|"vehicle", { w=…, soc=…, … })
 	// The type string is prepended to the table as a `type` field and
 	// the whole thing is serialized as JSON before hitting the telemetry store.
 	// Allowed fields per type:
@@ -196,6 +196,14 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	//              session_wh (optional, kWh for current session * 1000),
 	//              max_a (optional, charger current limit),
 	//              phases (optional, 1 or 3)
+	//   vehicle -> soc (required, vehicle battery level % 0-100),
+	//              charge_limit_pct (optional, vehicle-configured limit),
+	//              charging_state (optional, e.g. "Charging"|"Stopped"|"Complete"),
+	//              time_to_full_min (optional),
+	//              stale (optional bool, true when data hasn't refreshed
+	//              since stale_after_s — UI should de-emphasize).
+	//              w is unused for vehicle readings (charger's DerEV owns
+	//              the power number).
 	host.RawSetString("emit", L.NewFunction(func(L *lua.LState) int {
 		typ := L.CheckString(1)
 		tbl := L.CheckTable(2)

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"io"
 	net_http "net/http"
+	net_url "net/url"
 	"os"
 	"strings"
 	"sync"
@@ -438,6 +439,27 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	// headers is an optional Lua table {["Content-Type"]="application/json", ...}
 	httpClient := &net_http.Client{Timeout: 15 * time.Second}
 
+	// hostAllowed checks the URL's host component against the
+	// per-driver allowlist. Empty allowlist = any host (legacy
+	// behaviour). Matched case-insensitively, port-agnostic. See
+	// HostEnv.HTTPAllowedHosts docs.
+	hostAllowed := func(rawURL string) (bool, string) {
+		if len(env.HTTPAllowedHosts) == 0 {
+			return true, ""
+		}
+		u, err := net_url.Parse(rawURL)
+		if err != nil || u.Host == "" {
+			return false, "invalid URL"
+		}
+		host := strings.ToLower(u.Hostname())
+		for _, allowed := range env.HTTPAllowedHosts {
+			if strings.EqualFold(strings.TrimSpace(allowed), host) {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("host %q not in allowed_hosts", host)
+	}
+
 	applyHeaders := func(req *net_http.Request, L *lua.LState, argIdx int) {
 		tbl := L.OptTable(argIdx, nil)
 		if tbl == nil {
@@ -457,6 +479,11 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			return 2
 		}
 		url := L.CheckString(1)
+		if ok, reason := hostAllowed(url); !ok {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("http: " + reason))
+			return 2
+		}
 		req, err := net_http.NewRequest("GET", url, nil)
 		if err != nil {
 			L.Push(lua.LNil)
@@ -493,6 +520,11 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			return 2
 		}
 		url := L.CheckString(1)
+		if ok, reason := hostAllowed(url); !ok {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("http: " + reason))
+			return 2
+		}
 		payload := L.CheckString(2)
 		req, err := net_http.NewRequest("POST", url, strings.NewReader(payload))
 		if err != nil {

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -123,6 +123,9 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 	if cfg.Capabilities.HTTP != nil {
 		env.WithHTTP()
+		if hosts := cfg.Capabilities.HTTP.AllowedHosts; len(hosts) > 0 {
+			env.WithHTTPAllowedHosts(hosts)
+		}
 	}
 
 	luaDrv, err := NewLuaDriver(cfg.Lua, env)

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -34,6 +34,15 @@ type Controller struct {
 	tel     TelemetryFunc
 	send    SenderFunc
 
+	// fuseEVMax is the joint fuse-budget allocator's verdict for how much
+	// W this controller may command to the EV this tick. Set by the
+	// dispatch package each control cycle; nil/zero-returning func means
+	// "no fuse constraint" (loadpoint runs at its planner-determined
+	// budget). When the function returns (cap, true) with cap > 0, the
+	// controller clamps the planner's wantW to that cap so battery and
+	// EV cooperatively share the site fuse.
+	fuseEVMax func() (float64, bool)
+
 	// site is the grid-boundary fuse. Its values are passed through
 	// to the driver in every ev_set_current cmd so the driver knows
 	// the per-phase ceiling and the mains voltage. Zero MaxAmps
@@ -113,6 +122,17 @@ type SenderFunc func(ctx context.Context, driver string, payload []byte) error
 // or send disables the corresponding step — useful in tests.
 func NewController(mgr *Manager, plan PlanFunc, tel TelemetryFunc, send SenderFunc) *Controller {
 	return &Controller{manager: mgr, plan: plan, tel: tel, send: send}
+}
+
+// SetFuseEVMax wires the joint allocator's verdict from control.State.
+// Called once at startup from main.go. The returned (cap_w, true) is
+// honored as a hard upper bound on this tick's EV command; (_, false)
+// means no constraint. Pass nil to disable.
+func (c *Controller) SetFuseEVMax(f func() (float64, bool)) {
+	if c == nil {
+		return
+	}
+	c.fuseEVMax = f
 }
 
 // SetSiteFuse installs the grid-boundary fuse so the controller can
@@ -343,6 +363,14 @@ func (c *Controller) computeCommand(now time.Time, lpCfg Config, currentPowerW f
 	alreadyWh := currentPowerW * elapsed / 3600.0
 	remainingWh := budgetWh - alreadyWh
 	wantW := EnergyBudgetToPowerW(remainingWh, remainingS)
+	// Joint fuse allocator (dispatch.go) caps EV demand when battery + EV
+	// would together bust the fuse. Honour it before snapping to the
+	// charger's discrete steps so the snap chooses a level under the cap.
+	if c.fuseEVMax != nil {
+		if cap, ok := c.fuseEVMax(); ok && cap >= 0 && wantW > cap {
+			wantW = cap
+		}
+	}
 	// Clamp to the loadpoint's static MaxChargeW (configured cap; the
 	// driver's per-phase fuse clamp is the ultimate safety stop).
 	return SnapChargeW(wantW, lpCfg.MinChargeW, lpCfg.MaxChargeW, lpCfg.AllowedStepsW), true

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -115,6 +115,20 @@ type State struct {
 	TargetSoCPct       float64   `json:"target_soc_pct"`        // user intent
 	TargetTime         time.Time `json:"target_time,omitempty"` // user intent
 	UpdatedAtMs        int64     `json:"updated_at_ms"`
+
+	// Vehicle-side telemetry, populated by the API layer from the most
+	// recent DerVehicle reading whose charging_state indicates a likely
+	// physical connection. Zero values when no online vehicle driver is
+	// reporting. SoCSource is "vehicle" when CurrentSoCPct was overridden
+	// from the car's BMS, "inferred" when it's the loadpoint manager's
+	// pluginSoC + deliveredWh estimate, "" when not plugged in.
+	VehicleSoCPct         float64 `json:"vehicle_soc_pct,omitempty"`
+	VehicleChargeLimitPct float64 `json:"vehicle_charge_limit_pct,omitempty"`
+	VehicleChargingState  string  `json:"vehicle_charging_state,omitempty"`
+	VehicleDriver         string  `json:"vehicle_driver,omitempty"`
+	VehicleStale          bool    `json:"vehicle_stale,omitempty"`
+	SoCSource             string  `json:"soc_source,omitempty"`
+
 	// MinChargeW / MaxChargeW / AllowedStepsW are repeated here so the
 	// UI has everything for rendering in one fetch.
 	MinChargeW    float64   `json:"min_charge_w"`

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -89,6 +89,15 @@ type Service struct {
 	// derive actual load = grid − pv − bat. Empty = skip load check.
 	SiteMeter string
 
+	// FuseMaxW is the site's grid fuse ceiling (W). When > 0, every slot
+	// passed to Optimize gets `Limits.MaxImportW = FuseMaxW`, so the DP
+	// joint-plans battery + EV in a way that respects the fuse from the
+	// start — battery charge + EV charge + house net can't exceed this.
+	// Without this, the DP can prescribe (battery_charge + EV_charge)
+	// totals that bust the fuse, and dispatch has to scale them at
+	// execution time. Wired from main.go (cfg.Fuse → fuseMaxW).
+	FuseMaxW float64
+
 	lastReplanAt time.Time
 	lastReason   string // "scheduled" | "reactive-pv" | "reactive-load" | "manual"
 
@@ -517,6 +526,18 @@ func (s *Service) replan(_ context.Context) *Plan {
 	slots := buildSlots(prices, forecasts, s.BaseLoad, now.UnixMilli(), s.PV, s.Load)
 	if len(slots) == 0 {
 		return nil
+	}
+
+	// Plumb the site fuse into per-slot limits so the DP joint-plans
+	// battery + EV under the fuse constraint instead of producing plans
+	// that dispatch then has to scale at execution time. The DP already
+	// honours Slot.Limits.MaxImportW (mpc.go:450); we just feed it.
+	if s.FuseMaxW > 0 {
+		for i := range slots {
+			if slots[i].Limits.MaxImportW <= 0 || slots[i].Limits.MaxImportW > s.FuseMaxW {
+				slots[i].Limits.MaxImportW = s.FuseMaxW
+			}
+		}
 	}
 
 	// Current SoC: average of battery readings (weighted by capacity is

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -15,9 +15,17 @@ const (
 	DerPV
 	DerBattery
 	DerEV
+	// DerVehicle is a read-only reading from the connected vehicle
+	// itself (e.g. via TeslaBLEProxy), distinct from DerEV which is
+	// the charger. Carries SoC + `charge_limit_pct`/`charging_state`/
+	// `time_to_full_min`/`stale` in Data. RawW is always 0 — vehicle
+	// readings don't conflict with dispatch math, they only inform
+	// the loadpoint manager's SoC-source selection and the UI.
+	DerVehicle
 )
 
-// String returns the canonical string form ("meter", "pv", "battery", "ev").
+// String returns the canonical string form ("meter", "pv", "battery",
+// "ev", "vehicle").
 func (d DerType) String() string {
 	switch d {
 	case DerMeter:
@@ -28,6 +36,8 @@ func (d DerType) String() string {
 		return "battery"
 	case DerEV:
 		return "ev"
+	case DerVehicle:
+		return "vehicle"
 	}
 	return "unknown"
 }
@@ -43,6 +53,8 @@ func ParseDerType(s string) (DerType, error) {
 		return DerBattery, nil
 	case "ev":
 		return DerEV, nil
+	case "vehicle":
+		return DerVehicle, nil
 	}
 	return 0, fmt.Errorf("unknown der type %q", s)
 }
@@ -359,7 +371,7 @@ func (s *Store) DriverHealthMut(name string) *DriverHealth {
 func (s *Store) Remove(driver string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, t := range []DerType{DerMeter, DerPV, DerBattery, DerEV} {
+	for _, t := range []DerType{DerMeter, DerPV, DerBattery, DerEV, DerVehicle} {
 		k := key(driver, t)
 		delete(s.readings, k)
 		delete(s.filters, k)

--- a/web/components/ftw-energy-flow.js
+++ b/web/components/ftw-energy-flow.js
@@ -1365,25 +1365,25 @@ function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc,
   // the aggregation layer, "SoC" for a single-battery reading.
   // Honest about provenance — a 72 % on the aggregated bubble is not
   // the same fact as a 72 % on one inverter.
-  const socLabel = aggregated ? "Avg SoC" : "SoC";
-  // EV planets gain two extra honesty markers beyond plain SoC%:
+  // The "%" makes "SoC" redundant — drop the label, keep only the
+  // value. Aggregated batteries still get an "Avg" prefix to flag the
+  // value is a cross-battery mean. EV planets gain two honesty markers:
   //  - "~" prefix when the value came from the inferred path (pluginSoC
-  //    + deliveredWh) instead of the vehicle's own BMS — operator can
-  //    see at a glance which number is measured vs estimated.
+  //    + deliveredWh) instead of the vehicle's own BMS.
   //  - "★" suffix when the vehicle reading is stale (driver lost
   //    contact with the car for more than its stale_after_s window).
-  // When a charge-limit is also known (e.g. the Tesla app's "charge
-  // to 50 %"), render as "SoC 24 / 50 %" so the operator sees current
-  // and the vehicle-configured ceiling in one line.
+  // When a charge-limit is also known, render as "24/50%" — no spaces
+  // around the slash, the format reads as "current of limit".
   let socText = "";
   if (soc != null) {
     const socPrefix = socSource === "inferred" ? "~" : "";
+    const aggPrefix = aggregated ? "Avg " : "";
     const staleMark = socStale ? " ★" : "";
     const socBody = chargeLimit != null && chargeLimit > 0
-      ? `${socPrefix}${Math.round(soc)} / ${Math.round(chargeLimit)}%`
+      ? `${socPrefix}${Math.round(soc)}/${Math.round(chargeLimit)}%`
       : `${socPrefix}${Math.round(soc)}%`;
     socText = `<text x="${x}" y="${y + socY}" text-anchor="middle"
-             fill="var(--cyan)" class="sv-node-sub">${socLabel} ${socBody}${staleMark}</text>`;
+             fill="var(--cyan)" class="sv-node-sub">${aggPrefix}${socBody}${staleMark}</text>`;
   }
   // Icon swapped in during the loading + fade-in phases. Scale chosen
   // so a full-size planet (r ≈ 86) hosts a ~30 px icon — readable at

--- a/web/components/ftw-energy-flow.js
+++ b/web/components/ftw-energy-flow.js
@@ -592,6 +592,9 @@ class FtwEnergyFlow extends FtwElement {
         sub: p.sub,
         color: p.color,
         soc: p.placeholder ? null : p.soc,
+        chargeLimit: p.placeholder ? null : p.chargeLimit,
+        socStale: !p.placeholder && !!p.socStale,
+        socSource: p.placeholder ? null : p.socSource,
         radius: p._r,
         clickable: !p.placeholder && !!p.role,
         role: p.role || "",
@@ -1324,7 +1327,9 @@ function hashStr(s) {
 // a multi-device 55 px circle both read proportionally. Stroke is the
 // accent color so each node carries its identity on the edge of the
 // circle — no separate stripe needed the way rectangular boxes have.
-function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc, radius = 86,
+function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc,
+                            chargeLimit = null, socStale = false, socSource = null,
+                            radius = 86,
                             clickable = false, role = "", name = "", id = "",
                             aggregated = false }) {
   const r = radius;
@@ -1361,10 +1366,25 @@ function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc, radiu
   // Honest about provenance — a 72 % on the aggregated bubble is not
   // the same fact as a 72 % on one inverter.
   const socLabel = aggregated ? "Avg SoC" : "SoC";
-  const socText = soc != null
-    ? `<text x="${x}" y="${y + socY}" text-anchor="middle"
-             fill="var(--cyan)" class="sv-node-sub">${socLabel} ${Math.round(soc)}%</text>`
-    : "";
+  // EV planets gain two extra honesty markers beyond plain SoC%:
+  //  - "~" prefix when the value came from the inferred path (pluginSoC
+  //    + deliveredWh) instead of the vehicle's own BMS — operator can
+  //    see at a glance which number is measured vs estimated.
+  //  - "★" suffix when the vehicle reading is stale (driver lost
+  //    contact with the car for more than its stale_after_s window).
+  // When a charge-limit is also known (e.g. the Tesla app's "charge
+  // to 50 %"), render as "SoC 24 / 50 %" so the operator sees current
+  // and the vehicle-configured ceiling in one line.
+  let socText = "";
+  if (soc != null) {
+    const socPrefix = socSource === "inferred" ? "~" : "";
+    const staleMark = socStale ? " ★" : "";
+    const socBody = chargeLimit != null && chargeLimit > 0
+      ? `${socPrefix}${Math.round(soc)} / ${Math.round(chargeLimit)}%`
+      : `${socPrefix}${Math.round(soc)}%`;
+    socText = `<text x="${x}" y="${y + socY}" text-anchor="middle"
+             fill="var(--cyan)" class="sv-node-sub">${socLabel} ${socBody}${staleMark}</text>`;
+  }
   // Icon swapped in during the loading + fade-in phases. Scale chosen
   // so a full-size planet (r ≈ 86) hosts a ~30 px icon — readable at
   // the overview zoom without competing with the text once it fades

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -409,15 +409,43 @@
             soc: d.bat_soc != null ? Math.round(d.bat_soc * 100) : null,
           });
         }
-        // EV — always consumes from the house side.
+        // EV — always consumes from the house side. When a loadpoint
+        // maps to this driver AND a vehicle telemetry source is
+        // reporting (DerVehicle), inject the vehicle's own SoC +
+        // charge-limit so the bubble renders "24 / 50 %" — measured
+        // truth instead of session-Wh estimate.
         if (d.ev_w != null) {
           var eKw = d.ev_w / 1000;
           var eActive = eKw > 0.05;
+          var lpEv = loadpointsByDriver && loadpointsByDriver[name];
+          var evSoc = null;
+          var evLimit = null;
+          var evSocStale = false;
+          var evSocSource = null;
+          if (lpEv) {
+            // Prefer vehicle-reported when present; fall back to
+            // the inferred SoC the manager computed from session_wh.
+            if (lpEv.vehicle_soc_pct > 0) {
+              evSoc = lpEv.vehicle_soc_pct;
+              evSocSource = "vehicle";
+            } else if (lpEv.current_soc_pct > 0) {
+              evSoc = lpEv.current_soc_pct;
+              evSocSource = lpEv.soc_source || "inferred";
+            }
+            if (lpEv.vehicle_charge_limit_pct > 0) {
+              evLimit = lpEv.vehicle_charge_limit_pct;
+            }
+            evSocStale = !!lpEv.vehicle_stale;
+          }
           planets.push({
             id: "ev-" + name, corner: "bottom-right", title: "EV CHARGER", name: name, role: "ev",
             kw: eKw, toHub: false,
             color: eActive ? "var(--green-e)" : "var(--white-s)",
             sub: eActive ? "charging" : "idle",
+            soc: evSoc,
+            chargeLimit: evLimit,
+            socStale: evSocStale,
+            socSource: evSocSource,
           });
         }
       });
@@ -1471,13 +1499,28 @@
   // ---- API ----
   var firstLoad = true;
   var setupBannerShown = false;
+  // Loadpoint cache — keyed by driver_name so the EV-planet builder
+  // in render() can look up vehicle SoC + charge-limit without a
+  // second round of fetches per status tick. Refreshed in parallel
+  // with /api/status. `null` until the first fetch lands; missing
+  // entries mean "no loadpoint for this driver" and the planet
+  // falls back to legacy kW-only rendering.
+  var loadpointsByDriver = null;
   function fetchStatus() {
-    fetch("/api/status")
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (data) {
+    Promise.all([
+      fetch("/api/status").then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }),
+      fetch("/api/loadpoints").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
+    ])
+      .then(function (results) {
+        var data = results[0];
+        var lp = results[1];
+        if (lp && Array.isArray(lp.loadpoints)) {
+          var idx = {};
+          lp.loadpoints.forEach(function (l) {
+            if (l && l.driver_name) idx[l.driver_name] = l;
+          });
+          loadpointsByDriver = idx;
+        }
         setConnected(true);
         if (firstLoad) { firstLoad = false; }
         if (setupBannerShown) { hideSetupBanner(); }

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1291,12 +1291,62 @@
       var ticks = d.tick_count != null ? d.tick_count : 0;
       var errors = d.consecutive_errors != null ? d.consecutive_errors : 0;
 
-      // Detect EV driver by presence of any ev_* field. Render a distinct
-      // card body — PV/battery/meter rows are always 0 for EV chargers.
-      var isEV = (d.ev_w != null || d.ev_connected != null || d.ev_charging != null);
+      // Detect driver kind from telemetry shape. Vehicle drivers
+      // (e.g. tesla_vehicle) emit DerVehicle which carries SoC +
+      // charge_limit + charging_state but no power; render a vehicle-
+      // specific body. EV chargers emit DerEV with power. Anything
+      // else falls through to the legacy meter/pv/battery layout.
+      var isVehicle = (d.vehicle_soc != null || d.vehicle_charge_limit_pct != null);
+      var isEV = !isVehicle && (d.ev_w != null || d.ev_connected != null || d.ev_charging != null);
 
       var body;
-      if (isEV) {
+      if (isVehicle) {
+        var vSoc = d.vehicle_soc != null ? Math.round(d.vehicle_soc) : null;
+        var vLimit = d.vehicle_charge_limit_pct != null ? Math.round(d.vehicle_charge_limit_pct) : null;
+        var vState = d.vehicle_charging_state || "—";
+        var vTtf = d.vehicle_time_to_full_min;
+        var vStale = !!d.vehicle_stale;
+        var vAmps = d.vehicle_charge_amps;             // car's in-app current limit
+        var vActual = d.vehicle_charger_actual_current; // current actually flowing
+        var socDisplay = (vSoc != null && vLimit != null)
+          ? vSoc + " / " + vLimit + " %"
+          : (vSoc != null ? vSoc + " %" : "—");
+        if (vStale) socDisplay += " ★";
+        var stateClassV = (vState === "Charging") ? "stat-ok" : (vState === "Disconnected" ? "stat-dim" : "stat-warn");
+        var ttfStr = (vTtf != null && vTtf > 0)
+          ? (vTtf >= 60 ? Math.floor(vTtf / 60) + "h " + (vTtf % 60) + "m" : vTtf + " min")
+          : "—";
+        // Amps row reads "5 / 16 A" (actual / in-app limit) when both
+        // present; flags as warn when actual lags the limit (vehicle
+        // throttled itself or wallbox limit is lower than what the
+        // car would accept). Skipped entirely when neither field is
+        // reported (older proxies).
+        var ampsRow = "";
+        if (vAmps != null || vActual != null) {
+          var ampsText = (vActual != null ? Math.round(vActual) : "?") +
+                         " / " +
+                         (vAmps != null ? Math.round(vAmps) : "?") +
+                         " A";
+          var ampsCls = (vActual != null && vAmps != null && vActual + 0.5 < vAmps)
+            ? "stat-warn" : "stat-value";
+          ampsRow =
+            '  <span class="stat-label">Amps (actual/limit)</span>' +
+            '<span class="stat-value ' + ampsCls + '">' + ampsText + '</span>';
+        }
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">SoC</span><span class="stat-value">' + socDisplay + '</span>' +
+          '  <span class="stat-label">State</span><span class="stat-value ' + stateClassV + '">' + escHtml(vState) + '</span>' +
+          ampsRow +
+          '  <span class="stat-label">Time to full</span><span class="stat-value">' + ttfStr + '</span>' +
+          (vStale ? '  <span class="stat-label">Note</span><span class="stat-value stat-warn">data stale</span>' : '') +
+          '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + '</span>' +
+          '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + '</span>' +
+          '</div>' +
+          (vSoc != null
+            ? '<div class="driver-soc-bar"><div class="driver-soc-fill" style="width:' + vSoc + '%"></div></div>'
+            : '');
+      } else if (isEV) {
         var evWVal = d.ev_w != null ? d.ev_w : 0;
         // state_label + reason_no_current_label come from the driver —
         // UI renders them verbatim. Protocol knowledge stays in Lua.
@@ -1386,7 +1436,7 @@
         // Inline battery model — rendered from models.js's cached payload.
         // Drawing it here in the same pass as the driver card avoids the
         // earlier race where two independent polls fought over the slot.
-        (!isEV && !(d.disabled === true || d.status === "disabled") && window.renderInlineBatteryModel ? window.renderInlineBatteryModel(name) : "");
+        (!isEV && !isVehicle && !(d.disabled === true || d.status === "disabled") && window.renderInlineBatteryModel ? window.renderInlineBatteryModel(name) : "");
 
       driversGrid.appendChild(card);
     });

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -71,13 +71,43 @@
             '<input type="number" data-path="drivers.' + idx + '.capabilities.modbus.unit_id" value="' + (modbus.unit_id || 1) + '">' +
             '</fieldset>';
         }
-        // Local-HTTP vs cloud-HTTP driver detection by declared config shape.
+        // Local-HTTP vs cloud-HTTP vs vehicle-over-proxy detection by
+        // declared config shape + catalog capabilities. Vehicle drivers
+        // (e.g. tesla_vehicle against a TeslaBLEProxy) expose only
+        // {ip, vin} and read no power channel.
         var dcfg = d.config || {};
         var hasHostField = Object.prototype.hasOwnProperty.call(dcfg, 'host');
         var hasAuthField = Object.prototype.hasOwnProperty.call(dcfg, 'email') ||
                            Object.prototype.hasOwnProperty.call(dcfg, 'password');
-        var isLocalHTTP = cap.http != null && hasHostField;
-        var isCloudDriver = cap.http != null && !hasHostField && (hasAuthField || Object.keys(dcfg).length === 0);
+        var catalogEntry = (S.catalogByLua || {})[d.lua];
+        var caps = (catalogEntry && catalogEntry.capabilities) || [];
+        var isVehicleDriver = cap.http != null &&
+          (caps.indexOf("vehicle") >= 0 ||
+           Object.prototype.hasOwnProperty.call(dcfg, 'vin') ||
+           Object.prototype.hasOwnProperty.call(dcfg, 'ip'));
+        var isLocalHTTP = !isVehicleDriver && cap.http != null && hasHostField;
+        var isCloudDriver = !isVehicleDriver && cap.http != null && !hasHostField &&
+          (hasAuthField || Object.keys(dcfg).length === 0);
+        if (isVehicleDriver) {
+          // TeslaBLEProxy-style drivers only need the LAN IP of the
+          // proxy and the VIN it's paired to. "Verify connection"
+          // makes the backend issue a one-shot vehicle_data poll so
+          // the operator can confirm pairing before saving.
+          var vcfg = d.config || {};
+          html += '<fieldset><legend>Vehicle</legend>' +
+            '<div class="field-row"><div>' +
+            '<label>Proxy IP ' + help('LAN address of the TeslaBLEProxy. Bare IP uses port 8080; append ":port" to override (e.g. 192.168.1.50:1234).') + '</label>' +
+            '<input type="text" class="tesla-ip-input" data-driver-idx="' + idx + '" data-path="drivers.' + idx + '.config.ip" value="' + escHtml(vcfg.ip || '') + '" placeholder="192.168.1.50 (or 192.168.1.50:1234)">' +
+            '</div><div>' +
+            '<label>VIN ' + help('Vehicle Identification Number the proxy is paired to.') + '</label>' +
+            '<input type="text" data-path="drivers.' + idx + '.config.vin" value="' + escHtml(vcfg.vin || '') + '" placeholder="5YJ3E1EA1KF000000">' +
+            '</div></div>' +
+            '<div style="margin-top:8px;display:flex;gap:10px;align-items:center">' +
+            '<button class="btn-add tesla-verify-btn" type="button" data-driver-idx="' + idx + '">Verify connection</button>' +
+            '<span class="tesla-verify-status" data-driver-idx="' + idx + '" style="font-size:0.82rem;color:var(--text-dim)"></span>' +
+            '</div>' +
+            '</fieldset>';
+        }
         if (isLocalHTTP) {
           var lcfg = d.config || {};
           // Render the Disable-PV checkbox for every HTTP driver; the
@@ -147,6 +177,10 @@
         // what the driver itself declares, not a hard-coded list.
         var byLua = {};
         entries.forEach(function (e) { if (e && e.path) byLua[e.path] = e; });
+        // Cache by-lua so the synchronous render pass can detect
+        // catalog-driven driver kinds (e.g. "vehicle") on re-renders
+        // without waiting for the fetch to resolve again.
+        S.catalogByLua = byLua;
         bodyEl.querySelectorAll(".drv-disable-pv").forEach(function (lbl) {
           var lua = lbl.getAttribute("data-drv-lua");
           var entry = lua && byLua[lua];
@@ -196,9 +230,20 @@
         if (protocols.indexOf("http") >= 0) {
           var hosts = (chosen.dataset.httpHosts || "").split(",").filter(Boolean);
           driver.capabilities.http = { allowed_hosts: hosts };
+          // Vehicle drivers (e.g. tesla_vehicle) take {ip, vin}, not
+          // {host} or {email,password,serial}. Detect via catalog
+          // capability so existing local-HTTP and cloud branches stay
+          // untouched.
+          var entry = (S.catalogByLua || {})[sel.value];
+          var entryCaps = (entry && entry.capabilities) || [];
           var connHost = chosen.dataset.connectionHost || "";
-          if (connHost) driver.config = { host: connHost };
-          else driver.config = { email: "", password: "", serial: "" };
+          if (entryCaps.indexOf("vehicle") >= 0) {
+            driver.config = { ip: "", vin: "" };
+          } else if (connHost) {
+            driver.config = { host: connHost };
+          } else {
+            driver.config = { email: "", password: "", serial: "" };
+          }
         }
         config.drivers.push(driver);
         ctx.renderTab("devices");
@@ -262,6 +307,73 @@
             connectBtn.disabled = false;
           });
         });
+      });
+
+      // Tesla "Verify connection" buttons. Issues a backend probe
+      // against the configured proxy IP + VIN and renders the result
+      // inline. Backend handles SSRF hardening — the UI just collects
+      // the two fields and displays the response.
+      bodyEl.querySelectorAll(".tesla-verify-btn").forEach(function (vbtn) {
+        vbtn.addEventListener("click", function () {
+          var dIdx = vbtn.dataset.driverIdx;
+          var statusEl = bodyEl.querySelector('.tesla-verify-status[data-driver-idx="' + dIdx + '"]');
+          var ipInput = bodyEl.querySelector('[data-path="drivers.' + dIdx + '.config.ip"]');
+          var vinInput = bodyEl.querySelector('[data-path="drivers.' + dIdx + '.config.vin"]');
+          var ip = ipInput ? ipInput.value.trim() : "";
+          var vin = vinInput ? vinInput.value.trim() : "";
+          if (!ip || !vin) {
+            if (statusEl) statusEl.textContent = "Enter Proxy IP + VIN first";
+            return;
+          }
+          if (statusEl) { statusEl.textContent = "Verifying…"; statusEl.style.color = "var(--text-dim)"; }
+          vbtn.disabled = true;
+          fetch("/api/drivers/verify_tesla", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ ip: ip, vin: vin }),
+          }).then(function (r) {
+            return r.json().then(function (j) { return { ok: r.ok, body: j }; });
+          }).then(function (res) {
+            if (!statusEl) return;
+            if (res.ok && res.body && res.body.ok) {
+              var soc = res.body.soc_pct != null ? Math.round(res.body.soc_pct) + "%" : "?";
+              var lim = res.body.charge_limit_pct != null ? Math.round(res.body.charge_limit_pct) + "%" : "?";
+              var st = res.body.charging_state || "";
+              statusEl.style.color = "#2a7";
+              statusEl.textContent = "✓ SoC " + soc + " · limit " + lim + (st ? " · " + st : "");
+            } else {
+              statusEl.style.color = "#c44";
+              statusEl.textContent = "✗ " + ((res.body && res.body.error) || "verification failed");
+            }
+          }).catch(function (e) {
+            if (statusEl) {
+              statusEl.style.color = "#c44";
+              statusEl.textContent = "✗ " + e.message;
+            }
+          }).finally(function () {
+            vbtn.disabled = false;
+          });
+        });
+      });
+
+      // Auto-sync capabilities.http.allowed_hosts from the configured
+      // Proxy IP. Without this, a fresh tesla driver gets allowed_hosts=[]
+      // (set by catalog-add) and every host.http_get call returns
+      // "host not in allowed_hosts" — driver never reaches the proxy
+      // and watchdog flips it stale. Strip any ":port" suffix; the
+      // allowlist is matched on hostname only.
+      bodyEl.querySelectorAll(".tesla-ip-input").forEach(function (inp) {
+        function syncAllowedHosts() {
+          var dIdx = inp.dataset.driverIdx;
+          var d = config.drivers[dIdx];
+          if (!d || !d.capabilities) return;
+          if (!d.capabilities.http) d.capabilities.http = { allowed_hosts: [] };
+          var ip = (inp.value || "").trim();
+          var bare = ip.split(":")[0];
+          d.capabilities.http.allowed_hosts = bare ? [bare] : [];
+        }
+        inp.addEventListener("input", syncAllowedHosts);
+        inp.addEventListener("blur", syncAllowedHosts);
       });
 
       // Add/remove-device buttons.


### PR DESCRIPTION
## Summary

End-to-end Tesla BLE Proxy integration plus a fuse-aware coordination layer between battery dispatch and EV charging:

- **Tesla driver pipeline** — \`tesla_vehicle.lua\` polls TeslaBLEProxy on the LAN, emits \`DerVehicle\` telemetry (SoC, charge_limit, charging_state, …). Steady-state poll runs cached; once every 30 min one poll forces a BLE wakeup. **First poll after startup also forces wakeup** so SoC isn't stale from the previous run.
- **Joint fuse-budget allocator** (\`go/internal/control/dispatch.go\`) — when EV draw + planned battery charge would exceed the site fuse, both are scaled proportionally so they share the budget. Battery side mutated locally; EV side published as \`state.FuseEVMaxW\` + \`FuseSaturated\` for the loadpoint controller to honor on its next tick. Battery discharge never trips it.
- **Plan-time fuse awareness** (\`go/internal/mpc/service.go\`) — fuse plumbed into every slot's \`Limits.MaxImportW\` so the DP joint-plans battery + EV under fuse from the start.
- **MPC reactive replan triggers** (60 s cooldown):
  - Fuse-saturation rising edge.
  - **Startup** — fire one replan ~2 s after \`mpcSvc.Start\` so the dashboard isn't waiting up to 15 min for the first scheduled tick.
  - **First DerVehicle SoC** — once any vehicle driver reports SoC, redo the plan with measured truth (replaces the inferred-SoC startup replan).
- **\`BatteryCoversEV=false\` energy-path fix** — toggle was honoured on legacy reactive PI but silently bypassed in \`planner_arbitrage\`/\`planner_cheap\`. Now capped at the level the reactive path would target.
- **DerVehicle SoC overlay on \`/api/loadpoints\`** — picks the most-likely-connected car (rank: Charging > NoPower > Stopped/Complete > Disconnected, freshness as tiebreaker) so multi-vehicle households (one wallbox + 2 Teslas) get the right car automatically. Verified live with \`tesla-vehicle\` + \`tesla-vehicle-2\`. MPC \`LoadpointSpec.InitialSoCPct\` uses the same source.
- **EV bubble UI** (\`web/components/ftw-energy-flow.js\`, \`web/next-app.js\`) — renders \`24/50%\` (current/charge_limit, no spaces, no "SoC" label since "%" already says it). \`~\` prefix when sourced from inferred path, \`★\` when reading is stale. Aggregated batteries get \`Avg\` prefix.

## Test plan

- [x] \`go test ./...\` — all green incl. e2e (27 s)
- [x] 5 new control regression tests cover joint allocator (scaling, discharge no-op, no-EV no-op) + BatteryCoversEV energy-path
- [x] Cross-compiled \`linux/arm64\` deployed to fortytwo (192.168.1.139); container restart shows \`(startup)\` wakeup on both Teslas + \`mpc: startup replan completed\` within 3 s
- [ ] Verify EV bubble renders \`24/50%\` once a Tesla driver is online + plugged in
- [ ] Watch a real charging session for the previously-reported oscillation (battery ramp → fuse cut → ramp loop) — should stay smooth
- [ ] Confirm \`BatteryCoversEV=false\` in \`planner_arbitrage\` no longer drains the home battery into the EV

🤖 Generated with [Claude Code](https://claude.com/claude-code)