### PR TITLE
chore: add issue templates + enable Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug report
+description: Report a bug in forty-two-watts
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the
+        details below so we can reproduce and fix it quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Configure '...'
+        2. Run '...'
+        3. Observe '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `forty-two-watts --version` or release tag / commit.
+      placeholder: e.g. v0.42.0 or commit 65aaf18
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Raspberry Pi (official image)
+        - Raspberry Pi (dev binary)
+        - Docker compose
+        - Local dev (`make dev`)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware / drivers in use
+      description: Inverter / battery / meter brands and which Lua drivers are loaded.
+      placeholder: e.g. Sungrow SH10RT, Ferroamp EnergyHub, P1 meter
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste relevant `slog` output. Redact secrets / IPs as needed.
+      render: shell
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Config snippets, screenshots, network topology, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/frahlg/forty-two-watts/discussions
+    about: Questions, ideas, and open-ended conversation belong here. Issues are for concrete bugs and feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? Great. For open-ended discussion, consider starting
+        a thread in [Discussions](../../discussions) first — issues are
+        best for concrete, actionable proposals.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do? What's missing or painful today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Sketch the API / UX / config.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds or other approaches you've tried or thought about.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Driver (new hardware support)
+        - Control / dispatch
+        - Battery model / self-tune
+        - MPC / planner
+        - PV / load / price twins
+        - HTTP API
+        - Web UI
+        - Home Assistant integration
+        - Nova federation
+        - Self-update / deploy
+        - Docs
+        - Other
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Hardware datasheets, protocol docs, screenshots, links.


### PR DESCRIPTION
## Summary
- Add structured GitHub issue templates: `bug_report.yml` and `feature_request.yml`
- Add `config.yml` to disable blank issues and route open-ended discussions to GitHub Discussions
- Discussions is enabled separately on the repo (already done via `gh api`)

## Why
Make it easy for anyone (field testers, contributors, drive-by users) to file high-quality bug reports and feature requests, while keeping open-ended chat in Discussions instead of issue tracker noise.

## Test plan
- [ ] Open https://github.com/frahlg/forty-two-watts/issues/new/choose and confirm both templates appear with the right fields
- [ ] Confirm "blank issue" option is gone
- [ ] Confirm the Discussions link is visible on the new-issue chooser
- [ ] Confirm Discussions tab is enabled on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)