### PR TITLE
docs(readme): add HA OS add-on Quick Start option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ dev-data/
 # Per-user Claude Code harness settings — machine-local.
 .claude/settings.local.json
 
+# Per-user Claude Code worktrees — machine-local, never tracked.
+.claude/worktrees/
+
 # pi-gen image builder — cloned by deploy/pi-gen/build.sh into the
 # deploy/pi-gen/ subtree, plus the per-build copies of files that
 # the stage pulls from the repo root at build time.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scrip
 
 Then open `http://<your-pi>:8080/setup` to run the first-time wizard.
 
-### Option C — build from source
+### Option C — Home Assistant OS add-on
+
+If you already run Home Assistant OS or HA Supervised, install
+forty-two-watts as an add-on directly from the supervisor — no
+separate Pi or Docker host needed. Maintained at
+[erikarenhill/ha-addon-forty-two-watts](https://github.com/erikarenhill/ha-addon-forty-two-watts).
+
+### Option D — build from source
 
 **Prerequisites:** Go 1.25+, a Raspberry Pi (or any `linux/arm64` machine), and at least one supported inverter/battery on your LAN.
 


### PR DESCRIPTION
## Summary

Adds the community-maintained Home Assistant OS add-on at [erikarenhill/ha-addon-forty-two-watts](https://github.com/erikarenhill/ha-addon-forty-two-watts) as a Quick Start option (slots in as Option C, "build from source" becomes Option D). HA OS / Supervised users can now install forty-two-watts directly from the supervisor without a separate Docker host.

## Test plan

- [ ] Render README on GitHub and confirm the new section + link work

🤖 Generated with [Claude Code](https://claude.com/claude-code)