### PR TITLE
fix(drivers): drop battery emits when battery_capacity_wh ≤ 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ dev-data/
 # Per-user Claude Code harness settings — machine-local.
 .claude/settings.local.json
 
+# Per-user Claude Code worktrees — machine-local, never tracked.
+.claude/worktrees/
+
 # pi-gen image builder — cloned by deploy/pi-gen/build.sh into the
 # deploy/pi-gen/ subtree, plus the per-build copies of files that
 # the stage pulls from the repo root at build time.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,7 +68,7 @@ drivers:
   - name: ferroamp                # unique key, used in API + HA topics
     lua: drivers/ferroamp.lua     # path to driver script
     is_site_meter: true           # exactly one driver must have this
-    battery_capacity_wh: 15200    # 0 if not a battery
+    battery_capacity_wh: 15200    # 0 (or unset) → driver's battery emits are dropped
     max_charge_w: 10000           # per-driver cap; 0/unset → 5 kW default
     max_discharge_w: 10000
     inverter_group: ferroamp      # optional — see "Inverter affinity" below

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -55,6 +55,16 @@ type HostEnv struct {
 	HTTP       bool       // false → http_* calls return ErrNoCapability
 	Start      time.Time  // monotonic start; host.millis() computed from here
 
+	// BatteryCapacityWh mirrors the operator's `battery_capacity_wh`
+	// declaration for this driver. Zero means "no physical battery
+	// wired here" — typical for a hybrid inverter used PV-only. When
+	// zero, emitTelemetry drops `host.emit("battery", …)` calls so
+	// phantom SoC readings never reach the telemetry store, the
+	// /api/status drivers map, or the frontend's Combined view (which
+	// would otherwise mean-average a real battery's 24 % SoC with the
+	// phantom 0 % from a no-battery hybrid, halving the displayed SoC).
+	BatteryCapacityWh float64
+
 	mu sync.Mutex
 	// Desired poll interval — driver can set via host.set_poll_interval OR
 	// return it from driver_poll. We persist the last hint here.
@@ -149,6 +159,20 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 	t, err := telemetry.ParseDerType(env.Type)
 	if err != nil {
 		return err
+	}
+	// Drop battery emits from drivers the operator declared as no-battery
+	// (battery_capacity_wh ≤ 0). Hybrid inverters used PV-only still expose
+	// battery registers in firmware, and the driver dutifully emits whatever
+	// it reads — but without a physical pack those readings are phantom
+	// (typically w=0, soc=0). Letting them through pollutes the telemetry
+	// store, /api/status drivers map, and the frontend's Combined view.
+	// Health success is still recorded — the driver IS alive, just emitting
+	// data the operator told us to ignore.
+	if t == telemetry.DerBattery && h.BatteryCapacityWh <= 0 {
+		if h.Telemetry != nil {
+			h.Telemetry.DriverHealthMut(h.DriverName).RecordSuccess()
+		}
+		return nil
 	}
 	if h.Telemetry != nil {
 		h.Telemetry.Update(h.DriverName, t, env.W, env.SoC, rawJSON)

--- a/go/internal/drivers/lua_test.go
+++ b/go/internal/drivers/lua_test.go
@@ -41,6 +41,7 @@ func TestLuaDriverLifecycle(t *testing.T) {
 	}
 	tel := telemetry.NewStore()
 	env := NewHostEnv("test", tel)
+	env.BatteryCapacityWh = 9600 // declared physical battery — emits flow through
 
 	d, err := NewLuaDriver(path, env)
 	if err != nil {
@@ -82,6 +83,97 @@ func TestLuaDriverLifecycle(t *testing.T) {
 	err = d.Command(context.Background(), []byte(`{"action":"set","w":-1500}`))
 	if err != nil {
 		t.Fatalf("command: %v", err)
+	}
+}
+
+// A hybrid inverter without a physical battery (operator-declared via
+// battery_capacity_wh = 0) still polls battery registers and emits via
+// host.emit("battery", …). The host must drop those emits so phantom
+// SoC readings never reach the telemetry store, the /api/status drivers
+// map, or the frontend's Combined view (which would otherwise mean-
+// average a real battery's SoC with the phantom 0 %).
+func TestEmitBatteryDroppedWhenCapacityZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lua")
+	src := `
+function driver_init(config) end
+function driver_poll()
+    host.emit("meter", { w = 1000 })
+    host.emit("battery", { w = 0, soc = 0.0 })
+    host.emit("pv", { w = -500 })
+    return 1000
+end
+`
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tel := telemetry.NewStore()
+	env := NewHostEnv("hybrid-no-batt", tel)
+	env.BatteryCapacityWh = 0
+
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if got := tel.Get("hybrid-no-batt", telemetry.DerBattery); got != nil {
+		t.Errorf("battery reading should be dropped for capacity-0 driver; got %+v", got)
+	}
+	if got := tel.Get("hybrid-no-batt", telemetry.DerMeter); got == nil || got.RawW != 1000 {
+		t.Errorf("meter still expected; got %+v", got)
+	}
+	if got := tel.Get("hybrid-no-batt", telemetry.DerPV); got == nil || got.RawW != -500 {
+		t.Errorf("pv still expected; got %+v", got)
+	}
+	// Driver is alive — health success must still be recorded so the
+	// watchdog doesn't flip it offline.
+	h := tel.DriverHealthMut("hybrid-no-batt")
+	if h == nil || h.TickCount == 0 {
+		t.Errorf("expected health tick recorded; got %+v", h)
+	}
+}
+
+func TestEmitBatteryPassesWhenCapacitySet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lua")
+	src := `
+function driver_init(config) end
+function driver_poll()
+    host.emit("battery", { w = -500, soc = 0.42 })
+    return 1000
+end
+`
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tel := telemetry.NewStore()
+	env := NewHostEnv("real-batt", tel)
+	env.BatteryCapacityWh = 9600
+
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	bat := tel.Get("real-batt", telemetry.DerBattery)
+	if bat == nil || bat.SoC == nil || *bat.SoC != 0.42 {
+		t.Errorf("battery reading should pass through; got %+v", bat)
 	}
 }
 

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -97,6 +97,7 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 
 	env := NewHostEnv(cfg.Name, r.tel)
+	env.BatteryCapacityWh = cfg.BatteryCapacityWh
 	if mq := cfg.EffectiveMQTT(); mq != nil && r.MQTTFactory != nil {
 		cap, err := r.MQTTFactory(cfg.Name, mq)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Hybrid inverters with `battery_capacity_wh: 0` (or unset) still poll battery registers and call `host.emit("battery", {w=0, soc=0.0})`. Those phantom readings flowed into `/api/status` per-driver `bat_w`/`bat_soc`, which the frontend's **Combined** view mean-averages — halving a real 24% SoC to 12%.
- Fix at the host emit boundary: `HostEnv.BatteryCapacityWh` mirrors the operator's config; `emitTelemetry` drops `type="battery"` emits when it's ≤ 0. Health-success is still recorded so the watchdog doesn't trip.
- Single chokepoint applies to all 14 battery-emitting Lua drivers without per-driver edits. `sameDriverConfig` already compares `BatteryCapacityWh`, so flipping the value in YAML cleanly hot-reloads.

## Test plan

- [x] `go test ./...` (incl. e2e) all green
- [x] New unit tests: emit dropped when capacity = 0; pass-through when capacity > 0; existing lifecycle test updated to declare capacity
- [ ] Smoke check live UI: with one driver `battery_capacity_wh: 0`, `/api/status drivers.<name>` has no `bat_w`/`bat_soc` and Combined SoC matches the real battery's SoC

🤖 Generated with [Claude Code](https://claude.com/claude-code)