### PR TITLE
feat(control): plan/exec sign-mismatch idle floor

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1817,3 +1817,181 @@ func TestJointFuseAllocatorWithBatteryCoversEV(t *testing.T) {
 			delta, st1.FuseEVMaxW, st2.FuseEVMaxW)
 	}
 }
+
+// Plan/exec sign-mismatch floor — operator-report 2026-04-28 (08:00–08:15
+// CEST): planner_arbitrage peak slot wanted -2400 W (discharge to export
+// at 334 öre), dispatch produced +1640 W (charged surplus). The floor's
+// job is to make that whole class of bug a no-op: when sign(plan_intent)
+// disagrees with sign(executed total), every battery target becomes 0.
+//
+// Direct exercise of applyPlanSignFloor — keeps the test focused on the
+// floor's contract and independent of which upstream path produced the
+// wrong-sign target.
+func TestPlanSignFloorClampsChargeWhenPlanSaysDischarge(t *testing.T) {
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	// Plan intent: discharge — BatteryEnergyWh < -idleWh (-50).
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{
+			SlotStart:       time.Now(),
+			SlotEnd:         time.Now().Add(15 * time.Minute),
+			BatteryEnergyWh: -600,
+		}, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: 1700}} // would-be charge
+	out := applyPlanSignFloor(in, st)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	if out[0].TargetW != 0 {
+		t.Errorf("TargetW = %f, want 0 (plan says discharge, exec said charge)", out[0].TargetW)
+	}
+	if !out[0].Clamped {
+		t.Error("expected Clamped=true so the dispatch trace shows the floor fired")
+	}
+}
+
+func TestPlanSignFloorClampsDischargeWhenPlanSaysCharge(t *testing.T) {
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{
+			SlotStart:       time.Now(),
+			SlotEnd:         time.Now().Add(15 * time.Minute),
+			BatteryEnergyWh: 1500, // charge intent
+		}, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: -2000}}
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != 0 || !out[0].Clamped {
+		t.Errorf("symmetric case: got TargetW=%f Clamped=%v, want 0/true",
+			out[0].TargetW, out[0].Clamped)
+	}
+}
+
+func TestPlanSignFloorPassesThroughWhenSignsAgree(t *testing.T) {
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{
+			SlotStart:       time.Now(),
+			SlotEnd:         time.Now().Add(15 * time.Minute),
+			BatteryEnergyWh: -600,
+		}, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: -1800}}
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != -1800 {
+		t.Errorf("matching signs: TargetW = %f, want unchanged -1800", out[0].TargetW)
+	}
+	if out[0].Clamped {
+		t.Error("Clamped should not be set when the floor was a no-op")
+	}
+}
+
+func TestPlanSignFloorIgnoresManualModes(t *testing.T) {
+	// Manual modes (self_consumption, peak_shaving, charge, etc.) have
+	// no plan to disagree with. The floor must be a no-op so the
+	// operator's manual selection executes as written.
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{BatteryEnergyWh: -600}, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: 1700}}
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != 1700 {
+		t.Errorf("manual mode: TargetW = %f, want unchanged 1700", out[0].TargetW)
+	}
+}
+
+func TestPlanSignFloorIdleBandIsNoOp(t *testing.T) {
+	// An executed total inside ±100 W is "idle, no opinion on sign" —
+	// don't trigger the floor on it.
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{BatteryEnergyWh: -600}, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: 50}} // tiny positive — within band
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != 50 {
+		t.Errorf("inside idle band: TargetW = %f, want unchanged 50", out[0].TargetW)
+	}
+}
+
+func TestPlanSignFloorReadsLegacyPlanTarget(t *testing.T) {
+	// When SlotDirective isn't wired (legacy path), intent comes from
+	// PlanTarget. mpc.actionToSlot encodes a planned discharge as
+	// ("self_consumption", negative_grid_w) — verify we follow that
+	// mapping.
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.PlanTarget = func(time.Time) (string, float64, bool) {
+		return "self_consumption", -4000, true
+	}
+	in := []DispatchTarget{{Driver: "pixii", TargetW: 1700}} // charge against discharge plan
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != 0 {
+		t.Errorf("legacy-path discharge intent: TargetW = %f, want 0", out[0].TargetW)
+	}
+}
+
+func TestPlanSignFloorNoOpWhenNoIntent(t *testing.T) {
+	// Neither callback wired, OR both return !ok → no plan to compare
+	// against; let the dispatch result through unchanged.
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	in := []DispatchTarget{{Driver: "pixii", TargetW: 1700}}
+	out := applyPlanSignFloor(in, st)
+	if out[0].TargetW != 1700 {
+		t.Errorf("no plan intent: TargetW = %f, want unchanged", out[0].TargetW)
+	}
+}
+
+// End-to-end through ComputeDispatch: simulate the 06:00-06:15 UTC bug
+// (planner_arbitrage discharge slot, but the dispatch math somehow
+// produces charge — e.g. because the energy-allocation path didn't
+// engage and the legacy path absorbed surplus). The floor must clamp.
+//
+// Constructed without UseEnergyDispatch so we land in the legacy PI
+// path — same path that was active during the live incident.
+func TestComputeDispatchAppliesSignFloorOnDischargeSlot(t *testing.T) {
+	now := time.Now()
+	store := seedStore(-1700, []struct {
+		name    string
+		currentW, soc float64
+	}{
+		{"pixii", 0, 0.15},
+	})
+	st := NewState(0, 0, "pixii")
+	st.Mode = ModePlannerArbitrage
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	// Legacy path: PlanTarget returns ("self_consumption", -4000, true).
+	// dispatch will set GridTargetW=-4000; but we OVERRIDE PlanTarget
+	// here to return grid_target=0 to model the bug behaviour where the
+	// negative grid target failed to plumb through (whatever the cause).
+	// The plan INTENT (discharge) still comes from SlotDirective.
+	st.PlanTarget = func(time.Time) (string, float64, bool) {
+		return "self_consumption", 0, true // bug: should have been negative
+	}
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		return SlotDirective{
+			SlotStart:       now,
+			SlotEnd:         now.Add(15 * time.Minute),
+			BatteryEnergyWh: -600, // peak-slot discharge intent
+		}, true
+	}
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"pixii": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	// Without the floor, PI on grid_target=0 with grid=-1700 would
+	// command +1700 W charge to absorb the export. With the floor,
+	// that charge command must be clamped to 0.
+	if targets[0].TargetW > 100 {
+		t.Errorf("TargetW = %f W — sign floor should have clamped charge to 0 on a discharge slot",
+			targets[0].TargetW)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -765,6 +765,31 @@ func ComputeDispatch(
 
 	// ---- Fuse guard (bidirectional, #145) ----
 	raw = applyFuseGuard(raw, store, state, fuseMaxW)
+
+	// ---- Plan/exec sign-mismatch floor (planner modes only) ----
+	// Operator-report 2026-04-28 (08:00–08:15 CEST): planner_arbitrage
+	// peak slot wanted battery_w = -2400 W (discharge to export at peak),
+	// dispatch produced +1640..+1860 W (charged from PV surplus). PV
+	// got swallowed by the battery instead of sold at 334 öre/kWh.
+	//
+	// Root cause was a code-path divergence elsewhere; this is the
+	// rail that makes that whole class of bug a no-op:
+	//
+	//   plan says discharge, exec produces charge → idle this tick
+	//   plan says charge,    exec produces discharge → idle this tick
+	//
+	// "Idle for this tick" is the right floor because:
+	//   - Discharging a charge slot would burn cycles against operator
+	//     intent. Idling and waiting for the next replan is harmless.
+	//   - Charging a discharge slot would buy energy at the exact slot
+	//     the planner intended to SELL it. Idling and letting PV export
+	//     naturally captures most of the lost revenue without any risk.
+	//
+	// Only applied in planner modes — manual modes have no plan to
+	// disagree with. forceFuseDischarge runs AFTER this so a fuse
+	// overflow can still drive discharge regardless of plan intent.
+	raw = applyPlanSignFloor(raw, state)
+
 	// forceFuseDischarge runs LAST, deliberately AFTER the slew loop
 	// at line 625. A fuse overflow can demand a battery target that's
 	// far beyond what slew would normally allow in a single 5 s tick
@@ -1172,6 +1197,93 @@ func perPhaseImportOverageW(store *telemetry.Store, state *State) float64 {
 		v = 230 // sensible default; main wires the actual config voltage
 	}
 	return (maxA - state.SiteFuseAmps) * v
+}
+
+// applyPlanSignFloor enforces "executed battery total must agree in sign
+// with the plan's intent for this slot" — the safety rail described at
+// the call-site comment. Only active in planner modes. When the sum of
+// post-distribute, post-clamp targets has the opposite sign to the
+// active slot's plan intent, every target is forced to zero (idle).
+//
+// Sources of plan intent (first-non-empty wins):
+//   - state.SlotDirective(now).BatteryEnergyWh — energy-allocation path
+//   - state.PlanTarget(now) "charge" mode → charge intent
+//   - state.PlanTarget(now) "self_consumption" with negative gridW →
+//     discharge-to-export intent (matches mpc.actionToSlot's mapping)
+//
+// If no source is available (no planner callbacks wired, or both
+// returned !ok) the floor is a no-op — there's no intent to compare
+// against. Threshold of 100 W matches mpc.IdleGateThresholdW so a
+// near-zero plan target counts as "idle, no opinion on sign".
+func applyPlanSignFloor(targets []DispatchTarget, state *State) []DispatchTarget {
+	if len(targets) == 0 || state == nil || !state.Mode.IsPlannerMode() {
+		return targets
+	}
+	intent := planSignIntent(state)
+	if intent == 0 {
+		return targets
+	}
+	var sumTarget float64
+	for _, t := range targets {
+		sumTarget += t.TargetW
+	}
+	const idleBand = 100.0
+	if math.Abs(sumTarget) < idleBand {
+		return targets
+	}
+	execSign := 0
+	if sumTarget > idleBand {
+		execSign = 1
+	} else if sumTarget < -idleBand {
+		execSign = -1
+	}
+	if execSign == 0 || execSign == intent {
+		return targets
+	}
+	slog.Warn("plan/exec sign mismatch — clamping to idle for this tick",
+		"plan_intent", intent, "exec_sum_w", sumTarget, "mode", string(state.Mode))
+	out := make([]DispatchTarget, len(targets))
+	for i, t := range targets {
+		out[i] = DispatchTarget{Driver: t.Driver, TargetW: 0, Clamped: true}
+	}
+	return out
+}
+
+// planSignIntent returns +1 for charge, -1 for discharge, 0 for idle /
+// unknown. Reads SlotDirective first (energy path), falls back to
+// PlanTarget (legacy path). Centralises the multi-source lookup so the
+// floor and any future intent-aware code stay aligned.
+func planSignIntent(state *State) int {
+	const idleWh = 50.0     // a near-zero per-slot energy is idle, not signed
+	const idleGridW = 100.0 // matches mpc.IdleGateThresholdW for sign decisions
+	if state.SlotDirective != nil {
+		if dir, ok := state.SlotDirective(time.Now()); ok {
+			if dir.BatteryEnergyWh > idleWh {
+				return +1
+			}
+			if dir.BatteryEnergyWh < -idleWh {
+				return -1
+			}
+			return 0
+		}
+	}
+	if state.PlanTarget != nil {
+		if modeStr, gridW, ok := state.PlanTarget(time.Now()); ok {
+			switch Mode(modeStr) {
+			case ModeCharge:
+				return +1
+			case ModeSelfConsumption:
+				// mpc.actionToSlot encodes a planned discharge-to-export
+				// as ("self_consumption", negative_grid_w). Mirror that
+				// mapping here: negative grid target = discharge intent.
+				if gridW < -idleGridW {
+					return -1
+				}
+				return 0
+			}
+		}
+	}
+	return 0
 }
 
 // fuseSaverFromZero is the early-return entry point for the fuse-saver.


### PR DESCRIPTION
## Summary

Stacked on #213. Installs the safety rail discussed after today's 08:00–08:15 CEST incident — when sign(plan_intent) disagrees with sign(executed total) under a planner mode, every battery target is forced to idle for that tick.

## What happened (the trigger)

Planner_arbitrage peak slot wanted \`battery_w = -2400 W\` (discharge to export at 334 öre/kWh peak). Dispatch produced \`+1640..+1860 W\` charge instead, swallowing 1.7 kW of PV surplus that should have been sold. Root cause was upstream — the negative grid target from \`mpc.actionToSlot\` didn't reach the PI setpoint — but the operator-facing damage is the same regardless of which path produced the wrong sign.

## What this changes

- New \`applyPlanSignFloor\` runs between \`applyFuseGuard\` and \`forceFuseDischarge\` (so the fuse-saver still overrides it — fuse is non-negotiable).
- Plan intent sourced from \`SlotDirective.BatteryEnergyWh\` (energy path) or \`PlanTarget\` mode/grid (legacy path). Mirrors \`mpc.actionToSlot\`'s mapping of "self_consumption + negative grid_w = planned discharge-to-export".
- Manual modes (self_consumption, peak_shaving, charge, priority, weighted) are bypassed — they have no plan to disagree with.
- Idle band of 100 W matches \`mpc.IdleGateThresholdW\` so near-zero plans or executions count as "no signed opinion" and skip the floor.

## Why idle (not "follow the plan harder")

- Discharging a charge slot would burn cycles against operator intent. Idling and waiting for the next replan is harmless.
- Charging a discharge slot would buy energy at the exact slot the planner intended to SELL it. Idling and letting PV export naturally captures most of the lost revenue without any risk.

## Test plan

- [x] 8 new tests pass: charge-on-discharge clamp, discharge-on-charge clamp, signs-agree pass-through, manual-mode no-op, idle-band no-op, legacy-path intent reading, no-intent no-op, full ComputeDispatch e2e replicating today's incident.
- [x] Full Go suite + e2e green (29.8 s).
- [ ] Deploy to pi@192.168.1.139 and watch logs for "plan/exec sign mismatch — clamping to idle for this tick" warnings during the next discharge-at-peak slot.

## Follow-up (out of scope)

PR #2 from the discussion: replace the legacy PI's blind \`grid=plan_target\` chase with directional self_consumption (discharge slot allows only \`[-maxDischarge, 0]\`, charge slot allows only \`[0, +maxCharge]\`). That's the proper fix for the underlying execution model; this PR is the rail underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)