### PR TITLE
fix(tesla-ble,mpc,api): post-#211 review fixes — fuse cap republish, vehicle SoC sanity, tesla-verify hardening

### DIFF
--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -173,21 +173,28 @@ function driver_poll()
   --
   -- BUT once every WAKEUP_INTERVAL_MS (30 min) we DO request a
   -- wakeup so cached data can't drift forever while the car sleeps.
-  -- last_wakeup_ms == 0 is the "never woken since process start" sentinel
-  -- so the FIRST poll after startup always forces a wakeup. The car may
-  -- have been asleep for hours while forty-two-watts was down — we want
-  -- ground-truth SoC on the dashboard immediately, not the proxy's stale
-  -- cache from the previous run. After this initial wake, the 30-min
-  -- cadence takes over.
+  -- The cadence is anchored to driver-process uptime, so the FIRST
+  -- poll after startup intentionally does NOT force a wakeup. Reason:
+  -- a crash-loop (the host wedges, restarts every few seconds) would
+  -- otherwise hammer Tesla's BLE radio at multiple wakeups per minute,
+  -- draining the 12 V battery and likely hitting Tesla's "Command
+  -- Disallowed" rate limit. The tradeoff is that immediately after a
+  -- restart the dashboard may show up to 30 min of stale SoC; the
+  -- operator can press "Verify connection" in settings to force a
+  -- one-shot wake, or wait for the next scheduled 30-min wake.
   local now = host.millis()
-  local do_wakeup = (last_wakeup_ms == 0) or ((now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS)
+  local do_wakeup = (last_wakeup_ms > 0) and ((now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS)
+  if last_wakeup_ms == 0 then
+    -- Anchor the cadence at "now" so the first FORCED wake fires
+    -- exactly WAKEUP_INTERVAL_MS after startup, not on first poll.
+    last_wakeup_ms = now
+  end
   local url = base_url .. "/api/1/vehicles/" .. vin ..
               "/vehicle_data?endpoints=charge_state"
   if do_wakeup then
     url = url .. "&wakeup=true"
-    local reason = (last_wakeup_ms == 0) and "startup" or "30-min cadence"
     last_wakeup_ms = now
-    host.log("info", "tesla: forcing BLE wakeup on this poll (" .. reason .. ")")
+    host.log("info", "tesla: forcing BLE wakeup on this poll (30-min cadence)")
   end
   -- host.http_get returns (body_string, nil) or (nil, error_string) —
   -- first return is the body directly, NOT a table with .body. The
@@ -314,5 +321,16 @@ function driver_default_mode()
 end
 
 function driver_cleanup()
-  last.soc = nil
+  -- Reset every persistent piece of state so a hot-reload looks
+  -- identical to a fresh process start (the `last_wakeup_ms` reset
+  -- in particular re-anchors the 30-min cadence so we don't fire a
+  -- wakeup the moment the reloaded driver runs its first poll).
+  last.soc                    = nil
+  last.charge_limit           = nil
+  last.charging_state         = nil
+  last.time_to_full           = nil
+  last.charge_amps            = nil
+  last.charger_actual_current = nil
+  last.ts_ms                  = 0
+  last_wakeup_ms              = 0
 end

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -579,47 +579,18 @@ func main() {
 				// car); when a vehicle driver such as TeslaBLEProxy is
 				// online, its SoC reading is ground truth.
 				//
-				// Multi-vehicle case: one charger may be paired with N
-				// vehicle drivers (a household with 2 Teslas sharing one
-				// wallbox). Pick the one most likely to be the car
-				// physically connected right now: rank by charging_state
-				// (Charging > NoPower/Starting > Stopped/Complete >
-				// Disconnected/unknown), tiebreak by freshness. Falls
-				// back to inferred SoC when nothing online matches.
+				// Picker (rank + freshness + bounds) lives in
+				// telemetry.PickBestVehicle so api.go's loadpoint
+				// decoration agrees with us on which vehicle is "the
+				// one". Falls back to inferred SoC when nothing usable
+				// online matches.
 				initSoC := st.CurrentSoCPct
 				socSource := "inferred"
 				var vehicleChargeLimit float64 // 0 = unknown
-				var bestRank = -1
-				var bestUpdated time.Time
-				for _, vr := range tel.ReadingsByType(telemetry.DerVehicle) {
-					if vr.SoC == nil {
-						continue
-					}
-					if h := tel.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
-						continue
-					}
-					var meta struct {
-						ChargingState  string  `json:"charging_state"`
-						ChargeLimitPct float64 `json:"charge_limit_pct"`
-					}
-					if len(vr.Data) > 0 {
-						_ = json.Unmarshal(vr.Data, &meta)
-					}
-					rank := vehicleConnectedRank(meta.ChargingState)
-					if rank < 0 {
-						continue // explicitly disconnected — not this car
-					}
-					if rank < bestRank {
-						continue
-					}
-					if rank == bestRank && !vr.UpdatedAt.After(bestUpdated) {
-						continue
-					}
-					bestRank = rank
-					bestUpdated = vr.UpdatedAt
-					initSoC = *vr.SoC
-					socSource = "vehicle:" + vr.Driver
-					vehicleChargeLimit = meta.ChargeLimitPct
+				if pick := telemetry.PickBestVehicle(tel, time.Now()); pick.Driver != "" {
+					initSoC = pick.SoCPct
+					socSource = "vehicle:" + pick.Driver
+					vehicleChargeLimit = pick.ChargeLimitPct
 				}
 				// Map target time → slot index using the DP's
 				// actual slot length (hour-of-prices vs. 15-min
@@ -755,9 +726,18 @@ func main() {
 		// Startup replan: the scheduled tick is up to mpcSvc.Interval
 		// (15 min) away. Don't make the operator wait — fire one
 		// immediately so /api/mpc/plan is populated as soon as
-		// telemetry, prices, and forecasts have settled.
+		// telemetry, prices, and forecasts have settled. Observe ctx
+		// during the warm-up sleep so SIGTERM during startup doesn't
+		// keep this goroutine alive past shutdown.
 		go func() {
-			time.Sleep(2 * time.Second) // give drivers a moment to seed SoC
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second): // give drivers a moment to seed SoC
+			}
+			if ctx.Err() != nil {
+				return
+			}
 			_ = mpcSvc.Replan(ctx)
 			slog.Info("mpc: startup replan completed")
 		}()
@@ -1729,26 +1709,6 @@ func isConfigMissing(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "no such file")
-}
-
-// vehicleConnectedRank scores how likely a DerVehicle driver is to be the
-// one physically plugged into the loadpoint right now, based on Tesla
-// Owner-API charging_state semantics (other vendors use the same
-// vocabulary). Higher rank = more likely connected. Negative = explicitly
-// not connected; caller should skip.
-func vehicleConnectedRank(chargingState string) int {
-	switch chargingState {
-	case "Charging", "Starting":
-		return 3 // actively pulling power — definitely this car
-	case "NoPower":
-		return 2 // plugged but wallbox not delivering yet
-	case "Stopped", "Complete":
-		return 1 // plugged + idle (charge limit reached, paused, etc.)
-	case "Disconnected":
-		return -1 // explicitly unplugged — never pick this one
-	default:
-		return 0 // unknown/missing — usable but de-prioritised
-	}
 }
 
 func recordHistory(st *state.Store, tel *telemetry.Store, ctrl *control.State, nowMs int64) {

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1809,12 +1809,19 @@ func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
 
 // decorateLoadpointsWithVehicle overlays the best-matching DerVehicle
 // reading onto each plugged-in loadpoint state. Mutates the input
-// slice in place. The "best" reading is the one most likely to be the
-// car physically connected: rank by charging_state, tiebreak by
-// freshness; an explicit "Disconnected" is skipped entirely.
+// slice in place. Picker (rank + freshness + bounds) lives in
+// telemetry.PickBestVehicle so main.go's MPC plumbing and this
+// presentation path agree on which vehicle is "the one".
+//
+// CurrentSoCPct is intentionally NOT overwritten with the BMS reading.
+// The loadpoint controller uses CurrentSoCPct as its inference state;
+// overlaying it from the BMS would mean the UI shows BMS truth while
+// the controller's plan was computed from the inferred value the
+// previous tick — a presentation lie. VehicleSoCPct exposes the BMS
+// value separately; the frontend renders both and labels which one
+// the controller used.
 func decorateLoadpointsWithVehicle(states []loadpoint.State, tel *telemetry.Store) {
-	readings := tel.ReadingsByType(telemetry.DerVehicle)
-	if len(readings) == 0 {
+	if len(tel.ReadingsByType(telemetry.DerVehicle)) == 0 {
 		// No vehicle drivers — mark every plugged-in lp as inferred.
 		for i := range states {
 			if states[i].PluggedIn {
@@ -1823,76 +1830,20 @@ func decorateLoadpointsWithVehicle(states []loadpoint.State, tel *telemetry.Stor
 		}
 		return
 	}
-	// Pick the single best vehicle reading across all DerVehicle drivers.
-	// Multi-vehicle ranking lives close to where it matters: this is the
-	// only place that needs to interpret charging_state today.
-	type vehicleData struct {
-		ChargingState  string  `json:"charging_state"`
-		ChargeLimitPct float64 `json:"charge_limit_pct"`
-		Stale          bool    `json:"stale"`
-	}
-	rankFn := func(s string) int {
-		switch s {
-		case "Charging", "Starting":
-			return 3
-		case "NoPower":
-			return 2
-		case "Stopped", "Complete":
-			return 1
-		case "Disconnected":
-			return -1
-		default:
-			return 0
-		}
-	}
-	var bestRank = -1
-	var bestUpdated time.Time
-	var bestSoC, bestLimit float64
-	var bestState, bestDriver string
-	var bestStale bool
-	for _, vr := range readings {
-		if vr.SoC == nil {
-			continue
-		}
-		if h := tel.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
-			continue
-		}
-		var meta vehicleData
-		if len(vr.Data) > 0 {
-			_ = json.Unmarshal(vr.Data, &meta)
-		}
-		rank := rankFn(meta.ChargingState)
-		if rank < 0 {
-			continue
-		}
-		if rank < bestRank || (rank == bestRank && !vr.UpdatedAt.After(bestUpdated)) {
-			continue
-		}
-		bestRank = rank
-		bestUpdated = vr.UpdatedAt
-		bestSoC = *vr.SoC
-		bestLimit = meta.ChargeLimitPct
-		bestState = meta.ChargingState
-		bestStale = meta.Stale
-		bestDriver = vr.Driver
-	}
+	pick := telemetry.PickBestVehicle(tel, time.Now())
 	for i := range states {
 		if !states[i].PluggedIn {
 			continue
 		}
-		if bestDriver == "" {
+		if pick.Driver == "" {
 			states[i].SoCSource = "inferred"
 			continue
 		}
-		states[i].VehicleDriver = bestDriver
-		states[i].VehicleSoCPct = bestSoC
-		states[i].VehicleChargeLimitPct = bestLimit
-		states[i].VehicleChargingState = bestState
-		states[i].VehicleStale = bestStale
-		// Override CurrentSoCPct with measured value. The loadpoint
-		// manager's inferred value is preserved internally — this is
-		// purely a presentation overlay so the dashboard shows truth.
-		states[i].CurrentSoCPct = bestSoC
+		states[i].VehicleDriver = pick.Driver
+		states[i].VehicleSoCPct = pick.SoCPct
+		states[i].VehicleChargeLimitPct = pick.ChargeLimitPct
+		states[i].VehicleChargingState = pick.ChargingState
+		states[i].VehicleStale = pick.Stale
 		states[i].SoCSource = "vehicle"
 	}
 }

--- a/go/internal/api/api_tesla_verify.go
+++ b/go/internal/api/api_tesla_verify.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -61,6 +63,62 @@ var errRedirectsForbidden = errors.New("redirects disabled")
 // vehicle_data responses are typically 5-15 KB; 1 MB is pessimistic
 // headroom. Prevents a malicious proxy from stalling the handler.
 const maxVerifyBody = 1 << 20
+
+// verifyMinInterval is the minimum gap between consecutive
+// /api/drivers/verify_tesla calls for the SAME vin. Anything closer
+// gets a 429. The aim is to make this endpoint useless as a "keep my
+// car awake" pump for a same-origin XSS or a tab the operator left
+// open: each call costs the vehicle's 12 V battery a measurable amount
+// of energy when wakeup=true is attached.
+const verifyMinInterval = 30 * time.Second
+
+// verifyWakeupCooldown gates the `wakeup=true` query parameter. The
+// first call (or one issued ≥ this far after the previous) wakes the
+// car over BLE; calls inside the window omit wakeup=true and the
+// proxy serves cached data. The user-facing flow ("press Verify")
+// works either way — the proxy cache is fresh enough to confirm
+// reachability + correct VIN — but the BLE radio doesn't get hammered.
+const verifyWakeupCooldown = 5 * time.Minute
+
+// verifyTracker is a small per-vin rate-limit + last-wakeup tracker.
+// Persists for the process lifetime; resets on restart, which is fine
+// because operators can always wait 30 s if they really need to retry.
+var verifyTracker = struct {
+	mu          sync.Mutex
+	lastCall    map[string]time.Time
+	lastWakeup  map[string]time.Time
+}{
+	lastCall:   map[string]time.Time{},
+	lastWakeup: map[string]time.Time{},
+}
+
+// shouldWakeup returns true if this verify call should attach
+// wakeup=true. Updates lastWakeup as a side effect when it returns
+// true. Holds the tracker lock briefly.
+func shouldWakeup(vin string, now time.Time) bool {
+	verifyTracker.mu.Lock()
+	defer verifyTracker.mu.Unlock()
+	prev, ok := verifyTracker.lastWakeup[vin]
+	if !ok || now.Sub(prev) >= verifyWakeupCooldown {
+		verifyTracker.lastWakeup[vin] = now
+		return true
+	}
+	return false
+}
+
+// rateLimitVerify returns a non-nil time.Duration when the call is too
+// soon and should be rejected; the duration is how long the caller
+// must wait. Updates lastCall on success.
+func rateLimitVerify(vin string, now time.Time) (time.Duration, bool) {
+	verifyTracker.mu.Lock()
+	defer verifyTracker.mu.Unlock()
+	prev, ok := verifyTracker.lastCall[vin]
+	if ok && now.Sub(prev) < verifyMinInterval {
+		return verifyMinInterval - now.Sub(prev), false
+	}
+	verifyTracker.lastCall[vin] = now
+	return 0, true
+}
 
 // validateProxyIP accepts "host" or "host:port" where host is an IPv4
 // literal in RFC1918 space. Hostnames are rejected — we want no DNS
@@ -137,14 +195,27 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url := fmt.Sprintf("http://%s:%d/api/1/vehicles/%s/vehicle_data?endpoints=charge_state&wakeup=true",
+	now := time.Now()
+	if wait, ok := rateLimitVerify(vin, now); !ok {
+		writeJSON(w, 429, verifyTeslaResponse{
+			Error: fmt.Sprintf("too many verify attempts — wait %d s before retrying",
+				int(wait.Seconds())+1),
+		})
+		return
+	}
+
+	wakeup := shouldWakeup(vin, now)
+	urlStr := fmt.Sprintf("http://%s:%d/api/1/vehicles/%s/vehicle_data?endpoints=charge_state",
 		host, port, vin)
+	if wakeup {
+		urlStr += "&wakeup=true"
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
-		writeJSON(w, 500, verifyTeslaResponse{Error: "build request: " + err.Error(), URL: url})
+		writeJSON(w, 500, verifyTeslaResponse{Error: "build request: " + err.Error(), URL: urlStr})
 		return
 	}
 	httpReq.Header.Set("Accept", "application/json")
@@ -160,7 +231,21 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		writeJSON(w, 200, verifyTeslaResponse{Error: "request failed: " + err.Error(), URL: url})
+		// CheckRedirect rejection wraps errRedirectsForbidden in a
+		// *url.Error whose .Err carries the upstream Location header —
+		// reflecting that back to the caller would leak the redirect
+		// target. Detect the wrapped sentinel and replace with a fixed
+		// message. All other transport errors (timeout, conn refused,
+		// TLS) are safe to surface verbatim — they don't carry
+		// upstream-controlled content.
+		if isRedirectError(err) {
+			writeJSON(w, 200, verifyTeslaResponse{
+				Error: "proxy attempted a redirect (refused) — TeslaBLEProxy should respond directly",
+				URL:   urlStr,
+			})
+			return
+		}
+		writeJSON(w, 200, verifyTeslaResponse{Error: "request failed: " + err.Error(), URL: urlStr})
 		return
 	}
 	defer resp.Body.Close()
@@ -168,7 +253,7 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode == http.StatusRequestTimeout { // 408: car asleep
 		writeJSON(w, 200, verifyTeslaResponse{
 			Error:  "vehicle asleep (408) — the proxy reached your car but it did not wake in time. Try again in a few seconds.",
-			URL:    url,
+			URL:    urlStr,
 			Status: resp.StatusCode,
 		})
 		return
@@ -179,7 +264,7 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 		// metadata-service tokens on a successful SSRF hop. Fixed message.
 		writeJSON(w, 200, verifyTeslaResponse{
 			Error:  fmt.Sprintf("HTTP %d from proxy", resp.StatusCode),
-			URL:    url,
+			URL:    urlStr,
 			Status: resp.StatusCode,
 		})
 		return
@@ -212,7 +297,7 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxVerifyBody)).Decode(&parsed); err != nil {
 		writeJSON(w, 200, verifyTeslaResponse{
-			Error: "decode failed (upstream response not recognizable JSON)", URL: url, Status: resp.StatusCode,
+			Error: "decode failed (upstream response not recognizable JSON)", URL: urlStr, Status: resp.StatusCode,
 		})
 		return
 	}
@@ -226,13 +311,13 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 	if cs.BatteryLevel == 0 && cs.ChargeLimitSoC == 0 && cs.ChargingState == "" {
 		writeJSON(w, 200, verifyTeslaResponse{
 			Error: "proxy returned 200 but no charge_state fields — VIN may not be paired",
-			URL:   url, Status: resp.StatusCode,
+			URL:   urlStr, Status: resp.StatusCode,
 		})
 		return
 	}
 	writeJSON(w, 200, verifyTeslaResponse{
 		OK:             true,
-		URL:            url,
+		URL:            urlStr,
 		Status:         resp.StatusCode,
 		SoCPct:         cs.BatteryLevel,
 		ChargeLimitPct: cs.ChargeLimitSoC,
@@ -241,27 +326,52 @@ func (s *Server) handleVerifyTesla(w http.ResponseWriter, r *http.Request) {
 }
 
 // splitHostPort parses "host" or "host:port" and returns the port
-// defaulting to `def` when absent. Copes with IPv4 and bracketed
-// IPv6 (though brackets aren't expected in the typical config).
+// defaulting to `def` when no port is present. Uses net.SplitHostPort
+// so bracketed IPv6 + edge cases behave like the rest of the stdlib.
+// An explicit ":0", non-numeric, or out-of-range port falls back to
+// def — there's no use case for port 0 in this endpoint and the
+// operator probably meant the default.
 func splitHostPort(s string, def int) (string, int) {
-	// Only split on the LAST colon that's followed by digits — avoids
-	// eating a port out of an IPv6 without brackets. Good enough for
-	// the LAN-only case this endpoint serves.
-	i := strings.LastIndex(s, ":")
-	if i < 0 {
+	if !strings.Contains(s, ":") {
 		return s, def
 	}
-	host := s[:i]
-	portStr := s[i+1:]
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		return s, def
+	}
+	if portStr == "" {
+		return host, def
+	}
 	var port int
 	for _, r := range portStr {
 		if r < '0' || r > '9' {
-			return s, def
+			return host, def
 		}
 		port = port*10 + int(r-'0')
+		if port > 65535 {
+			return host, def
+		}
 	}
 	if port == 0 {
-		return s, def
+		return host, def
 	}
 	return host, port
+}
+
+// isRedirectError reports whether the error returned by http.Client.Do
+// originated from our CheckRedirect rejection (vs a transport-level
+// failure). The stdlib wraps the rejection in *url.Error whose Unwrap
+// returns errRedirectsForbidden.
+func isRedirectError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errRedirectsForbidden) {
+		return true
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return errors.Is(ue.Err, errRedirectsForbidden)
+	}
+	return false
 }

--- a/go/internal/api/api_tesla_verify_test.go
+++ b/go/internal/api/api_tesla_verify_test.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// SSRF + input-validation regression tests for /api/drivers/verify_tesla.
+// These lock in the security boundary the endpoint exists to enforce —
+// remove a guard, the matching test fails. PR #184 review S1 is the
+// origin of every constraint asserted here.
+
+// resetVerifyTracker wipes the per-process rate-limit/wakeup state so
+// each test starts clean. The tracker is a package var; concurrent
+// tests must not run in parallel against it.
+func resetVerifyTracker() {
+	verifyTracker.mu.Lock()
+	verifyTracker.lastCall = map[string]time.Time{}
+	verifyTracker.lastWakeup = map[string]time.Time{}
+	verifyTracker.mu.Unlock()
+}
+
+func TestValidateProxyIPRejectsPublicAndSpecial(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expErr string
+	}{
+		{"public dns ipv4", "8.8.8.8", "public IP not permitted"},
+		{"loopback v4", "127.0.0.1", "loopback"},
+		{"link-local v4", "169.254.10.10", "link-local"},
+		{"ipv6", "::1", "IPv6 not supported"},
+		{"hostname rejected", "tesla.local", "invalid IP literal"},
+		{"port not allowed", "192.168.1.50:22", "port 22 not permitted"},
+		{"port 6379", "192.168.1.50:6379", "port 6379 not permitted"},
+		{"empty", "", "invalid IP literal"},
+		{"path-smuggle", "192.168.1.50/admin", "invalid IP literal"},
+		// Carrier-grade NAT (100.64/10) is intentionally NOT in the
+		// RFC1918 set — should be rejected as public.
+		{"cgn 100.64", "100.64.1.1", "public IP not permitted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := validateProxyIP(tc.input)
+			if err == nil {
+				t.Fatalf("validateProxyIP(%q) accepted, expected error containing %q",
+					tc.input, tc.expErr)
+			}
+			if !strings.Contains(err.Error(), tc.expErr) {
+				t.Errorf("validateProxyIP(%q) err = %v, want substring %q",
+					tc.input, err, tc.expErr)
+			}
+		})
+	}
+}
+
+func TestValidateProxyIPAcceptsRFC1918(t *testing.T) {
+	cases := []struct {
+		input    string
+		wantHost string
+		wantPort int
+	}{
+		{"10.0.0.1", "10.0.0.1", 8080},
+		{"172.16.0.1", "172.16.0.1", 8080},
+		{"172.31.255.255", "172.31.255.255", 8080},
+		{"192.168.1.50", "192.168.1.50", 8080},
+		{"192.168.1.50:80", "192.168.1.50", 80},
+		{"192.168.1.50:443", "192.168.1.50", 443},
+		{"192.168.1.50:8080", "192.168.1.50", 8080},
+	}
+	for _, tc := range cases {
+		host, port, err := validateProxyIP(tc.input)
+		if err != nil {
+			t.Errorf("validateProxyIP(%q) err = %v, want ok", tc.input, err)
+			continue
+		}
+		if host != tc.wantHost || port != tc.wantPort {
+			t.Errorf("validateProxyIP(%q) = (%s,%d), want (%s,%d)",
+				tc.input, host, port, tc.wantHost, tc.wantPort)
+		}
+	}
+}
+
+func TestSplitHostPortDefaultsAndEdges(t *testing.T) {
+	cases := []struct {
+		in       string
+		def      int
+		wantHost string
+		wantPort int
+	}{
+		{"192.168.1.50", 8080, "192.168.1.50", 8080},
+		{"192.168.1.50:1234", 8080, "192.168.1.50", 1234},
+		// :0 must NOT silently become the default — operator probably
+		// meant something specific; we treat zero as no port and fall
+		// back, but document the behaviour explicitly via this test.
+		{"192.168.1.50:0", 8080, "192.168.1.50", 8080},
+		// Port overflow + non-numeric → fall back rather than panic.
+		{"192.168.1.50:99999", 8080, "192.168.1.50", 8080},
+		{"192.168.1.50:abc", 8080, "192.168.1.50", 8080},
+		// Empty port after colon.
+		{"192.168.1.50:", 8080, "192.168.1.50", 8080},
+	}
+	for _, tc := range cases {
+		host, port := splitHostPort(tc.in, tc.def)
+		if host != tc.wantHost || port != tc.wantPort {
+			t.Errorf("splitHostPort(%q,%d) = (%s,%d), want (%s,%d)",
+				tc.in, tc.def, host, port, tc.wantHost, tc.wantPort)
+		}
+	}
+}
+
+func TestValidVINRegex(t *testing.T) {
+	good := []string{
+		"5YJ3E1EA1KF000000",
+		"7SAYGDEE9PA000000",
+		"ABCDEFGHJKLMNPRST", // exactly 17, no I/O/Q
+	}
+	bad := []string{
+		"",                      // empty
+		"5YJ3E1EA1KF00000",      // 16 chars
+		"5YJ3E1EA1KF0000000",    // 18 chars
+		"5YJ3E1EA1KF00000I",     // contains I
+		"5YJ3E1EA1KF00000O",     // contains O
+		"5YJ3E1EA1KF00000Q",     // contains Q
+		"5YJ3E1EA1KF00000/",     // contains slash (path-smuggle attempt)
+		"5YJ3E1EA1KF00000?",     // contains ? (query smuggle)
+		"5yj3e1ea1kf000000",     // lowercase (handler upper-cases first)
+		"5YJ3E1EA1KF00 0000",    // contains space
+	}
+	for _, v := range good {
+		if !validVINRe.MatchString(v) {
+			t.Errorf("validVINRe rejected good VIN %q", v)
+		}
+	}
+	for _, v := range bad {
+		if validVINRe.MatchString(v) {
+			t.Errorf("validVINRe accepted bad VIN %q", v)
+		}
+	}
+}
+
+func TestVerifyTeslaRejectsBadInput(t *testing.T) {
+	resetVerifyTracker()
+	srv := New(&Deps{})
+	cases := []struct {
+		name     string
+		body     string
+		wantCode int
+		wantErr  string
+	}{
+		{"empty body", `{}`, 400, "required"},
+		{"no vin", `{"ip":"192.168.1.50"}`, 400, "required"},
+		{"no ip", `{"vin":"5YJ3E1EA1KF000000"}`, 400, "required"},
+		{"bad vin", `{"ip":"192.168.1.50","vin":"BADVIN"}`, 400, "invalid VIN"},
+		{"public ip", `{"ip":"8.8.8.8","vin":"5YJ3E1EA1KF000000"}`, 400, "public IP"},
+		{"loopback", `{"ip":"127.0.0.1","vin":"5YJ3E1EA1KF000000"}`, 400, "loopback"},
+		{"port 22", `{"ip":"192.168.1.50:22","vin":"5YJ3E1EA1KF000000"}`, 400, "port 22"},
+		{"hostname", `{"ip":"tesla.local","vin":"5YJ3E1EA1KF000000"}`, 400, "invalid IP"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/drivers/verify_tesla",
+				strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+			if rr.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d (body=%s)", rr.Code, tc.wantCode, rr.Body.String())
+			}
+			var resp verifyTeslaResponse
+			_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+			if !strings.Contains(resp.Error, tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", resp.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Tested at the helper level rather than through the full HTTP path —
+// the handler issues a network call against an unreachable RFC1918 IP
+// which would block the test for the full 30 s timeout. The rate-limit
+// gate runs BEFORE the network call, so verifying it via the helper
+// directly catches the same regression without the wait.
+func TestRateLimitVerifyHelper(t *testing.T) {
+	resetVerifyTracker()
+	now := time.Now()
+	if _, ok := rateLimitVerify("VIN_RL", now); !ok {
+		t.Fatal("first call should pass the rate limiter")
+	}
+	if wait, ok := rateLimitVerify("VIN_RL", now.Add(1*time.Second)); ok {
+		t.Errorf("second call within window should be rate-limited (wait=%v)", wait)
+	}
+	if _, ok := rateLimitVerify("VIN_RL", now.Add(verifyMinInterval+time.Second)); !ok {
+		t.Errorf("call past window should pass")
+	}
+	if _, ok := rateLimitVerify("VIN_OTHER", now.Add(1*time.Second)); !ok {
+		t.Errorf("different VIN should pass independently")
+	}
+}
+
+func TestVerifyTeslaWakeupCooldown(t *testing.T) {
+	resetVerifyTracker()
+	now := time.Now()
+	// First call wakes.
+	if !shouldWakeup("VIN_A", now) {
+		t.Error("first wakeup should be granted")
+	}
+	// Immediately retry → no wakeup.
+	if shouldWakeup("VIN_A", now.Add(1*time.Second)) {
+		t.Error("second wakeup within cooldown should be denied")
+	}
+	// Past the cooldown → wakeup again.
+	if !shouldWakeup("VIN_A", now.Add(verifyWakeupCooldown+time.Second)) {
+		t.Error("wakeup after cooldown should be granted")
+	}
+	// Different VIN tracked independently.
+	if !shouldWakeup("VIN_B", now.Add(1*time.Second)) {
+		t.Error("different VIN should track independently")
+	}
+}
+
+func TestVerifyTrackerConcurrentSafe(t *testing.T) {
+	// Smoke test that the mutex actually protects the maps under load —
+	// catch regressions where someone "optimises" to atomics.
+	resetVerifyTracker()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			vin := "VIN_X"
+			now := time.Now()
+			_, _ = rateLimitVerify(vin, now)
+			_ = shouldWakeup(vin, now)
+		}(i)
+	}
+	wg.Wait()
+	// No assertion beyond "did not panic / race".
+}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -831,10 +831,15 @@ func TestJointFuseAllocatorScalesBothBatteryAndEV(t *testing.T) {
 	if !st.FuseSaturated {
 		t.Errorf("FuseSaturated = false; want true after joint scaling")
 	}
-	// EV cap is the allocator's verdict (independent of fuse guard's
-	// in-tick safety net): scale × current EV ≈ 0.831 × 8000 ≈ 6650.
-	if st.FuseEVMaxW < 6000 || st.FuseEVMaxW > 7200 {
-		t.Errorf("FuseEVMaxW = %.0f — want ~6650 (scaled EV cap)", st.FuseEVMaxW)
+	// EV cap is the post-republish verdict: after applyFuseGuard +
+	// forceFuseDischarge constrain battery further (and may swing it
+	// into discharge), the cap accounts for the now-greater fuse
+	// headroom. Bound below by ~6000 (the original allocator's
+	// pessimistic cap) and above by the current EV draw — a cap
+	// greater than the EV is currently drawing would be loose.
+	if st.FuseEVMaxW < 6000 || st.FuseEVMaxW > st.EVChargingW {
+		t.Errorf("FuseEVMaxW = %.0f — want in [6000, %.0f] (post-republish cap)",
+			st.FuseEVMaxW, st.EVChargingW)
 	}
 	// Sanity: post-dispatch projected grid stays at or below fuse.
 	projected := 8200.0 + got

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -660,6 +660,12 @@ func ComputeDispatch(
 	// Discharge alone never trips this — Bn is negative, so it lifts the
 	// numerator (more headroom). Only positive battery demand competes
 	// with EV.
+	//
+	// BatteryCoversEV mode: H is computed from rawGridW (the raw meter,
+	// unchanged regardless of BatteryCoversEV) so H stays correct in
+	// both modes. The PI's gridW is the only place that branches on
+	// BatteryCoversEV; the joint allocator's geometry is independent
+	// of that. Regression: TestJointFuseAllocatorWithBatteryCoversEV.
 	state.FuseEVMaxW = 0
 	state.FuseSaturated = false
 	if fuseMaxW > 0 && state.EVChargingW > 0 {
@@ -809,6 +815,44 @@ func ComputeDispatch(
 	// non-negotiable ceiling — it bypasses slew. Regression-guarded
 	// by TestFuseSaverBypassesSlew.
 	raw = forceFuseDischarge(raw, store, state, driverCapacities, fuseMaxW)
+
+	// ---- Republish FuseEVMaxW after forceFuseDischarge ----
+	// The joint allocator (line 625) computes FuseEVMaxW assuming the
+	// battery target it just produced is what gets dispatched. But
+	// forceFuseDischarge may have flipped that target from charge to
+	// discharge — freeing additional fuse headroom for the EV.
+	// Without this re-publish the loadpoint controller throttles the
+	// EV against a stale (too-conservative) cap for one tick. Run only
+	// when the joint allocator already engaged this tick — otherwise
+	// FuseEVMaxW is "no advice" and should stay 0.
+	if state.FuseSaturated && state.EVChargingW > 0 && fuseMaxW > 0 {
+		var postBat float64
+		seen := make(map[string]struct{}, len(raw))
+		for _, t := range raw {
+			if _, ok := seen[t.Driver]; ok {
+				continue
+			}
+			seen[t.Driver] = struct{}{}
+			postBat += t.TargetW
+		}
+		// H = rawGridW − currentTotal − E (unchanged from joint allocator)
+		// newGrid = H + postBat + E*scale ≤ fuseMaxW
+		// → scale ≤ (fuseMaxW − H − postBat) / E, capped to ≤1
+		var rawGridW2 float64
+		if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
+			rawGridW2 = r.SmoothedW
+		}
+		H := rawGridW2 - currentTotal - state.EVChargingW
+		headroom := fuseMaxW - H - postBat
+		if headroom < 0 {
+			headroom = 0
+		}
+		newCap := headroom
+		if newCap > state.EVChargingW {
+			newCap = state.EVChargingW
+		}
+		state.FuseEVMaxW = newCap
+	}
 
 	// Update state
 	now := time.Now()

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -441,23 +441,61 @@ func registerHost(L *lua.LState, env *HostEnv) {
 
 	// hostAllowed checks the URL's host component against the
 	// per-driver allowlist. Empty allowlist = any host (legacy
-	// behaviour). Matched case-insensitively, port-agnostic. See
-	// HostEnv.HTTPAllowedHosts docs.
+	// behaviour). Matched case-insensitively.
+	//
+	// Allowlist entry semantics:
+	//   "192.168.1.50"        → host-only match (any port allowed —
+	//                           backward-compatible default)
+	//   "192.168.1.50:8080"   → host AND port must match
+	//
+	// The port-aware form lets operators tighten an allowlist so a
+	// driver granted access to a single proxy can't probe other ports
+	// on the same host (e.g. SSH/22, Redis/6379, internal admin UIs).
+	// Existing configs that don't specify a port keep working.
+	//
+	// Schemes other than http/https are rejected outright — file://,
+	// data://, ftp:// etc. have no business here and would otherwise
+	// produce opaque "unsupported protocol scheme" errors from the
+	// stdlib client.
 	hostAllowed := func(rawURL string) (bool, string) {
-		if len(env.HTTPAllowedHosts) == 0 {
-			return true, ""
-		}
 		u, err := net_url.Parse(rawURL)
 		if err != nil || u.Host == "" {
 			return false, "invalid URL"
 		}
+		switch strings.ToLower(u.Scheme) {
+		case "http", "https":
+		default:
+			return false, fmt.Sprintf("scheme %q not supported (http/https only)", u.Scheme)
+		}
+		if len(env.HTTPAllowedHosts) == 0 {
+			return true, ""
+		}
 		host := strings.ToLower(u.Hostname())
-		for _, allowed := range env.HTTPAllowedHosts {
-			if strings.EqualFold(strings.TrimSpace(allowed), host) {
+		port := u.Port()
+		if port == "" {
+			if u.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		for _, raw := range env.HTTPAllowedHosts {
+			entry := strings.ToLower(strings.TrimSpace(raw))
+			if entry == "" {
+				continue
+			}
+			eHost, ePort, hasPort := splitHostPortLower(entry)
+			if !hasPort {
+				if entry == host {
+					return true, ""
+				}
+				continue
+			}
+			if eHost == host && ePort == port {
 				return true, ""
 			}
 		}
-		return false, fmt.Sprintf("host %q not in allowed_hosts", host)
+		return false, fmt.Sprintf("host %q (port %s) not in allowed_hosts", host, port)
 	}
 
 	applyHeaders := func(req *net_http.Request, L *lua.LState, argIdx int) {
@@ -557,6 +595,46 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	}))
 
 	L.SetGlobal("host", host)
+}
+
+// splitHostPortLower parses an allowlist entry as "host" or "host:port".
+// Returns lowercased host, port string, and a flag indicating whether a
+// port was present. Bracketed IPv6 ([::1]:8080) is supported via the
+// explicit "]" boundary; unbracketed IPv6 ("fe80::1") is treated as
+// host-only because the trailing ":1" would otherwise be misread as
+// port 1.
+func splitHostPortLower(s string) (host, port string, hasPort bool) {
+	s = strings.ToLower(s)
+	if strings.HasPrefix(s, "[") {
+		end := strings.Index(s, "]")
+		if end < 0 {
+			return s, "", false
+		}
+		h := s[1:end]
+		rest := s[end+1:]
+		if strings.HasPrefix(rest, ":") && len(rest) > 1 {
+			return h, rest[1:], true
+		}
+		return h, "", false
+	}
+	// Two or more colons → unbracketed IPv6, treat as host-only.
+	if strings.Count(s, ":") >= 2 {
+		return s, "", false
+	}
+	i := strings.LastIndex(s, ":")
+	if i < 0 {
+		return s, "", false
+	}
+	maybePort := s[i+1:]
+	if maybePort == "" {
+		return s, "", false
+	}
+	for _, r := range maybePort {
+		if r < '0' || r > '9' {
+			return s, "", false
+		}
+	}
+	return s[:i], maybePort, true
 }
 
 func modbusKindFromString(s string) int32 {

--- a/go/internal/drivers/lua_http_test.go
+++ b/go/internal/drivers/lua_http_test.go
@@ -1,0 +1,171 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// HTTP allowlist tests for the Lua host. Port-aware semantics + scheme
+// gating are the SSRF mitigation that gates every Lua-side network
+// call; if hostAllowed silently regresses, drivers can probe arbitrary
+// hosts and ports on the LAN.
+
+func runHTTPTestDriver(t *testing.T, allowed []string, targetURL string) (gotBody bool, errMsg string) {
+	t.Helper()
+	tel := telemetry.NewStore()
+	env := NewHostEnv("httptest", tel).WithHTTP()
+	if allowed != nil {
+		env.WithHTTPAllowedHosts(allowed)
+	}
+	src := `
+		function driver_init() end
+		function driver_poll()
+			local body, err = host.http_get("` + targetURL + `")
+			if err then
+				host.emit_metric("result_err", 1)
+				host.log("info", "ERR:" .. tostring(err))
+			else
+				host.emit_metric("result_ok", 1)
+				host.log("info", "BODY:" .. tostring(body))
+			end
+			return 60000
+		end
+		function driver_command() end
+		function driver_default_mode() end
+		function driver_cleanup() end
+	`
+	path := filepath.Join(t.TempDir(), "drv.lua")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if v, _, ok := tel.LatestMetric("httptest", "result_ok"); ok && v == 1 {
+		return true, ""
+	}
+	if v, _, ok := tel.LatestMetric("httptest", "result_err"); ok && v == 1 {
+		return false, "errored"
+	}
+	return false, "neither metric set — driver did not run"
+}
+
+func TestLuaHTTPAllowlistEnforcement(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer srv.Close()
+	srvHost := strings.TrimPrefix(srv.URL, "http://")
+
+	cases := []struct {
+		name     string
+		allowed  []string
+		url      string
+		wantBody bool
+	}{
+		{"empty allowlist permits all (scheme ok)", nil, srv.URL, true},
+		{"host-only entry permits this port", []string{strings.Split(srvHost, ":")[0]}, srv.URL + "/path", true},
+		{"host:port match exact", []string{srvHost}, srv.URL, true},
+		{"host:port mismatch on port", []string{strings.Split(srvHost, ":")[0] + ":1"}, srv.URL, false},
+		{"different host blocked", []string{"10.99.99.99"}, srv.URL, false},
+		// file:// would otherwise hit /etc/passwd through stdlib client.
+		{"file scheme rejected", []string{srvHost}, "file:///etc/passwd", false},
+		{"ftp scheme rejected", []string{srvHost}, "ftp://" + srvHost + "/x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, errMsg := runHTTPTestDriver(t, tc.allowed, tc.url)
+			if got != tc.wantBody {
+				t.Errorf("wantBody=%v, got=%v (err=%s)", tc.wantBody, got, errMsg)
+			}
+		})
+	}
+}
+
+func TestLuaHTTPCapabilityNotGranted(t *testing.T) {
+	tel := telemetry.NewStore()
+	env := NewHostEnv("nohttp", tel) // NO WithHTTP()
+	src := `
+		function driver_init() end
+		function driver_poll()
+			local _, err = host.http_get("http://example.com/")
+			if err then host.emit_metric("blocked", 1) end
+			return 60000
+		end
+		function driver_command() end
+		function driver_default_mode() end
+		function driver_cleanup() end
+	`
+	path := filepath.Join(t.TempDir(), "drv.lua")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	_ = d.Init(context.Background(), nil)
+	_, _ = d.Poll(context.Background())
+	v, _, ok := tel.LatestMetric("nohttp", "blocked")
+	if !ok || v != 1 {
+		t.Error("driver without HTTP cap should have been blocked")
+	}
+}
+
+func TestSplitHostPortLowerHandlesIPv6(t *testing.T) {
+	cases := []struct {
+		in      string
+		host    string
+		port    string
+		hasPort bool
+	}{
+		{"192.168.1.50", "192.168.1.50", "", false},
+		{"192.168.1.50:8080", "192.168.1.50", "8080", true},
+		{"[::1]:8080", "::1", "8080", true},
+		{"[::1]", "::1", "", false},
+		{"fe80::1", "fe80::1", "", false},
+		{"HOST:80", "host", "80", true},
+		{"", "", "", false},
+		{"foo:", "foo:", "", false},
+	}
+	for _, tc := range cases {
+		h, p, hp := splitHostPortLower(tc.in)
+		if h != tc.host || p != tc.port || hp != tc.hasPort {
+			t.Errorf("splitHostPortLower(%q) = (%s,%s,%v), want (%s,%s,%v)",
+				tc.in, h, p, hp, tc.host, tc.port, tc.hasPort)
+		}
+	}
+}
+
+func TestHTTPTestRigSelfCheck(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer srv.Close()
+	got, _ := runHTTPTestDriver(t, nil, srv.URL)
+	if !got {
+		t.Fatal("rig sanity: empty allowlist + reachable server must succeed")
+	}
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Errorf("rig sanity: server saw %d hits, want 1", atomic.LoadInt32(&hits))
+	}
+}

--- a/go/internal/telemetry/vehicle.go
+++ b/go/internal/telemetry/vehicle.go
@@ -7,10 +7,11 @@ import (
 
 // VehicleMaxAge is the freshness window past which a DerVehicle reading
 // is considered stale enough to ignore for control decisions. Picked
-// conservatively at 5 min — TeslaBLEProxy polls cached every ~60 s, and
-// the driver itself force-wakes every 30 min. Anything older than 5 min
-// is either a sleeping car the proxy hasn't woken or a proxy outage,
-// either way not safe to act on as ground truth.
+// conservatively at 5 min so a vehicle driver that has lost contact
+// (asleep car, paired-proxy outage, cloud-API throttle) cannot keep an
+// old SoC live as ground truth. Tighter than this would churn against
+// vendors whose backends only refresh on a 60–120 s cadence; looser
+// would mean acting on a value that no longer reflects reality.
 const VehicleMaxAge = 5 * time.Minute
 
 // VehiclePick is the "best matching" DerVehicle reading for a loadpoint:
@@ -22,15 +23,16 @@ type VehiclePick struct {
 	SoCPct         float64 // bounded [0,100]
 	ChargeLimitPct float64 // bounded [0,100]
 	ChargingState  string
-	Stale          bool      // proxy says "this is last-known, vehicle asleep"
+	Stale          bool      // driver says "this is last-known, vehicle unreachable"
 	UpdatedAt      time.Time // wall-clock of the underlying reading
 }
 
-// VehicleConnectedRank scores how likely a DerVehicle driver is to be the
-// one physically plugged into the loadpoint right now, based on Tesla
-// Owner-API charging_state semantics (other vendors use the same
-// vocabulary). Higher rank = more likely connected. Negative = explicitly
-// not connected; caller should skip.
+// VehicleConnectedRank scores how likely a DerVehicle driver is to be
+// the one physically plugged into the loadpoint right now, using the
+// charging_state vocabulary every vehicle driver normalizes to (the
+// strings below are the canonical values; vendor specifics are
+// translated inside each Lua driver). Higher rank = more likely
+// connected. Negative = explicitly not connected; caller should skip.
 //
 // Single source of truth for the rank table — both main.go (MPC plan
 // inputs) and api.go (loadpoint decoration) call this so multi-vehicle
@@ -55,14 +57,15 @@ func VehicleConnectedRank(chargingState string) int {
 // VehicleConnectedRank, tiebreak by freshness. Returns a zero-value
 // VehiclePick if no usable reading exists.
 //
-// Defenses applied here (do NOT skip — the BLE proxy is a network
-// trust boundary):
-//   - SoC bounded to [0,100] — a misbehaving proxy reporting 200 % or
+// Defenses applied here (do NOT skip — every vehicle driver pulls
+// from a network trust boundary, whether a local BLE proxy, an
+// in-LAN OEM gateway, or a cloud API):
+//   - SoC bounded to [0,100] — a misbehaving driver reporting 200 % or
 //     -50 % must not be able to overcharge or freeze EV charging.
 //   - ChargeLimitPct bounded to [0,100] — same risk.
 //   - Stale by `now − UpdatedAt > VehicleMaxAge` — wallclock check on
-//     the reading's own timestamp, even when the proxy didn't set the
-//     `stale` flag. A proxy that stops responding mustn't keep the
+//     the reading's own timestamp, even when the driver didn't set the
+//     `stale` flag. A driver that stops publishing mustn't keep the
 //     last-known SoC live forever.
 //   - Driver health-online check — offline drivers contribute nothing.
 //
@@ -83,7 +86,7 @@ func PickBestVehicle(s *Store, now time.Time) VehiclePick {
 		}
 		if !vr.UpdatedAt.IsZero() && now.Sub(vr.UpdatedAt) > VehicleMaxAge {
 			// Reading is older than we're willing to trust as ground
-			// truth — proxy probably stopped publishing. Skip rather
+			// truth — driver probably stopped publishing. Skip rather
 			// than risk acting on a stale SoC.
 			continue
 		}

--- a/go/internal/telemetry/vehicle.go
+++ b/go/internal/telemetry/vehicle.go
@@ -1,0 +1,128 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// VehicleMaxAge is the freshness window past which a DerVehicle reading
+// is considered stale enough to ignore for control decisions. Picked
+// conservatively at 5 min — TeslaBLEProxy polls cached every ~60 s, and
+// the driver itself force-wakes every 30 min. Anything older than 5 min
+// is either a sleeping car the proxy hasn't woken or a proxy outage,
+// either way not safe to act on as ground truth.
+const VehicleMaxAge = 5 * time.Minute
+
+// VehiclePick is the "best matching" DerVehicle reading for a loadpoint:
+// the one most likely to be the car physically connected right now.
+// Empty Driver means "no usable reading" — the caller should fall back
+// to whatever inferred SoC was already in place.
+type VehiclePick struct {
+	Driver         string
+	SoCPct         float64 // bounded [0,100]
+	ChargeLimitPct float64 // bounded [0,100]
+	ChargingState  string
+	Stale          bool      // proxy says "this is last-known, vehicle asleep"
+	UpdatedAt      time.Time // wall-clock of the underlying reading
+}
+
+// VehicleConnectedRank scores how likely a DerVehicle driver is to be the
+// one physically plugged into the loadpoint right now, based on Tesla
+// Owner-API charging_state semantics (other vendors use the same
+// vocabulary). Higher rank = more likely connected. Negative = explicitly
+// not connected; caller should skip.
+//
+// Single source of truth for the rank table — both main.go (MPC plan
+// inputs) and api.go (loadpoint decoration) call this so multi-vehicle
+// pick decisions stay consistent.
+func VehicleConnectedRank(chargingState string) int {
+	switch chargingState {
+	case "Charging", "Starting":
+		return 3 // actively pulling power — definitely this car
+	case "NoPower":
+		return 2 // plugged but wallbox not delivering yet
+	case "Stopped", "Complete":
+		return 1 // plugged + idle (charge limit reached, paused, etc.)
+	case "Disconnected":
+		return -1 // explicitly unplugged — never pick this one
+	default:
+		return 0 // unknown/missing — usable but de-prioritised
+	}
+}
+
+// PickBestVehicle scans the store for the single DerVehicle reading
+// most likely to be the car connected right now: highest
+// VehicleConnectedRank, tiebreak by freshness. Returns a zero-value
+// VehiclePick if no usable reading exists.
+//
+// Defenses applied here (do NOT skip — the BLE proxy is a network
+// trust boundary):
+//   - SoC bounded to [0,100] — a misbehaving proxy reporting 200 % or
+//     -50 % must not be able to overcharge or freeze EV charging.
+//   - ChargeLimitPct bounded to [0,100] — same risk.
+//   - Stale by `now − UpdatedAt > VehicleMaxAge` — wallclock check on
+//     the reading's own timestamp, even when the proxy didn't set the
+//     `stale` flag. A proxy that stops responding mustn't keep the
+//     last-known SoC live forever.
+//   - Driver health-online check — offline drivers contribute nothing.
+//
+// Lives in telemetry/ rather than api/ or cmd/ because both packages
+// need it and the dependency direction otherwise cycles.
+func PickBestVehicle(s *Store, now time.Time) VehiclePick {
+	if s == nil {
+		return VehiclePick{}
+	}
+	var best VehiclePick
+	bestRank := -1
+	for _, vr := range s.ReadingsByType(DerVehicle) {
+		if vr.SoC == nil {
+			continue
+		}
+		if h := s.DriverHealth(vr.Driver); h == nil || !h.IsOnline() {
+			continue
+		}
+		if !vr.UpdatedAt.IsZero() && now.Sub(vr.UpdatedAt) > VehicleMaxAge {
+			// Reading is older than we're willing to trust as ground
+			// truth — proxy probably stopped publishing. Skip rather
+			// than risk acting on a stale SoC.
+			continue
+		}
+		var meta struct {
+			ChargingState  string  `json:"charging_state"`
+			ChargeLimitPct float64 `json:"charge_limit_pct"`
+			Stale          bool    `json:"stale"`
+		}
+		if len(vr.Data) > 0 {
+			_ = json.Unmarshal(vr.Data, &meta)
+		}
+		rank := VehicleConnectedRank(meta.ChargingState)
+		if rank < 0 {
+			continue
+		}
+		if rank < bestRank || (rank == bestRank && !vr.UpdatedAt.After(best.UpdatedAt)) {
+			continue
+		}
+		soc := *vr.SoC
+		if soc < 0 {
+			soc = 0
+		} else if soc > 100 {
+			soc = 100
+		}
+		limit := meta.ChargeLimitPct
+		if limit < 0 {
+			limit = 0
+		} else if limit > 100 {
+			limit = 100
+		}
+		best = VehiclePick{
+			Driver:         vr.Driver,
+			SoCPct:         soc,
+			ChargeLimitPct: limit,
+			ChargingState:  meta.ChargingState,
+			Stale:          meta.Stale,
+			UpdatedAt:      vr.UpdatedAt,
+		}
+		bestRank = rank
+	}
+	return best
+}

--- a/go/internal/telemetry/vehicle_test.go
+++ b/go/internal/telemetry/vehicle_test.go
@@ -1,0 +1,130 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// PickBestVehicle is the trust boundary between BLE-proxy telemetry
+// (potentially attacker-controlled) and the loadpoint controller / MPC.
+// These tests lock in the bounds, freshness check, and rank ordering.
+
+func TestVehicleConnectedRankOrdering(t *testing.T) {
+	if VehicleConnectedRank("Charging") <= VehicleConnectedRank("NoPower") {
+		t.Error("Charging must outrank NoPower")
+	}
+	if VehicleConnectedRank("NoPower") <= VehicleConnectedRank("Stopped") {
+		t.Error("NoPower must outrank Stopped")
+	}
+	if VehicleConnectedRank("Stopped") <= VehicleConnectedRank("unknown") {
+		t.Error("Stopped must outrank unknown")
+	}
+	if VehicleConnectedRank("Disconnected") >= 0 {
+		t.Error("Disconnected must score negative — never picked")
+	}
+	if VehicleConnectedRank("Starting") != VehicleConnectedRank("Charging") {
+		t.Error("Starting and Charging share top rank — vehicle is engaged")
+	}
+}
+
+// pushVehicle is a tiny helper that publishes a DerVehicle reading
+// with the given fields. Mirrors what tesla_vehicle.lua does on poll
+// — DerVehicle SoC is stored in percent (0-100), not 0-1, because
+// vehicles report battery_level as percent and the picker bounds
+// against [0,100].
+func pushVehicle(t *testing.T, s *Store, driver string, soc, limit float64,
+	state string, stale bool, age time.Duration) {
+	t.Helper()
+	socPct := soc
+	data, _ := json.Marshal(map[string]any{
+		"charging_state":   state,
+		"charge_limit_pct": limit,
+		"stale":            stale,
+	})
+	s.Update(driver, DerVehicle, 0, &socPct, data)
+	// Mark health online + age the reading by reaching into the
+	// store's UpdatedAt directly via a follow-up Update with a
+	// known timestamp would be invasive; instead the test passes
+	// `age` by comparing relative to (now - age) inside the helper.
+	if age > 0 {
+		s.mu.Lock()
+		if r := s.readings[key(driver, DerVehicle)]; r != nil {
+			r.UpdatedAt = time.Now().Add(-age)
+		}
+		s.mu.Unlock()
+	}
+	s.DriverHealthMut(driver).RecordSuccess()
+}
+
+func TestPickBestVehicleHonoursRank(t *testing.T) {
+	s := NewStore()
+	pushVehicle(t, s, "garage", 50, 80, "Stopped", false, 0)
+	pushVehicle(t, s, "driveway", 30, 80, "Charging", false, 0)
+	pick := PickBestVehicle(s, time.Now())
+	if pick.Driver != "driveway" {
+		t.Errorf("expected Charging vehicle to win, got %q", pick.Driver)
+	}
+}
+
+func TestPickBestVehicleSkipsDisconnected(t *testing.T) {
+	s := NewStore()
+	pushVehicle(t, s, "garage", 50, 80, "Disconnected", false, 0)
+	pick := PickBestVehicle(s, time.Now())
+	if pick.Driver != "" {
+		t.Errorf("Disconnected reading must not be picked, got %q", pick.Driver)
+	}
+}
+
+func TestPickBestVehicleBoundsSoC(t *testing.T) {
+	s := NewStore()
+	// Lying proxy reports out-of-range SoC + limit.
+	pushVehicle(t, s, "rogue", 250, 200, "Charging", false, 0)
+	pick := PickBestVehicle(s, time.Now())
+	if pick.SoCPct != 100 {
+		t.Errorf("SoC = %v, want clamped to 100", pick.SoCPct)
+	}
+	if pick.ChargeLimitPct != 100 {
+		t.Errorf("ChargeLimit = %v, want clamped to 100", pick.ChargeLimitPct)
+	}
+
+	s2 := NewStore()
+	pushVehicle(t, s2, "rogue2", -50, -10, "Charging", false, 0)
+	pick2 := PickBestVehicle(s2, time.Now())
+	if pick2.SoCPct != 0 {
+		t.Errorf("negative SoC = %v, want clamped to 0", pick2.SoCPct)
+	}
+	if pick2.ChargeLimitPct != 0 {
+		t.Errorf("negative limit = %v, want clamped to 0", pick2.ChargeLimitPct)
+	}
+}
+
+func TestPickBestVehicleSkipsStaleByWallclock(t *testing.T) {
+	s := NewStore()
+	// Reading is 10 min old, well past VehicleMaxAge. Even though
+	// the proxy didn't set the `stale` flag, freshness is decided
+	// by wallclock — a proxy that stops talking can't keep the
+	// last-known SoC live forever.
+	pushVehicle(t, s, "asleep", 50, 80, "Charging", false, 10*time.Minute)
+	pick := PickBestVehicle(s, time.Now())
+	if pick.Driver != "" {
+		t.Errorf("stale-by-wallclock reading must not be picked, got %q", pick.Driver)
+	}
+}
+
+func TestPickBestVehicleNilStoreSafe(t *testing.T) {
+	pick := PickBestVehicle(nil, time.Now())
+	if pick.Driver != "" {
+		t.Errorf("nil store must return zero-value pick, got %+v", pick)
+	}
+}
+
+func TestPickBestVehicleTiebreakByFreshness(t *testing.T) {
+	s := NewStore()
+	pushVehicle(t, s, "a", 40, 80, "Charging", false, 60*time.Second)
+	pushVehicle(t, s, "b", 60, 80, "Charging", false, 5*time.Second)
+	pick := PickBestVehicle(s, time.Now())
+	if pick.Driver != "b" {
+		t.Errorf("fresher reading should win tiebreak, got %q (soc=%v)", pick.Driver, pick.SoCPct)
+	}
+}

--- a/web/components/ftw-energy-flow.js
+++ b/web/components/ftw-energy-flow.js
@@ -1370,20 +1370,29 @@ function renderCircleNode({ pos, title, nameLabel, value, sub, color, soc,
   // value is a cross-battery mean. EV planets gain two honesty markers:
   //  - "~" prefix when the value came from the inferred path (pluginSoC
   //    + deliveredWh) instead of the vehicle's own BMS.
-  //  - "★" suffix when the vehicle reading is stale (driver lost
+  //  - "⚠ " prefix when the vehicle reading is stale (driver lost
   //    contact with the car for more than its stale_after_s window).
+  //    Used to be "★ " — but "★" universally reads as "favourite",
+  //    the opposite of "degraded". A warning glyph + amber color
+  //    matches the rest of the app's stale signalling.
   // When a charge-limit is also known, render as "24/50%" — no spaces
   // around the slash, the format reads as "current of limit".
+  // At small radii (r<50, e.g. 4+ planets clustered in one corner) the
+  // chargeLimit suffix overflows the disc — drop it and show only the
+  // current SoC so the text always fits.
   let socText = "";
   if (soc != null) {
     const socPrefix = socSource === "inferred" ? "~" : "";
     const aggPrefix = aggregated ? "Avg " : "";
-    const staleMark = socStale ? " ★" : "";
-    const socBody = chargeLimit != null && chargeLimit > 0
+    const stalePrefix = socStale ? "⚠ " : "";
+    const showLimit = chargeLimit != null && chargeLimit > 0 && r >= 50;
+    const socBody = showLimit
       ? `${socPrefix}${Math.round(soc)}/${Math.round(chargeLimit)}%`
       : `${socPrefix}${Math.round(soc)}%`;
+    const fillColor = socStale ? "var(--stat-warn, #f59e0b)" : "var(--cyan)";
+    const titleAttr = socStale ? ` data-tooltip="Reading is stale (no recent contact with vehicle)"` : "";
     socText = `<text x="${x}" y="${y + socY}" text-anchor="middle"
-             fill="var(--cyan)" class="sv-node-sub">${aggPrefix}${socBody}${staleMark}</text>`;
+             fill="${fillColor}" class="sv-node-sub"${titleAttr}>${aggPrefix}${stalePrefix}${socBody}</text>`;
   }
   // Icon swapped in during the loading + fade-in phases. Scale chosen
   // so a full-size planet (r ≈ 86) hosts a ~30 px icon — readable at
@@ -1456,6 +1465,27 @@ function aggregateGroups(groups) {
     // detailed per-battery SoC lives in the individual view.
     const socs = group.map(p => p.soc).filter(s => s != null);
     const soc = socs.length ? socs.reduce((a, b) => a + b, 0) / socs.length : null;
+    // EV-only metadata: chargeLimit / socStale / socSource come from
+    // the vehicle driver and only ever appear on EV planets. Aggregating
+    // these across multiple EVs would mix unrelated cars, so we only
+    // forward them when the group contains exactly one EV reporter
+    // (e.g. one wallbox + one paired Tesla). Otherwise drop them and
+    // the aggregated bubble renders just the averaged SoC, no badge.
+    let chargeLimit = null;
+    let socStale = false;
+    let socSource = null;
+    if (first.role === "ev") {
+      const limits = group.map(p => p.chargeLimit).filter(v => v != null && v > 0);
+      if (limits.length === 1) chargeLimit = limits[0];
+      // socStale is true if ANY underlying reading is stale — better
+      // to over-warn than under-warn here.
+      socStale = group.some(p => !!p.socStale);
+      // socSource: prefer "vehicle" when at least one reporter has BMS
+      // truth; otherwise inherit "inferred" from the first.
+      const sources = group.map(p => p.socSource).filter(Boolean);
+      socSource = sources.includes("vehicle") ? "vehicle"
+                : sources.find(s => s === "inferred") || first.socSource || null;
+    }
     out[corner] = [{
       id: `agg-${corner}`,
       corner,
@@ -1466,6 +1496,9 @@ function aggregateGroups(groups) {
       color: absKw < 0.05 ? "var(--fg-muted)" : first.color,
       sub,
       soc,
+      chargeLimit,
+      socStale,
+      socSource,
       name: `${group.length}×`,
       aggregated: true,
     }];

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1339,7 +1339,7 @@
         var socDisplay = (vSoc != null && vLimit != null)
           ? vSoc + " / " + vLimit + " %"
           : (vSoc != null ? vSoc + " %" : "—");
-        if (vStale) socDisplay += " ★";
+        if (vStale) socDisplay = "⚠ " + socDisplay;
         var stateClassV = (vState === "Charging") ? "stat-ok" : (vState === "Disconnected" ? "stat-dim" : "stat-warn");
         var ttfStr = (vTtf != null && vTtf > 0)
           ? (vTtf >= 60 ? Math.floor(vTtf / 60) + "h " + (vTtf % 60) + "m" : vTtf + " min")


### PR DESCRIPTION
## Summary

Picks up the Tesla-BLE / MPC review-fix work that was merged into the
orphaned `tesla-ble-driver` branch via #213 but never made it to master.
Three of the original four commits (`921b9dd` startup-replan, `3480b34`
exclude-vehicle-from-battery-capacity, `34b7405` gate EV planning on
schedule) turned out to already be in master via the squash of #211 —
this PR carries the remaining substantive `fe46069` fix bundle.

## What's in `fe46069`

control/dispatch (must)
- Republish `FuseEVMaxW` after `forceFuseDischarge` runs. The reactive
  fuse-saver may swing the battery from charge → discharge between
  when the joint allocator computes the EV cap and when targets are
  dispatched; the published cap was stale by the time the loadpoint
  controller read it. Now reflects post-saver battery totals so the
  EV gets the fuse headroom it actually has.
- Document that the joint allocator's `H` computation uses `rawGridW`
  directly, so its math is independent of `BatteryCoversEV`.
  Regression test pins the design contract.

telemetry (must)
- New `telemetry.PickBestVehicle` helper centralises the multi-vehicle
  picker that was inline-duplicated in `main.go` and `api.go`. SoC and
  charge-limit are bounded to [0,100] and readings older than
  `VehicleMaxAge` (5 min) are skipped — defends the loadpoint and MPC
  against a misbehaving BLE proxy publishing 200 % SoC or stalling.
- `VehicleConnectedRank` moved into the same package as the single
  source of truth for the rank table.

api/loadpoints (must)
- `decorateLoadpointsWithVehicle` no longer overwrites `CurrentSoCPct`
  with the BMS reading. The controller's plan was computed from the
  inferred value the previous tick; mirroring BMS truth onto
  `CurrentSoCPct` made the UI lie about which value the controller
  used. `VehicleSoCPct` already exposes the BMS value separately.

api/tesla-verify (should + sec)
- Per-VIN rate limit (30 s) on `/api/drivers/verify_tesla` — same-origin
  XSS or a tab the operator left open can no longer pump verifies as a
  "keep car awake" loop.
- `wakeup=true` cooldown (5 min) — calls inside the window omit the
  flag and the proxy serves cached data, sparing the 12 V battery.
- Detect `CheckRedirect` rejection wrapped in `*url.Error` so the
  upstream redirect surfaces a readable error.

## Test plan

- [x] `go test ./...` passes (1 conflict during cherry-pick on
  `control_test.go` — kept HEAD's sign-floor tests; resolved cleanly)
- [x] Branch builds for `linux/arm64`
- [x] Deploy to live Pi for sanity (loadpoint controller behaviour
  with vehicle SoC bounded; tesla-verify rate-limit visible)

## Notes

The other three commits in the original `tesla-ble-driver-review-fixes`
divergence (`921b9dd`, `3480b34`, `34b7405`) cherry-picked as empty —
their content was already present on master (almost certainly squashed
in via #211).

🤖 Generated with [Claude Code](https://claude.com/claude-code)