### PR TITLE
fix(control,pixii): per-phase export fuse guard + configurable safety margin

### DIFF
--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -221,13 +221,21 @@ function driver_poll()
 
     -- ---- Meter Values ----
 
-    -- Per-phase current: 40237-40239, I16 each
+    -- Per-phase current: 40237-40239, I16 each. Emit MAGNITUDE only —
+    -- consistent with ferroamp.lua / sungrow.lua and with the
+    -- l1_a/l2_a/l3_a meter contract that the dispatch's per-phase fuse
+    -- guard reads. Direction is already conveyed by meter_w (signed at
+    -- the aggregate level); per-phase signed values would only make
+    -- sense for unbalanced-load diagnostics, and we don't expose those
+    -- as separate metrics today. Without abs() the dispatch's per-phase
+    -- guard had a sign-blind spot on export — site exported at 17 A on
+    -- one phase before any clamp fired.
     local ok_la, la_regs = pcall(host.modbus_read, 40237, 3, "holding")
     local l1_a, l2_a, l3_a = 0, 0, 0
     if ok_la and la_regs then
-        l1_a = scale(host.decode_i16(la_regs[1]), meter_a_sf)
-        l2_a = scale(host.decode_i16(la_regs[2]), meter_a_sf)
-        l3_a = scale(host.decode_i16(la_regs[3]), meter_a_sf)
+        l1_a = math.abs(scale(host.decode_i16(la_regs[1]), meter_a_sf))
+        l2_a = math.abs(scale(host.decode_i16(la_regs[2]), meter_a_sf))
+        l3_a = math.abs(scale(host.decode_i16(la_regs[3]), meter_a_sf))
     end
 
     -- Per-phase voltage: 40242-40244, I16 each

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -171,6 +171,11 @@ func main() {
 	// when SiteFuseAmps > 0; otherwise the per-phase clamp is disabled.
 	ctrl.SiteFuseAmps = cfg.Fuse.MaxAmps
 	ctrl.SiteFuseVoltage = cfg.Fuse.Voltage
+	ctrl.SiteFusePhases = cfg.Fuse.Phases
+	ctrl.SiteFuseSafetyA = cfg.Fuse.SafetyMarginA
+	if ctrl.SiteFuseSafetyA <= 0 {
+		ctrl.SiteFuseSafetyA = 0.5 // hardware self-protection headroom; cfg can override
+	}
 	// Restore persisted mode + target if present. The planner variants
 	// have to be listed too — without them the strategy the user picked in
 	// the UI (planner_self / planner_cheap / planner_arbitrage) is silently
@@ -329,6 +334,18 @@ func main() {
 			ctrlMu.Lock()
 			ctrl.InverterGroups = inverterGroupsFrom(newCfg.Drivers)
 			ctrl.DriverLimits = driverLimitsFrom(newCfg.Drivers, newCfg.Batteries)
+			// Fuse params + safety margin: previously startup-only.
+			// Hot-reload them so operators can tune the per-phase margin
+			// from the UI without restarting (e.g. raising it after the
+			// inverter's own protection trips, lowering it to recover
+			// last few hundred W of arbitrage headroom).
+			ctrl.SiteFuseAmps = newCfg.Fuse.MaxAmps
+			ctrl.SiteFuseVoltage = newCfg.Fuse.Voltage
+			ctrl.SiteFusePhases = newCfg.Fuse.Phases
+			ctrl.SiteFuseSafetyA = newCfg.Fuse.SafetyMarginA
+			if ctrl.SiteFuseSafetyA <= 0 {
+				ctrl.SiteFuseSafetyA = 0.5
+			}
 			ctrlMu.Unlock()
 
 			// Push the new pool totals into the planner so its next

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -172,10 +172,10 @@ func main() {
 	ctrl.SiteFuseAmps = cfg.Fuse.MaxAmps
 	ctrl.SiteFuseVoltage = cfg.Fuse.Voltage
 	ctrl.SiteFusePhases = cfg.Fuse.Phases
-	ctrl.SiteFuseSafetyA = cfg.Fuse.SafetyMarginA
-	if ctrl.SiteFuseSafetyA <= 0 {
-		ctrl.SiteFuseSafetyA = 0.5 // hardware self-protection headroom; cfg can override
-	}
+	// EffectiveSafetyMarginA distinguishes nil ("unset, use default")
+	// from explicit 0 ("operator chose to disable"). The earlier
+	// `<= 0 → default` shortcut clobbered the disable case.
+	ctrl.SiteFuseSafetyA = cfg.Fuse.EffectiveSafetyMarginA()
 	// Restore persisted mode + target if present. The planner variants
 	// have to be listed too — without them the strategy the user picked in
 	// the UI (planner_self / planner_cheap / planner_arbitrage) is silently
@@ -342,10 +342,9 @@ func main() {
 			ctrl.SiteFuseAmps = newCfg.Fuse.MaxAmps
 			ctrl.SiteFuseVoltage = newCfg.Fuse.Voltage
 			ctrl.SiteFusePhases = newCfg.Fuse.Phases
-			ctrl.SiteFuseSafetyA = newCfg.Fuse.SafetyMarginA
-			if ctrl.SiteFuseSafetyA <= 0 {
-				ctrl.SiteFuseSafetyA = 0.5
-			}
+			// Mirror the startup-path default semantics — nil → 0.5,
+			// explicit 0 → disabled. See EffectiveSafetyMarginA.
+			ctrl.SiteFuseSafetyA = newCfg.Fuse.EffectiveSafetyMarginA()
 			ctrlMu.Unlock()
 
 			// Push the new pool totals into the planner so its next

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1121,7 +1121,9 @@ func main() {
 
 	// ---- Control loop ----
 	controlInterval := time.Duration(cfg.Site.ControlIntervalS) * time.Second
-	fuseMaxW := cfg.Fuse.MaxPowerW()
+	// fuseMaxW is recomputed per tick from ctrl.SiteFuse* under ctrlMu —
+	// the configreload watcher updates those fields directly, so a
+	// startup snapshot here would go stale on the first hot-reload.
 	dtS := float64(cfg.Site.ControlIntervalS)
 
 	// Graceful shutdown
@@ -1226,6 +1228,7 @@ func main() {
 			capMu.RUnlock()
 
 			ctrlMu.Lock()
+			fuseMaxW := ctrl.SiteFuseAmps * ctrl.SiteFuseVoltage * float64(ctrl.SiteFusePhases)
 			targets := control.ComputeDispatch(tel, ctrl, capsSnap, fuseMaxW)
 			ctrlMu.Unlock()
 

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -204,6 +204,16 @@ type Fuse struct {
 	MaxAmps float64 `yaml:"max_amps" json:"max_amps"`
 	Phases  int     `yaml:"phases" json:"phases"`
 	Voltage float64 `yaml:"voltage" json:"voltage"`
+
+	// SafetyMarginA reserves headroom (per-phase amps) below MaxAmps
+	// inside the dispatch fuse guard. Defaults to 0.5 A when unset
+	// (omitempty, so the example config stays compact). Inverters
+	// often have their own per-phase current protection that trips
+	// before the breaker; without a margin the dispatch can ride right
+	// up to MaxAmps and the inverter cuts to 0 W in one tick, then
+	// dispatch ramps back up — visible as a flap. 0.5 A × 230 V × 3
+	// phases ≈ 345 W of aggregate headroom.
+	SafetyMarginA float64 `yaml:"safety_margin_a,omitempty" json:"safety_margin_a,omitempty"`
 }
 
 // MaxPowerW returns the total power budget for the fuse guard.

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -199,6 +199,12 @@ type Site struct {
 	MinDispatchIntervalS int     `yaml:"min_dispatch_interval_s" json:"min_dispatch_interval_s"`
 }
 
+// DefaultFuseSafetyMarginA is the fall-back per-phase amp headroom
+// applied when fuse.safety_margin_a is unset (nil) in the YAML.
+// Single source of truth — main.go routes through Fuse.Effective-
+// SafetyMarginA() rather than re-declaring it.
+const DefaultFuseSafetyMarginA = 0.5
+
 // Fuse describes the shared breaker limit used by the fuse guard.
 type Fuse struct {
 	MaxAmps float64 `yaml:"max_amps" json:"max_amps"`
@@ -206,19 +212,31 @@ type Fuse struct {
 	Voltage float64 `yaml:"voltage" json:"voltage"`
 
 	// SafetyMarginA reserves headroom (per-phase amps) below MaxAmps
-	// inside the dispatch fuse guard. Defaults to 0.5 A when unset
-	// (omitempty, so the example config stays compact). Inverters
-	// often have their own per-phase current protection that trips
-	// before the breaker; without a margin the dispatch can ride right
-	// up to MaxAmps and the inverter cuts to 0 W in one tick, then
-	// dispatch ramps back up — visible as a flap. 0.5 A × 230 V × 3
-	// phases ≈ 345 W of aggregate headroom.
-	SafetyMarginA float64 `yaml:"safety_margin_a,omitempty" json:"safety_margin_a,omitempty"`
+	// inside the dispatch fuse guard. Pointer so we can distinguish
+	// "unset" (nil → DefaultFuseSafetyMarginA) from "explicitly
+	// disabled" (non-nil 0.0). Inverters often have their own per-
+	// phase current protection that trips before the breaker; without
+	// a margin the dispatch can ride right up to MaxAmps and the
+	// inverter cuts to 0 W in one tick, then dispatch ramps back up —
+	// visible as a flap. 0.5 A × 230 V × 3 phases ≈ 345 W of aggregate
+	// headroom.
+	SafetyMarginA *float64 `yaml:"safety_margin_a,omitempty" json:"safety_margin_a,omitempty"`
 }
 
 // MaxPowerW returns the total power budget for the fuse guard.
 func (f Fuse) MaxPowerW() float64 {
 	return f.MaxAmps * f.Voltage * float64(f.Phases)
+}
+
+// EffectiveSafetyMarginA returns the per-phase amp headroom to apply,
+// resolving nil ("unset → use default") vs an explicit value (including
+// 0.0 to disable the margin entirely). Single read site so the default
+// can never drift across consumers.
+func (f Fuse) EffectiveSafetyMarginA() float64 {
+	if f.SafetyMarginA == nil {
+		return DefaultFuseSafetyMarginA
+	}
+	return *f.SafetyMarginA
 }
 
 // Driver is one driver entry. Each driver is a Lua script loaded by
@@ -816,16 +834,20 @@ func (c *Config) Validate() error {
 	if c.Fuse.MaxAmps <= 0 {
 		return errors.New("fuse.max_amps must be > 0")
 	}
-	// safety_margin_a must be in [0, max_amps). Negative would *raise*
-	// the per-phase threshold above the breaker rating (defeating the
-	// guard); >= max_amps zeroes out the headroom and silently disables
-	// the per-phase clamp — both are real safety holes if reached
-	// through a typo'd config.
-	if c.Fuse.SafetyMarginA < 0 {
-		return errors.New("fuse.safety_margin_a must be >= 0")
-	}
-	if c.Fuse.SafetyMarginA >= c.Fuse.MaxAmps {
-		return errors.New("fuse.safety_margin_a must be < fuse.max_amps")
+	// safety_margin_a must be in [0, max_amps) when explicitly set.
+	// Negative would *raise* the per-phase threshold above the breaker
+	// rating (defeating the guard); >= max_amps zeroes the headroom
+	// and silently disables the per-phase clamp — both are real safety
+	// holes if reached through a typo'd config. nil (unset) is OK and
+	// resolves to DefaultFuseSafetyMarginA at the consumer.
+	if c.Fuse.SafetyMarginA != nil {
+		v := *c.Fuse.SafetyMarginA
+		if v < 0 {
+			return errors.New("fuse.safety_margin_a must be >= 0")
+		}
+		if v >= c.Fuse.MaxAmps {
+			return errors.New("fuse.safety_margin_a must be < fuse.max_amps")
+		}
 	}
 	if n := c.Notifications; n != nil {
 		if n.DefaultPriority < 0 || n.DefaultPriority > 5 {

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -816,6 +816,17 @@ func (c *Config) Validate() error {
 	if c.Fuse.MaxAmps <= 0 {
 		return errors.New("fuse.max_amps must be > 0")
 	}
+	// safety_margin_a must be in [0, max_amps). Negative would *raise*
+	// the per-phase threshold above the breaker rating (defeating the
+	// guard); >= max_amps zeroes out the headroom and silently disables
+	// the per-phase clamp — both are real safety holes if reached
+	// through a typo'd config.
+	if c.Fuse.SafetyMarginA < 0 {
+		return errors.New("fuse.safety_margin_a must be >= 0")
+	}
+	if c.Fuse.SafetyMarginA >= c.Fuse.MaxAmps {
+		return errors.New("fuse.safety_margin_a must be < fuse.max_amps")
+	}
 	if n := c.Notifications; n != nil {
 		if n.DefaultPriority < 0 || n.DefaultPriority > 5 {
 			return errors.New("notifications.default_priority must be in [0,5]")

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -477,6 +478,89 @@ func TestNotificationsMaskSecrets(t *testing.T) {
 	}
 	if c.Notifications.Ntfy.AccessToken != "tk_secret" {
 		t.Errorf("original mutated")
+	}
+}
+
+func TestFuseSafetyMarginNilUsesDefault(t *testing.T) {
+	// Field omitted in YAML → nil pointer → default 0.5 A.
+	f := Fuse{MaxAmps: 16, Voltage: 230, Phases: 3}
+	if got := f.EffectiveSafetyMarginA(); got != DefaultFuseSafetyMarginA {
+		t.Errorf("nil margin: got %v, want %v (DefaultFuseSafetyMarginA)",
+			got, DefaultFuseSafetyMarginA)
+	}
+}
+
+func TestFuseSafetyMarginExplicitZeroDisables(t *testing.T) {
+	// The whole point of switching to *float64: explicit 0 is a real
+	// operator choice ("no margin") and must NOT be silently upgraded
+	// to the default. Regression for PR #219 review #1/#2/#3.
+	zero := 0.0
+	f := Fuse{MaxAmps: 16, Voltage: 230, Phases: 3, SafetyMarginA: &zero}
+	if got := f.EffectiveSafetyMarginA(); got != 0 {
+		t.Errorf("explicit 0 must disable margin, got %v", got)
+	}
+}
+
+func TestFuseSafetyMarginExplicitValuePassesThrough(t *testing.T) {
+	v := 1.5
+	f := Fuse{MaxAmps: 16, Voltage: 230, Phases: 3, SafetyMarginA: &v}
+	if got := f.EffectiveSafetyMarginA(); got != 1.5 {
+		t.Errorf("got %v, want 1.5", got)
+	}
+}
+
+func TestValidateRejectsNegativeSafetyMargin(t *testing.T) {
+	yaml := `
+site: { name: x, smoothing_alpha: 0.3 }
+fuse: { max_amps: 16, phases: 3, voltage: 230, safety_margin_a: -0.1 }
+drivers:
+  - name: m
+    lua: m.lua
+    is_site_meter: true
+    capabilities: { mqtt: { host: 1.1.1.1 } }
+api: { port: 8080 }
+`
+	_, err := Parse([]byte(yaml), ".")
+	if err == nil || !strings.Contains(err.Error(), "safety_margin_a") {
+		t.Errorf("expected safety_margin_a >= 0 rejection, got %v", err)
+	}
+}
+
+func TestValidateRejectsSafetyMarginAtOrAboveMaxAmps(t *testing.T) {
+	yaml := `
+site: { name: x, smoothing_alpha: 0.3 }
+fuse: { max_amps: 16, phases: 3, voltage: 230, safety_margin_a: 16.0 }
+drivers:
+  - name: m
+    lua: m.lua
+    is_site_meter: true
+    capabilities: { mqtt: { host: 1.1.1.1 } }
+api: { port: 8080 }
+`
+	_, err := Parse([]byte(yaml), ".")
+	if err == nil || !strings.Contains(err.Error(), "< fuse.max_amps") {
+		t.Errorf("expected safety_margin_a < max_amps rejection, got %v", err)
+	}
+}
+
+func TestValidateAcceptsExplicitZeroSafetyMargin(t *testing.T) {
+	yaml := `
+site: { name: x, smoothing_alpha: 0.3 }
+fuse: { max_amps: 16, phases: 3, voltage: 230, safety_margin_a: 0.0 }
+drivers:
+  - name: m
+    lua: m.lua
+    is_site_meter: true
+    capabilities: { mqtt: { host: 1.1.1.1 } }
+api: { port: 8080 }
+`
+	c, err := Parse([]byte(yaml), ".")
+	if err != nil {
+		t.Fatalf("explicit 0 must validate (operator-disabled margin), got %v", err)
+	}
+	// And the resolved value must be 0, not the default.
+	if got := c.Fuse.EffectiveSafetyMarginA(); got != 0 {
+		t.Errorf("EffectiveSafetyMarginA after explicit 0: got %v, want 0", got)
 	}
 }
 

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1576,17 +1576,22 @@ func forceFuseDischarge(
 	}
 	predicted := currentGrid - currentBat + sumTarget
 
-	// Per-phase overage trumps aggregate when bigger. Same balanced-3Φ
-	// assumption as applyFuseGuard (× 3 multiplier on the worst-phase
-	// W to get the equivalent total-battery W needed).
-	perPhaseOverage := perPhaseOverageW(store, state) * 3.0
 	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
 	if effFuseW < 0 {
 		effFuseW = 0
 	}
 	overage := predicted - effFuseW
-	if perPhaseOverage > overage {
-		overage = perPhaseOverage
+	// Per-phase overage trumps aggregate when bigger — but ONLY on the
+	// import side. perPhaseOverageW is direction-agnostic (uses |amps|),
+	// so an export-side phase trip would otherwise cause this function
+	// to command MORE discharge, pushing the over-current phase further
+	// over the breaker. applyFuseGuard's exportOverage branch already
+	// shrinks discharge for that case before we run.
+	if predicted >= 0 {
+		perPhaseOverage := perPhaseOverageW(store, state) * 3.0
+		if perPhaseOverage > overage {
+			overage = perPhaseOverage
+		}
 	}
 	if overage <= 0 {
 		return targets

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1212,10 +1212,14 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	// #208 follow-up in `docs/safety.md` §3a.
 	//
 	// `perPhaseOverageW` is direction-agnostic — phase amps from the
-	// meter are absolute magnitudes. We attribute the per-phase overage
-	// to whichever direction the aggregate grid is currently flowing,
-	// so a per-phase EXPORT trip pushes the discharge-shrink path the
-	// same way per-phase IMPORT pushes the charge-shrink path.
+	// meter are absolute magnitudes. Attribute to whichever side the
+	// AGGREGATE METER is currently flowing (currentGrid), not to the
+	// post-target `predicted`. Per-phase amps and currentGrid are read
+	// from the same DerMeter sample, so they're internally consistent;
+	// `predicted` mixes in `sumTarget` (a hypothetical future state)
+	// and can swing across 0 on a large planner request, attributing
+	// a current-export overage to the import path (or vice versa) and
+	// pushing the grid further into the violating direction.
 	perPhase := perPhaseOverageW(store, state) * 3.0
 	// Aggregate budget honours the safety margin too — keep dispatch
 	// commands strictly inside the breaker envelope so the inverter's
@@ -1227,7 +1231,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	importOverage := predicted - effFuseW
 	exportOverage := -effFuseW - predicted
 	if perPhase > 0 {
-		if predicted >= 0 {
+		if currentGrid >= 0 {
 			if perPhase > importOverage {
 				importOverage = perPhase
 			}
@@ -1587,7 +1591,12 @@ func forceFuseDischarge(
 	// to command MORE discharge, pushing the over-current phase further
 	// over the breaker. applyFuseGuard's exportOverage branch already
 	// shrinks discharge for that case before we run.
-	if predicted >= 0 {
+	//
+	// Gate on `currentGrid` (live aggregate at the meter) rather than
+	// `predicted`. Per-phase amps and currentGrid come from the same
+	// DerMeter sample; predicted mixes in sumTarget which can swing
+	// across 0 and silently flip the gate.
+	if currentGrid >= 0 {
 		perPhaseOverage := perPhaseOverageW(store, state) * 3.0
 		if perPhaseOverage > overage {
 			overage = perPhaseOverage

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -120,6 +120,18 @@ type State struct {
 	// sites without per-phase meter data).
 	SiteFuseAmps    float64
 	SiteFuseVoltage float64
+	SiteFusePhases  int
+
+	// SiteFuseSafetyA is the headroom (in amps) the dispatch keeps
+	// below the breaker's nominal trip current. Phase amps are clamped
+	// at SiteFuseAmps − SiteFuseSafetyA on both directions. Without
+	// this margin, hardware-side per-phase protection inside the
+	// inverter (e.g. Pixii's local current limiter) trips before the
+	// dispatch sees the aggregate go over fuse — the inverter cuts
+	// output to 0 in one tick and the dispatch then has to ramp from
+	// idle, producing a visible flap. Defaults to 0.5 A wired in main.
+	// Zero disables the margin (back-compat).
+	SiteFuseSafetyA float64
 
 	// For Priority mode
 	PriorityOrder []string
@@ -1056,22 +1068,44 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	}
 	predicted := currentGrid - currentBat + sumTarget
 
-	// Per-phase import overage: the worst single-phase amperage above
-	// the fuse, expressed as the AGGREGATE battery reduction needed
-	// to bring it back. Assumes a 3Φ balanced battery — each unit of
-	// total battery action contributes 1/3 to each phase, so a worst-
-	// phase overage of N watts requires 3 × N watts of total battery
-	// action to bring it under. Conservative for 1Φ batteries (e.g.
-	// Pixii Home) — they over-correct on the other phases, which
-	// means LESS import on those, still safe. See PR #208 follow-up
-	// in `docs/safety.md` §3a.
-	perPhaseImport := perPhaseImportOverageW(store, state) * 3.0
-	importOverage := predicted - fuseMaxW
-	if perPhaseImport > importOverage {
-		importOverage = perPhaseImport
+	// Per-phase overage: the worst single-phase amperage above the fuse
+	// trip threshold (less the safety margin), expressed as AGGREGATE
+	// battery action needed to bring it back. Assumes a 3Φ-balanced
+	// battery — each unit of total battery action contributes 1/3 to
+	// each phase, so a worst-phase overage of N watts requires 3 × N
+	// watts of total battery action to bring it under. Conservative
+	// for 1Φ batteries (Pixii Home etc.): they over-correct on the
+	// other phases, less import / export there, still safe. See PR
+	// #208 follow-up in `docs/safety.md` §3a.
+	//
+	// `perPhaseOverageW` is direction-agnostic — phase amps from the
+	// meter are absolute magnitudes. We attribute the per-phase overage
+	// to whichever direction the aggregate grid is currently flowing,
+	// so a per-phase EXPORT trip pushes the discharge-shrink path the
+	// same way per-phase IMPORT pushes the charge-shrink path.
+	perPhase := perPhaseOverageW(store, state) * 3.0
+	// Aggregate budget honours the safety margin too — keep dispatch
+	// commands strictly inside the breaker envelope so the inverter's
+	// own per-phase limiter doesn't fire first and cause a flap.
+	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
+	if effFuseW < 0 {
+		effFuseW = 0
+	}
+	importOverage := predicted - effFuseW
+	exportOverage := -effFuseW - predicted
+	if perPhase > 0 {
+		if predicted >= 0 {
+			if perPhase > importOverage {
+				importOverage = perPhase
+			}
+		} else {
+			if perPhase > exportOverage {
+				exportOverage = perPhase
+			}
+		}
 	}
 
-	if importOverage <= 0 && math.Abs(predicted) <= fuseMaxW {
+	if importOverage <= 0 && exportOverage <= 0 {
 		return targets
 	}
 
@@ -1105,8 +1139,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 				out[i].Clamped = true
 			}
 		}
-	case predicted < -fuseMaxW:
-		overage := -fuseMaxW - predicted // positive magnitude over export fuse
+	case exportOverage > 0:
 		var totalDischarge float64
 		for _, t := range out {
 			if t.TargetW < 0 {
@@ -1119,7 +1152,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 			// is the lever in that scenario (annotateCurtailment).
 			return out
 		}
-		newTotal := totalDischarge - overage
+		newTotal := totalDischarge - exportOverage
 		if newTotal < 0 {
 			newTotal = 0
 		}
@@ -1134,13 +1167,30 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	return out
 }
 
-// perPhaseImportOverageW returns the wattage by which the worst single
-// phase exceeds the per-phase fuse amperage. 0 when within limits, when
-// per-phase data isn't available, or when the per-phase clamp is
-// disabled (state.SiteFuseAmps == 0). The meter driver must emit
-// l1_a / l2_a / l3_a in DerReading.Data — Pixii, Ferroamp, and Sungrow
-// all do this today.
-func perPhaseImportOverageW(store *telemetry.Store, state *State) float64 {
+// fuseSafetyMarginW converts SiteFuseSafetyA into aggregate watts using
+// the configured per-phase voltage and phase count. Returns 0 when the
+// margin is unset OR the dependent fuse params are unset (back-compat
+// with tests / e2e harness that wire only SiteFuseAmps). No hardcoded
+// 230 V / 3 phases here — both come from config.
+func (s *State) fuseSafetyMarginW() float64 {
+	if s == nil || s.SiteFuseSafetyA <= 0 || s.SiteFuseVoltage <= 0 || s.SiteFusePhases <= 0 {
+		return 0
+	}
+	return s.SiteFuseSafetyA * s.SiteFuseVoltage * float64(s.SiteFusePhases)
+}
+
+// perPhaseOverageW returns the wattage by which the worst single phase
+// exceeds the per-phase fuse amperage (less the safety margin). 0 when
+// within limits, when per-phase data isn't available, or when the
+// per-phase clamp is disabled (state.SiteFuseAmps == 0). The meter
+// driver must emit l1_a / l2_a / l3_a in DerReading.Data — Pixii,
+// Ferroamp, and Sungrow all do this today.
+//
+// Direction-agnostic: phase amps from the meter are absolute magnitudes,
+// so this function reports overage regardless of whether the breaker is
+// being approached on the import or export side. The caller attributes
+// the overage to whichever direction the aggregate grid is flowing.
+func perPhaseOverageW(store *telemetry.Store, state *State) float64 {
 	if state == nil || state.SiteFuseAmps <= 0 || state.SiteMeterDriver == "" {
 		return 0
 	}
@@ -1156,20 +1206,34 @@ func perPhaseImportOverageW(store *telemetry.Store, state *State) float64 {
 	if err := json.Unmarshal(r.Data, &d); err != nil {
 		return 0
 	}
+	// Use absolute magnitude — drivers like Pixii decode per-phase amps
+	// as signed i16, so export shows up as negative numbers and a naive
+	// `*p > maxA` walk starting from 0 leaves maxA = 0 (no fire) even
+	// when a phase is at -17 A. The fuse trips on current magnitude
+	// regardless of direction, and the caller attributes the overage
+	// to the active aggregate-grid direction.
 	maxA := 0.0
 	for _, p := range []*float64{d.L1A, d.L2A, d.L3A} {
-		if p != nil && *p > maxA {
-			maxA = *p
+		if p == nil {
+			continue
+		}
+		a := math.Abs(*p)
+		if a > maxA {
+			maxA = a
 		}
 	}
-	if maxA <= state.SiteFuseAmps {
+	threshold := state.SiteFuseAmps - state.SiteFuseSafetyA
+	if threshold < 0 {
+		threshold = 0
+	}
+	if maxA <= threshold {
 		return 0
 	}
 	v := state.SiteFuseVoltage
 	if v <= 0 {
-		v = 230 // sensible default; main wires the actual config voltage
+		v = 230 // back-compat for tests / e2e that wire only SiteFuseAmps
 	}
-	return (maxA - state.SiteFuseAmps) * v
+	return (maxA - threshold) * v
 }
 
 // applyPlanSignFloor enforces "executed battery total must agree in sign
@@ -1382,8 +1446,12 @@ func forceFuseDischarge(
 	// Per-phase overage trumps aggregate when bigger. Same balanced-3Φ
 	// assumption as applyFuseGuard (× 3 multiplier on the worst-phase
 	// W to get the equivalent total-battery W needed).
-	perPhaseOverage := perPhaseImportOverageW(store, state) * 3.0
-	overage := predicted - fuseMaxW
+	perPhaseOverage := perPhaseOverageW(store, state) * 3.0
+	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
+	if effFuseW < 0 {
+		effFuseW = 0
+	}
+	overage := predicted - effFuseW
 	if perPhaseOverage > overage {
 		overage = perPhaseOverage
 	}

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -331,6 +331,98 @@ func TestPerPhaseClampDominatesAggregateWhenLarger(t *testing.T) {
 	}
 }
 
+// Per-phase EXPORT overage: PV is exporting hard on a single phase
+// (e.g. 1Φ inverter on L2), aggregate gridW negative. The per-phase
+// guard must fire on the EXPORT side and shrink discharging — NOT
+// trigger forceFuseDischarge, which would push more power out and
+// worsen the over-current phase. Regression for PR #219 review S1.
+func TestPerPhaseClampFiresOnExportImbalance(t *testing.T) {
+	// Aggregate gridW = -7000 W (heavy export). Phases (magnitude):
+	// L2 = 18 A (over the 16 A fuse), L1 = 12, L3 = 8. Per-phase
+	// overage = (18 − 16) × 230 × 3 = 1380 W of discharge to shrink.
+	// Battery is currently discharging −5000 W; the target reduces
+	// magnitude to bring L2 back under fuse.
+	store, state, _ := setupPerPhase(-7000, 12, 18, 8, 0.6, 10000)
+	// Set the live battery reading so applyFuseGuard's "predicted"
+	// reflects the current discharge state.
+	soc := 0.6
+	store.Update("bat", telemetry.DerBattery, -5000, &soc, nil)
+	store.DriverHealthMut("bat").RecordSuccess()
+
+	targets := []DispatchTarget{{Driver: "bat", TargetW: -5000}}
+	guarded := applyFuseGuard(targets, store, state, 11040)
+	if !guarded[0].Clamped {
+		t.Errorf("export-side per-phase overage must clamp the discharge target")
+	}
+	// New discharge magnitude: 5000 − 1380 = 3620 W → target = −3620 W.
+	expected := -3620.0
+	if math.Abs(guarded[0].TargetW-expected) > 1 {
+		t.Errorf("discharge after export-side per-phase clamp = %.0f W, want %.0f W",
+			guarded[0].TargetW, expected)
+	}
+}
+
+// forceFuseDischarge must NOT fire on export-side per-phase overage.
+// Its job is to relieve IMPORT — commanding more discharge during
+// export-side per-phase trip would push the over-current phase
+// further over the breaker. Regression for PR #219 review S1.
+func TestForceFuseDischargeIgnoresExportSidePerPhase(t *testing.T) {
+	// Heavy export with one phase over fuse. fuseSaverFromZero (which
+	// calls forceFuseDischarge) MUST return nil — the export-side
+	// overage is not its problem.
+	store, state, caps := setupPerPhase(-9000, 12, 18, 8, 0.6, 10000)
+	out := fuseSaverFromZero(store, state, caps, 11040)
+	if out != nil {
+		t.Errorf("forceFuseDischarge fired on export-side per-phase overage; "+
+			"would worsen the over-current phase. got %v", out)
+	}
+}
+
+// SiteFuseSafetyA shrinks the per-phase threshold below MaxAmps so the
+// dispatch stops trying to ride right up to the breaker (where the
+// inverter's own per-phase limiter trips first and causes a flap).
+// Regression for PR #219 — the bug class motivating the safety margin.
+func TestPerPhaseClampHonorsSafetyMargin(t *testing.T) {
+	// Phases (15.5, 12, 8). MaxAmps = 16, SafetyA = 1.0 → effective
+	// threshold = 15 A. L1 at 15.5 A is OVER the effective threshold
+	// (under the raw 16 A). Per-phase overage = (15.5 − 15) × 230 × 3
+	// = 345 W of charge to shrink.
+	store, state, _ := setupPerPhase(7000, 15.5, 12, 8, 0.6, 10000)
+	state.SiteFuseSafetyA = 1.0
+	state.SiteFusePhases = 3
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 4000}}
+	guarded := applyFuseGuard(targets, store, state, 11040)
+	if !guarded[0].Clamped {
+		t.Errorf("safety margin should pull the threshold under L1 = 15.5 A")
+	}
+	// Aggregate effFuseW = 11040 − 1.0×230×3 = 10350. Predicted =
+	// 7000 + 4000 − 0 = 11000 → aggregate overage = 11000 − 10350 = 650.
+	// Per-phase overage × 3 = 345. Aggregate wins (650 > 345).
+	// Charge 4000 − 650 = 3350.
+	expected := 3350.0
+	if math.Abs(guarded[0].TargetW-expected) > 1 {
+		t.Errorf("charge after safety-margin clamp = %.0f W, want %.0f W",
+			guarded[0].TargetW, expected)
+	}
+}
+
+// SafetyMarginA = 0 must produce identical output to the pre-PR
+// behaviour (locks the back-compat contract every existing per-phase
+// test relies on by leaving the field unset).
+func TestPerPhaseClampSafetyMarginZeroIsBackCompat(t *testing.T) {
+	store, state, _ := setupPerPhase(7000, 18, 12, 8, 0.6, 10000)
+	state.SiteFuseSafetyA = 0
+	state.SiteFusePhases = 3
+	targets := []DispatchTarget{{Driver: "bat", TargetW: 4000}}
+	guarded := applyFuseGuard(targets, store, state, 11040)
+	// Same math as TestPerPhaseClampScalesChargingOnImbalance.
+	expected := 2620.0
+	if math.Abs(guarded[0].TargetW-expected) > 1 {
+		t.Errorf("safety_margin_a=0 must match pre-PR behaviour: got %.0f W, want %.0f W",
+			guarded[0].TargetW, expected)
+	}
+}
+
 // End-to-end via ComputeDispatch: idle mode + grid surge → returns
 // non-empty discharge targets. Idle mode would normally return [].
 func TestFuseSaverFiresInIdleMode(t *testing.T) {

--- a/web/settings/tabs/control.js
+++ b/web/settings/tabs/control.js
@@ -5,7 +5,16 @@
 
   S.tabs.control = {
     render: function (ctx) {
-      var field = ctx.field;
+      var field = ctx.field, help = ctx.help, getByPath = ctx.getByPath, escHtml = ctx.escHtml, config = ctx.config;
+      // Local helper for fractional-amp fields — the central field()
+      // helper emits no step attribute, which most browsers treat as
+      // step=1 and refuse 0.5 entries on validation.
+      function decimalField(label, path, dflt, helpText, step) {
+        var val = getByPath(config, path, dflt);
+        return '<label>' + label + (helpText ? ' ' + help(helpText) : '') + '</label>' +
+          '<input type="number" step="' + step + '" data-path="' + path +
+          '" value="' + escHtml(val == null ? "" : String(val)) + '">';
+      }
       return '<fieldset><legend>Site</legend>' +
         field("Name", "site.name", "text", "Home") +
         '<div class="field-row"><div>' +
@@ -37,7 +46,13 @@
         '</div><div>' +
         field("Phases", "fuse.phases", "number", 3) +
         '</div></div>' +
+        '<div class="field-row"><div>' +
         field("Voltage (V)", "fuse.voltage", "number", 230) +
+        '</div><div>' +
+        decimalField("Safety margin (A)", "fuse.safety_margin_a", 0.5,
+          "Headroom below max amps so the inverter's own per-phase limiter doesn't trip first. Defaults to 0.5 A.",
+          "0.1") +
+        '</div></div>' +
         '</fieldset>';
     },
   };


### PR DESCRIPTION
## Summary

Closes the per-phase export blind spot in the dispatch fuse guard and adds
a configurable amp-margin so the dispatch stops trying to ride right up to
the breaker's trip current, where the inverter's own per-phase limiter
fires first and causes a flap.

Three commits:

1. **`65d1c00` feat(control,config): per-phase export fuse guard +
   configurable safety margin**
   - `applyFuseGuard` now attributes per-phase overage to whichever
     direction the aggregate grid is flowing (was: import-only). A
     phase exporting at 17 A while aggregate stayed under fuseMaxW
     used to slip through entirely.
   - `state.SiteFuseSafetyA` (yaml: `fuse.safety_margin_a`) reserves
     headroom below the breaker's trip current. Defaults to 0.5 A.
     Voltage / phase count come from configured `fuse.voltage` and
     `fuse.phases` — no hardcoded 230 V / 3 phases in the watts math.
   - Renamed `perPhaseImportOverageW` → `perPhaseOverageW` (it's
     direction-agnostic).
   - Fuse params hot-reload on config change (was startup-only).

2. **`f4fc599` fix(pixii): emit per-phase amps as magnitude, not signed**
   Pixii's holding registers are i16, so `host.decode_i16` on
   l1_a/l2_a/l3_a returned negative values during export. Caused the
   per-phase guard's `*p > maxA` walk (starting from 0) to leave maxA
   at 0 and the threshold check to silently pass. Other site-meter
   drivers (ferroamp, sungrow) already emit magnitudes — pixii now
   matches. Belt-and-suspenders: `perPhaseOverageW` also takes
   `math.Abs(*p)` before comparing.

3. **`3de0a48` feat(web/settings): Safety margin (A) input under
   Control → Fuse**
   New input alongside Max amps / Phases / Voltage in the existing
   settings tab. 0.1 A step, tooltip, default 0.5 A.

## Test plan

- [x] `go test ./...` clean
- [x] Built `linux/arm64`, deployed to live RPi (`v0.55.1-dirty`)
- [x] Verified pixii now emits positive amps when grid is in export
  (live: `bat_w=+8599, grid_w=-5519, phase_amps=[7.85, 8.64, 7.75]`
  — all positive)
- [x] Verified hot-reload via `POST /api/config` round-trip — log
  emits "config reload: applied" within 1 s
- [ ] Watch a discharge slot peak and confirm phase amps top out
  near `MaxAmps − SafetyA` instead of overshooting + flapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)