### PR TITLE
fix(web/diagnose): make detail pane scrollable on short viewports

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -208,12 +208,18 @@ header h1 {
 }
 .diag-ev { background: rgba(6,182,212,0.18); color: #67e8f9; }
 
-/* Detail pane */
+/* Detail pane — single scroll container so the chart can roll out
+   of view on short viewports (small laptops); the sticky thead still
+   pins to the top of the pane once the table starts scrolling under
+   it. The inner .diagnose-table-wrap previously owned the scrollbar
+   with `flex: 1; overflow: auto`, which forced the chart to keep its
+   full 320 px regardless of remaining height — leaving < 100 px for
+   the table on a 720p laptop. */
 .diagnose-detail {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  overflow: hidden;
+  overflow: auto;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -247,9 +253,10 @@ header h1 {
 .diag-chart-highlight.hidden { display: none; }
 
 .diagnose-table-wrap {
-  flex: 1;
-  overflow: auto;
   padding: 0 0.5rem 1rem 0.5rem;
+  /* No own overflow / flex grow — the parent .diagnose-detail is the
+     single scroll container; the sticky `thead th { top: 0 }` pins
+     against it when the chart scrolls out of view. */
 }
 .diag-table {
   width: 100%;


### PR DESCRIPTION
## Summary

On small laptops the diagnose detail's bottom table was unreachable: the inner \`.diagnose-table-wrap\` held its own scrollbar with \`flex: 1\`, and the parent \`.diagnose-detail\` was \`overflow: hidden\` — so the fixed 320 px chart canvas couldn't scroll out of view, leaving very little vertical space for the table.

Fix: move the scroll container up to \`.diagnose-detail\` itself. The chart + table now flow together; scrolling down rolls the chart out of view and the table's existing \`thead { position: sticky; top: 0 }\` pins the header to the pane edge once the table starts scrolling under it.

## Test plan

- [x] Wide viewport (≥ 1080 px tall): no behavioural change — content fits without scrolling
- [ ] 720p laptop: scroll the detail pane down, table thead pins, all rows reachable
- [ ] Hover-highlight crosstalk between chart and table still works (chart hover narrows the table window)
- [ ] Mobile breakpoint (< 900 px wide) — timeline stacks above, detail below — still single-column

🤖 Generated with [Claude Code](https://claude.com/claude-code)