### PR TITLE
fix(control): break fuse-guard boundary oscillation

### DIFF
--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -227,6 +227,21 @@ type State struct {
 	// Issue #145.
 	DriverLimits map[string]PowerLimits
 
+	// FuseHold* — hysteresis state from applyFuseGuard. After a clamp
+	// fires, the latched maximum aggregate-battery magnitude (for the
+	// direction that tripped) is held for ~30 s so the planner can't
+	// immediately re-ramp into the same threshold and oscillate at
+	// the boundary. Each new fire extends the window.
+	//
+	// Without this, the dispatch + slew + planner feedback loop
+	// stabilises with phase amps riding right at the trip threshold:
+	// every tick scales the discharge JUST enough to clear the trip,
+	// the next tick the planner re-asks for more, and the system
+	// hovers permanently at the boundary instead of leaving headroom.
+	FuseHoldMaxDischargeW float64
+	FuseHoldMaxChargeW    float64
+	FuseHoldUntil         time.Time
+
 	// ManualHold pins the aggregate battery setpoint to a fixed power
 	// for a bounded duration, bypassing both the active manual mode
 	// and the MPC. Hot-installed via POST /api/battery/manual_hold;
@@ -1242,12 +1257,75 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 		}
 	}
 
-	if importOverage <= 0 && exportOverage <= 0 {
-		return targets
-	}
-
 	out := make([]DispatchTarget, len(targets))
 	copy(out, targets)
+
+	// Hold-mode hysteresis: a recent clamp latched a max-magnitude per
+	// direction. Re-apply it now even if the live overage is zero so
+	// the planner can't ramp back through the boundary on the next
+	// tick. Window is refreshed every time the clamp fires, so the
+	// hold persists as long as the planner keeps trying to push past.
+	now := time.Now()
+	if state.FuseHoldUntil.After(now) {
+		if state.FuseHoldMaxDischargeW > 0 {
+			var totalDischarge float64
+			for _, t := range out {
+				if t.TargetW < 0 {
+					totalDischarge += -t.TargetW
+				}
+			}
+			if totalDischarge > state.FuseHoldMaxDischargeW {
+				scale := state.FuseHoldMaxDischargeW / totalDischarge
+				for i := range out {
+					if out[i].TargetW < 0 {
+						out[i].TargetW *= scale
+						out[i].Clamped = true
+					}
+				}
+			}
+		}
+		if state.FuseHoldMaxChargeW > 0 {
+			var totalCharge float64
+			for _, t := range out {
+				if t.TargetW > 0 {
+					totalCharge += t.TargetW
+				}
+			}
+			if totalCharge > state.FuseHoldMaxChargeW {
+				scale := state.FuseHoldMaxChargeW / totalCharge
+				for i := range out {
+					if out[i].TargetW > 0 {
+						out[i].TargetW *= scale
+						out[i].Clamped = true
+					}
+				}
+			}
+		}
+	} else if !state.FuseHoldUntil.IsZero() {
+		// Hold window expired — reset the latch so a future planner
+		// re-ramp doesn't get permanently capped by stale state.
+		state.FuseHoldMaxDischargeW = 0
+		state.FuseHoldMaxChargeW = 0
+		state.FuseHoldUntil = time.Time{}
+	}
+
+	if importOverage <= 0 && exportOverage <= 0 {
+		return out
+	}
+
+	// Headroom buffer: shrink targets by `overage + half the configured
+	// safety margin` so post-clamp the grid sits *below* the threshold
+	// instead of riding right at it. Without this, the next dispatch
+	// tick lets the planner re-ramp into the threshold and the system
+	// oscillates at the boundary — the operator's "safety margin"
+	// becomes the active steady-state instead of a buffer below it.
+	//
+	// Half-margin chosen so the post-clamp phase amps still cluster
+	// near the threshold (operator wants the fuse used efficiently)
+	// but with enough buffer to absorb load fluctuations and per-phase
+	// imbalance on the next tick. Operators wanting tighter or looser
+	// buffer just adjust safety_margin_a.
+	buffer := state.fuseSafetyMarginW() * 0.5
 
 	switch {
 	case importOverage > 0:
@@ -1265,7 +1343,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 			// still flip idle batteries to discharge.
 			return out
 		}
-		newTotal := totalCharge - importOverage
+		newTotal := totalCharge - importOverage - buffer
 		if newTotal < 0 {
 			newTotal = 0
 		}
@@ -1276,6 +1354,10 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 				out[i].Clamped = true
 			}
 		}
+		// Latch the new charge cap for the hold window. Each fire
+		// extends the window so the planner can't ramp through.
+		state.FuseHoldMaxChargeW = newTotal
+		state.FuseHoldUntil = now.Add(30 * time.Second)
 	case exportOverage > 0:
 		var totalDischarge float64
 		for _, t := range out {
@@ -1289,7 +1371,7 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 			// is the lever in that scenario (annotateCurtailment).
 			return out
 		}
-		newTotal := totalDischarge - exportOverage
+		newTotal := totalDischarge - exportOverage - buffer
 		if newTotal < 0 {
 			newTotal = 0
 		}
@@ -1300,6 +1382,8 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 				out[i].Clamped = true
 			}
 		}
+		state.FuseHoldMaxDischargeW = newTotal
+		state.FuseHoldUntil = now.Add(30 * time.Second)
 	}
 	return out
 }

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
 )
@@ -398,8 +399,9 @@ func TestPerPhaseClampHonorsSafetyMargin(t *testing.T) {
 	// Aggregate effFuseW = 11040 − 1.0×230×3 = 10350. Predicted =
 	// 7000 + 4000 − 0 = 11000 → aggregate overage = 11000 − 10350 = 650.
 	// Per-phase overage × 3 = 345. Aggregate wins (650 > 345).
-	// Charge 4000 − 650 = 3350.
-	expected := 3350.0
+	// Buffer = half-margin = 0.5×1×230×3 = 345 W (post-fix headroom).
+	// Charge 4000 − 650 − 345 = 3005.
+	expected := 3005.0
 	if math.Abs(guarded[0].TargetW-expected) > 1 {
 		t.Errorf("charge after safety-margin clamp = %.0f W, want %.0f W",
 			guarded[0].TargetW, expected)
@@ -437,5 +439,112 @@ func TestFuseSaverFiresInIdleMode(t *testing.T) {
 	}
 	if !out[0].Clamped {
 		t.Errorf("Clamped flag must mark fuse-saver activation")
+	}
+}
+
+// Operator-report 2026-04-30: with safety_margin_a=1 (threshold = 15 A)
+// the system stabilised with phase amps oscillating between 15.0 and
+// 15.8 A — fuse guard reactively scaled targets just enough to clear
+// the trip, then the planner re-ramped, then it re-tripped. Half-margin
+// buffer keeps post-clamp aggregate below the threshold by an explicit
+// margin so the next tick has room before re-tripping.
+func TestFuseGuardLeavesHeadroomBelowThreshold(t *testing.T) {
+	store, state, _ := setupPerPhase(-7000, 12, 18, 8, 0.6, 10000)
+	state.SiteFuseSafetyA = 1.0
+	state.SiteFusePhases = 3
+	soc := 0.6
+	store.Update("bat", telemetry.DerBattery, -5000, &soc, nil)
+	store.DriverHealthMut("bat").RecordSuccess()
+
+	out := applyFuseGuard(
+		[]DispatchTarget{{Driver: "bat", TargetW: -5000}},
+		store, state, 11040)
+	if !out[0].Clamped {
+		t.Fatalf("expected per-phase export clamp")
+	}
+	// perPhase = (18−15) × 230 × 3 = 2070 W
+	// half-margin buffer = 0.5 × 1A × 230V × 3p = 345 W
+	// totalDischarge = 5000 → newTotal = 5000 − 2070 − 345 = 2585
+	expected := -2585.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("post-clamp target = %.0f W, want %.0f W (overage + half-margin)",
+			out[0].TargetW, expected)
+	}
+}
+
+// Hold-mode hysteresis prevents the planner from immediately
+// re-ramping into the threshold on the next tick. The clamp's max
+// is latched for ~30 s and re-applied even when the live overage
+// is zero.
+func TestFuseGuardHoldsClampAcrossTicks(t *testing.T) {
+	// Tick 1: clamp fires, latches max.
+	store, state, _ := setupPerPhase(-7000, 12, 18, 8, 0.6, 10000)
+	state.SiteFuseSafetyA = 1.0
+	state.SiteFusePhases = 3
+	soc := 0.6
+	store.Update("bat", telemetry.DerBattery, -5000, &soc, nil)
+	store.DriverHealthMut("bat").RecordSuccess()
+
+	tick1 := applyFuseGuard(
+		[]DispatchTarget{{Driver: "bat", TargetW: -5000}},
+		store, state, 11040)
+	if !tick1[0].Clamped {
+		t.Fatalf("tick 1: expected initial clamp")
+	}
+	if state.FuseHoldMaxDischargeW <= 0 {
+		t.Fatalf("tick 1: hold-max should be latched, got %v", state.FuseHoldMaxDischargeW)
+	}
+	if state.FuseHoldUntil.IsZero() {
+		t.Fatalf("tick 1: hold-until should be set")
+	}
+	tick1Cap := state.FuseHoldMaxDischargeW
+
+	// Tick 2: phase amps look clean (battery responded), planner
+	// asks for the original full discharge again. Hold-mode must
+	// re-apply the latched cap.
+	store2, state2, _ := setupPerPhase(-3000, 8, 10, 6, 0.6, 10000)
+	state2.SiteFuseSafetyA = 1.0
+	state2.SiteFusePhases = 3
+	state2.FuseHoldMaxDischargeW = state.FuseHoldMaxDischargeW
+	state2.FuseHoldUntil = state.FuseHoldUntil
+	store2.Update("bat", telemetry.DerBattery, -2500, &soc, nil)
+	store2.DriverHealthMut("bat").RecordSuccess()
+
+	tick2 := applyFuseGuard(
+		[]DispatchTarget{{Driver: "bat", TargetW: -5000}},
+		store2, state2, 11040)
+	if !tick2[0].Clamped {
+		t.Errorf("tick 2: hold-mode should still clamp the re-ramp")
+	}
+	if -tick2[0].TargetW > tick1Cap+0.5 {
+		t.Errorf("tick 2: target magnitude %.0f exceeds latched cap %.0f — hold not enforced",
+			-tick2[0].TargetW, tick1Cap)
+	}
+}
+
+// Hold expires after the window so future planner re-ramps aren't
+// permanently capped by stale state.
+func TestFuseGuardHoldExpiresAfterWindow(t *testing.T) {
+	store, state, _ := setupPerPhase(-3000, 8, 10, 6, 0.6, 10000)
+	state.SiteFuseSafetyA = 1.0
+	state.SiteFusePhases = 3
+	soc := 0.6
+	store.Update("bat", telemetry.DerBattery, -2500, &soc, nil)
+	store.DriverHealthMut("bat").RecordSuccess()
+
+	state.FuseHoldMaxDischargeW = 1000
+	state.FuseHoldUntil = time.Now().Add(-1 * time.Second)
+
+	out := applyFuseGuard(
+		[]DispatchTarget{{Driver: "bat", TargetW: -4000}},
+		store, state, 11040)
+	if !state.FuseHoldUntil.IsZero() {
+		t.Errorf("expired hold-until should be cleared, got %v", state.FuseHoldUntil)
+	}
+	if state.FuseHoldMaxDischargeW != 0 {
+		t.Errorf("expired hold-max should be cleared, got %v", state.FuseHoldMaxDischargeW)
+	}
+	if out[0].Clamped {
+		t.Errorf("post-expiry, no live overage: target should pass through, got %v", out[0])
 	}
 }


### PR DESCRIPTION
## Summary

Operator report from the live Pi: with \`safety_margin_a=1\` (threshold = 15 A on 16 A fuse), phase amps were stabilising at 15.6–15.8 A — well past the configured threshold. Battery discharge wouldn't back off and a manual charge command was needed to recover.

Two reinforcing fixes that together break the boundary oscillation:

1. **Half-margin headroom buffer.** \`applyFuseGuard\` was shrinking targets by exactly the overage — post-clamp aggregate sat at the threshold, leaving zero buffer for per-phase imbalance and load noise on the next tick.

2. **Hold-mode hysteresis.** The clamp's max (per direction) is latched for ~30 s and re-applied even when the live overage is zero. Without it, the planner re-asks for full discharge each tick, live phase amps read clean for one tick (battery hasn't responded yet), the clamp doesn't fire, the next tick the battery follows through and re-trips — a 5-second oscillation.

## Changes

- \`go/internal/control/dispatch.go\`: \`applyFuseGuard\` adds half-margin buffer to the scaling math, latches \`state.FuseHoldMaxDischargeW\` / \`FuseHoldMaxChargeW\` / \`FuseHoldUntil\` on each fire, re-applies the latched cap at the top of every subsequent call within the hold window, clears the latch on expiry.
- New State fields \`FuseHoldMaxDischargeW\`, \`FuseHoldMaxChargeW\`, \`FuseHoldUntil\`.
- 3 new regression tests + 1 existing test updated for the buffer.

## Test plan

- [x] \`go test ./...\` clean (incl. e2e)
- [x] Deploy to live Pi and watch peak phase amps stay ≤ threshold under heavy export
- [ ] Confirm no false-positive holds (clamp doesn't latch indefinitely once the planner stops asking for over-fuse magnitudes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)