### PR TITLE
feat(web): electricity price chart + history numbers/cakes toggle

### DIFF
--- a/web/components/ftw-energy-cake.js
+++ b/web/components/ftw-energy-cake.js
@@ -1,0 +1,312 @@
+// <ftw-energy-cake> — donut chart that splits total household
+// consumption into "self-consumption" (PV + battery) vs "import"
+// (grid), with the surplus EXPORT shown as a separate big number
+// next to it. Used by both the "Energy today" panel and the
+// "History in numbers" panel under their respective Numbers/Cakes
+// toggle.
+//
+// Inputs are kWh totals over whatever time window the parent picked
+// (today, week, month). The component does the percentage maths
+// itself so callers can keep blasting raw Wh without conversion.
+//
+// API:
+//   <ftw-energy-cake></ftw-energy-cake>
+//   el.setTotals({ import_wh, load_wh, export_wh });
+//
+// Sign convention: all inputs are non-negative magnitudes (Wh
+// integrated over the window). load_wh is total household
+// consumption; self-consumption is derived as load_wh − import_wh.
+
+import { FtwElement } from "./ftw-element.js";
+
+const SIZE = 168;       // donut outer diameter (px in viewBox units)
+const RING = 28;        // ring thickness
+const CX = SIZE / 2;
+const CY = SIZE / 2;
+const R_OUTER = SIZE / 2 - 2;
+const R_INNER = R_OUTER - RING;
+
+class FtwEnergyCake extends FtwElement {
+  static styles = `
+    :host {
+      display: block;
+      font-family: var(--sans);
+      color: var(--fg);
+    }
+    .wrap {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 24px;
+      align-items: center;
+    }
+    .chart-col {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
+    }
+    svg.donut {
+      width: ${SIZE}px;
+      height: ${SIZE}px;
+      display: block;
+    }
+    .legend {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      width: 100%;
+    }
+    .legend-row {
+      display: grid;
+      grid-template-columns: 12px 1fr auto;
+      gap: 8px;
+      align-items: center;
+      font-size: 12px;
+    }
+    .swatch {
+      width: 12px;
+      height: 12px;
+      border-radius: 3px;
+    }
+    .legend-label {
+      color: var(--fg-dim);
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+    .legend-value {
+      font-family: var(--mono);
+      font-variant-numeric: tabular-nums;
+      color: var(--fg);
+    }
+    .export-col {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      padding-left: 8px;
+      border-left: 1px solid var(--line);
+    }
+    .export-eyebrow {
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--fg-muted);
+    }
+    .export-number {
+      font-family: var(--mono);
+      font-variant-numeric: tabular-nums;
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      font-weight: 600;
+      color: var(--green-e);
+      line-height: 1;
+    }
+    .export-unit {
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      color: var(--fg-dim);
+    }
+    .center-pct {
+      font-family: var(--mono);
+      font-variant-numeric: tabular-nums;
+      font-size: 1.6rem;
+      font-weight: 600;
+      fill: var(--fg);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+    .center-label {
+      font-family: var(--mono);
+      font-size: 0.6rem;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      fill: var(--fg-muted);
+      text-anchor: middle;
+    }
+    .empty {
+      color: var(--fg-muted);
+      font-size: 0.8rem;
+      padding: 8px;
+    }
+    @media (max-width: 600px) {
+      .wrap {
+        grid-template-columns: 1fr;
+        gap: 14px;
+      }
+      .export-col {
+        padding-left: 0;
+        border-left: 0;
+        border-top: 1px solid var(--line);
+        padding-top: 12px;
+        align-items: center;
+      }
+    }
+  `;
+
+  constructor() {
+    super();
+    this._totals = null;
+  }
+
+  // Bulk setter — preferred entry point. Pass raw Wh; the component
+  // handles unit conversion + percentage maths.
+  setTotals(t) {
+    this._totals = (t && typeof t === "object") ? t : null;
+    this.update();
+  }
+
+  render() {
+    if (!this._totals) {
+      return `<div class="empty">No data yet.</div>`;
+    }
+    const importWh = Math.max(0, Number(this._totals.import_wh) || 0);
+    const loadWh = Math.max(0, Number(this._totals.load_wh) || 0);
+    const exportWh = Math.max(0, Number(this._totals.export_wh) || 0);
+    // Self-consumption = total load − whatever was sourced from grid.
+    // Clamp at 0 so a sensor glitch (import > load reported by the
+    // metering driver, which can happen at sub-watt resolution) can
+    // never produce a negative slice.
+    const selfWh = Math.max(0, loadWh - importWh);
+    const total = selfWh + importWh;
+
+    // Empty-state: no consumption recorded. Render the empty donut +
+    // export-only number so the layout doesn't jump on first load.
+    if (total <= 0) {
+      return this._layout({
+        slices: this._renderEmpty(),
+        centerTop: "—",
+        centerSub: "self use",
+        legend: [
+          { color: "var(--accent-e)", label: "Self-consumption", value: "—" },
+          { color: "var(--red-e)", label: "Imported", value: "—" },
+        ],
+        exportKwh: exportWh / 1000,
+      });
+    }
+
+    const selfPct = (selfWh / total) * 100;
+    const importPct = 100 - selfPct;
+
+    return this._layout({
+      slices: this._renderSlices(selfPct),
+      centerTop: `${Math.round(selfPct)}%`,
+      centerSub: "self use",
+      legend: [
+        {
+          color: "var(--accent-e)",
+          label: "Self-consumption",
+          value: `${formatKwh(selfWh)} · ${fmtPct(selfPct)}`,
+        },
+        {
+          color: "var(--red-e)",
+          label: "Imported",
+          value: `${formatKwh(importWh)} · ${fmtPct(importPct)}`,
+        },
+      ],
+      exportKwh: exportWh / 1000,
+    });
+  }
+
+  _layout({ slices, centerTop, centerSub, legend, exportKwh }) {
+    return `
+      <div class="wrap">
+        <div class="chart-col">
+          <svg class="donut" viewBox="0 0 ${SIZE} ${SIZE}" role="img"
+               aria-label="Consumption breakdown">
+            ${slices}
+            <text class="center-pct" x="${CX}" y="${CY - 6}">${centerTop}</text>
+            <text class="center-label" x="${CX}" y="${CY + 18}">${centerSub}</text>
+          </svg>
+          <div class="legend">
+            ${legend.map((row) => `
+              <div class="legend-row">
+                <span class="swatch" style="background:${row.color}"></span>
+                <span class="legend-label">${row.label}</span>
+                <span class="legend-value">${row.value}</span>
+              </div>
+            `).join("")}
+          </div>
+        </div>
+        <div class="export-col">
+          <span class="export-eyebrow">Exported</span>
+          <span class="export-number">${formatKwhNum(exportKwh)}</span>
+          <span class="export-unit">kWh sold to grid</span>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderEmpty() {
+    // Single 100 % muted ring so the donut shape is obvious.
+    return ringPath({
+      startPct: 0,
+      endPct: 100,
+      stroke: "var(--line)",
+    });
+  }
+
+  _renderSlices(selfPct) {
+    // Two-slice donut. Self-consumption is the amber/accent slice
+    // because it's "yours"; import is the red/--red-e slice because
+    // it's the bit you'd want to shrink.
+    const self = ringPath({
+      startPct: 0,
+      endPct: selfPct,
+      stroke: "var(--accent-e)",
+    });
+    const imp = ringPath({
+      startPct: selfPct,
+      endPct: 100,
+      stroke: "var(--red-e)",
+    });
+    return self + imp;
+  }
+}
+
+// ringPath — render a single donut arc as a thick stroke between two
+// percentages of the full circle. Returns an SVG <path>; concatenate
+// multiple paths to compose the donut. Avoiding <circle stroke-dasharray>
+// because it doesn't give clean slice boundaries when slices touch.
+function ringPath({ startPct, endPct, stroke }) {
+  const a = (startPct / 100) * 2 * Math.PI - Math.PI / 2;
+  const b = (endPct / 100) * 2 * Math.PI - Math.PI / 2;
+  // Full ring (100 %): SVG can't draw an arc that ends where it starts.
+  // Split into two semicircles in that case.
+  if (endPct - startPct >= 99.999) {
+    const m = Math.PI / 2;
+    return ringPath({ startPct: 0, endPct: 50, stroke }) +
+           ringPath({ startPct: 50, endPct: 100, stroke });
+  }
+  const r = (R_OUTER + R_INNER) / 2;
+  const x1 = CX + r * Math.cos(a);
+  const y1 = CY + r * Math.sin(a);
+  const x2 = CX + r * Math.cos(b);
+  const y2 = CY + r * Math.sin(b);
+  const largeArc = endPct - startPct > 50 ? 1 : 0;
+  return `<path d="M ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2}"
+                 fill="none"
+                 stroke="${stroke}"
+                 stroke-width="${RING}"
+                 stroke-linecap="butt"/>`;
+}
+
+function formatKwh(wh) {
+  const kwh = wh / 1000;
+  return `${kwh.toFixed(kwh < 10 ? 2 : 1)} kWh`;
+}
+
+function formatKwhNum(kwh) {
+  if (!isFinite(kwh)) return "—";
+  if (kwh >= 100) return kwh.toFixed(0);
+  if (kwh >= 10) return kwh.toFixed(1);
+  return kwh.toFixed(2);
+}
+
+function fmtPct(p) {
+  if (!isFinite(p)) return "—";
+  return `${p.toFixed(1)}%`;
+}
+
+customElements.define("ftw-energy-cake", FtwEnergyCake);

--- a/web/components/ftw-energy-cake.js
+++ b/web/components/ftw-energy-cake.js
@@ -177,7 +177,7 @@ class FtwEnergyCake extends FtwElement {
       return this._layout({
         slices: this._renderEmpty(),
         centerTop: "—",
-        centerSub: "self use",
+        centerSub: "kWh consumed",
         legend: [
           { color: "var(--accent-e)", label: "Self-consumption", value: "—" },
           { color: "var(--red-e)", label: "Imported", value: "—" },
@@ -191,8 +191,12 @@ class FtwEnergyCake extends FtwElement {
 
     return this._layout({
       slices: this._renderSlices(selfPct),
-      centerTop: `${Math.round(selfPct)}%`,
-      centerSub: "self use",
+      // Centre of the donut now shows TOTAL CONSUMED — the headline
+      // "how much energy did the household actually use over this
+      // window" number. Self-consumption % still reads off the legend
+      // so we don't lose the per-slice context.
+      centerTop: formatKwhNum(loadWh / 1000),
+      centerSub: "kWh consumed",
       legend: [
         {
           color: "var(--accent-e)",

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -286,9 +286,13 @@ class FtwPriceChart extends FtwElement {
                     stroke="${stroke}" stroke-width="${stroke === 'none' ? 0 : 1}" />`;
     }).join("");
 
-    // Mean reference line — dashed, dimmed.
+    // Mean reference line — true dotted (round caps + zero-length
+    // dashes spaced by 6 px) so it reads as "average over the known
+    // price period" rather than a regular dashed grid line. Sits
+    // above the bars but below the markers and tooltip.
     const meanLine = `<line x1="${pad.l}" x2="${pad.l + plotW}" y1="${meanY}" y2="${meanY}"
-                          stroke="var(--line)" stroke-width="1" stroke-dasharray="3 4" />`;
+                          stroke="var(--fg-muted)" stroke-width="1.5"
+                          stroke-linecap="round" stroke-dasharray="0.01 6" />`;
 
     // X-axis time ticks — every 6 hours.
     const xTicks = [];

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -242,7 +242,10 @@ class FtwPriceChart extends FtwElement {
     // the section holds twice the fuse-card height (DESIGN spec).
     const W = 1000;
     const H = 240;
-    const pad = { t: 16, r: 16, b: 28, l: 36 };
+    // Wider left padding so the y-axis öre labels have breathing
+    // room between the SVG edge and the plot's first bar (was 36 →
+    // labels rendered too close to the card's left border).
+    const pad = { t: 16, r: 16, b: 28, l: 56 };
     const plotW = W - pad.l - pad.r;
     const plotH = H - pad.t - pad.b;
     const barW = plotW / n;

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -294,12 +294,14 @@ class FtwPriceChart extends FtwElement {
                           stroke="var(--fg-muted)" stroke-width="1.5"
                           stroke-linecap="round" stroke-dasharray="0.01 6" />`;
 
-    // X-axis time ticks — every 6 hours.
+    // X-axis time ticks — every 3 hours so 48 h reads as ~16 evenly
+    // spaced labels, not the 8-label sparse grid we had before.
+    // Operators kept asking "what hour is this?" mid-chart.
     const xTicks = [];
     if (n > 0) {
       const startT = items[0].tsMs;
       const endT = items[n - 1].tsMs + items[n - 1].lenMin * 60_000;
-      const step = 6 * 3600_000;
+      const step = 3 * 3600_000;
       for (let t = ceilTo(startT, step); t < endT; t += step) {
         const frac = (t - startT) / (endT - startT);
         const x = pad.l + frac * plotW;

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -1,0 +1,453 @@
+// <ftw-price-chart> — full-width bar chart of known electricity spot
+// prices (next 48 h or so), with a toggle to include VAT (default on)
+// and hover tooltip per slot. Peaks + lows are marked. Self-fetching:
+// hits /api/prices and /api/config on connect, polls /api/prices
+// every 5 min after that.
+//
+// Inputs (none — autonomous). The component renders its own header
+// (label + VAT toggle) and the SVG chart underneath.
+//
+// Data shape from /api/prices:
+//   { zone: "SE4", enabled: true, items: [
+//       { slot_ts_ms, slot_len_min, spot_ore_kwh, total_ore_kwh, ... }
+//     ] }
+//
+// Sweden VAT rate (25 %) is read from /api/config price.vat_percent
+// when available; falls back to 25 for the toggle math when the
+// config endpoint is missing.
+
+import { FtwElement } from "./ftw-element.js";
+
+class FtwPriceChart extends FtwElement {
+  static styles = `
+    :host {
+      display: block;
+      font-family: var(--sans);
+      color: var(--fg);
+    }
+    .head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .label {
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--fg-muted);
+    }
+    .meta {
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--fg-dim);
+    }
+    .toggle {
+      position: relative;
+      display: inline-grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(0, 1fr);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--ink-sunken);
+      padding: 2px;
+      isolation: isolate;
+    }
+    .toggle::before {
+      content: '';
+      position: absolute;
+      top: 2px; bottom: 2px;
+      left: 2px;
+      width: calc(50% - 2px);
+      background: var(--accent-e);
+      border-radius: 999px;
+      transform: translateX(0);
+      transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1);
+      z-index: 0;
+    }
+    .toggle[data-vat="off"]::before {
+      transform: translateX(100%);
+    }
+    .toggle button {
+      position: relative;
+      z-index: 1;
+      background: transparent;
+      border: 0;
+      color: var(--fg-dim);
+      font-family: var(--mono);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      padding: 4px 14px;
+      cursor: pointer;
+      transition: color 220ms ease;
+    }
+    .toggle button.active { color: #0a0a0a; }
+    .toggle button:not(.active):hover { color: var(--fg); }
+
+    .chart-wrap {
+      position: relative;
+    }
+    svg.chart {
+      width: 100%;
+      display: block;
+      user-select: none;
+    }
+    .empty {
+      color: var(--fg-muted);
+      font-size: 0.85rem;
+      padding: 24px 8px;
+      text-align: center;
+    }
+    /* Tooltip — absolutely positioned, follows the cursor's slot. */
+    .tip {
+      position: absolute;
+      pointer-events: none;
+      background: var(--ink-raised);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--fg);
+      transform: translate(-50%, -110%);
+      white-space: nowrap;
+      opacity: 0;
+      transition: opacity 80ms;
+      z-index: 5;
+    }
+    .tip.visible { opacity: 1; }
+    .tip-time {
+      color: var(--fg-dim);
+      margin-bottom: 2px;
+    }
+    .tip-price {
+      font-size: 14px;
+      font-weight: 600;
+    }
+    .tip-price.peak  { color: var(--red-e); }
+    .tip-price.low   { color: var(--green-e); }
+  `;
+
+  constructor() {
+    super();
+    this._data = null;        // { zone, items: [{tsMs, ore}], min, max, vatPct }
+    this._vatOn = true;       // toggle state — default ON per spec
+    this._refreshTimer = null;
+    this._hover = null;       // { idx, x, y } during hover
+    this._vatPct = 25;        // fallback; overwritten from /api/config
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._loadConfig();
+    this._loadPrices();
+    this._refreshTimer = setInterval(() => this._loadPrices(), 5 * 60 * 1000);
+  }
+
+  disconnectedCallback() {
+    if (this._refreshTimer) {
+      clearInterval(this._refreshTimer);
+      this._refreshTimer = null;
+    }
+  }
+
+  async _loadConfig() {
+    try {
+      const r = await fetch("/api/config");
+      const j = await r.json();
+      const v = j && j.price && j.price.vat_percent;
+      if (typeof v === "number" && v > 0) {
+        this._vatPct = v;
+        this.update();
+      }
+    } catch (e) { /* ignore — fallback 25 % is fine */ }
+  }
+
+  async _loadPrices() {
+    try {
+      const r = await fetch("/api/prices?hours=48");
+      const j = await r.json();
+      if (!j || !Array.isArray(j.items)) {
+        this._data = null;
+      } else {
+        // Items already carry both spot_ore_kwh and total_ore_kwh, but
+        // the operator's mental model is "spot price ± VAT" — so we
+        // base on spot and let the toggle add VAT. Keeps the toggle
+        // semantics honest (it's NOT a tariff/grid-fee toggle, just
+        // VAT) and matches the API spec the user asked for.
+        const items = j.items.map((it) => ({
+          tsMs:  Number(it.slot_ts_ms) || 0,
+          lenMin: Number(it.slot_len_min) || 60,
+          spot:  Number(it.spot_ore_kwh) || 0,
+        })).sort((a, b) => a.tsMs - b.tsMs);
+        this._data = { zone: j.zone || "", items };
+      }
+      this.update();
+    } catch (e) {
+      this._data = null;
+      this.update();
+    }
+  }
+
+  // Resolved öre/kWh per slot for the active toggle.
+  _priceFor(item) {
+    return this._vatOn
+      ? item.spot * (1 + this._vatPct / 100)
+      : item.spot;
+  }
+
+  render() {
+    const data = this._data;
+    const vatLabel = this._vatOn ? "incl. VAT" : "spot only";
+    const head = `
+      <div class="head">
+        <div>
+          <div class="label">Electricity prices</div>
+          <div class="meta">${data ? `${escapeXml(data.zone)} · ${vatLabel}` : "—"}</div>
+        </div>
+        <div class="toggle" role="tablist" data-vat="${this._vatOn ? "on" : "off"}">
+          <button type="button" data-vat="on"  class="${this._vatOn ? "active" : ""}" aria-selected="${this._vatOn}">Incl. VAT</button>
+          <button type="button" data-vat="off" class="${!this._vatOn ? "active" : ""}" aria-selected="${!this._vatOn}">Spot</button>
+        </div>
+      </div>
+    `;
+    if (!data || !data.items.length) {
+      return head + `<div class="empty">No price data available.</div>`;
+    }
+    return head + this._renderChart(data);
+  }
+
+  _renderChart(data) {
+    // Compute prices, min/max, and the indices of the lowest +
+    // highest slots for the marker overlays.
+    const items = data.items;
+    const n = items.length;
+    const prices = items.map((it) => this._priceFor(it));
+    let lo = 0, hi = 0;
+    for (let i = 1; i < n; i++) {
+      if (prices[i] < prices[lo]) lo = i;
+      if (prices[i] > prices[hi]) hi = i;
+    }
+    const minP = prices[lo];
+    const maxP = prices[hi];
+    const meanP = prices.reduce((a, p) => a + p, 0) / n;
+
+    // SVG geometry. Width = 100 % via viewBox; height fixed-ish so
+    // the section holds twice the fuse-card height (DESIGN spec).
+    const W = 1000;
+    const H = 240;
+    const pad = { t: 16, r: 16, b: 28, l: 36 };
+    const plotW = W - pad.l - pad.r;
+    const plotH = H - pad.t - pad.b;
+    const barW = plotW / n;
+    // Y scale: include 0 so a negative-spot day still renders, and
+    // pad the top so the peak's marker doesn't kiss the edge.
+    const yMin = Math.min(0, minP);
+    const yMax = Math.max(maxP * 1.08, 1);
+    const yToPx = (v) => pad.t + plotH - ((v - yMin) / (yMax - yMin)) * plotH;
+    const zeroY = yToPx(0);
+    const meanY = yToPx(meanP);
+
+    // "Now" vertical line — falls inside one of the slots if any.
+    const now = Date.now();
+    let nowIdx = -1;
+    for (let i = 0; i < n; i++) {
+      const start = items[i].tsMs;
+      const end   = start + items[i].lenMin * 60_000;
+      if (now >= start && now < end) { nowIdx = i; break; }
+    }
+
+    // Bars — colour by relative price (cheaper = green, expensive =
+    // red, mid = neutral). Using the per-slot deviation from the mean
+    // keeps the colour discipline meaningful even on flat-price days.
+    const bars = items.map((it, i) => {
+      const x = pad.l + i * barW;
+      const p = prices[i];
+      const y = yToPx(p);
+      const h = Math.max(1, zeroY - y);
+      const dev = (p - meanP) / Math.max(1, maxP - minP);
+      const fill = i === lo ? "var(--green-e)"
+                  : i === hi ? "var(--red-e)"
+                  : (p < meanP ? `color-mix(in srgb, var(--green-e) ${Math.round(40 - dev * 40)}%, transparent)`
+                              : `color-mix(in srgb, var(--red-e) ${Math.round(40 + dev * 40)}%, transparent)`);
+      const stroke = (i === lo || i === hi) ? "currentColor" : "none";
+      return `<rect x="${x + 0.5}" y="${y}" width="${Math.max(0.1, barW - 1)}" height="${h}"
+                    fill="${fill}" data-idx="${i}"
+                    style="${i === lo ? 'color: var(--green-e)' : i === hi ? 'color: var(--red-e)' : ''}"
+                    stroke="${stroke}" stroke-width="${stroke === 'none' ? 0 : 1}" />`;
+    }).join("");
+
+    // Mean reference line — dashed, dimmed.
+    const meanLine = `<line x1="${pad.l}" x2="${pad.l + plotW}" y1="${meanY}" y2="${meanY}"
+                          stroke="var(--line)" stroke-width="1" stroke-dasharray="3 4" />`;
+
+    // X-axis time ticks — every 6 hours.
+    const xTicks = [];
+    if (n > 0) {
+      const startT = items[0].tsMs;
+      const endT = items[n - 1].tsMs + items[n - 1].lenMin * 60_000;
+      const step = 6 * 3600_000;
+      for (let t = ceilTo(startT, step); t < endT; t += step) {
+        const frac = (t - startT) / (endT - startT);
+        const x = pad.l + frac * plotW;
+        xTicks.push(`<line x1="${x}" x2="${x}" y1="${pad.t + plotH}" y2="${pad.t + plotH + 4}"
+                          stroke="var(--line)" />
+                     <text x="${x}" y="${pad.t + plotH + 16}" text-anchor="middle"
+                           fill="var(--fg-muted)" font-family="var(--mono)" font-size="10">
+                       ${fmtClock(t)}
+                     </text>`);
+      }
+    }
+    // Y-axis labels — min / mean / max.
+    const yLabels = [
+      { y: yToPx(yMax), text: roundOre(yMax) + " ö" },
+      { y: meanY,       text: roundOre(meanP) + " ö" },
+      { y: yToPx(yMin), text: roundOre(yMin) + " ö" },
+    ].map((l) => `<text x="${pad.l - 4}" y="${l.y + 3}" text-anchor="end"
+                       fill="var(--fg-muted)" font-family="var(--mono)" font-size="10">${l.text}</text>`).join("");
+
+    // "Now" marker — vertical line plus a "now" pill.
+    let nowMarker = "";
+    if (nowIdx >= 0) {
+      const x = pad.l + (nowIdx + 0.5) * barW;
+      nowMarker = `
+        <line x1="${x}" x2="${x}" y1="${pad.t}" y2="${pad.t + plotH}"
+              stroke="var(--accent-e)" stroke-width="1.5" stroke-dasharray="2 3"
+              opacity="0.7" />
+        <text x="${x}" y="${pad.t - 4}" text-anchor="middle"
+              fill="var(--accent-e)" font-family="var(--mono)" font-size="10"
+              font-weight="600">NOW</text>
+      `;
+    }
+
+    // Peak / low markers — small triangles above their bars.
+    const markBar = (idx, color, glyph) => {
+      const x = pad.l + (idx + 0.5) * barW;
+      const y = yToPx(prices[idx]) - 6;
+      return `<text x="${x}" y="${y}" text-anchor="middle"
+                    fill="${color}" font-family="var(--mono)" font-size="11"
+                    font-weight="700">${glyph}</text>`;
+    };
+
+    // Hit-target overlay — invisible rects sized to bar width that
+    // cover the FULL plot height so hover is forgiving even when a
+    // bar is short (cheap slots).
+    const hits = items.map((_, i) => {
+      const x = pad.l + i * barW;
+      return `<rect x="${x}" y="${pad.t}" width="${barW}" height="${plotH}"
+                    fill="transparent" data-idx="${i}" class="hit" />`;
+    }).join("");
+
+    return `
+      <div class="chart-wrap">
+        <svg class="chart" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none"
+             role="img" aria-label="Electricity price chart">
+          ${meanLine}
+          ${bars}
+          ${nowMarker}
+          ${markBar(lo, "var(--green-e)", "▼")}
+          ${markBar(hi, "var(--red-e)",   "▲")}
+          ${xTicks.join("")}
+          ${yLabels}
+          ${hits}
+        </svg>
+        <div class="tip" data-tip>
+          <div class="tip-time" data-tip-time>—</div>
+          <div class="tip-price" data-tip-price>—</div>
+        </div>
+      </div>
+    `;
+  }
+
+  afterRender() {
+    const root = this.shadowRoot;
+    const toggle = root.querySelector(".toggle");
+    if (toggle) {
+      toggle.querySelectorAll("button[data-vat]").forEach((b) => {
+        b.addEventListener("click", () => {
+          const next = b.dataset.vat === "on";
+          if (next === this._vatOn) return;
+          this._vatOn = next;
+          this.update();
+        });
+      });
+    }
+    // Tooltip wiring — listen on the SVG and route by data-idx.
+    const svg = root.querySelector("svg.chart");
+    const tip = root.querySelector("[data-tip]");
+    if (!svg || !tip || !this._data) return;
+    const onMove = (e) => {
+      const target = e.target.closest("[data-idx]");
+      if (!target) { this._hideTip(); return; }
+      const i = Number(target.dataset.idx);
+      if (!Number.isFinite(i)) { this._hideTip(); return; }
+      this._showTip(i, e);
+    };
+    svg.addEventListener("mousemove", onMove);
+    svg.addEventListener("mouseleave", () => this._hideTip());
+  }
+
+  _showTip(idx, e) {
+    const tip = this.shadowRoot.querySelector("[data-tip]");
+    const item = this._data.items[idx];
+    if (!tip || !item) return;
+    const price = this._priceFor(item);
+    const tEnd = item.tsMs + item.lenMin * 60_000;
+    tip.querySelector("[data-tip-time]").textContent =
+      `${fmtClock(item.tsMs)}–${fmtClock(tEnd)}`;
+    const priceEl = tip.querySelector("[data-tip-price]");
+    priceEl.textContent = `${roundOre(price)} öre / kWh`;
+    // Annotate peak/low per the same indices used in render.
+    const items = this._data.items;
+    const prices = items.map((it) => this._priceFor(it));
+    let lo = 0, hi = 0;
+    for (let i = 1; i < items.length; i++) {
+      if (prices[i] < prices[lo]) lo = i;
+      if (prices[i] > prices[hi]) hi = i;
+    }
+    priceEl.classList.toggle("peak", idx === hi);
+    priceEl.classList.toggle("low",  idx === lo);
+    // Position the tooltip at the cursor's X, anchored above.
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    tip.style.left = x + "px";
+    tip.style.top  = y + "px";
+    tip.classList.add("visible");
+  }
+
+  _hideTip() {
+    const tip = this.shadowRoot.querySelector("[data-tip]");
+    if (tip) tip.classList.remove("visible");
+  }
+}
+
+function fmtClock(tsMs) {
+  const d = new Date(tsMs);
+  return d.getHours().toString().padStart(2, "0") + ":" +
+         d.getMinutes().toString().padStart(2, "0");
+}
+
+function roundOre(v) {
+  if (Math.abs(v) >= 100) return v.toFixed(0);
+  if (Math.abs(v) >= 10)  return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+function ceilTo(t, step) {
+  return Math.ceil(t / step) * step;
+}
+
+function escapeXml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;"
+  }[c]));
+}
+
+customElements.define("ftw-price-chart", FtwPriceChart);

--- a/web/components/index.js
+++ b/web/components/index.js
@@ -13,6 +13,8 @@ import "./ftw-tabs.js";
 import "./ftw-legend.js";
 import "./ftw-energy-flow.js";
 import "./ftw-battery-control.js";
+import "./ftw-price-chart.js";
+import "./ftw-energy-cake.js";
 import "./ftw-bar-chart.js";
 import "./ftw-history-card.js";
 import "./ftw-update-check.js";

--- a/web/index.html
+++ b/web/index.html
@@ -157,6 +157,15 @@
       </div>
     </section>
 
+    <!-- Electricity prices — full-width chart of upcoming spot prices
+         with a VAT-on/off toggle, peak/low markers, and a hover
+         tooltip. Self-fetching: hits /api/prices on connect. -->
+    <section class="prices-row">
+      <div class="card prices-group">
+        <ftw-price-chart></ftw-price-chart>
+      </div>
+    </section>
+
     <!-- Energy today — one wrapper card with six sub-tiles. Mirrors the
          fuse-card pattern: outer card owns the label; each inner tile
          has its own sub-label + kWh value. Sub-labels drop the "today"
@@ -203,16 +212,25 @@
       <div class="card history-group">
         <div class="history-head">
           <div class="card-label">History in numbers</div>
-          <div class="history-toggle" id="history-toggle" role="tablist" data-active="week">
-            <button type="button" role="tab" data-range="week"  class="active" aria-selected="true">Week</button>
-            <button type="button" role="tab" data-range="month" aria-selected="false">Month</button>
+          <div class="history-toggles">
+            <div class="history-toggle" id="history-view-toggle" role="tablist" data-active="numbers">
+              <button type="button" role="tab" data-view="numbers" class="active" aria-selected="true">Numbers</button>
+              <button type="button" role="tab" data-view="cakes"   aria-selected="false">Cakes</button>
+            </div>
+            <div class="history-toggle" id="history-toggle" role="tablist" data-active="week">
+              <button type="button" role="tab" data-range="week"  class="active" aria-selected="true">Week</button>
+              <button type="button" role="tab" data-range="month" aria-selected="false">Month</button>
+            </div>
           </div>
         </div>
-        <div class="history-tiles">
+        <div class="history-tiles" id="history-tiles">
           <ftw-history-card metric="import" label="Imported" hide-toggle range="week"></ftw-history-card>
           <ftw-history-card metric="pv"     label="Produced" hide-toggle range="week"></ftw-history-card>
           <ftw-history-card metric="load"   label="Consumed" hide-toggle range="week"></ftw-history-card>
           <ftw-history-card metric="export" label="Exported" hide-toggle range="week"></ftw-history-card>
+        </div>
+        <div class="history-cake hidden" id="history-cake">
+          <ftw-energy-cake id="history-cake-el"></ftw-energy-cake>
         </div>
       </div>
     </section>

--- a/web/index.html
+++ b/web/index.html
@@ -215,7 +215,7 @@
           <div class="history-toggles">
             <div class="history-toggle" id="history-view-toggle" role="tablist" data-active="bars">
               <button type="button" role="tab" data-view="bars"  class="active" aria-selected="true">Bars</button>
-              <button type="button" role="tab" data-view="cakes" aria-selected="false">Cakes</button>
+              <button type="button" role="tab" data-view="cakes" aria-selected="false">Pie</button>
             </div>
             <div class="history-toggle" id="history-toggle" role="tablist" data-active="week">
               <button type="button" role="tab" data-range="week"  class="active" aria-selected="true">Week</button>

--- a/web/index.html
+++ b/web/index.html
@@ -213,9 +213,9 @@
         <div class="history-head">
           <div class="card-label">History in numbers</div>
           <div class="history-toggles">
-            <div class="history-toggle" id="history-view-toggle" role="tablist" data-active="numbers">
-              <button type="button" role="tab" data-view="numbers" class="active" aria-selected="true">Numbers</button>
-              <button type="button" role="tab" data-view="cakes"   aria-selected="false">Cakes</button>
+            <div class="history-toggle" id="history-view-toggle" role="tablist" data-active="bars">
+              <button type="button" role="tab" data-view="bars"  class="active" aria-selected="true">Bars</button>
+              <button type="button" role="tab" data-view="cakes" aria-selected="false">Cakes</button>
             </div>
             <div class="history-toggle" id="history-toggle" role="tablist" data-active="week">
               <button type="button" role="tab" data-range="week"  class="active" aria-selected="true">Week</button>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2025,6 +2025,36 @@
   // `range=week|month` onto every child — the component observes that
   // attribute and re-fetches, so the three charts stay in lock-step.
   var historyToggle = $("history-toggle");
+  var historyViewToggle = $("history-view-toggle");
+  var historyTiles = $("history-tiles");
+  var historyCakeWrap = $("history-cake");
+  var historyCakeEl = $("history-cake-el");
+
+  // historyState mirrors both toggles so the Numbers/Cakes view and
+  // the Week/Month range stay coordinated. Only the cake re-fetches
+  // /api/energy/daily on a range change; the numbers tiles each
+  // re-fetch themselves when their range= attribute is updated.
+  var historyState = { range: "week", view: "numbers" };
+
+  function fetchHistoryCake() {
+    if (!historyCakeEl || typeof historyCakeEl.setTotals !== "function") return;
+    var days = historyState.range === "month" ? 30 : 7;
+    fetch("/api/energy/daily?days=" + days)
+      .then(function (r) { return r.json(); })
+      .then(function (j) {
+        var arr = (j && j.days) || [];
+        var totals = { import_wh: 0, load_wh: 0, export_wh: 0, pv_wh: 0 };
+        for (var i = 0; i < arr.length; i++) {
+          totals.import_wh += arr[i].import_wh || 0;
+          totals.load_wh   += arr[i].load_wh   || 0;
+          totals.export_wh += arr[i].export_wh || 0;
+          totals.pv_wh     += arr[i].pv_wh     || 0;
+        }
+        historyCakeEl.setTotals(totals);
+      })
+      .catch(function () { /* network blip — leave the previous render */ });
+  }
+
   if (historyToggle) {
     historyToggle.addEventListener("click", function (e) {
       var btn = e.target.closest("button[data-range]");
@@ -2032,6 +2062,7 @@
       var next = btn.getAttribute("data-range");
       if (!next || next === historyToggle.getAttribute("data-active")) return;
       historyToggle.setAttribute("data-active", next);
+      historyState.range = next;
       var buttons = historyToggle.querySelectorAll("button[data-range]");
       for (var i = 0; i < buttons.length; i++) {
         var on = buttons[i].getAttribute("data-range") === next;
@@ -2042,6 +2073,28 @@
       for (var j = 0; j < tiles.length; j++) {
         tiles[j].setAttribute("range", next);
       }
+      // Cake: refresh only when it's the active view.
+      if (historyState.view === "cakes") fetchHistoryCake();
+    });
+  }
+
+  if (historyViewToggle) {
+    historyViewToggle.addEventListener("click", function (e) {
+      var btn = e.target.closest("button[data-view]");
+      if (!btn) return;
+      var next = btn.getAttribute("data-view");
+      if (!next || next === historyViewToggle.getAttribute("data-active")) return;
+      historyViewToggle.setAttribute("data-active", next);
+      historyState.view = next;
+      var buttons = historyViewToggle.querySelectorAll("button[data-view]");
+      for (var i = 0; i < buttons.length; i++) {
+        var on = buttons[i].getAttribute("data-view") === next;
+        buttons[i].classList.toggle("active", on);
+        buttons[i].setAttribute("aria-selected", on ? "true" : "false");
+      }
+      if (historyTiles) historyTiles.classList.toggle("hidden", next !== "numbers");
+      if (historyCakeWrap) historyCakeWrap.classList.toggle("hidden", next !== "cakes");
+      if (next === "cakes") fetchHistoryCake();
     });
   }
 

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2030,11 +2030,11 @@
   var historyCakeWrap = $("history-cake");
   var historyCakeEl = $("history-cake-el");
 
-  // historyState mirrors both toggles so the Numbers/Cakes view and
+  // historyState mirrors both toggles so the Bars/Cakes view and
   // the Week/Month range stay coordinated. Only the cake re-fetches
-  // /api/energy/daily on a range change; the numbers tiles each
+  // /api/energy/daily on a range change; the bar tiles each
   // re-fetch themselves when their range= attribute is updated.
-  var historyState = { range: "week", view: "numbers" };
+  var historyState = { range: "week", view: "bars" };
 
   function fetchHistoryCake() {
     if (!historyCakeEl || typeof historyCakeEl.setTotals !== "function") return;
@@ -2092,7 +2092,7 @@
         buttons[i].classList.toggle("active", on);
         buttons[i].setAttribute("aria-selected", on ? "true" : "false");
       }
-      if (historyTiles) historyTiles.classList.toggle("hidden", next !== "numbers");
+      if (historyTiles) historyTiles.classList.toggle("hidden", next !== "bars");
       if (historyCakeWrap) historyCakeWrap.classList.toggle("hidden", next !== "cakes");
       if (next === "cakes") fetchHistoryCake();
     });

--- a/web/next.css
+++ b/web/next.css
@@ -477,6 +477,23 @@ body.ftw-next .history-head {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 10px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+/* Two stacked toggle pills (Numbers/Cakes + Week/Month) ride to the
+   right of the panel label. Wrap onto a new line on narrow viewports
+   instead of squashing the label. */
+body.ftw-next .history-toggles {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+/* History view-mode swap: tiles vs cake. Both children of the panel
+   stay in the DOM so swapping is a CSS class flip, no fetch round-trip. */
+body.ftw-next .history-tiles.hidden,
+body.ftw-next .history-cake.hidden { display: none; }
+body.ftw-next .history-cake {
+  padding: 4px 0 6px;
 }
 /* Shared Week/Month segmented pill — same visual as the per-card
    toggle that used to live inside the shadow DOM so the brand
@@ -541,6 +558,20 @@ body.ftw-next .history-tiles {
 }
 @media (max-width: 900px) {
   body.ftw-next .history-tiles { grid-template-columns: 1fr; }
+}
+
+/* ---- Electricity prices — full-width chart between fuse and energy
+   sections. Section height ≈ 2× fuse-card height per spec; the
+   <ftw-price-chart> component owns its own SVG geometry inside. */
+body.ftw-next .prices-row {
+  display: block;
+  margin: 12px 0;
+}
+body.ftw-next .prices-group {
+  background: var(--ink-raised);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: var(--card-pad, 14px 16px);
 }
 
 /* ---- Energy today — one outer card with sub-tiles, mirrors fuse-card ---- */

--- a/web/next.css
+++ b/web/next.css
@@ -523,7 +523,13 @@ body.ftw-next .history-toggle::before {
   transition: transform 260ms cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 0;
 }
-body.ftw-next .history-toggle[data-active="month"]::before {
+/* Slide the amber pill to the right side of the toggle when the
+   second option is active. Generalised so both Week/Month
+   (data-active="month") and Bars/Cakes (data-active="cakes") share
+   the same pill animation — the toggle markup is otherwise
+   identical and shouldn't need a special CSS branch per option set. */
+body.ftw-next .history-toggle[data-active="month"]::before,
+body.ftw-next .history-toggle[data-active="cakes"]::before {
   transform: translateX(100%);
 }
 body.ftw-next .history-toggle button {


### PR DESCRIPTION
## Summary

Two related dashboard additions, one PR:

### 1. Full-width spot-price chart

New \`<ftw-price-chart>\` component placed between the fuse section and "Energy today". Self-fetches \`/api/prices\` (refreshes every 5 min) and renders a bar chart of upcoming 48 h slots:

- Peak slot marked ▲ in red, low slot marked ▼ in green, mean drawn as a dashed reference line
- "NOW" indicator over the active slot
- **VAT toggle** in the header — default ON. Applied as \`spot × (1 + vat_percent / 100)\`; \`vat_percent\` is read from \`/api/config\` with a 25 % fallback for SE
- **Hover tooltip** anywhere on the plot: shows the slot window (HH:MM–HH:MM) and the price in öre/kWh; peak/low slots tint the tooltip price in the matching accent colour
- Section height ~2× fuse-card per spec (240 px SVG viewBox; preserves aspect across viewports)

### 2. Numbers / Cakes toggle on the History panel

New segmented pill next to the existing Week/Month toggle.

- Default "Numbers" — the existing 4 daily-kWh tiles (unchanged)
- "Cakes" — swaps in a donut chart of **self-consumption vs import** (calculated from \`/api/energy/daily\` summed across the active range), with a standalone **export-kWh number** alongside per spec
- The cake component (\`<ftw-energy-cake>\`) was authored on feat/history-cakes-view; cherry-picked here so the toggle ships with both halves of the feature
- Range toggle still drives both views; switching is a CSS class swap so re-opening Cakes is instant

## Files

- \`web/components/ftw-price-chart.js\` (new)
- \`web/components/ftw-energy-cake.js\` (cherry-picked from feat/history-cakes-view)
- \`web/components/index.js\` — register both
- \`web/index.html\` — new \`<section class="prices-row">\` between fuse and energy-row, history toggle pair + cake wrapper
- \`web/next.css\` — \`.prices-row\` + \`.history-toggles\` + show/hide CSS
- \`web/next-app.js\` — bind the new view toggle, fetch + reduce \`/api/energy/daily\` into cake totals

## Test plan

- [x] JS syntax clean
- [x] Live data via dev proxy: \`/api/prices?hours=48\` returns 53 items for SE4
- [ ] Visual check on desktop — peak/low markers placed correctly, tooltip follows cursor
- [ ] Compact viewport — chart still readable, tooltip doesn't overflow
- [ ] History → Cakes — donut renders self/import correctly across week + month windows
- [ ] VAT toggle flips bar heights without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)