### PR TITLE
feat(web/plan): add "?" help modal explaining the monetary numbers

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -329,7 +329,12 @@
       <!-- MPC Plan (right) -->
       <section id="plan-section">
         <div class="chart-header">
-          <h2>Plan</h2>
+          <div class="plan-title">
+            <h2>Plan</h2>
+            <button id="plan-help-btn" class="plan-help-btn" type="button"
+                    aria-label="Explain the numbers shown in the Plan section"
+                    title="What do these numbers mean?">?</button>
+          </div>
           <div class="plan-actions">
             <span id="plan-summary" class="plan-summary">…</span>
             <button id="plan-replan" class="btn-send" title="Force a fresh plan">Replan</button>
@@ -448,6 +453,63 @@
 
   <!-- Battery manual-hold popup — opened from the battery planet click. -->
   <ftw-battery-control id="battery-control"></ftw-battery-control>
+
+  <!-- Plan numbers — what they mean -->
+  <ftw-modal id="plan-help-modal" style="--ftw-modal-max-width:560px">
+    <span slot="title">What do these numbers mean?</span>
+    <div class="plan-help-body">
+      <p>
+        Everything the planner shows is in two units:
+        <b>öre/kWh</b> for prices (1 SEK = 100 öre) and
+        <b>SEK</b> for whole-horizon totals.
+      </p>
+
+      <h3>Header line</h3>
+      <ul>
+        <li><b>start SoC</b> — battery state of charge right now. The plan starts from this point.</li>
+        <li>
+          <b>expected cost / earnings</b> — total grid spend over the
+          full horizon (e.g. <code>48h</code>) at the planner's chosen schedule,
+          using real spot prices, grid tariff and VAT.
+          A <em>negative</em> number means the plan expects to <em>earn</em>
+          money (net export over the horizon).
+        </li>
+        <li><b>replanned … ago</b> — time since the last optimisation pass; the reason it ran is shown next to it.</li>
+      </ul>
+
+      <h3>Price bars (top of the chart)</h3>
+      <p>Each bar is one 15-minute slot, stacked as the three pieces of your real consumer price:</p>
+      <ul>
+        <li>
+          <span class="legend-color" style="background:rgba(148,163,184,0.72);display:inline-block;width:10px;height:10px;border-radius:2px;vertical-align:middle"></span>
+          <b>spot</b> — raw Nord Pool wholesale price. Colours green / slate / red by tercile across the horizon (cheap / mid / expensive). This is the part the planner actually optimises against.
+        </li>
+        <li>
+          <span class="legend-color" style="background:rgba(100,116,139,0.45);display:inline-block;width:10px;height:10px;border-radius:2px;vertical-align:middle"></span>
+          <b>grid tariff</b> — fixed transport / network fee from the grid operator (öre/kWh). Same value every slot.
+        </li>
+        <li>
+          <span class="legend-color" style="background:rgba(100,116,139,0.25);display:inline-block;width:10px;height:10px;border-radius:2px;vertical-align:middle"></span>
+          <b>VAT</b> — moms applied to spot + grid tariff. Set in <em>Settings → Price</em>.
+        </li>
+      </ul>
+      <p class="plan-help-note">
+        Hover any bar for the exact split (spot / grid / VAT) plus PV, load, battery and SoC for that slot.
+      </p>
+
+      <h3>Savings badges</h3>
+      <p>Each badge compares the plan's expected cost against an alternative scenario over the same horizon. All three numbers are computed by the same cost model, so they're directly comparable.</p>
+      <ul>
+        <li><b>vs no battery</b> — what this horizon would cost with no battery at all (grid flow = load + PV each slot, priced normally). Captures the combined value of battery + planner.</li>
+        <li><b>vs self-consumption</b> — what plain self-consumption mode would cost over the same forecast (same battery, same constraints, no arbitrage). Captures the extra value the planner adds on top of passive SC.</li>
+        <li><b>vs flat avg price</b> — what no-battery import would cost if every kWh were priced at the horizon's average price. Captures the value of <em>timing</em> — shifting consumption into cheap hours — independently of the battery.</li>
+      </ul>
+      <p class="plan-help-note">
+        <span class="saving-pos-inline">Green +</span> means the plan saves vs that baseline.
+        <span class="saving-neg-inline">Red −</span> means it costs more (rare, usually a sign the baseline benefits from a lucky forecast).
+      </p>
+    </div>
+  </ftw-modal>
 
   <!-- EV detail popup -->
   <ftw-modal id="ev-modal" style="--ftw-modal-max-width:380px">

--- a/web/next.css
+++ b/web/next.css
@@ -870,6 +870,74 @@ body.ftw-next .saving-badge.saving-pos { border-color: rgba(34,197,94,0.45); col
 body.ftw-next .saving-badge.saving-neg { border-color: rgba(239,68,68,0.45); color: #f87171; }
 body.ftw-next .plan-actions { gap: 10px; display: flex; align-items: center; }
 
+/* ---- Plan "?" help button + explanation modal ---- */
+body.ftw-next .plan-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+body.ftw-next .plan-help-btn {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--fg-dim);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 180ms ease, border-color 180ms ease;
+}
+body.ftw-next .plan-help-btn:hover {
+  color: var(--accent-e);
+  border-color: var(--accent-e);
+}
+body.ftw-next .plan-help-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent-e);
+  color: var(--accent-e);
+}
+body.ftw-next .plan-help-body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fg-dim);
+}
+body.ftw-next .plan-help-body p { margin: 0 0 10px; }
+body.ftw-next .plan-help-body h3 {
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 14px 0 6px;
+  letter-spacing: -0.005em;
+}
+body.ftw-next .plan-help-body ul {
+  margin: 0 0 10px;
+  padding-left: 18px;
+}
+body.ftw-next .plan-help-body li { margin: 0 0 6px; }
+body.ftw-next .plan-help-body b { color: var(--fg); font-weight: 600; }
+body.ftw-next .plan-help-body code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg);
+  background: rgba(255,255,255,0.04);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+body.ftw-next .plan-help-note {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-top: 4px;
+}
+body.ftw-next .plan-help-body .saving-pos-inline { color: #4ade80; font-weight: 600; }
+body.ftw-next .plan-help-body .saving-neg-inline { color: #f87171; font-weight: 600; }
+
 /* ---- ML twins / drivers / calibration sections ---- */
 body.ftw-next .section-header h2,
 body.ftw-next #twins-section h2,

--- a/web/plan.js
+++ b/web/plan.js
@@ -647,6 +647,14 @@
     window.addEventListener('resize', render);
     const btn = document.getElementById('plan-replan');
     if (btn) btn.addEventListener('click', replan);
+    const helpBtn = document.getElementById('plan-help-btn');
+    const helpModal = document.getElementById('plan-help-modal');
+    if (helpBtn && helpModal) {
+      helpBtn.addEventListener('click', function () {
+        if (typeof helpModal.open === 'function') helpModal.open();
+        else helpModal.setAttribute('open', '');
+      });
+    }
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

User feedback: operators couldn't tell what the öre / SEK figures in the Plan section actually mean. The hover tooltips already cover most of it but they're hard to discover.

Adds a small `?` button next to the **Plan** heading that opens an `<ftw-modal>` with a structured rundown of every monetary number:

- **Header line** — `start SoC`, `expected cost / earnings` (SEK over the horizon, negative = expected earnings), `replanned … ago`.
- **Price bars** — each 15-min slot is stacked as **spot** (Nord Pool wholesale, tercile-coloured) + **grid tariff** (fixed öre/kWh) + **VAT** (moms). Matching colour swatches in the modal so the explanation maps back to the chart segments.
- **Savings badges** — what `vs no battery`, `vs self-consumption`, `vs flat avg price` actually compare against, and what green `+` / red `−` mean.
- Note that prices are in **öre/kWh** and totals in **SEK** (1 SEK = 100 öre).

DESIGN.md compliant: tokens only (`--accent-e`, `--line`, `--fg-dim`, `--fg-muted`), 1 px hairline border on the round button, no drop shadow, sans for prose. Reuses the existing `<ftw-modal>` component (already loaded via `components/index.js`).

## Files

- `web/index.html` — `?` button in the chart header + new `<ftw-modal id="plan-help-modal">` body
- `web/next.css` — styling for `.plan-help-btn` and `.plan-help-body`
- `web/plan.js` — wires the button click to `helpModal.open()`

## Test plan

- [ ] Click the `?` next to "Plan" → modal opens with the explanation
- [ ] ESC and backdrop-click both close the modal (inherited from `<ftw-modal>`)
- [ ] Button hover lights up amber (`--accent-e`)
- [ ] Layout still looks right next to the existing `plan-summary` + `Replan` button on narrow viewports
- [ ] Light theme: button border and modal text remain legible (no hardcoded hex)

https://claude.ai/code/session_01VrKcnq6zQS87xtMmkMotov

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrKcnq6zQS87xtMmkMotov)_