### PR TITLE
feat(settings): hot-reload HA bridge + restart-required dialog

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -225,6 +225,23 @@ func main() {
 	// ---- Self-tune coordinator ----
 	selfTune := selftune.NewCoordinator()
 
+	// ---- Restart signal ----
+	// Closing restartCh from /api/restart drops the main control loop out
+	// of its select, which returns from main() so every defer (HA Stop,
+	// state.Close, http.Shutdown, …) runs in normal LIFO order. The
+	// bottom-of-stack `os.Exit` defer below then translates exitCode 1
+	// into a non-zero process exit so docker (`unless-stopped`) and
+	// systemd (`Restart=on-failure`) bring the binary back up. SIGTERM /
+	// SIGINT take the same return path with exitCode 0.
+	restartCh := make(chan struct{})
+	var restartOnce sync.Once
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
+
 	// ---- Driver registry ----
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -304,6 +321,22 @@ func main() {
 	// wired up. nil until that point — the reload closure guards.
 	var mpcSvc *mpc.Service
 
+	// Pre-declared so the hot-reload Applier can call (*ha.Bridge).Reload
+	// when broker / credentials / publish interval change. Constructed
+	// further down once the registry + control callbacks exist; the
+	// Applier nil-guards against the bridge being disabled.
+	var haBridge *ha.Bridge
+
+	// deps is the API server's runtime dependency container. Forward-
+	// declared as a *Deps so the hot-reload Applier closure can capture
+	// it as a variable: the closure dereferences `deps` only after the
+	// HTTP server has been wired up (deps is populated below), so
+	// applier-time reads always observe the fully-constructed value.
+	// Updating deps.HA from the applier (e.g. when an operator toggles
+	// HA from disabled to enabled at runtime) keeps the API handler's
+	// pointer in sync without forcing a process restart.
+	var deps *api.Deps
+
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
@@ -379,6 +412,42 @@ func main() {
 			}
 			notifSvc.SetPublisher(newPub)
 			notifSvc.Reload(newCfg.Notifications)
+
+			// Home Assistant: hot-reload broker / credentials / publish
+			// interval / driver list. Bridge.Reload tears down the paho
+			// client and re-publishes discovery so an operator changing
+			// the broker IP from Settings sees HA reconnect within a
+			// second — no process restart required.
+			//
+			// Three transitions to handle:
+			//   running → running:  Bridge.Reload swaps connection.
+			//   running → disabled: Stop the existing bridge.
+			//   disabled → enabled: Start a fresh bridge (handles both
+			//                       the "previously toggled off" case and
+			//                       the "Start failed at boot, operator
+			//                       fixed the broker" recovery path).
+			haEnabled := newCfg.HomeAssistant != nil && newCfg.HomeAssistant.Enabled
+			switch {
+			case haBridge != nil && haEnabled:
+				if err := haBridge.Reload(newCfg.HomeAssistant, reg.Names()); err != nil {
+					slog.Warn("HA bridge reload failed", "err", err)
+				} else {
+					slog.Info("HA bridge reloaded", "broker", newCfg.HomeAssistant.Broker)
+				}
+			case haBridge != nil && !haEnabled:
+				haBridge.Stop()
+				haBridge = nil
+				deps.HA = nil
+				slog.Info("HA bridge stopped (disabled in config)")
+			case haBridge == nil && haEnabled:
+				if bridge, err := ha.Start(newCfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctrl, ctrlMu, st)); err != nil {
+					slog.Warn("HA bridge start failed", "err", err)
+				} else {
+					haBridge = bridge
+					deps.HA = bridge
+					slog.Info("HA bridge started", "broker", newCfg.HomeAssistant.Broker)
+				}
+			}
 
 			// Weather diff → push live into the PV twin + forecast
 			// fetcher without a process restart. Users adjust rated PV
@@ -866,10 +935,10 @@ func main() {
 	}
 
 	// ---- Start HTTP API ----
-	// Forward-declare haBridge so Deps can reference it; the bridge
-	// gets wired further down (HA is optional + depends on reg.Names()).
-	var haBridge *ha.Bridge
-	deps := &api.Deps{
+	// haBridge is forward-declared at the top of the file so the config
+	// hot-reload closure can call Reload on it; the bridge instance gets
+	// wired further down (HA is optional + depends on reg.Names()).
+	deps = &api.Deps{
 		Tel: tel, Ctrl: ctrl, CtrlMu: ctrlMu,
 		State: st,
 		CapMu: capMu, Capacities: capacities,
@@ -899,6 +968,30 @@ func main() {
 		Events:     bus,
 		Notifications: notifSvc,
 		SelfUpdate: selfUpdater,
+		Restart: func(reqCtx context.Context) error {
+			// Prefer the docker-compose sidecar path when wired up: the
+			// updater container does docker compose up -d --force-recreate,
+			// which is the same code path post-update restarts use, so
+			// there's only one battle-tested escape hatch in production.
+			if selfUpdater != nil {
+				if err := selfUpdater.Trigger(reqCtx, "restart", ""); err == nil {
+					slog.Info("restart: dispatched via updater sidecar")
+					return nil
+				} else {
+					slog.Info("restart: sidecar unavailable, falling back to in-process exit", "err", err)
+				}
+			}
+			// Fallback: drop the main control loop out of its select so
+			// every defer (HA Stop, st.Close, http.Shutdown, …) runs
+			// cleanly. The os.Exit(1) at the bottom of the defer stack
+			// then makes docker (`unless-stopped`) and systemd
+			// (`Restart=on-failure`) bring the binary back up.
+			restartOnce.Do(func() {
+				exitCode = 1
+				close(restartCh)
+			})
+			return nil
+		},
 		Version:    Version,
 	}
 	srv := api.New(deps)
@@ -1020,54 +1113,22 @@ func main() {
 
 	// ---- HA MQTT bridge (optional) ----
 	if cfg.HomeAssistant != nil && cfg.HomeAssistant.Enabled {
-		cb := ha.CommandCallbacks{
-			SetMode: func(m string) error {
-				ctrlMu.Lock()
-				defer ctrlMu.Unlock()
-				switch control.Mode(m) {
-				case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
-					control.ModeCharge, control.ModePriority, control.ModeWeighted:
-					ctrl.Mode = control.Mode(m)
-					return st.SaveConfig("mode", m)
-				}
-				return fmt.Errorf("unknown mode: %s", m)
-			},
-			SetGridTarget: func(w float64) error {
-				ctrlMu.Lock()
-				defer ctrlMu.Unlock()
-				ctrl.SetGridTarget(w)
-				return st.SaveConfig("grid_target_w", strconv.FormatFloat(w, 'f', 1, 64))
-			},
-			SetPeakLimit: func(w float64) error {
-				ctrlMu.Lock()
-				defer ctrlMu.Unlock()
-				ctrl.PeakLimitW = w
-				return nil
-			},
-			SetEVCharging: func(w float64, active bool) error {
-				ctrlMu.Lock()
-				defer ctrlMu.Unlock()
-				if active { ctrl.EVChargingW = w } else { ctrl.EVChargingW = 0 }
-				return nil
-			},
-			SetBatteryCoversEV: func(enabled bool) error {
-				ctrlMu.Lock()
-				ctrl.BatteryCoversEV = enabled
-				ctrlMu.Unlock()
-				val := "false"
-				if enabled { val = "true" }
-				return st.SaveConfig("battery_covers_ev", val)
-			},
-		}
-		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), cb)
+		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctrl, ctrlMu, st))
 		if err != nil {
 			slog.Warn("HA MQTT bridge failed to start", "err", err)
 		} else {
 			haBridge = bridge
-			defer haBridge.Stop()
 			deps.HA = haBridge // late-binding for API
 		}
 	}
+	// Stop deferred for whichever bridge instance is current at exit
+	// time — Reload may have swapped haBridge mid-flight, so re-read here
+	// rather than capturing the boot-time pointer.
+	defer func() {
+		if haBridge != nil {
+			haBridge.Stop()
+		}
+	}()
 
 	// ---- Nova Core federation (optional) ----
 	// Publishes telemetry to Sourceful Nova Core's MQTT broker (NATS
@@ -1150,6 +1211,12 @@ func main() {
 			slog.Info("shutting down")
 			if err := st.RecordEvent("shutdown"); err != nil {
 				slog.Warn("failed to persist shutdown event", "err", err)
+			}
+			return
+		case <-restartCh:
+			slog.Info("restart requested via API — exiting cleanly so the supervisor brings us back")
+			if err := st.RecordEvent("restart"); err != nil {
+				slog.Warn("failed to persist restart event", "err", err)
 			}
 			return
 		case <-ticker.C:
@@ -1797,6 +1864,59 @@ func recordHistory(st *state.Store, tel *telemetry.Store, ctrl *control.State, n
 // operator can explicitly blank a path to disable a feature — see
 // docs/self-update.md on FTW_UPDATER_SOCKET=""). Returns def only when
 // the variable is unset.
+// haCallbacks builds the bridge's command-callback set. Extracted so
+// the boot-time ha.Start path and the configreload "disabled → enabled"
+// path can share the exact same wiring — drift between them would mean
+// HA commands behave one way after boot and a different way after a
+// hot-reload, which is the kind of silent skew that's hardest to debug.
+func haCallbacks(ctrl *control.State, ctrlMu *sync.Mutex, st *state.Store) ha.CommandCallbacks {
+	return ha.CommandCallbacks{
+		SetMode: func(m string) error {
+			ctrlMu.Lock()
+			defer ctrlMu.Unlock()
+			switch control.Mode(m) {
+			case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
+				control.ModeCharge, control.ModePriority, control.ModeWeighted:
+				ctrl.Mode = control.Mode(m)
+				return st.SaveConfig("mode", m)
+			}
+			return fmt.Errorf("unknown mode: %s", m)
+		},
+		SetGridTarget: func(w float64) error {
+			ctrlMu.Lock()
+			defer ctrlMu.Unlock()
+			ctrl.SetGridTarget(w)
+			return st.SaveConfig("grid_target_w", strconv.FormatFloat(w, 'f', 1, 64))
+		},
+		SetPeakLimit: func(w float64) error {
+			ctrlMu.Lock()
+			defer ctrlMu.Unlock()
+			ctrl.PeakLimitW = w
+			return nil
+		},
+		SetEVCharging: func(w float64, active bool) error {
+			ctrlMu.Lock()
+			defer ctrlMu.Unlock()
+			if active {
+				ctrl.EVChargingW = w
+			} else {
+				ctrl.EVChargingW = 0
+			}
+			return nil
+		},
+		SetBatteryCoversEV: func(enabled bool) error {
+			ctrlMu.Lock()
+			ctrl.BatteryCoversEV = enabled
+			ctrlMu.Unlock()
+			val := "false"
+			if enabled {
+				val = "true"
+			}
+			return st.SaveConfig("battery_covers_ev", val)
+		},
+	}
+}
+
 func envOr(key, def string) string {
 	if v, ok := os.LookupEnv(key); ok {
 		return v

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -121,6 +122,17 @@ type Deps struct {
 	// /api/notifications/* endpoints.
 	Notifications *notifications.Service
 
+	// Restart triggers a graceful process restart from POST /api/restart.
+	// Implementations:
+	//   - production (docker compose): dispatch to the ftw-updater sidecar
+	//     so the running container is force-recreated against the same
+	//     image — exact same code path as the post-update restart.
+	//   - dev / systemd: signal main() to return with a non-zero exit
+	//     code; docker (unless-stopped) and systemd (on-failure) bring
+	//     the binary back up.
+	// nil disables /api/restart (returns 503).
+	Restart func(ctx context.Context) error
+
 	Version string
 }
 
@@ -225,6 +237,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/version/snapshots", s.handleVersionSnapshots)
 	s.handle("DELETE /api/version/snapshots/{id}", s.handleVersionSnapshotDelete)
 	s.handle("POST /api/version/rollback", s.handleVersionRollback)
+	s.handle("POST /api/restart", s.handleRestart)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.
@@ -658,6 +671,13 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]string{"error": "validation: " + err.Error()})
 		return
 	}
+	// Diff against the live config BEFORE we mutate the shared pointer —
+	// otherwise the comparison would always come back empty.
+	s.deps.CfgMu.RLock()
+	oldCfg := *s.deps.Cfg
+	s.deps.CfgMu.RUnlock()
+	restartReasons := config.RestartRequiredFor(&oldCfg, &newCfg)
+
 	// Persist atomically (Password has yaml:"-" so it won't appear in YAML)
 	if err := s.deps.SaveConfig(s.deps.ConfigPath, &newCfg); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "save failed: " + err.Error()})
@@ -675,8 +695,12 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	s.deps.CfgMu.Lock()
 	*s.deps.Cfg = newCfg
 	s.deps.CfgMu.Unlock()
-	slog.Info("config updated via API")
-	writeJSON(w, 200, map[string]string{"status": "ok"})
+	slog.Info("config updated via API", "restart_required", len(restartReasons) > 0)
+	writeJSON(w, 200, map[string]any{
+		"status":           "ok",
+		"restart_required": len(restartReasons) > 0,
+		"restart_reasons":  restartReasons,
+	})
 }
 
 // ---- /api/mode ----

--- a/go/internal/api/api_restart.go
+++ b/go/internal/api/api_restart.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// handleRestart triggers a graceful process restart so the binary picks
+// up changes that the configreload watcher can't apply in flight (the
+// dwindling list in config.RestartRequiredFor).
+//
+// The handler always returns first and triggers the restart from a
+// background goroutine: the caller (typically the Settings dialog) needs
+// to render its "Restarting…" overlay before the HTTP server starts
+// shutting down, otherwise the response gets dropped mid-flight and the
+// UI shows a generic network error.
+//
+// The 200 ms delay between sending the response and signaling the
+// restart is the smallest window we observed reliably gives the kernel
+// time to flush the TCP buffer back to the browser. Shorter and the
+// dialog never sees a 202.
+func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Restart == nil {
+		writeJSON(w, 503, map[string]string{"error": "restart not configured"})
+		return
+	}
+	writeJSON(w, 202, map[string]any{"status": "restarting"})
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		// Don't reuse r.Context() — it's canceled the instant the
+		// response is flushed, and the sidecar dial path needs a live
+		// context to negotiate the unix socket.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.deps.Restart(ctx); err != nil {
+			slog.Warn("restart trigger failed", "err", err)
+		}
+	}()
+}

--- a/go/internal/api/api_restart_test.go
+++ b/go/internal/api/api_restart_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRestart_503WhenNotConfigured guards the contract that a build
+// without a Restart callback (e.g. a test harness, or the proxy mode
+// that just forwards to an upstream) returns 503 instead of falsely
+// reporting success and leaving the operator confused about why
+// nothing happened.
+func TestRestart_503WhenNotConfigured(t *testing.T) {
+	srv := New(&Deps{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/restart", nil)
+	srv.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+// TestRestart_DispatchesCallback verifies the handler returns 202 and
+// invokes the Restart callback exactly once. The callback is async (200
+// ms delay) so we wait on a result channel rather than polling.
+func TestRestart_DispatchesCallback(t *testing.T) {
+	var called int32
+	done := make(chan struct{}, 1)
+	deps := &Deps{
+		Restart: func(ctx context.Context) error {
+			atomic.AddInt32(&called, 1)
+			done <- struct{}{}
+			return nil
+		},
+	}
+	srv := New(deps)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/restart", nil)
+	srv.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "restarting" {
+		t.Fatalf("expected status=restarting, got %v", body["status"])
+	}
+
+	// Wait for the goroutine to actually fire.
+	<-done
+	if got := atomic.LoadInt32(&called); got != 1 {
+		t.Fatalf("Restart callback fired %d times, want 1", got)
+	}
+}
+
+// TestRestart_CallbackErrorIsLogged verifies the handler still responds
+// 202 when the callback errors — the user-facing UI has already
+// transitioned to the "restarting" overlay, so failing the response
+// would just confuse them. The error lands in the server log instead.
+func TestRestart_CallbackErrorIsLogged(t *testing.T) {
+	done := make(chan struct{}, 1)
+	deps := &Deps{
+		Restart: func(ctx context.Context) error {
+			done <- struct{}{}
+			return errors.New("sidecar offline")
+		},
+	}
+	srv := New(deps)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/restart", nil)
+	srv.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 (response sent before callback runs), got %d", w.Code)
+	}
+	<-done
+}

--- a/go/internal/config/restart_required.go
+++ b/go/internal/config/restart_required.go
@@ -1,0 +1,126 @@
+package config
+
+import "reflect"
+
+// RestartRequiredFor diffs old vs new and returns a list of human-readable
+// section names whose changes are NOT picked up by the configreload watcher.
+// An empty slice means the running process can safely apply `new` without a
+// restart.
+//
+// The list mirrors what the applier in cmd/forty-two-watts/main.go already
+// hot-reloads:
+//
+//   - Site control scalars (grid_target, tolerance, slew, min_dispatch),
+//     fuse params, drivers, capacities, inverter groups, driver limits,
+//     loadpoints, notifications, MPC capacity, the Weather subset
+//     {pv_rated_w, latitude, longitude}, and home_assistant.* reload live.
+//   - Everything else (api.port, state.path, price.*, planner.*, nova.*,
+//     ocpp.*, ev_charger.*, weather.provider/arrays, site.control_interval_s,
+//     site.watchdog_timeout_s, site.smoothing_alpha, site.gain) needs the
+//     binary restarted to take effect.
+//
+// The long-term goal is for this list to shrink to {state.path,
+// state.cold_dir, api.port}: the rest of the boot-time wiring can be made
+// hot-reloadable with the same Reload pattern (*ha.Bridge).Reload uses,
+// the only blocker is engineering time. Issues #TBD track the per-section
+// follow-ups.
+//
+// Keep this in sync with the applier whenever a section becomes
+// hot-reloadable. The cost of forgetting is benign: an unnecessary
+// "restart required" prompt to the operator. The cost of the inverse —
+// telling them no restart is needed when one is — leaves the process
+// running stale config silently, so when in doubt, list the section here.
+func RestartRequiredFor(oldCfg, newCfg *Config) []string {
+	if oldCfg == nil || newCfg == nil {
+		return nil
+	}
+	var reasons []string
+
+	// Site: only the four control scalars + fuse-related fields are
+	// hot-reloaded. Anything else in Site changes the boot-time wiring.
+	if oldCfg.Site.ControlIntervalS != newCfg.Site.ControlIntervalS {
+		reasons = append(reasons, "site.control_interval_s — control loop tick rate is set at startup")
+	}
+	if oldCfg.Site.WatchdogTimeoutS != newCfg.Site.WatchdogTimeoutS {
+		reasons = append(reasons, "site.watchdog_timeout_s — watchdog interval is captured at startup")
+	}
+	if oldCfg.Site.SmoothingAlpha != newCfg.Site.SmoothingAlpha {
+		reasons = append(reasons, "site.smoothing_alpha — Kalman smoothing factor is fixed at startup")
+	}
+	if oldCfg.Site.Gain != newCfg.Site.Gain {
+		reasons = append(reasons, "site.gain — PI controller gain is fixed at startup")
+	}
+	if oldCfg.Site.Name != newCfg.Site.Name {
+		reasons = append(reasons, "site.name — used by HA discovery + logging at boot")
+	}
+
+	if !reflect.DeepEqual(oldCfg.API, newCfg.API) {
+		reasons = append(reasons, "api.port — HTTP server binds the port at startup")
+	}
+	// homeassistant.* is hot-reloadable via (*ha.Bridge).Reload; see the
+	// applier in cmd/forty-two-watts/main.go.
+	if !pointerEqual(oldCfg.State, newCfg.State) {
+		reasons = append(reasons, "state — SQLite database paths are opened at startup")
+	}
+	if !pointerEqual(oldCfg.Price, newCfg.Price) {
+		reasons = append(reasons, "price — spot-price service is constructed once at startup")
+	}
+	if !pointerEqual(oldCfg.Planner, newCfg.Planner) {
+		reasons = append(reasons, "planner — MPC planner is constructed once at startup")
+	}
+	if !pointerEqual(oldCfg.Nova, newCfg.Nova) {
+		reasons = append(reasons, "nova — federation client is constructed once at startup")
+	}
+	if !pointerEqual(oldCfg.OCPP, newCfg.OCPP) {
+		reasons = append(reasons, "ocpp — OCPP server is bound once at startup")
+	}
+	if !pointerEqual(oldCfg.EVCharger, newCfg.EVCharger) {
+		reasons = append(reasons, "ev_charger — EV charger client is constructed once at startup")
+	}
+
+	// Weather: PVRatedW, Latitude, Longitude reload live; everything else
+	// (provider, arrays, tilt/azimuth, heating coefficient) is captured
+	// once when the forecast + PV-twin services are wired up.
+	if weatherNeedsRestart(oldCfg.Weather, newCfg.Weather) {
+		reasons = append(reasons, "weather (provider / pv_arrays / tilt / azimuth / heating) — forecast + PV-twin wiring is set at startup")
+	}
+
+	return reasons
+}
+
+func pointerEqual(a, b any) bool {
+	// reflect.DeepEqual already handles nil-vs-nil and value comparisons
+	// correctly through interfaces, but two *T's pointing at zero-valued
+	// structs and one *T-nil are intentionally distinct here: an operator
+	// adding an empty `homeassistant: {}` block IS a change worth flagging.
+	return reflect.DeepEqual(a, b)
+}
+
+func weatherNeedsRestart(oldW, newW *Weather) bool {
+	if oldW == nil && newW == nil {
+		return false
+	}
+	if oldW == nil || newW == nil {
+		// Toggling weather on/off requires re-wiring forecast + PV twin.
+		return true
+	}
+	if oldW.Provider != newW.Provider {
+		return true
+	}
+	if oldW.PVTiltDeg != newW.PVTiltDeg || oldW.PVAzimuthDeg != newW.PVAzimuthDeg {
+		return true
+	}
+	if oldW.HeatingWPerDegC != newW.HeatingWPerDegC {
+		return true
+	}
+	if !reflect.DeepEqual(oldW.PVArrays, newW.PVArrays) {
+		return true
+	}
+	// APIKey doesn't strictly require restart — the forecast service
+	// reads it on each fetch — but mid-flight rotation is rare enough
+	// that we flag it conservatively only when it goes from set→unset.
+	if (oldW.APIKey != "") != (newW.APIKey != "") {
+		return true
+	}
+	return false
+}

--- a/go/internal/config/restart_required_test.go
+++ b/go/internal/config/restart_required_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRestartRequiredFor_NoChange(t *testing.T) {
+	cfg := baseCfg()
+	if r := RestartRequiredFor(cfg, cfg); len(r) != 0 {
+		t.Fatalf("expected no reasons, got %v", r)
+	}
+}
+
+func TestRestartRequiredFor_HotReloadable(t *testing.T) {
+	old := baseCfg()
+	newC := baseCfg()
+	// All of these are hot-reloaded by the configreload applier today.
+	newC.Site.GridTargetW = 500
+	newC.Site.GridToleranceW = 200
+	newC.Site.SlewRateW = 1500
+	newC.Site.MinDispatchIntervalS = 30
+	newC.Fuse.MaxAmps = 25
+	newC.Drivers = append(newC.Drivers, Driver{Name: "extra"})
+	if newC.Weather == nil {
+		newC.Weather = &Weather{}
+	}
+	*newC.Weather = *old.Weather
+	newC.Weather.PVRatedW = 12000
+	newC.Weather.Latitude = 59.0
+	newC.Weather.Longitude = 18.0
+	// HA changes hot-reload via (*ha.Bridge).Reload.
+	newC.HomeAssistant = &HomeAssistant{
+		Enabled: true, Broker: "10.0.0.5", Port: 1883, PublishIntervalS: 10,
+	}
+	old.HomeAssistant = &HomeAssistant{
+		Enabled: true, Broker: "192.168.1.1", Port: 1883, PublishIntervalS: 5,
+	}
+
+	if r := RestartRequiredFor(old, newC); len(r) != 0 {
+		t.Fatalf("expected no reasons (all hot-reloadable), got %v", r)
+	}
+}
+
+func TestRestartRequiredFor_SiteBootScalars(t *testing.T) {
+	cases := []struct {
+		name   string
+		mut    func(*Config)
+		wantIn string
+	}{
+		{"control_interval_s", func(c *Config) { c.Site.ControlIntervalS = 10 }, "control_interval_s"},
+		{"watchdog_timeout_s", func(c *Config) { c.Site.WatchdogTimeoutS = 30 }, "watchdog_timeout_s"},
+		{"smoothing_alpha", func(c *Config) { c.Site.SmoothingAlpha = 0.9 }, "smoothing_alpha"},
+		{"gain", func(c *Config) { c.Site.Gain = 0.7 }, "site.gain"},
+		{"name", func(c *Config) { c.Site.Name = "renamed" }, "site.name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := baseCfg()
+			n := baseCfg()
+			tc.mut(n)
+			r := RestartRequiredFor(old, n)
+			if !containsSubstring(r, tc.wantIn) {
+				t.Fatalf("expected reason mentioning %q, got %v", tc.wantIn, r)
+			}
+		})
+	}
+}
+
+func TestRestartRequiredFor_BootSections(t *testing.T) {
+	cases := []struct {
+		name   string
+		mut    func(*Config)
+		wantIn string
+	}{
+		{"api.port", func(c *Config) { c.API.Port = 9090 }, "api.port"},
+		{"state path", func(c *Config) { c.State = &StateConf{Path: "/var/lib/ftw/state.db"} }, "state"},
+		{"price provider", func(c *Config) { c.Price = &Price{Provider: "entsoe"} }, "price"},
+		{"planner toggled", func(c *Config) { c.Planner = &Planner{Enabled: true} }, "planner"},
+		{"nova toggled", func(c *Config) { c.Nova = &Nova{Enabled: true, URL: "https://x"} }, "nova"},
+		{"ocpp toggled", func(c *Config) { c.OCPP = &OCPP{Enabled: true} }, "ocpp"},
+		{"ev_charger added", func(c *Config) {
+			c.EVCharger = &EVCharger{Provider: "easee", Email: "a@b.c"}
+		}, "ev_charger"},
+		{"weather provider change", func(c *Config) {
+			c.Weather = &Weather{Provider: "open_meteo", Latitude: 59, Longitude: 18}
+		}, "weather"},
+		{"weather pv_arrays added", func(c *Config) {
+			c.Weather = &Weather{Provider: "met_no", Latitude: 59, Longitude: 18,
+				PVArrays: []PVArray{{KWp: 5, TiltDeg: 30, AzimuthDeg: 180}}}
+		}, "weather"},
+		{"weather heating coefficient", func(c *Config) {
+			c.Weather.HeatingWPerDegC = 250
+		}, "weather"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := baseCfg()
+			n := baseCfg()
+			tc.mut(n)
+			r := RestartRequiredFor(old, n)
+			if !containsSubstring(r, tc.wantIn) {
+				t.Fatalf("expected reason mentioning %q, got %v", tc.wantIn, r)
+			}
+		})
+	}
+}
+
+func TestRestartRequiredFor_NilInputs(t *testing.T) {
+	if r := RestartRequiredFor(nil, baseCfg()); r != nil {
+		t.Fatalf("expected nil reasons for nil old, got %v", r)
+	}
+	if r := RestartRequiredFor(baseCfg(), nil); r != nil {
+		t.Fatalf("expected nil reasons for nil new, got %v", r)
+	}
+}
+
+func baseCfg() *Config {
+	return &Config{
+		Site: Site{
+			Name: "home", ControlIntervalS: 5, WatchdogTimeoutS: 60,
+			SmoothingAlpha: 0.5, Gain: 0.3, GridTargetW: 0,
+			GridToleranceW: 100, SlewRateW: 1000, MinDispatchIntervalS: 5,
+		},
+		Fuse:    Fuse{MaxAmps: 20, Phases: 3, Voltage: 230},
+		API:     API{Port: 8080},
+		Drivers: []Driver{{Name: "ferro"}},
+		Weather: &Weather{Provider: "met_no", Latitude: 59, Longitude: 18, PVRatedW: 10000},
+	}
+}
+
+func containsSubstring(reasons []string, sub string) bool {
+	for _, r := range reasons {
+		if strings.Contains(r, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/ha/CLAUDE.md
+++ b/go/internal/ha/CLAUDE.md
@@ -14,7 +14,8 @@ One-shot autodiscovery publisher + periodic state pump + command subscriber, all
 ## Public API surface
 
 - `Start(cfg, tel, ctrl, ctrlMu, driverNames, cb) (*Bridge, error)` — connects, publishes discovery, starts the publish loop.
-- `(*Bridge).Stop()` — closes the stop channel, waits for the loop, disconnects with 500 ms quiesce.
+- `(*Bridge).Reload(newCfg, driverNames) error` — tears down the current paho client + publish loop, swaps `cfg`/`driverNames` under `mu`, and re-connects. Diagnostic counters reset because the new connection is its own thing — operators reading `LastPublishMs` / `SensorsAnnounced` after a reload should see "fresh connection" semantics. Errors if the bridge has been Stop'd (lifecycle is one-shot — the configreload applier resurrects HA by calling `ha.Start` instead, see `cmd/forty-two-watts/main.go`).
+- `(*Bridge).Stop()` — closes the stop channel, waits for the loop, disconnects with 500 ms quiesce. Idempotent (`stopped` flag).
 - `(*Bridge).IsConnected() bool` / `BrokerAddr() string` / `LastPublishMs() int64` / `SensorsAnnounced() int` — diagnostics consumed by `/api/ha/status` in `../api`.
 
 ## How it talks to neighbors
@@ -34,4 +35,5 @@ Reads `../telemetry.Store` via `Get(driver, DerMeter/PV/Battery)` and `ReadingsB
 - **Do NOT block in a subscribe callback.** The callbacks in `subscribeCommands` must return fast; if a callback needs heavy work, dispatch it onto a goroutine (current callbacks are atomic control-state setters, which is fine).
 - **Do NOT drop the site sign convention when adding a sensor.** `publishState` pulls `SmoothedW` values that are already signed per the convention; HA's `device_class: power` expects those signs. Flipping here would confuse every existing dashboard.
 - **Do NOT change `deviceID` or `topicPrefix` casually.** HA devices and retained discovery topics are keyed on them; a rename orphans every existing HA entity. Migrate with intention.
+- **Do NOT bypass `lifecycleMu` from inside Reload / Stop.** The applier in `cmd/forty-two-watts/main.go` can fire Reload twice in rapid succession (debounced editor save followed by an API POST, say). `lifecycleMu` is what prevents the second tick from interleaving its `teardown()` with the first one's `connectAndStart()`. Touching it requires keeping that ordering invariant.
 - **Do NOT add QoS > 0 for telemetry.** Publish at QoS 0; the 5 s cadence makes QoS 1 storage-of-unacked messages an unnecessary memory hazard on long reconnects. Retained discovery is the exception (line 189).

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -34,39 +34,62 @@ type CommandCallbacks struct {
 }
 
 // Bridge is an instance of the HA MQTT bridge.
+//
+// Lifecycle invariants:
+//   - lifecycleMu serializes Reload + Stop so the connect/disconnect
+//     dance never races with a second config-reload tick.
+//   - mu guards every data field a diagnostic reader (IsConnected,
+//     BrokerAddr, LastPublishMs, SensorsAnnounced) might touch.
+//     publishLoop / publishState briefly acquire mu when bumping the
+//     diagnostics counters; Reload deliberately does NOT hold mu while
+//     waiting on the old loop's done channel — the loop needs mu to
+//     update lastPublishMs on its way out and would otherwise deadlock.
 type Bridge struct {
-	cfg         *config.HomeAssistant
-	client      paho.Client
-	tel         *telemetry.Store
-	ctrl        *control.State
-	ctrlMu      *sync.Mutex
-	cb          CommandCallbacks
-	driverNames []string
-
-	stop chan struct{}
-	done chan struct{}
+	tel    *telemetry.Store
+	ctrl   *control.State
+	ctrlMu *sync.Mutex
+	cb     CommandCallbacks
 
 	topicPrefix string // e.g. "forty-two-watts"
 	discoPrefix string // e.g. "homeassistant"
 	deviceID    string
 
+	lifecycleMu sync.Mutex // serializes Reload + Stop
+
 	mu               sync.Mutex
+	cfg              *config.HomeAssistant
+	client           paho.Client
+	driverNames      []string
+	stop             chan struct{}
+	done             chan struct{}
 	lastPublishMs    int64
 	sensorsAnnounced int
+	stopped          bool
 }
 
 // IsConnected returns true if the Paho MQTT client currently has an
 // active connection to the broker.
 func (b *Bridge) IsConnected() bool {
-	if b == nil || b.client == nil {
+	if b == nil {
 		return false
 	}
-	return b.client.IsConnected()
+	b.mu.Lock()
+	cli := b.client
+	b.mu.Unlock()
+	if cli == nil {
+		return false
+	}
+	return cli.IsConnected()
 }
 
 // BrokerAddr returns the configured "host:port" string for diagnostics.
 func (b *Bridge) BrokerAddr() string {
-	if b == nil || b.cfg == nil {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cfg == nil {
 		return ""
 	}
 	return fmt.Sprintf("%s:%d", b.cfg.Broker, b.cfg.Port)
@@ -105,18 +128,61 @@ func Start(
 	cb CommandCallbacks,
 ) (*Bridge, error) {
 	b := &Bridge{
-		cfg:         cfg,
 		tel:         tel,
 		ctrl:        ctrl,
 		ctrlMu:      ctrlMu,
 		cb:          cb,
-		driverNames: driverNames,
-		stop:        make(chan struct{}),
-		done:        make(chan struct{}),
 		topicPrefix: "forty-two-watts",
 		discoPrefix: "homeassistant",
 		deviceID:    "forty_two_watts",
 	}
+	if err := b.connectAndStart(cfg, driverNames); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Reload swaps the bridge's broker / credentials / driver list without
+// requiring a process restart. The current MQTT client is disconnected,
+// the publish loop drained, then a fresh paho client is built from
+// newCfg and a new loop is started. Diagnostic counters reset because
+// the new connection is its own thing — operators reading
+// LastPublishMs / SensorsAnnounced after a reload should see "fresh
+// connection" semantics, not stale figures from the previous broker.
+//
+// driverNames is the current driver registry as of reload time. The
+// applier in cmd/forty-two-watts/main.go passes in reg.Names() so a
+// driver added or removed in the same config-reload tick is reflected
+// in HA discovery without a second round-trip.
+func (b *Bridge) Reload(newCfg *config.HomeAssistant, driverNames []string) error {
+	b.lifecycleMu.Lock()
+	defer b.lifecycleMu.Unlock()
+
+	if b.stopped {
+		return fmt.Errorf("ha: bridge stopped, cannot reload")
+	}
+	b.teardown()
+	return b.connectAndStart(newCfg, driverNames)
+}
+
+// connectAndStart wires a paho client from cfg, opens the connection,
+// then starts the publish loop. Shared by Start (first-time wiring)
+// and Reload (after a teardown). Caller is responsible for serializing
+// access via lifecycleMu.
+func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string) error {
+	// Swap data fields BEFORE Connect: paho fires OnConnectHandler from
+	// inside Connect() and that handler calls publishDiscovery, which
+	// reads b.driverNames. Updating after Connect would publish discovery
+	// for the previous driver list.
+	b.mu.Lock()
+	b.cfg = cfg
+	b.driverNames = driverNames
+	b.stop = make(chan struct{})
+	b.done = make(chan struct{})
+	b.lastPublishMs = 0
+	b.sensorsAnnounced = 0
+	b.mu.Unlock()
+
 	opts := paho.NewClientOptions().
 		AddBroker(fmt.Sprintf("tcp://%s:%d", cfg.Broker, cfg.Port)).
 		SetClientID("forty-two-watts-ha").
@@ -128,22 +194,59 @@ func Start(
 			b.publishDiscovery()
 			b.subscribeCommands()
 		})
-	if cfg.Username != "" { opts.SetUsername(cfg.Username) }
-	if cfg.Password != "" { opts.SetPassword(cfg.Password) }
-	b.client = paho.NewClient(opts)
-	if tok := b.client.Connect(); tok.WaitTimeout(10*time.Second) && tok.Error() != nil {
-		return nil, tok.Error()
+	if cfg.Username != "" {
+		opts.SetUsername(cfg.Username)
+	}
+	if cfg.Password != "" {
+		opts.SetPassword(cfg.Password)
+	}
+	cli := paho.NewClient(opts)
+
+	b.mu.Lock()
+	b.client = cli
+	b.mu.Unlock()
+
+	if tok := cli.Connect(); tok.WaitTimeout(10*time.Second) && tok.Error() != nil {
+		return tok.Error()
 	}
 
 	go b.publishLoop()
-	return b, nil
+	return nil
 }
 
-// Stop disconnects and waits for the publish loop to exit.
+// teardown drops the current MQTT client + publish loop. Mirrors Stop()
+// but doesn't flip the stopped flag, so it can be followed by another
+// connectAndStart. Caller must hold lifecycleMu.
+func (b *Bridge) teardown() {
+	b.mu.Lock()
+	stopCh := b.stop
+	doneCh := b.done
+	cli := b.client
+	b.mu.Unlock()
+
+	if stopCh != nil {
+		close(stopCh)
+	}
+	if doneCh != nil {
+		<-doneCh
+	}
+	if cli != nil {
+		cli.Disconnect(500)
+	}
+}
+
+// Stop disconnects and waits for the publish loop to exit. Idempotent.
 func (b *Bridge) Stop() {
-	close(b.stop)
-	<-b.done
-	b.client.Disconnect(500)
+	if b == nil {
+		return
+	}
+	b.lifecycleMu.Lock()
+	defer b.lifecycleMu.Unlock()
+	if b.stopped {
+		return
+	}
+	b.teardown()
+	b.stopped = true
 }
 
 // ---- Autodiscovery ----

--- a/go/internal/ha/bridge_test.go
+++ b/go/internal/ha/bridge_test.go
@@ -118,3 +118,40 @@ func TestLastPublishMsRoundTrip(t *testing.T) {
 		t.Errorf("LastPublishMs = %d, want 1713200000000", got)
 	}
 }
+
+// TestStopIdempotent verifies the lifecycle Stop is safe to call multiple
+// times. main.go's defer-stack and the configreload "running → disabled"
+// path can both wind up calling Stop on the same bridge; a second call
+// must be a no-op rather than a panic-inducing double-close-of-channel.
+func TestStopIdempotent(t *testing.T) {
+	b := &Bridge{}
+	// Pretend Start ran and gave us channels to close.
+	b.stop = make(chan struct{})
+	b.done = make(chan struct{})
+	close(b.done) // simulate publishLoop having already exited
+
+	b.Stop()
+	b.Stop() // second call must be a no-op
+
+	if !b.stopped {
+		t.Error("Stop should mark bridge stopped")
+	}
+}
+
+// TestReloadAfterStopRejected guards the invariant that a Stop'd bridge
+// is terminal — operators must construct a fresh bridge, not resurrect
+// the dead one. The configreload applier in main.go relies on this: it
+// nulls haBridge after Stop and calls ha.Start on a re-enable, so a
+// Reload-on-stopped path that silently succeeded would mask wiring bugs.
+func TestReloadAfterStopRejected(t *testing.T) {
+	b := &Bridge{}
+	b.stop = make(chan struct{})
+	b.done = make(chan struct{})
+	close(b.done)
+	b.Stop()
+
+	err := b.Reload(&config.HomeAssistant{Broker: "x", Port: 1883}, nil)
+	if err == nil {
+		t.Fatal("Reload after Stop must error, got nil")
+	}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -111,6 +111,35 @@
     </div>
   </div>
 
+  <!-- Restart-required Dialog -->
+  <!--
+    Shown after a Settings save when the server reports that one or more
+    config sections can't be hot-reloaded (state.path, api.port, …). The
+    full list of "still needs a restart" reasons is the diminishing tail
+    in go/internal/config/restart_required.go — the long-term goal is
+    that this modal essentially never fires.
+  -->
+  <div id="restart-modal" class="modal hidden">
+    <div class="modal-content" style="max-width:480px">
+      <div class="modal-header">
+        <h2>Restart required</h2>
+      </div>
+      <div class="modal-body">
+        <p style="margin-top:0">Saved. Some changes can't be applied while the service is running:</p>
+        <ul id="restart-reasons" style="margin:8px 0 16px 18px;color:var(--text);font-size:0.9rem"></ul>
+        <p style="color:var(--text-dim);font-size:0.85rem;margin:0">Restart now to pick them up — the service comes back automatically (typically &lt;10 s).</p>
+        <div id="restart-progress" class="hidden" style="margin-top:14px;color:var(--text-dim);font-size:0.85rem">
+          <span class="spinner" aria-hidden="true"></span>
+          <span id="restart-progress-text">Restarting…</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button id="restart-later" class="btn-ghost">Restart later</button>
+        <button id="restart-now" class="btn-send">Restart now</button>
+      </div>
+    </div>
+  </div>
+
   <main id="view-live">
     <!-- Energy-flow hero — central house, PV top, Grid left, Battery right,
          EV bottom. next-app.js calls el.setReadings(...) each status tick. -->

--- a/web/settings.js
+++ b/web/settings.js
@@ -83,14 +83,111 @@
         if (!r.ok) return r.json().then(function (j) { throw new Error(j.error || ("HTTP " + r.status)); });
         return r.json();
       })
-      .then(function () {
+      .then(function (res) {
         setStatus("Saved ✓", "success");
         setTimeout(function () { setStatus(""); }, 2000);
+        // Server tells us when the change touched a section that the
+        // configreload watcher can't apply in flight (state.path,
+        // api.port, …). Surface that as a dialog so the operator
+        // doesn't walk away thinking their change took effect when
+        // it didn't. Almost every field is hot-reloaded; the dialog
+        // is meant to fire rarely.
+        if (res && res.restart_required) {
+          showRestartModal(res.restart_reasons || []);
+        }
       })
       .catch(function (e) {
         setStatus("Save failed: " + e.message, "error");
       });
   });
+
+  // ---- Restart-required modal ----
+
+  function showRestartModal(reasons) {
+    var modalEl = document.getElementById("restart-modal");
+    var listEl = document.getElementById("restart-reasons");
+    var laterBtn = document.getElementById("restart-later");
+    var nowBtn = document.getElementById("restart-now");
+    var progressEl = document.getElementById("restart-progress");
+    var progressTextEl = document.getElementById("restart-progress-text");
+    if (!modalEl || !listEl || !laterBtn || !nowBtn) return;
+
+    listEl.innerHTML = "";
+    if (reasons.length === 0) {
+      var li = document.createElement("li");
+      li.textContent = "(no specific reason reported)";
+      li.style.color = "var(--text-dim)";
+      listEl.appendChild(li);
+    } else {
+      reasons.forEach(function (reason) {
+        var li = document.createElement("li");
+        li.textContent = reason;
+        listEl.appendChild(li);
+      });
+    }
+
+    progressEl.classList.add("hidden");
+    progressTextEl.textContent = "Restarting…";
+    nowBtn.disabled = false;
+    laterBtn.disabled = false;
+    modalEl.classList.remove("hidden");
+
+    laterBtn.onclick = function () { modalEl.classList.add("hidden"); };
+    nowBtn.onclick = function () { triggerRestart(modalEl, nowBtn, laterBtn, progressEl, progressTextEl); };
+  }
+
+  function triggerRestart(modalEl, nowBtn, laterBtn, progressEl, progressTextEl) {
+    nowBtn.disabled = true;
+    laterBtn.disabled = true;
+    progressEl.classList.remove("hidden");
+    progressTextEl.textContent = "Restarting…";
+
+    fetch("/api/restart", { method: "POST" })
+      .then(function (r) {
+        if (!r.ok) {
+          return r.json()
+            .catch(function () { return {}; })
+            .then(function (j) { throw new Error(j.error || ("HTTP " + r.status)); });
+        }
+        // Server is on its way down. Wait a moment for the process to
+        // exit, then poll /api/health until it answers again.
+        progressTextEl.textContent = "Waiting for service…";
+        setTimeout(function () { pollHealth(progressTextEl); }, 1500);
+      })
+      .catch(function (e) {
+        nowBtn.disabled = false;
+        laterBtn.disabled = false;
+        progressEl.classList.add("hidden");
+        alert("Restart failed: " + e.message);
+      });
+  }
+
+  function pollHealth(progressTextEl) {
+    var startedAt = Date.now();
+    var TIMEOUT_MS = 90 * 1000; // ~90 s; sidecar pull+up can be slow on Pi.
+    function tick() {
+      // Cache-bust so an intermediate proxy can't lie about reachability.
+      fetch("/api/health?_=" + Date.now(), { cache: "no-store" })
+        .then(function (r) {
+          if (r.ok) {
+            progressTextEl.textContent = "Reloading…";
+            // Hard reload so any new static assets (post-update) are
+            // picked up — same dance ftw-update-check.js does.
+            setTimeout(function () { window.location.reload(); }, 400);
+            return;
+          }
+          throw new Error("HTTP " + r.status);
+        })
+        .catch(function () {
+          if (Date.now() - startedAt > TIMEOUT_MS) {
+            progressTextEl.textContent = "Service is taking longer than usual — reload manually when it's back.";
+            return;
+          }
+          setTimeout(tick, 1000);
+        });
+    }
+    tick();
+  }
 
   function setStatus(msg, kind) {
     statusEl.textContent = msg || "";

--- a/web/settings/tabs/ha.js
+++ b/web/settings/tabs/ha.js
@@ -23,8 +23,7 @@
         '</div></div>' +
         field("Publish interval (s)", "homeassistant.publish_interval_s", "number", 5,
           "How often state topics are pushed to HA. 5 s is a good default.") +
-        '</fieldset>' +
-        '<p style="color:var(--text-dim);font-size:0.8rem;margin-top:8px">Changes to HA config require a restart to take effect.</p>';
+        '</fieldset>';
     },
     after: function () {
       var el = document.getElementById("ha-status-indicator");

--- a/web/style.css
+++ b/web/style.css
@@ -571,6 +571,41 @@ body { padding-bottom: 28px; }
   opacity: 0.85;
 }
 
+.btn-ghost {
+  margin-top: 0.5rem;
+  padding: 0.4rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.btn-ghost:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+/* Tiny inline spinner for "restart in progress" / similar transient
+ * states. Uses currentColor so it adopts the surrounding text colour. */
+.spinner {
+  display: inline-block;
+  width: 0.8em;
+  height: 0.8em;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  vertical-align: -0.1em;
+  margin-right: 0.4em;
+  animation: ftw-spin 0.8s linear infinite;
+}
+
+@keyframes ftw-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* ---- Drivers ---- */
 #drivers-section h2,
 #dispatch-section h2 {


### PR DESCRIPTION
## Summary
- **Hot-reload Home Assistant bridge** — `(*ha.Bridge).Reload` swaps broker / credentials / publish-interval / driver list without restarting the binary. Removes the only explicit "requires a restart" hint that lived in the Settings UI.
- **Restart-required dialog** — for the remaining sections that genuinely need a restart, `POST /api/config` now returns `{restart_required, restart_reasons[]}` and the Settings save flow surfaces a modal listing the reasons with "Restart now / Restart later".
- **`POST /api/restart`** — prefers the `ftw-updater` sidecar (production), falls back to graceful exit-code-1 (dev / systemd / docker — the supervisor brings the binary back up).

## Why
Operators changing settings had no reliable signal for which fields took effect immediately and which didn't. The fix is two-pronged: shrink the "needs restart" set by hot-reloading more, and for what remains, prompt for restart instead of leaving the operator to guess.

The remaining still-restart-required sections (`price`, `planner`, `nova`, `ocpp`, `ev_charger`, `weather` provider, `state.path`, `api.port`) are tagged in `restart_required.go` for follow-up PRs in the same `Reload` pattern. The long-term goal is for that list to shrink to `{state.path, state.cold_dir}` only.

## Test plan
- [x] `go test ./...` — 771 passed in 38 packages
- [x] `go vet ./...` — clean
- [x] Live API smoke-test (HA broker change → `restart_required:false` and the watcher hot-reloaded the bridge; `api.port` change → `restart_required:true` with the right reason; `POST /api/restart` → 202 + the binary exited cleanly with code 1 for the supervisor to bring it back)
- [ ] Manual UI smoke-test in production-like deploy (the local Chrome extension wasn't connected, so the modal wasn't exercised end-to-end in the browser — worth a click-through after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)