### PR TITLE
fix(ha): close b.done when connectAndStart's Connect() fails

### DIFF
--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -65,7 +65,14 @@ type Bridge struct {
 	lastPublishMs    int64
 	sensorsAnnounced int
 	stopped          bool
+
+	// connectTimeout is the WaitTimeout passed to paho's Connect token.
+	// 0 means "use defaultConnectTimeout"; tests override to keep the
+	// refused-broker path fast.
+	connectTimeout time.Duration
 }
+
+const defaultConnectTimeout = 10 * time.Second
 
 // IsConnected returns true if the Paho MQTT client currently has an
 // active connection to the broker.
@@ -206,22 +213,31 @@ func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string
 	b.client = cli
 	b.mu.Unlock()
 
-	if tok := cli.Connect(); tok.WaitTimeout(10*time.Second) && tok.Error() != nil {
-		// Connect failed (unreachable broker, bad credentials, …). The
-		// fresh `b.done` we installed at the top of this function would
-		// otherwise stay open forever — publishLoop never starts, so no
-		// goroutine is responsible for closing it. The next teardown()
-		// would deadlock on `<-doneCh`. Close it now so a subsequent
-		// Reload / Stop can proceed.
-		b.mu.Lock()
-		if b.done != nil {
+	// We own b.done until publishLoop takes over — close it on any
+	// early return so the next teardown() doesn't block on <-doneCh.
+	started := false
+	defer func() {
+		if !started {
+			b.mu.Lock()
 			close(b.done)
+			b.mu.Unlock()
 		}
-		b.mu.Unlock()
-		return tok.Error()
+	}()
+
+	timeout := b.connectTimeout
+	if timeout == 0 {
+		timeout = defaultConnectTimeout
+	}
+	tok := cli.Connect()
+	if !tok.WaitTimeout(timeout) {
+		return fmt.Errorf("ha: connect timeout after %s", timeout)
+	}
+	if err := tok.Error(); err != nil {
+		return err
 	}
 
 	go b.publishLoop()
+	started = true
 	return nil
 }
 

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -207,6 +207,17 @@ func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string
 	b.mu.Unlock()
 
 	if tok := cli.Connect(); tok.WaitTimeout(10*time.Second) && tok.Error() != nil {
+		// Connect failed (unreachable broker, bad credentials, …). The
+		// fresh `b.done` we installed at the top of this function would
+		// otherwise stay open forever — publishLoop never starts, so no
+		// goroutine is responsible for closing it. The next teardown()
+		// would deadlock on `<-doneCh`. Close it now so a subsequent
+		// Reload / Stop can proceed.
+		b.mu.Lock()
+		if b.done != nil {
+			close(b.done)
+		}
+		b.mu.Unlock()
 		return tok.Error()
 	}
 

--- a/go/internal/ha/bridge_test.go
+++ b/go/internal/ha/bridge_test.go
@@ -157,38 +157,34 @@ func TestReloadAfterStopRejected(t *testing.T) {
 	}
 }
 
-// TestStopAfterFailedConnectDoesNotDeadlock documents the invariant
-// connectAndStart guarantees on its error path: when paho's Connect()
-// fails, the fresh stop+done channels it installed must not leak
-// (publishLoop never starts, so nothing else closes `b.done`). The
-// rollback in connectAndStart closes b.done explicitly — this test
-// simulates that post-rollback state and verifies Stop completes
-// rather than blocking forever in `<-doneCh`. Codex P1 on PR #232.
-//
-// The error path is rare in practice because the bridge wires paho
-// with `SetConnectRetry(true)` — refused connections never surface as
-// a synchronous error. The fix is still defensive: paho versions /
-// future config tweaks can re-introduce the path, and the cost of
-// always closing the rollback channel is one extra channel close.
+// TestStopAfterFailedConnectDoesNotDeadlock drives connectAndStart's
+// error path against a guaranteed-refused broker (127.0.0.1:1, with a
+// short connectTimeout to keep the test fast) and asserts the next
+// Stop() returns instead of blocking forever in teardown's <-doneCh.
+// Reverting the deferred close(b.done) rollback in connectAndStart
+// makes this test deadlock — that's the regression it guards.
 func TestStopAfterFailedConnectDoesNotDeadlock(t *testing.T) {
-	b := &Bridge{}
-	// Simulate the post-rollback state connectAndStart leaves behind
-	// after a Connect failure: stop is fresh + open, done is fresh +
-	// closed by the rollback, no goroutine running, no live client.
-	b.stop = make(chan struct{})
-	b.done = make(chan struct{})
-	close(b.done)
-	b.cfg = &config.HomeAssistant{Broker: "unreachable", Port: 1883}
+	b := &Bridge{
+		topicPrefix:    "forty-two-watts",
+		discoPrefix:    "homeassistant",
+		deviceID:       "forty_two_watts",
+		connectTimeout: 100 * time.Millisecond,
+	}
+	cfg := &config.HomeAssistant{Broker: "127.0.0.1", Port: 1}
 
-	doneCh := make(chan struct{})
+	if err := b.connectAndStart(cfg, nil); err == nil {
+		t.Fatal("connectAndStart against a refused broker must return an error")
+	}
+
+	stopped := make(chan struct{})
 	go func() {
 		b.Stop()
-		close(doneCh)
+		close(stopped)
 	}()
 	select {
-	case <-doneCh:
-		// Stop returned — invariant holds.
+	case <-stopped:
+		// Stop returned — rollback closed b.done, teardown didn't block.
 	case <-time.After(2 * time.Second):
-		t.Fatal("Stop blocked after a simulated failed Connect — teardown is stuck on <-doneCh")
+		t.Fatal("Stop blocked after a failed Connect — teardown is stuck on <-doneCh; the connectAndStart rollback regressed")
 	}
 }

--- a/go/internal/ha/bridge_test.go
+++ b/go/internal/ha/bridge_test.go
@@ -2,6 +2,7 @@ package ha
 
 import (
 	"testing"
+	"time"
 
 	"github.com/frahlg/forty-two-watts/go/internal/config"
 )
@@ -153,5 +154,41 @@ func TestReloadAfterStopRejected(t *testing.T) {
 	err := b.Reload(&config.HomeAssistant{Broker: "x", Port: 1883}, nil)
 	if err == nil {
 		t.Fatal("Reload after Stop must error, got nil")
+	}
+}
+
+// TestStopAfterFailedConnectDoesNotDeadlock documents the invariant
+// connectAndStart guarantees on its error path: when paho's Connect()
+// fails, the fresh stop+done channels it installed must not leak
+// (publishLoop never starts, so nothing else closes `b.done`). The
+// rollback in connectAndStart closes b.done explicitly — this test
+// simulates that post-rollback state and verifies Stop completes
+// rather than blocking forever in `<-doneCh`. Codex P1 on PR #232.
+//
+// The error path is rare in practice because the bridge wires paho
+// with `SetConnectRetry(true)` — refused connections never surface as
+// a synchronous error. The fix is still defensive: paho versions /
+// future config tweaks can re-introduce the path, and the cost of
+// always closing the rollback channel is one extra channel close.
+func TestStopAfterFailedConnectDoesNotDeadlock(t *testing.T) {
+	b := &Bridge{}
+	// Simulate the post-rollback state connectAndStart leaves behind
+	// after a Connect failure: stop is fresh + open, done is fresh +
+	// closed by the rollback, no goroutine running, no live client.
+	b.stop = make(chan struct{})
+	b.done = make(chan struct{})
+	close(b.done)
+	b.cfg = &config.HomeAssistant{Broker: "unreachable", Port: 1883}
+
+	doneCh := make(chan struct{})
+	go func() {
+		b.Stop()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		// Stop returned — invariant holds.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop blocked after a simulated failed Connect — teardown is stuck on <-doneCh")
 	}
 }


### PR DESCRIPTION
## Summary
Closes `b.done` on `connectAndStart`'s error path so the channel doesn't leak when paho's `Connect()` fails.

## Why
Spotted by Codex on #232. Without this rollback, a failed Connect leaves the fresh `stop`+`done` channels we just installed in a state where `publishLoop` never starts and nothing else closes `b.done`. The next `Reload` / `Stop` then blocks forever in `teardown()` on `<-doneCh`, stalling every later config-reload tick.

Rare in practice because the bridge wires paho with `SetConnectRetry(true)` — refused connections never surface as a synchronous `Connect` error. But it's cheap defensive code: one extra `close()` on the error path against a leak that would silently break HA reconfigure.

## Test plan
- [x] Regression test (`TestStopAfterFailedConnectDoesNotDeadlock`) documents the invariant + would catch any future regression that re-introduces the leak
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)