### PR TITLE
fix(ferroamp): drop stale MQTT cache + split RecordTick from RecordSuccess

### DIFF
--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -44,6 +44,25 @@ local ehub_data = nil
 local eso_data = nil
 local sso_data = nil
 
+-- Last-arrival timestamp per topic (host.millis()). The EnergyHub
+-- normally publishes ehub at ~1 Hz; if it goes silent (power off,
+-- fuse blow, broker partition) the cached tables above stay
+-- populated. Without per-topic age checks the driver would re-emit
+-- last-known values on every poll, host.emit would re-stamp
+-- LastSuccess, and the watchdog could not flip the driver offline.
+-- Real incident: 2026-05-02 fuse blow left ferroamp emitting
+-- pv_w=-3996.7040 / meter_w=-7294.0490 identical to four decimals
+-- for 30+ minutes while the EnergyHub itself was unpowered.
+local ehub_ts = 0
+local eso_ts  = 0
+local sso_ts  = 0
+
+-- Treat cached topic data as stale beyond this age. EnergyHub
+-- publishes ehub at ~1 Hz and eso/sso slightly slower; 30 s gives
+-- generous slack for a WiFi blip or broker reconnect without
+-- flipping the driver offline.
+local STALE_AFTER_MS = 30000
+
 -- Optional config knob: when `skip_battery` is true the driver will
 -- NOT emit battery telemetry even when the ESO/pbat fields are
 -- present on the wire. Useful for dev setups that want a PV-only
@@ -140,22 +159,45 @@ function driver_init(config)
 end
 
 function driver_poll()
+    local now = host.millis()
     local messages = host.mqtt_messages()
-    if not messages then return 1000 end
+    if not messages then messages = {} end
 
-    -- Process incoming messages and cache data
+    -- Process incoming messages and stamp arrival time per topic
     for _, msg in ipairs(messages) do
         local ok, data = pcall(host.json_decode, msg.payload)
         if ok and data then
             if msg.topic == "extapi/data/ehub" then
-                ehub_data = data
+                ehub_data = data; ehub_ts = now
             elseif msg.topic == "extapi/data/eso" then
-                eso_data = data
+                eso_data = data; eso_ts = now
             elseif msg.topic == "extapi/data/sso" then
-                sso_data = data
+                sso_data = data; sso_ts = now
             end
         end
     end
+
+    -- Drop stale caches so the rest of the poll falls through and
+    -- the watchdog catches us when the EnergyHub stops publishing.
+    -- Per-topic so a partial outage (e.g. eso lags but ehub flows)
+    -- still lets the live channels through.
+    if ehub_data and (now - ehub_ts) > STALE_AFTER_MS then
+        host.log("warn", "Ferroamp: ehub stale (" .. (now - ehub_ts) .. " ms) — dropping cache")
+        ehub_data = nil
+    end
+    if eso_data and (now - eso_ts) > STALE_AFTER_MS then
+        eso_data = nil
+    end
+    if sso_data and (now - sso_ts) > STALE_AFTER_MS then
+        sso_data = nil
+    end
+
+    -- Diagnostics: per-topic age into the long-format TS DB so
+    -- operators can see partial outages directly in the metric
+    -- browser. Reported as "0" when never seen yet (ts = 0).
+    host.emit_metric("ehub_age_ms", ehub_ts == 0 and 0 or (now - ehub_ts))
+    host.emit_metric("eso_age_ms",  eso_ts  == 0 and 0 or (now - eso_ts))
+    host.emit_metric("sso_age_ms",  sso_ts  == 0 and 0 or (now - sso_ts))
 
     --------------------------------------------------------------------------
     -- Meter (grid connection point)

--- a/go/internal/drivers/lua_mqtt_stale_test.go
+++ b/go/internal/drivers/lua_mqtt_stale_test.go
@@ -1,0 +1,146 @@
+package drivers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// fakeMQTT is a minimal MQTTCap stub for unit tests. Tests push messages
+// via Push(); the driver drains them through host.mqtt_messages() →
+// PopMessages().
+type fakeMQTT struct {
+	mu     sync.Mutex
+	queue  []MQTTMessage
+	subs   []string
+	closed bool
+}
+
+func (f *fakeMQTT) Subscribe(topic string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.subs = append(f.subs, topic)
+	return nil
+}
+
+func (f *fakeMQTT) Publish(topic string, payload []byte) error { return nil }
+
+func (f *fakeMQTT) PopMessages() []MQTTMessage {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := f.queue
+	f.queue = nil
+	return out
+}
+
+func (f *fakeMQTT) Close() error { f.closed = true; return nil }
+
+func (f *fakeMQTT) Push(topic, payload string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = append(f.queue, MQTTMessage{Topic: topic, Payload: payload})
+}
+
+// Regression: ferroamp.lua used to cache the last MQTT payload per
+// topic and emit from cache on every poll, regardless of how long
+// ago the last message arrived. When the EnergyHub lost power on a
+// fuse blow (real incident 2026-05-02) the driver re-emitted the
+// last-seen pv_w/meter_w to four decimals identical for 30+ minutes
+// while the inverter was physically dead. host.emit advanced
+// LastSuccess on every tick, so the watchdog never flipped offline.
+//
+// The fix is two-part:
+//  1. ferroamp.lua tracks per-topic arrival timestamps and stops
+//     emitting once the cache exceeds STALE_AFTER_MS.
+//  2. registry's runLoop bumps TickCount but NOT LastSuccess on a
+//     bare poll-return — only host.emit advances LastSuccess.
+//
+// This test exercises both: it loads the real ferroamp.lua, feeds a
+// few fresh messages, then stops the upstream and polls past the
+// staleness threshold. After staleness, the driver must:
+//   - NOT advance LastSuccess (watchdog will flip it offline)
+//   - NOT push fresh meter/pv readings into the telemetry store
+func TestFerroampDriverStopsEmittingWhenMQTTStalls(t *testing.T) {
+	// Resolve drivers/ferroamp.lua relative to the repo root.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	luaPath := filepath.Join(wd, "..", "..", "..", "drivers", "ferroamp.lua")
+	if _, err := os.Stat(luaPath); err != nil {
+		t.Fatalf("ferroamp.lua not found at %s: %v", luaPath, err)
+	}
+
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	env := NewHostEnv("ferroamp", tel).WithMQTT(mqtt)
+	env.BatteryCapacityWh = 15200
+
+	d, err := NewLuaDriver(luaPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Feed one fresh ehub payload — keep the JSON minimal but
+	// shape-compatible with extract_val (each field wraps its value
+	// in a {"val": …} object). The pext.L1 etc. trigger a meter
+	// emit; pext sums to -7000 W so the meter reading lands as
+	// negative (export, site convention).
+	ehub := `{"pext":{"L1":-2000,"L2":-2500,"L3":-2500},"ppv":{"val":7000},` +
+		`"pbat":{"val":-1000},"gridfreq":{"val":50.0},` +
+		`"ul":{"L1":230,"L2":230,"L3":230},` +
+		`"iext":{"L1":-8.7,"L2":-10.9,"L3":-10.9}}`
+	mqtt.Push("extapi/data/ehub", ehub)
+
+	// First poll: driver consumes the fresh message, emits meter +
+	// pv + battery → host.emit advances LastSuccess.
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-1: %v", err)
+	}
+	h := tel.DriverHealth("ferroamp")
+	if h == nil || h.LastSuccess == nil {
+		t.Fatalf("expected LastSuccess after a fresh emit; got %+v", h)
+	}
+	freshMeter := tel.Get("ferroamp", telemetry.DerMeter)
+	if freshMeter == nil || freshMeter.RawW == 0 {
+		t.Fatalf("meter should have a non-zero reading after fresh ehub; got %+v", freshMeter)
+	}
+
+	// Snapshot what was last seen, then go silent. Wait long enough
+	// to exceed STALE_AFTER_MS (30 s in the driver). Tests can't
+	// burn 30 s of wall-clock, so we cheat: rewind the host's
+	// monotonic Start so host.millis() reports a far-future value
+	// without sleeping. host.millis() = (now - Start) in ms.
+	env.Start = env.Start.Add(-2 * time.Minute) // -> millis() jumps by +120000
+
+	// Snapshot LastSuccess before the stale poll so we can check it
+	// doesn't advance.
+	lastBefore := *h.LastSuccess
+
+	// Drive several polls without feeding new MQTT data. The driver
+	// must detect the stale cache, drop it, and skip emit. Sleep
+	// 2 ms between polls so time.Now() in RecordSuccess can advance
+	// — otherwise an accidental RecordSuccess could leave
+	// LastSuccess unchanged at the same nanosecond and we'd miss a
+	// regression.
+	for i := 0; i < 3; i++ {
+		time.Sleep(2 * time.Millisecond)
+		if _, err := d.Poll(context.Background()); err != nil {
+			t.Fatalf("poll stale-%d: %v", i, err)
+		}
+	}
+
+	if !h.LastSuccess.Equal(lastBefore) {
+		t.Errorf("LastSuccess advanced while cache was stale (before=%v after=%v)",
+			lastBefore, *h.LastSuccess)
+	}
+}

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -212,13 +212,15 @@ func (r *Registry) runLoop(rd *runningDriver) {
 				slog.Warn("driver poll failed", "name", rd.cfg.Name, "err", err)
 				r.tel.DriverHealthMut(rd.cfg.Name).RecordError(err.Error())
 			} else if r.tel != nil {
-				// Record the successful tick so driver_poll bumps the
-				// health record's TickCount even when the driver itself
-				// has nothing to emit yet (e.g. ferroamp between MQTT
-				// subscribe and the first inbound message). Without
-				// this, drivers that wait on slow telemetry topics
-				// are indistinguishable from ones that crashed.
-				r.tel.DriverHealthMut(rd.cfg.Name).RecordSuccess()
+				// Bump TickCount so the loop is visibly alive in
+				// /api/status, but DON'T touch LastSuccess — that
+				// happens inside host.emit when the driver actually
+				// delivers telemetry. A driver that polls without
+				// emitting (waiting for first MQTT message, or feeding
+				// stale cache after upstream death) needs to surface
+				// as stale to the watchdog; otherwise a dead ferroamp
+				// re-stamps LastSuccess every tick from cached values.
+				r.tel.DriverHealthMut(rd.cfg.Name).RecordTick()
 			}
 			// Re-arm timer at driver's requested interval
 			interval = rd.env.PollInterval()

--- a/go/internal/drivers/registry_restart_test.go
+++ b/go/internal/drivers/registry_restart_test.go
@@ -224,12 +224,13 @@ func TestAddCreatesHealthRecordImmediately(t *testing.T) {
 	}
 }
 
-// runLoop should record a successful tick even when the driver poll
-// returns nil error AND doesn't emit any telemetry — so a Lua driver
-// waiting for its first MQTT message is visibly alive. Previously
-// the tick only bumped on RecordError (failure path) or a successful
-// emit, leaving a healthy-but-waiting driver indistinguishable from
-// a crashed one.
+// runLoop should bump TickCount on every poll-return-without-error so
+// a Lua driver that is alive but hasn't emitted yet (e.g. between
+// MQTT subscribe and the first inbound message) is visibly running
+// in /api/status. The tick is intentionally lighter than a full
+// RecordSuccess: LastSuccess is NOT advanced, because the watchdog
+// uses LastSuccess to flip stale drivers offline. host.emit (in the
+// hot path) is the only thing that should advance LastSuccess.
 func TestRunLoopRecordsSuccessEvenWithoutEmits(t *testing.T) {
 	r := NewRegistry(telemetry.NewStore())
 	// Driver polls every 50 ms but emits nothing.
@@ -252,5 +253,12 @@ function driver_command(action, w, cmd) end
 	}
 	if h.TickCount < 2 {
 		t.Errorf("TickCount = %d after 350ms of 50ms polls, want >= 2", h.TickCount)
+	}
+	// LastSuccess must remain nil — only host.emit advances it. A
+	// driver that polls for hours without emitting is, from the
+	// watchdog's perspective, stale; that's the correct signal so
+	// the operator (and notification rules) see the outage.
+	if h.LastSuccess != nil {
+		t.Errorf("LastSuccess advanced without any host.emit call: %v", h.LastSuccess)
 	}
 }

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -101,13 +101,34 @@ type DriverHealth struct {
 	TickCount         uint64
 }
 
-// RecordSuccess resets error state and marks the driver healthy.
+// RecordSuccess resets error state and marks the driver healthy. Call
+// this when the driver actually delivered fresh telemetry (i.e. on
+// host.emit), not just when its poll loop returned without error.
+// LastSuccess is the timestamp the watchdog uses to decide stale-
+// ness, so it must only advance when real data flowed.
 func (h *DriverHealth) RecordSuccess() {
 	now := time.Now()
 	h.LastSuccess = &now
 	h.ConsecutiveErrors = 0
 	h.LastError = ""
 	h.Status = StatusOk
+	h.TickCount++
+}
+
+// RecordTick marks one poll cycle as completed without error, but
+// without claiming fresh data flowed. Bumps TickCount so the loop is
+// visibly alive in /api/status, but leaves LastSuccess untouched so
+// the watchdog correctly flips the driver offline when emits stop.
+//
+// Why split this from RecordSuccess: an MQTT-fed driver (ferroamp)
+// caches the last payload per topic and emits from cache on every
+// poll. If the upstream stops publishing — e.g. the EnergyHub loses
+// power on a fuse blow — the cache stays populated, the lua poll
+// returns nil, and without this split the registry's per-poll
+// RecordSuccess would re-stamp LastSuccess forever. Issue: real-world
+// outage on 2026-05-02 where ferroamp showed pv_w=-3996.7040 to four
+// decimals identical for 30+ minutes after the inverter died.
+func (h *DriverHealth) RecordTick() {
 	h.TickCount++
 }
 


### PR DESCRIPTION
## Summary

- ferroamp.lua now tracks per-topic arrival timestamps and stops emitting once the cache exceeds **STALE_AFTER_MS = 30 s**. Drops a stale cache + falls through the emit block so the watchdog can do its job.
- `telemetry.DriverHealth` splits into two methods:
  - `RecordSuccess()` — fresh telemetry actually flowed (called from `host.emit`). Advances `LastSuccess`.
  - `RecordTick()` — poll loop is alive, no fresh data. Bumps `TickCount` only, leaves `LastSuccess` alone.
- Registry's `runLoop` switches its bare-poll-return path from `RecordSuccess` → `RecordTick`. The watchdog (which keys on `LastSuccess`) now correctly flips a silent driver offline.
- New regression test `TestFerroampDriverStopsEmittingWhenMQTTStalls` loads the real `drivers/ferroamp.lua`, feeds one fresh ehub message, then rewinds `env.Start` so `host.millis()` reports past the stale threshold without burning real wall-clock seconds. Asserts `LastSuccess` does NOT advance after the cache goes stale.

## Why

Real incident on 2026-05-02: a house fuse blew, took out both ferroamp + sungrow. ferroamp.lua kept emitting the last cached `pv_w=-3996.7040` / `meter_w=-7294.0490` values **identical to four decimals for 30+ minutes** while the EnergyHub itself was unpowered. `host.emit` advanced `LastSuccess` on every tick, so the watchdog never flipped the driver offline, the dispatcher kept treating the cached numbers as live, and the operator only noticed when checking the dashboard manually.

Sungrow recovered correctly because its modbus reads errored out hard once the inverter died; the ferroamp MQTT path doesn't fail loudly when the upstream stops publishing, so the driver-host needs to detect it.

## Test plan

- [x] `go test ./...` — 773 passed
- [x] New regression test reproduces the stale-cache scenario and would fail without the fix (verified by reverting individually).
- [ ] Hot-reload `drivers/ferroamp.lua` on homelab-rpi after merge and confirm: under healthy MQTT, telemetry stays live; if EnergyHub is power-cycled, `/api/status` shows `ferroamp` flipping to `offline` within 30 s instead of holding stale numbers.