### PR TITLE
fix(mpc): stop clamping export revenue at zero on negative spot

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -733,6 +733,7 @@ func main() {
 		if cfg.Price != nil {
 			mpcSvc.ExportBonusOreKwh = cfg.Price.ExportBonusOreKwh
 			mpcSvc.ExportFeeOreKwh = cfg.Price.ExportFeeOreKwh
+			mpcSvc.ExportFloorOreKwh = cfg.Price.ExportFloorOreKwh
 			mpcSvc.GridTariffOreKwh = cfg.Price.GridTariffOreKwh
 			mpcSvc.VATPercent = cfg.Price.VATPercent
 		}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -377,6 +377,15 @@ type Price struct {
 	// ExportFeeOreKwh is a per-kWh deduction on export (e.g. transmission
 	// fees some DSOs charge for feed-in). Reduces effective export price.
 	ExportFeeOreKwh float64 `yaml:"export_fee_ore_kwh,omitempty" json:"export_fee_ore_kwh,omitempty"`
+
+	// ExportFloorOreKwh, if set, clamps per-slot export revenue at the
+	// given floor (öre/kWh). Use this only when your retailer caps
+	// negative-spot export at zero — i.e. they don't bill you when
+	// spot goes negative. Default (unset / nil) lets export revenue
+	// follow real spot, which can go negative; that's the physics
+	// most Swedish customer agreements pass through. Set to a pointer
+	// to 0.0 if you have a guaranteed-zero-floor agreement.
+	ExportFloorOreKwh *float64 `yaml:"export_floor_ore_kwh,omitempty" json:"export_floor_ore_kwh,omitempty"`
 }
 
 // Weather is the weather-forecast source config.

--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -55,8 +55,9 @@ type DiagnosticParams struct {
 	DischargeEfficiency float64 `json:"discharge_efficiency"`
 	CapacityWh          float64 `json:"capacity_wh"`
 	TerminalSoCPrice    float64 `json:"terminal_soc_price_ore_kwh"`
-	ExportBonusOreKwh   float64 `json:"export_bonus_ore_kwh"`
-	ExportFeeOreKwh     float64 `json:"export_fee_ore_kwh"`
+	ExportBonusOreKwh   float64  `json:"export_bonus_ore_kwh"`
+	ExportFeeOreKwh     float64  `json:"export_fee_ore_kwh"`
+	ExportFloorOreKwh   *float64 `json:"export_floor_ore_kwh,omitempty"`
 }
 
 // Diagnostic is the full post-mortem of the most recent Optimize call.
@@ -154,6 +155,7 @@ func buildDiagnostic(plan *Plan, slots []Slot, p Params, zone string,
 			TerminalSoCPrice:    p.TerminalSoCPrice,
 			ExportBonusOreKwh:   p.ExportBonusOreKwh,
 			ExportFeeOreKwh:     p.ExportFeeOreKwh,
+			ExportFloorOreKwh:   p.ExportFloorOreKwh,
 		},
 		Slots:          out,
 		LastReplanAtMs: replanAtMs,

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -121,11 +121,20 @@ type Params struct {
 	//     export. Useful for operators with a fixed feed-in tariff.
 	//   - If ExportOrePerKWh == 0, each slot earns
 	//         slot.SpotOre + ExportBonusOreKwh − ExportFeeOreKwh
-	//     (clamped to zero) — per-slot pricing, which the DP needs to
-	//     see morning-vs-midday arbitrage opportunities.
+	//     i.e. raw spot pricing. The value can go negative when spot
+	//     is negative (Sweden + Nordic markets, increasingly common
+	//     during midday solar peaks). The DP treats a negative export
+	//     ore as a positive cost — exactly right when most retailers
+	//     pass the negative spot through to the customer.
+	//
+	//     ExportFloorOreKwh, if non-nil, clamps the per-slot export
+	//     ore at the given floor. Set to a pointer-to-zero for
+	//     retailers that cap export at 0 öre (no negative-spot
+	//     billing). nil = no clamp (default; matches the physics).
 	ExportOrePerKWh    float64
 	ExportBonusOreKwh  float64
 	ExportFeeOreKwh    float64
+	ExportFloorOreKwh  *float64
 
 	// Loadpoint extends the DP state space with one EV charge point.
 	// Nil (default) keeps the battery-only optimization path. See
@@ -286,11 +295,25 @@ func Optimize(slots []Slot, p Params) Plan {
 	effPrice := func(s Slot) float64 {
 		return s.Confidence*s.PriceOre + (1-s.Confidence)*meanPrice
 	}
-	// slotExportOre: per-slot export revenue. When Params.ExportOrePerKWh
-	// is set, it wins (fixed feed-in tariff). Otherwise each slot earns
-	// spot + bonus − fee, clamped at zero. Without this, the DP saw
-	// flat export revenue across the day and couldn't prefer "export
-	// at high-price morning, charge at cheap midday".
+	// slotExportOre: per-slot export revenue (öre/kWh). When
+	// Params.ExportOrePerKWh is set, it wins (fixed feed-in tariff).
+	// Otherwise each slot earns spot + bonus − fee.
+	//
+	// The DP's cost formula for an exporting slot is
+	//   cost = -slotExportOre(slot) * |gridKWh|
+	// so a NEGATIVE return value here is a positive cost — exactly
+	// what we want when spot is below zero (you pay to export under
+	// most Swedish retail agreements). Earlier code clamped this at
+	// zero, which made the DP indifferent between "stand still" and
+	// "blast export from battery" during minus-price hours and
+	// occasionally tripped the discharge in the latter direction by
+	// tie-break. Real incident: 2026-05-02 user switched to arbitrage
+	// at spot ≈ −5 öre and watched the battery discharge full power
+	// into the grid.
+	//
+	// If a retailer caps you at zero (no negative-spot billing) set
+	// Params.ExportFloorOreKwh to 0 — that re-introduces the clamp at
+	// the operator's choice rather than as silent default.
 	slotExportOre := func(s Slot) float64 {
 		if p.ExportOrePerKWh > 0 {
 			return p.ExportOrePerKWh
@@ -299,8 +322,8 @@ func Optimize(slots []Slot, p Params) Plan {
 		// Confidence blend on the same principle as import price.
 		mean := meanPrice * 0.7 // rough: spot ≈ 70% of consumer total
 		v = s.Confidence*v + (1-s.Confidence)*mean
-		if v < 0 {
-			v = 0
+		if p.ExportFloorOreKwh != nil && v < *p.ExportFloorOreKwh {
+			v = *p.ExportFloorOreKwh
 		}
 		return v
 	}

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -139,6 +139,79 @@ func TestArbitrageDischargesToExpensive(t *testing.T) {
 	}
 }
 
+// Regression: arbitrage at negative spot must NOT discharge battery to
+// grid. Real incident 2026-05-02: operator switched to planner_arbitrage
+// during −5 öre spot prices and watched batteries discharge full power
+// into the grid. Root cause was slotExportOre clamping at 0 — exporting
+// at negative spot looked "free" instead of "costly", so the DP tied on
+// multiple paths and could pick aggressive discharge by tie-break.
+//
+// With the clamp removed (default), exporting at negative spot is a
+// positive cost, so the DP MUST prefer idle/charge over discharge.
+func TestArbitrageDoesNotDischargeAtNegativeSpot(t *testing.T) {
+	// Six 60-min slots, all with negative spot. Light load + steady PV
+	// surplus, so the baseline grid is already exporting; the question
+	// is whether the battery makes export *worse*.
+	slots := make([]Slot, 6)
+	for i := range slots {
+		slots[i] = Slot{
+			StartMs:    int64(i) * 60 * 60 * 1000,
+			LenMin:     60,
+			PriceOre:   80,   // consumer total stays positive (grid + VAT
+			SpotOre:    -5.0, // wholesale spot pays you to consume
+			LoadW:      500,
+			PVW:        -2000, // 2 kW solar
+			Confidence: 1.0,
+		}
+	}
+	p := baseParams(ModeArbitrage)
+	p.InitialSoCPct = 60      // plenty of headroom either direction
+	p.TerminalSoCPrice = 80.0 // realistic — same scale as PriceOre, so
+	//                            cycling losses register in the objective
+	plan := Optimize(slots, p)
+
+	for i, a := range plan.Actions {
+		if a.BatteryW < -1e-6 {
+			t.Errorf("slot %d: battery discharging %fW at negative spot %.2f öre",
+				i, a.BatteryW, a.SpotOre)
+		}
+	}
+}
+
+// With ExportFloorOreKwh set to a pointer-to-zero, the old clamp
+// behaviour returns: export at negative spot looks free again. This
+// codifies the back-compat knob for retailers that don't bill for
+// negative-spot export, and also guards against accidental removal of
+// the per-customer override.
+func TestArbitrageNegativeSpotWithExportFloorClampsAtZero(t *testing.T) {
+	zero := 0.0
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 80, SpotOre: -5.0,
+			LoadW: 500, PVW: -2000, Confidence: 1.0},
+		// Second slot identical so the planner has multiple
+		// indistinguishable options to pick from. With the floor at 0
+		// the cost of discharging vs idling is exactly equal — but
+		// neither should exhibit a *positive* cost (i.e. v < 0 must
+		// have been clamped out).
+		{StartMs: 60 * 60 * 1000, LenMin: 60, PriceOre: 80, SpotOre: -5.0,
+			LoadW: 500, PVW: -2000, Confidence: 1.0},
+	}
+	p := baseParams(ModeArbitrage)
+	p.InitialSoCPct = 60
+	p.ExportFloorOreKwh = &zero
+	p.TerminalSoCPrice = 0
+	// We don't assert a specific dispatch — the floor makes export
+	// a tie. Just sanity-check that Optimize doesn't crash and the
+	// reported plan cost isn't artificially negative.
+	plan := Optimize(slots, p)
+	for i, a := range plan.Actions {
+		if a.CostOre < -1e-6 {
+			t.Errorf("slot %d: cost %f öre went negative under export floor=0",
+				i, a.CostOre)
+		}
+	}
+}
+
 // ---- Efficiency ----
 
 func TestEfficiencyCostsSoC(t *testing.T) {

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -106,6 +106,11 @@ type Service struct {
 	ExportBonusOreKwh float64
 	ExportFeeOreKwh   float64
 
+	// ExportFloorOreKwh, when non-nil, clamps the per-slot export ore
+	// at the floor. Wired from config.Price.ExportFloorOreKwh; nil =
+	// no clamp, real spot pass-through (default).
+	ExportFloorOreKwh *float64
+
 	// GridTariffOreKwh and VATPercent let the MPC turn forecast spot
 	// prices into consumer-total prices when back-filling future slots
 	// using s.Price. Mirrors prices.Applier semantics.
@@ -552,6 +557,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// to force a flat feed-in tariff).
 	p.ExportBonusOreKwh = s.ExportBonusOreKwh
 	p.ExportFeeOreKwh = s.ExportFeeOreKwh
+	p.ExportFloorOreKwh = s.ExportFloorOreKwh
 
 	// Default terminal valuation. Mode-dependent because self-consumption
 	// is a constrained game: the battery can only offset local load, not


### PR DESCRIPTION
## Summary

- Remove the unconditional `if v < 0 { v = 0 }` clamp in `mpc.slotExportOre`. The DP now treats export at negative spot as a positive cost via `cost = -slotExportOre × |gridKWh|`, matching the physics under most Swedish retail agreements (negative spot is passed through to the customer).
- Add `Params.ExportFloorOreKwh *float64` + `config.Price.ExportFloorOreKwh` (yaml: `export_floor_ore_kwh`) so retailers that cap export at zero can opt back into the clamp at their explicit choice. `nil` (default) = real spot pass-through.
- Surface `export_floor_ore_kwh` in `/api/mpc/diagnose` for verification.
- New regression tests: arbitrage at negative spot + realistic terminal-SoC value must NOT discharge battery to grid; floor knob still produces sane non-negative slot costs when configured.

## Why

Real incident on 2026-05-02: operator switched to `planner_arbitrage` during −5 öre/kWh spot prices and watched both batteries discharge full power into the grid. MPC plan reported `bat = −11040 W` in slot 0 even though the site was already exporting PV at negative prices. The DP saw export as free (clamped at 0) and ties between "idle" and "aggressive discharge"; with discrete action grid + tie-break it occasionally picked discharge.

Cost to the operator: paying spot to dump PV + battery into the grid AND round-trip efficiency loss.

## Test plan

- [x] `go test ./...` — 775 passed
- [x] New regression tests fail with the clamp re-introduced (verified locally).
- [ ] After deploy: switch to `planner_arbitrage` on a negative-spot day and confirm `/api/mpc/plan` shows charge/idle, not aggressive discharge.