### PR TITLE
feat(control): wire MPC pv_limit_w into per-driver curtail dispatch

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -165,6 +165,7 @@ func main() {
 	ctrl.SlewRateW = cfg.Site.SlewRateW
 	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
 	ctrl.InverterGroups = inverterGroupsFrom(cfg.Drivers)
+	ctrl.SupportsPVCurtail = supportsPVCurtailFrom(cfg.Drivers)
 	ctrl.DriverLimits = driverLimitsFrom(cfg.Drivers, cfg.Batteries)
 	// Per-phase fuse params for the per-phase clamp inside applyFuseGuard
 	// + forceFuseDischarge. Reads l1_a/l2_a/l3_a from the meter driver
@@ -366,6 +367,7 @@ func main() {
 			// a bare replace would race with the control loop's 5 s tick.
 			ctrlMu.Lock()
 			ctrl.InverterGroups = inverterGroupsFrom(newCfg.Drivers)
+			ctrl.SupportsPVCurtail = supportsPVCurtailFrom(newCfg.Drivers)
 			ctrl.DriverLimits = driverLimitsFrom(newCfg.Drivers, newCfg.Batteries)
 			// Fuse params + safety margin: previously startup-only.
 			// Hot-reload them so operators can tune the per-phase margin
@@ -767,6 +769,7 @@ func main() {
 				BatteryEnergyWh: d.BatteryEnergyWh,
 				SoCTargetPct:    d.SoCTargetPct,
 				Strategy:        string(d.Strategy),
+				PVLimitW:        d.PVLimitW,
 			}, true
 		}
 		// Default to the energy-allocation path. The plan is a
@@ -1320,6 +1323,34 @@ func main() {
 				}
 			}
 
+			// ---- PV curtailment dispatch ----
+			// MPC's annotateCurtailment sets pv_limit_w on slots where
+			// exporting more PV would lose money (negative spot, no
+			// positive feed-in tariff). ComputePVCurtail picks the
+			// drivers that opted in via supports_pv_curtail and emits
+			// either a `curtail` command (limit > 0) or a one-shot
+			// `curtail_disable` when a previously-curtailed driver
+			// drops out of the active set.
+			ctrlMu.Lock()
+			curtailTargets := control.ComputePVCurtail(ctrl, tel)
+			ctrlMu.Unlock()
+			for _, c := range curtailTargets {
+				var payload []byte
+				if c.LimitW > 0 {
+					payload, _ = json.Marshal(map[string]any{
+						"action":  "curtail",
+						"power_w": c.LimitW,
+					})
+				} else {
+					payload, _ = json.Marshal(map[string]any{
+						"action": "curtail_disable",
+					})
+				}
+				if err := reg.Send(ctx, c.Driver, payload); err != nil {
+					slog.Warn("pv curtail send", "name", c.Driver, "err", err)
+				}
+			}
+
 			// ---- EV dispatch: per-loadpoint observe + command ----
 			// The per-loadpoint state machine (observe → plan lookup
 			// → snap → send) is owned by loadpoint.Controller so the
@@ -1556,6 +1587,22 @@ func inverterGroupsFrom(drivers []config.Driver) map[string]string {
 			continue
 		}
 		out[d.Name] = d.InverterGroup
+	}
+	return out
+}
+
+// supportsPVCurtailFrom builds the per-driver opt-in map used by
+// ComputePVCurtail. Operators set `supports_pv_curtail: true` on
+// each driver whose lua handles the `curtail` / `curtail_disable`
+// actions (sungrow, ferroamp, deye, huawei, solis ship with it).
+// Drivers not in the map are silently skipped by the curtail
+// dispatcher — no risk of an EV charger receiving a curtail payload.
+func supportsPVCurtailFrom(drivers []config.Driver) map[string]bool {
+	out := map[string]bool{}
+	for _, d := range drivers {
+		if d.SupportsPVCurtail {
+			out[d.Name] = true
+		}
 	}
 	return out
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -265,6 +265,15 @@ type Driver struct {
 	// cross-charging. Untagged drivers keep today's capacity-proportional
 	// behavior. See issue #143 and docs/configuration.md.
 	InverterGroup string `yaml:"inverter_group,omitempty" json:"inverter_group,omitempty"`
+	// SupportsPVCurtail flags this driver as one that handles the
+	// `curtail` / `curtail_disable` actions in its lua. Drivers with
+	// it set become eligible for ComputePVCurtail dispatch when the
+	// MPC's slot directive carries a PVLimitW > 0 (negative-export
+	// economic guard). Default false — operators must opt in per
+	// driver to avoid surprising older configs. The lua side has
+	// always been there for sungrow / ferroamp / deye / huawei /
+	// solis; this flag just turns on the Go-side dispatcher.
+	SupportsPVCurtail bool `yaml:"supports_pv_curtail,omitempty" json:"supports_pv_curtail,omitempty"`
 	// Disabled skips this driver at startup / reload. Set via the UI when
 	// you want to temporarily take a driver out without editing yaml.
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -60,7 +60,8 @@ type SlotDirective struct {
 	SlotEnd         time.Time
 	BatteryEnergyWh float64 // site-signed: + = charge, − = discharge
 	SoCTargetPct    float64
-	Strategy        string // echoed for logging / API; mirrors mpc.Mode
+	Strategy        string  // echoed for logging / API; mirrors mpc.Mode
+	PVLimitW        float64 // 0 = no curtail; > 0 = cap aggregate PV output
 }
 
 // SlotDirectiveFunc returns the plan's energy-allocation directive for
@@ -98,6 +99,20 @@ type DispatchTarget struct {
 	Driver  string  `json:"driver"`
 	TargetW float64 `json:"target_w"`
 	Clamped bool    `json:"clamped"`
+}
+
+// CurtailTarget is a per-driver PV curtailment command. Emitted by
+// ComputePVCurtail when the active plan slot's PVLimitW signals that
+// exporting more PV than the limit would lose money (negative-spot
+// hours with no positive feed-in tariff, plus zero export bonus).
+//
+// LimitW=0 means "release any previous curtail" — main.go translates
+// the zero-limit form into a `curtail_disable` action so the driver
+// returns to its default operating mode. LimitW>0 dispatches as
+// `curtail` with the magnitude as the absolute power cap.
+type CurtailTarget struct {
+	Driver string  `json:"driver"`
+	LimitW float64 `json:"limit_w"`
 }
 
 // State holds all persistent state for one instance of the control loop.
@@ -206,6 +221,21 @@ type State struct {
 	// the AC bus (DC→AC→AC→DC ≈ 3-4 pp loss vs DC-local). Nil or empty
 	// preserves the capacity-proportional default. Issue #143.
 	InverterGroups map[string]string
+
+	// SupportsPVCurtail flags drivers whose lua advertises a "curtail"
+	// action (sungrow, ferroamp, deye, huawei, …). ComputePVCurtail
+	// only dispatches to flagged drivers; an EV charger or a meter
+	// driver wouldn't know what to do with a `curtail` payload.
+	// Populated from config.Driver.SupportsPVCurtail in main.go;
+	// hot-swappable via the config-reload watcher.
+	SupportsPVCurtail map[string]bool
+
+	// LastCurtailedDrivers remembers which drivers got a non-zero
+	// curtail dispatch on the previous tick. ComputePVCurtail uses
+	// the diff to emit a `curtail_disable` exactly once when the
+	// plan no longer wants curtailment — without this we'd silently
+	// leave the inverter capped after a slot rolls over.
+	LastCurtailedDrivers map[string]bool
 
 	// FuseEVMaxW is the joint allocator's verdict for the EV's allowed
 	// wattage this tick. Only meaningful when FuseSaturated is true.
@@ -978,6 +1008,96 @@ func ComputeDispatch(
 	}
 	state.LastTargets = raw
 	return raw
+}
+
+// ComputePVCurtail returns one CurtailTarget per affected driver for
+// this dispatch tick.
+//
+// When the active plan slot's PVLimitW > 0 (the MPC's annotateCurtailment
+// flagged that exporting more PV than the limit would lose money — e.g.
+// negative spot, no positive feed-in tariff), the limit is allocated
+// proportionally across drivers in `state.SupportsPVCurtail` according
+// to each driver's live PV output. Drivers not in that set are silently
+// skipped — an EV charger or a meter driver wouldn't know what to do
+// with a `curtail` payload.
+//
+// Drivers that received curtail last tick but aren't in the new set
+// (slot rolled over, or PVLimitW dropped to 0) get LimitW=0, which
+// main.go translates to `curtail_disable`. That guarantees the cap
+// is released exactly once when the plan no longer wants it — no
+// silent capping after a mode change or a fresh plan.
+//
+// Returns nil when nothing is curtailed and nothing needs releasing.
+//
+// Idempotent: state mutation (LastCurtailedDrivers) reflects the
+// post-call set of actively-curtailed drivers.
+func ComputePVCurtail(state *State, store *telemetry.Store) []CurtailTarget {
+	if state == nil {
+		return nil
+	}
+	// Fetch the active slot directly — independent of dispatch mode,
+	// because curtailment is an economic decision that applies in
+	// any mode the operator picked. The plan's `annotateCurtailment`
+	// already gated PVLimitW on negative export revenue.
+	var limit float64
+	if state.SlotDirective != nil {
+		if dir, ok := state.SlotDirective(time.Now()); ok {
+			limit = dir.PVLimitW
+		}
+	}
+
+	// Decide which drivers should be curtailed this tick.
+	next := map[string]float64{}
+	if limit > 0 && store != nil && len(state.SupportsPVCurtail) > 0 {
+		// Allocate the site-wide limit proportionally to each PV-
+		// supporting driver's live |PV|. A driver currently producing
+		// nothing gets nothing (no point asking it to cap output it
+		// isn't producing).
+		type pvD struct {
+			name string
+			abs  float64
+		}
+		var drivers []pvD
+		var total float64
+		for _, r := range store.ReadingsByType(telemetry.DerPV) {
+			if !state.SupportsPVCurtail[r.Driver] {
+				continue
+			}
+			if r.RawW >= 0 {
+				continue // not generating right now
+			}
+			abs := -r.RawW
+			drivers = append(drivers, pvD{name: r.Driver, abs: abs})
+			total += abs
+		}
+		if total > 0 {
+			for _, d := range drivers {
+				next[d.name] = limit * (d.abs / total)
+			}
+		}
+	}
+
+	var out []CurtailTarget
+	// Release any driver we curtailed last tick but not this one.
+	for d := range state.LastCurtailedDrivers {
+		if _, ok := next[d]; !ok {
+			out = append(out, CurtailTarget{Driver: d, LimitW: 0})
+		}
+	}
+	for d, w := range next {
+		out = append(out, CurtailTarget{Driver: d, LimitW: w})
+	}
+
+	if len(next) == 0 {
+		state.LastCurtailedDrivers = nil
+	} else {
+		updated := make(map[string]bool, len(next))
+		for d := range next {
+			updated[d] = true
+		}
+		state.LastCurtailedDrivers = updated
+	}
+	return out
 }
 
 // distributeProportional splits the total desired battery power across the

--- a/go/internal/control/pv_curtail_test.go
+++ b/go/internal/control/pv_curtail_test.go
@@ -1,0 +1,199 @@
+package control
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// stubSlotDirective returns a fixed directive whenever called. Lets us
+// pin PVLimitW for the test without standing up a full mpc.Service.
+func stubSlotDirective(d SlotDirective) SlotDirectiveFunc {
+	return func(now time.Time) (SlotDirective, bool) {
+		return d, true
+	}
+}
+
+func staleSlotDirective() SlotDirectiveFunc {
+	return func(now time.Time) (SlotDirective, bool) {
+		return SlotDirective{}, false
+	}
+}
+
+// emitPV pushes a fresh pv reading into the store via the public Update
+// API, matching the path the lua host uses. RawW must be site-signed:
+// negative = generation.
+func emitPV(t *testing.T, s *telemetry.Store, driver string, w float64) {
+	t.Helper()
+	s.DriverHealthMut(driver).RecordSuccess()
+	s.Update(driver, telemetry.DerPV, w, nil, nil)
+}
+
+// findCurtail returns the per-driver LimitW from a CurtailTarget slice
+// for stable assertions independent of slice order.
+func findCurtail(targets []CurtailTarget) map[string]float64 {
+	out := map[string]float64{}
+	for _, t := range targets {
+		out[t.Driver] = t.LimitW
+	}
+	return out
+}
+
+func TestComputePVCurtail_NoDirective_DoesNothing(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = staleSlotDirective()
+	st.SupportsPVCurtail = map[string]bool{"sungrow": true}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -5000)
+	if got := ComputePVCurtail(st, store); got != nil {
+		t.Errorf("expected no targets when plan is stale; got %+v", got)
+	}
+}
+
+func TestComputePVCurtail_LimitZero_DoesNothing(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 0})
+	st.SupportsPVCurtail = map[string]bool{"sungrow": true}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -5000)
+	if got := ComputePVCurtail(st, store); got != nil {
+		t.Errorf("expected no targets when PVLimitW=0; got %+v", got)
+	}
+}
+
+func TestComputePVCurtail_AllocatesLimitProportionally(t *testing.T) {
+	// Two PV drivers: sungrow producing 6 kW, ferroamp producing 4 kW.
+	// Total = 10 kW; plan caps at 1500 W. Expect:
+	//   sungrow  → 1500 × 6/10 = 900 W
+	//   ferroamp → 1500 × 4/10 = 600 W
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1500})
+	st.SupportsPVCurtail = map[string]bool{
+		"sungrow":  true,
+		"ferroamp": true,
+	}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -6000)
+	emitPV(t, store, "ferroamp", -4000)
+
+	got := findCurtail(ComputePVCurtail(st, store))
+	if len(got) != 2 {
+		t.Fatalf("want 2 targets, got %d: %+v", len(got), got)
+	}
+	if abs(got["sungrow"]-900) > 1e-3 {
+		t.Errorf("sungrow limit: want 900, got %.2f", got["sungrow"])
+	}
+	if abs(got["ferroamp"]-600) > 1e-3 {
+		t.Errorf("ferroamp limit: want 600, got %.2f", got["ferroamp"])
+	}
+}
+
+func TestComputePVCurtail_SkipsNonSupportingDriver(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1000})
+	st.SupportsPVCurtail = map[string]bool{"sungrow": true}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -3000)
+	emitPV(t, store, "easee", -2000) // hypothetical PV reading on a non-curtail driver
+
+	got := findCurtail(ComputePVCurtail(st, store))
+	if len(got) != 1 {
+		t.Fatalf("only sungrow should be curtailed; got %+v", got)
+	}
+	if abs(got["sungrow"]-1000) > 1e-3 {
+		// 100% of limit (only one supporting driver in the pool).
+		t.Errorf("sungrow limit: want 1000, got %.2f", got["sungrow"])
+	}
+}
+
+func TestComputePVCurtail_SkipsDriverNotGenerating(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 800})
+	st.SupportsPVCurtail = map[string]bool{
+		"sungrow":  true,
+		"ferroamp": true,
+	}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -2000)
+	emitPV(t, store, "ferroamp", 0) // night, not generating
+
+	got := findCurtail(ComputePVCurtail(st, store))
+	if _, ok := got["ferroamp"]; ok {
+		t.Errorf("ferroamp not generating; should not receive curtail: %+v", got)
+	}
+	if abs(got["sungrow"]-800) > 1e-3 {
+		t.Errorf("sungrow should get full limit; got %.2f", got["sungrow"])
+	}
+}
+
+// Regression: when the plan stops asking for curtailment, the driver
+// that was previously curtailed must receive a one-shot LimitW=0
+// (translated to `curtail_disable` by main.go) — otherwise the cap
+// stays applied silently after the slot rolls over.
+func TestComputePVCurtail_ReleasesPreviouslyCurtailedDriver(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SupportsPVCurtail = map[string]bool{"sungrow": true}
+	store := telemetry.NewStore()
+	emitPV(t, store, "sungrow", -3000)
+
+	// Tick 1: plan caps PV at 1000 W → sungrow gets curtailed.
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1000})
+	tick1 := findCurtail(ComputePVCurtail(st, store))
+	if abs(tick1["sungrow"]-1000) > 1e-3 {
+		t.Fatalf("tick1: want sungrow=1000, got %+v", tick1)
+	}
+	if !st.LastCurtailedDrivers["sungrow"] {
+		t.Fatalf("tick1: state should remember sungrow as curtailed")
+	}
+
+	// Tick 2: plan no longer caps (slot rolled over). Expect a
+	// release target for sungrow with LimitW=0.
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 0})
+	tick2 := ComputePVCurtail(st, store)
+	if len(tick2) != 1 {
+		t.Fatalf("tick2: want one release target, got %+v", tick2)
+	}
+	if tick2[0].Driver != "sungrow" || tick2[0].LimitW != 0 {
+		t.Errorf("tick2: want {sungrow, 0}, got %+v", tick2[0])
+	}
+	if len(st.LastCurtailedDrivers) != 0 {
+		t.Errorf("tick2: state should have cleared LastCurtailedDrivers; got %+v",
+			st.LastCurtailedDrivers)
+	}
+
+	// Tick 3: still no curtail, no driver to release. Expect nil.
+	if got := ComputePVCurtail(st, store); got != nil {
+		t.Errorf("tick3: want nil (idempotent release), got %+v", got)
+	}
+}
+
+// Sanity: target slice is deterministic enough that callers can sort
+// by driver name without relying on map iteration order.
+func TestComputePVCurtail_DeterministicSortable(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1000})
+	st.SupportsPVCurtail = map[string]bool{"a": true, "b": true, "c": true}
+	store := telemetry.NewStore()
+	emitPV(t, store, "a", -1000)
+	emitPV(t, store, "b", -1000)
+	emitPV(t, store, "c", -1000)
+	got := ComputePVCurtail(st, store)
+	if len(got) != 3 {
+		t.Fatalf("want 3 targets, got %d", len(got))
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].Driver < got[j].Driver })
+	for i, d := range []string{"a", "b", "c"} {
+		if got[i].Driver != d {
+			t.Errorf("idx %d: want driver %q, got %q", i, d, got[i].Driver)
+		}
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -202,6 +202,13 @@ type SlotDirective struct {
 	SoCTargetPct    float64 // plan's SoC at SlotEnd — used by divergence detector
 	Strategy        Mode    // echoed for logging + API
 
+	// PVLimitW is the recommended cap on aggregate PV inverter output
+	// for this slot (W, positive). 0 means "no curtailment". Set by
+	// annotateCurtailment when exporting at zero / negative revenue
+	// would lose money — the dispatch layer divides this across the
+	// site's PV-supporting drivers and sends `curtail` commands.
+	PVLimitW float64
+
 	// LoadpointEnergyWh carries per-loadpoint EV energy budgets for
 	// this slot. Keyed by Loadpoint.ID. Positive = charging energy
 	// the plan allocated. Empty map when no loadpoints are
@@ -251,6 +258,7 @@ func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
 			BatteryEnergyWh: energyWh,
 			SoCTargetPct:    a.SoCPct,
 			Strategy:        s.Defaults.Mode,
+			PVLimitW:        a.PVLimitW,
 		}
 		// EV energy budget for the slot (single-loadpoint for now —
 		// keyed under lpID snapshot so the dispatch layer routes


### PR DESCRIPTION
## Summary

Wires the missing leg between `mpc.annotateCurtailment` (which has been computing PV curtail recommendations for a while) and the actual driver-side action. Operators with negative-spot pricing now see `curtail` commands fire when the plan says exporting unconstrained PV would lose money.

- `mpc.SlotDirective` gains `PVLimitW` — surfaced through the main.go adapter into the control package's mirror struct.
- New `control.ComputePVCurtail` allocates the site-wide cap proportionally to each PV-supporting driver's live `|PV|`. Returns one `CurtailTarget` per affected driver; `LimitW=0` means "release any prior curtail" (`curtail_disable`).
- New `State.SupportsPVCurtail` (per-driver opt-in) gates dispatch. Lua side has shipped curtail handlers in sungrow / ferroamp / deye / huawei / solis for a while — this just turns on the Go-side dispatcher per driver. Operators set `supports_pv_curtail: true` in YAML.
- New `State.LastCurtailedDrivers` diffs across ticks so a previously-curtailed driver gets exactly one `curtail_disable` when it drops out of the active set (slot rollover, plan no longer asking for curtail). No silent caps left applied.
- `main.go` dispatch tick now runs `ComputePVCurtail` after `ComputeDispatch` and sends each result through `reg.Send`.

## Why

Real incident on 2026-05-02: spot at −5 öre/kWh, the operator's site exporting ~6 kW of PV, MPC plan reported `pv_limit_w: 1338` for the active slot — but no Go code read it. The lua drivers have curtail handlers; the wiring just wasn't there.

## Test plan

- [x] `go test ./...` — 782 passed (+7 new in `pv_curtail_test.go`)
- [ ] On homelab-rpi after deploy: set `supports_pv_curtail: true` on `sungrow` and `ferroamp` drivers, switch to a planner mode during a negative-spot hour, confirm `/api/mpc/diagnose` shows `pv_limit_w > 0` AND the inverters' export limit registers reflect the cap (sungrow holding 13073, ferroamp `pplim` MQTT echo).
- [ ] Cross-check: after slot rollover when prices return to positive, drivers receive exactly one `curtail_disable` and PV inverter resumes uncapped output.