### PR TITLE
feat(notifications): concurrent_drivers_offline event for fuse-blow signature

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -67,6 +67,11 @@ type NotificationRule struct {
 	Type          string `yaml:"type" json:"type"`
 	Enabled       bool   `yaml:"enabled" json:"enabled"`
 	ThresholdS    int    `yaml:"threshold_s,omitempty" json:"threshold_s,omitempty"`
+	// ThresholdN is a count-based threshold used by event types that
+	// aggregate across drivers (concurrent_drivers_offline). Ignored
+	// by per-driver events. Default behaviour per event documented
+	// alongside the const in notifications/service.go.
+	ThresholdN    int    `yaml:"threshold_n,omitempty" json:"threshold_n,omitempty"`
 	Priority      int    `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Tags          string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	TitleTemplate string `yaml:"title_template,omitempty" json:"title_template,omitempty"`

--- a/go/internal/notifications/service.go
+++ b/go/internal/notifications/service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"text/template"
@@ -36,7 +37,28 @@ const (
 	EventDriverRecovered = "driver_recovered"
 	EventUpdateAvailable = "update_available"
 	EventFuseOverLimit   = "fuse_over_limit"
+
+	// EventConcurrentDriversOffline fires when ≥ ThresholdN drivers
+	// are simultaneously stale beyond ThresholdS — the typical
+	// signature of a fuse blow / breaker trip / power outage that
+	// took out multiple inverters at once. A single flaky driver
+	// uses driver_offline; this catches the multi-driver
+	// "something bigger just happened" pattern that motivated
+	// the 2026-05-02 incident: house fuse blew, both ferroamp +
+	// sungrow went silent, the dashboard kept rendering stale
+	// numbers and nobody noticed for 2+ hours.
+	//
+	// Default ThresholdN = 2. Configure via the rule's
+	// `threshold_n` field. ThresholdS reuses the same per-driver
+	// staleness threshold semantics — a driver is "stale" when its
+	// LastSuccess is older than ThresholdS (default DefaultThresholdS).
+	EventConcurrentDriversOffline = "concurrent_drivers_offline"
 )
+
+// DefaultConcurrentThresholdN is the count of drivers that must be
+// concurrently offline before EventConcurrentDriversOffline fires,
+// when the rule doesn't override.
+const DefaultConcurrentThresholdN = 2
 
 // Defaults for a freshly-seeded rule.
 const (
@@ -54,6 +76,14 @@ func DefaultRules() []config.NotificationRule {
 		// Default threshold 30 s — brief inrush / dryer starts shouldn't
 		// page the operator. Cooldown 15 min per phase.
 		{Type: EventFuseOverLimit, Enabled: false, ThresholdS: 30, Priority: 5, CooldownS: 900},
+		// Concurrent-drivers-offline: the fuse-blow signature. Default
+		// thresholds: 2 drivers offline for 5 minutes, 30 min cooldown
+		// (it's an "infrastructure" alert, you don't want it pinging
+		// every minute while the operator is on the way home to fix
+		// the breaker).
+		{Type: EventConcurrentDriversOffline, Enabled: false,
+			ThresholdS: 300, ThresholdN: DefaultConcurrentThresholdN,
+			Priority: 5, CooldownS: 1800},
 	}
 }
 
@@ -527,6 +557,64 @@ func (s *Service) observeAt(health map[string]telemetry.DriverHealth, now time.T
 			}
 		}
 	}
+	// Per-rule (post per-driver loop): concurrent drivers offline.
+	// This rule is ABOUT the fleet, not a single driver, so it can't
+	// be evaluated inside the per-driver inner loop. We collect the
+	// stale set once and decide whether the count crosses threshold.
+	for _, rule := range rules {
+		if !rule.Enabled || rule.Type != EventConcurrentDriversOffline {
+			continue
+		}
+		threshS := time.Duration(rule.ThresholdS) * time.Second
+		if threshS == 0 {
+			threshS = time.Duration(DefaultThresholdS) * time.Second
+		}
+		threshN := rule.ThresholdN
+		if threshN <= 0 {
+			threshN = DefaultConcurrentThresholdN
+		}
+		var stale []string
+		for d, h := range health {
+			// Cold-start drivers don't count — same exception as
+			// driver_offline. A driver that's never emitted yet
+			// shouldn't pull the fleet into a fuse-blow alert.
+			if h.LastSuccess == nil && h.TickCount == 0 {
+				continue
+			}
+			var since time.Duration
+			if h.LastSuccess != nil {
+				since = now.Sub(*h.LastSuccess)
+			}
+			if h.LastSuccess == nil || since >= threshS {
+				stale = append(stale, d)
+			}
+		}
+		sort.Strings(stale)
+		key := rule.Type + "|fleet"
+		if len(stale) < threshN {
+			// Healthy / partial outage — clear the latch so the
+			// next concurrent failure can fire.
+			delete(s.alreadyFired, key)
+			continue
+		}
+		if s.alreadyFired[key] {
+			continue
+		}
+		if rule.CooldownS > 0 {
+			if last, ok := s.lastFired[key]; ok && now.Sub(last) < time.Duration(rule.CooldownS)*time.Second {
+				continue
+			}
+		}
+		s.alreadyFired[key] = true
+		s.lastFired[key] = now
+		td := templateData{
+			Device:    strings.Join(stale, ", "),
+			Devices:   stale,
+			EventType: rule.Type,
+			Timestamp: now.UTC().Format(time.RFC3339),
+		}
+		pending = append(pending, dispatch{rule, td})
+	}
 	// Post-pass: if no enabled driver_recovered rule exists, nothing
 	// above ever clears activeAlert when a driver goes healthy again,
 	// and Status().ActiveAlert would leak upward forever. Clean up
@@ -617,6 +705,10 @@ type templateData struct {
 	Phase  string  // "L1" | "L2" | "L3"
 	Amps   float64 // current reading on that phase
 	LimitA float64 // fuse rating (site.fuse.max_amps)
+	// Populated for concurrent_drivers_offline only. Devices is the
+	// sorted list of stale drivers; Device contains the same names
+	// joined by ", " for the default body template.
+	Devices []string
 }
 
 func (s *Service) buildData(driver, eventType string, since time.Duration, now time.Time) templateData {
@@ -768,6 +860,8 @@ func defaultTitleFor(eventType string) string {
 		return "forty-two-watts: update {{.Version}} available"
 	case EventFuseOverLimit:
 		return "forty-two-watts: {{.Phase}} over fuse limit"
+	case EventConcurrentDriversOffline:
+		return "forty-two-watts: {{len .Devices}} drivers offline (likely fuse / outage)"
 	}
 	return "forty-two-watts: {{.EventType}}"
 }
@@ -782,6 +876,8 @@ func defaultBodyFor(eventType string) string {
 		return "Version {{.Version}} is available (running {{.PreviousVersion}}). {{.ReleaseURL}}"
 	case EventFuseOverLimit:
 		return "{{.Phase}} draw {{printf \"%.1f\" .Amps}} A exceeded the {{printf \"%.0f\" .LimitA}} A fuse for {{.Duration}}."
+	case EventConcurrentDriversOffline:
+		return "{{len .Devices}} drivers went silent at once: {{.Device}}. Check the fuse / breaker / wifi."
 	}
 	return "{{.EventType}} for {{.Device}}"
 }

--- a/go/internal/notifications/service_test.go
+++ b/go/internal/notifications/service_test.go
@@ -573,3 +573,131 @@ func TestFuseOverLimitFiresAfterThresholdAndResets(t *testing.T) {
 		t.Fatalf("cooldown did not block refire: got %d msgs", n)
 	}
 }
+
+// ---- concurrent_drivers_offline ----
+
+func concurrentCfg() *config.Notifications {
+	return &config.Notifications{
+		Enabled:         true,
+		Provider:        "ntfy",
+		DefaultPriority: 3,
+		Ntfy:            &config.NtfyConfig{Server: "https://example", Topic: "test"},
+		Events: []config.NotificationRule{
+			{Type: EventConcurrentDriversOffline, Enabled: true,
+				ThresholdS: 300, ThresholdN: 2,
+				Priority: 5, CooldownS: 1800},
+		},
+	}
+}
+
+func TestConcurrentOffline_FiresOnFleetOutage(t *testing.T) {
+	pub := &fakePub{}
+	svc, clk := newSvc(concurrentCfg(), pub)
+	// Both drivers were healthy 10 minutes ago; rule threshold is 5
+	// minutes. Now, both have gone stale at the same time — the
+	// fuse-blow signature.
+	last := clk.now().Add(-10 * time.Minute)
+	health := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: &last, TickCount: 100,
+			Status: telemetry.StatusOffline},
+		"sungrow": {Name: "sungrow", LastSuccess: &last, TickCount: 100,
+			Status: telemetry.StatusOffline},
+		"easee": {Name: "easee", LastSuccess: addr(clk.now()), TickCount: 100,
+			Status: telemetry.StatusOk},
+	}
+	svc.Observe(health)
+	msgs := pub.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 fire, got %d", len(msgs))
+	}
+	body := msgs[0].Body
+	if !strings.Contains(body, "ferroamp") || !strings.Contains(body, "sungrow") {
+		t.Errorf("body should list both stale drivers; got %q", body)
+	}
+	if strings.Contains(body, "easee") {
+		t.Errorf("healthy driver should NOT appear in body; got %q", body)
+	}
+}
+
+func TestConcurrentOffline_DoesNotFireForSingleStale(t *testing.T) {
+	// Single stale driver below ThresholdN — driver_offline's job,
+	// not concurrent's.
+	pub := &fakePub{}
+	svc, clk := newSvc(concurrentCfg(), pub)
+	last := clk.now().Add(-10 * time.Minute)
+	health := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: &last, TickCount: 100,
+			Status: telemetry.StatusOffline},
+		"sungrow": {Name: "sungrow", LastSuccess: addr(clk.now()), TickCount: 100,
+			Status: telemetry.StatusOk},
+	}
+	svc.Observe(health)
+	if n := len(pub.Messages()); n != 0 {
+		t.Errorf("single stale should not fire concurrent rule; got %d msgs", n)
+	}
+}
+
+func TestConcurrentOffline_FiresOnceUntilRecovery(t *testing.T) {
+	pub := &fakePub{}
+	svc, clk := newSvc(concurrentCfg(), pub)
+	last := clk.now().Add(-10 * time.Minute)
+	stale := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: &last, TickCount: 100,
+			Status: telemetry.StatusOffline},
+		"sungrow": {Name: "sungrow", LastSuccess: &last, TickCount: 100,
+			Status: telemetry.StatusOffline},
+	}
+	// Fire once.
+	svc.Observe(stale)
+	if n := len(pub.Messages()); n != 1 {
+		t.Fatalf("first observe: want 1, got %d", n)
+	}
+	// Re-observing while still stale must NOT refire (the latch).
+	for i := 0; i < 5; i++ {
+		clk.advance(60 * time.Second)
+		svc.Observe(stale)
+	}
+	if n := len(pub.Messages()); n != 1 {
+		t.Fatalf("repeat-stale: want still 1, got %d", n)
+	}
+	// Recovery — both back to healthy. Latch clears.
+	now := clk.now()
+	healthy := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: &now, TickCount: 200,
+			Status: telemetry.StatusOk},
+		"sungrow": {Name: "sungrow", LastSuccess: &now, TickCount: 200,
+			Status: telemetry.StatusOk},
+	}
+	svc.Observe(healthy)
+	// New outage triggers a NEW fire (after cooldown).
+	clk.advance(40 * time.Minute) // > CooldownS (1800)
+	last2 := clk.now().Add(-10 * time.Minute)
+	stale2 := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: &last2, TickCount: 300,
+			Status: telemetry.StatusOffline},
+		"sungrow": {Name: "sungrow", LastSuccess: &last2, TickCount: 300,
+			Status: telemetry.StatusOffline},
+	}
+	svc.Observe(stale2)
+	if n := len(pub.Messages()); n != 2 {
+		t.Fatalf("after recovery + cooldown: want 2 fires, got %d", n)
+	}
+}
+
+func TestConcurrentOffline_IgnoresColdStartDrivers(t *testing.T) {
+	// A driver that never emitted (cold start) shouldn't pull the
+	// fleet into a concurrent-offline alert. Only previously-healthy-
+	// now-silent drivers count, mirroring driver_offline's exception.
+	pub := &fakePub{}
+	svc, _ := newSvc(concurrentCfg(), pub)
+	health := map[string]telemetry.DriverHealth{
+		"ferroamp": {Name: "ferroamp", LastSuccess: nil, TickCount: 0}, // cold start
+		"sungrow":  {Name: "sungrow", LastSuccess: nil, TickCount: 0},  // cold start
+	}
+	svc.Observe(health)
+	if n := len(pub.Messages()); n != 0 {
+		t.Errorf("cold-start drivers should be excluded; got %d msgs", n)
+	}
+}
+
+func addr(t time.Time) *time.Time { return &t }


### PR DESCRIPTION
## Summary

New `concurrent_drivers_offline` notification rule that catches the multi-driver-down pattern `driver_offline` misses. Fires once for a whole-fleet outage, with a body listing every stale driver.

- New event type (constant + DefaultRules entry).
- New `NotificationRule.ThresholdN` field for count-based thresholds (yaml: `threshold_n`).
- `templateData.Devices []string` for templates that want to enumerate the stale set.
- Default title/body — title shows the count, body lists driver names + suggests "check the fuse / breaker / wifi".
- Defaults: `threshold_s=300`, `threshold_n=2`, `priority=5`, `cooldown_s=1800`. Disabled until operator opts in via UI.

Cold-start drivers (`LastSuccess=nil && TickCount=0`) are excluded so a fresh restart doesn't self-trigger.

## Why

Real incident on 2026-05-02: house fuse blew, ferroamp + sungrow went silent simultaneously. With the existing `driver_offline` rule the operator would have received two separate notifications eventually, but only after each crossed its per-driver threshold individually. This rule recognises the multi-driver concurrent failure pattern as "infrastructure event" and fires once.

Pairs with #234 (ferroamp staleness fix) — that fix made `LastSuccess` correctly go stale when MQTT stops flowing; this rule polls that signal.

## Test plan

- [x] `go test ./...` — 786 passed (+4 in `service_test.go`)
- [ ] After deploy: enable the new rule in Settings → Notifications, set thresholds, simulate by killing the EnergyHub MQTT broker (or pulling its ethernet) and verifying ntfy fires once with both driver names in the body.
- [ ] After recovery + cooldown elapses, simulate again and verify a second fire does fire.