### PR TITLE
feat(drivers): add Solis string inverter driver

### DIFF
--- a/docs/driver-catalog.md
+++ b/docs/driver-catalog.md
@@ -6,8 +6,8 @@ in `drivers/` that follows the v2.1 host API (see
 
 ## At a glance
 
-22 drivers covering 17 manufacturers across 3 protocols (Modbus TCP,
-MQTT, HTTP/REST). Read-only: 13. With control: 9.
+23 drivers covering 17 manufacturers across 3 protocols (Modbus TCP,
+MQTT, HTTP/REST). Read-only: 14. With control: 9.
 
 Protocols in use: Modbus TCP, MQTT, HTTP/REST.
 
@@ -39,6 +39,7 @@ back to the device; read-only drivers only emit telemetry.
 | SolarEdge inverter (PV only) | SolarEdge | Modbus | pv | no | HD-Wave, StorEdge | `drivers/solaredge_pv.lua` |
 | SolarEdge legacy K-series (display) | SolarEdge | Modbus | pv | no | SE7K, SE10K, SE17K, SE25K | `drivers/solaredge_legacy.lua` |
 | Solis hybrid inverter | Solis | Modbus | battery, meter, pv | yes | RHI-6K-48ES-5G, S6-EH3P10K-H | `drivers/solis.lua` |
+| Solis string inverter | Solis | Modbus | pv | no | S5-GC, S6-GR1P, 3P-G4, 1P-G4 | `drivers/solis_string.lua` |
 | Sungrow SH Hybrid Inverter | Sungrow | Modbus | battery, meter, pv | yes | SH5.0RT, SH6.0RT, SH8.0RT, SH10RT | `drivers/sungrow.lua` |
 | Victron Cerbo GX / Venus GX | Victron | Modbus | battery, meter, pv | no | Cerbo GX, Venus GX | `drivers/victron.lua` |
 

--- a/drivers/solis_string.lua
+++ b/drivers/solis_string.lua
@@ -1,0 +1,160 @@
+-- Solis non-hybrid string inverter driver
+-- Emits: PV
+-- Protocol: Modbus TCP, input registers
+--
+-- Sign convention (site boundary -- positive W = into site):
+--   PV w is always negative because generation reduces grid import.
+
+DRIVER = {
+  id           = "solis-string",
+  name         = "Solis string inverter",
+  manufacturer = "Ginlong Solis",
+  version      = "1.0.0",
+  protocols    = { "modbus" },
+  capabilities = { "pv" },
+  description  = "Solis non-hybrid PV inverters via Modbus TCP.",
+  homepage     = "https://www.ginlong.com",
+  authors      = { "forty-two-watts contributors" },
+  tested_models = { "S5-GC", "S6-GR1P", "3P-G4", "1P-G4" },
+  verification_status = "experimental",
+  verification_notes = "Read-only PV driver. Awaiting field verification on a 42W site.",
+  connection_defaults = {
+    port    = 502,
+    unit_id = 1,
+  },
+}
+
+PROTOCOL = "modbus"
+
+local sn_set = false
+
+local function set_serial_from_config(config)
+    if sn_set or type(config) ~= "table" then return end
+
+    local sn = config.serial or config.sn
+    if type(sn) == "string" then
+        sn = sn:gsub("^%s+", ""):gsub("%s+$", "")
+        if #sn > 0 then
+            host.set_sn(sn)
+            sn_set = true
+        end
+    end
+end
+
+function driver_init(config)
+    host.set_make("Ginlong Solis")
+    set_serial_from_config(config)
+    host.log("info", "Solis string: driver_init")
+end
+
+local function read_input(addr, count)
+    local ok, regs = pcall(host.modbus_read, addr, count, "input")
+    if ok and regs then return regs end
+    return nil
+end
+
+local function u16(regs, idx)
+    if regs and regs[idx] then return regs[idx] end
+    return 0
+end
+
+local function i16(regs, idx)
+    if regs and regs[idx] then return host.decode_i16(regs[idx]) end
+    return 0
+end
+
+local function u32be(regs, idx)
+    if regs and regs[idx] and regs[idx + 1] then
+        return host.decode_u32_be(regs[idx], regs[idx + 1])
+    end
+    return 0
+end
+
+function driver_poll()
+    local energy_regs = read_input(3004, 6)
+    local ac_w = u32be(energy_regs, 1)
+    local dc_w = u32be(energy_regs, 3)
+    local lifetime_wh = u32be(energy_regs, 5) * 1000
+
+    local dc_regs = read_input(3021, 8)
+    local mppt1_v = u16(dc_regs, 1) * 0.1
+    local mppt1_a = u16(dc_regs, 2) * 0.1
+    local mppt2_v = u16(dc_regs, 3) * 0.1
+    local mppt2_a = u16(dc_regs, 4) * 0.1
+    local mppt3_v = u16(dc_regs, 5) * 0.1
+    local mppt3_a = u16(dc_regs, 6) * 0.1
+    local mppt4_v = u16(dc_regs, 7) * 0.1
+    local mppt4_a = u16(dc_regs, 8) * 0.1
+
+    local ac_regs = read_input(3033, 6)
+    local l1_v = u16(ac_regs, 1) * 0.1
+    local l2_v = u16(ac_regs, 2) * 0.1
+    local l3_v = u16(ac_regs, 3) * 0.1
+    local l1_a = u16(ac_regs, 4) * 0.1
+    local l2_a = u16(ac_regs, 5) * 0.1
+    local l3_a = u16(ac_regs, 6) * 0.1
+
+    local status_regs = read_input(3040, 4)
+    local mode = u16(status_regs, 1)
+    local temp_c = i16(status_regs, 2) * 0.1
+    local hz = u16(status_regs, 3) * 0.01
+    local status = u16(status_regs, 4)
+
+    host.emit("pv", {
+        w           = -ac_w,
+        dc_w        = dc_w,
+        mppt1_v     = mppt1_v,
+        mppt1_a     = mppt1_a,
+        mppt2_v     = mppt2_v,
+        mppt2_a     = mppt2_a,
+        mppt3_v     = mppt3_v,
+        mppt3_a     = mppt3_a,
+        mppt4_v     = mppt4_v,
+        mppt4_a     = mppt4_a,
+        l1_v        = l1_v,
+        l2_v        = l2_v,
+        l3_v        = l3_v,
+        l1_a        = l1_a,
+        l2_a        = l2_a,
+        l3_a        = l3_a,
+        hz          = hz,
+        temp_c      = temp_c,
+        status      = status,
+        mode        = mode,
+        lifetime_wh = lifetime_wh,
+    })
+
+    host.emit_metric("pv_dc_w", dc_w)
+    host.emit_metric("pv_mppt1_v", mppt1_v)
+    host.emit_metric("pv_mppt1_a", mppt1_a)
+    host.emit_metric("pv_mppt2_v", mppt2_v)
+    host.emit_metric("pv_mppt2_a", mppt2_a)
+    host.emit_metric("pv_mppt3_v", mppt3_v)
+    host.emit_metric("pv_mppt3_a", mppt3_a)
+    host.emit_metric("pv_mppt4_v", mppt4_v)
+    host.emit_metric("pv_mppt4_a", mppt4_a)
+    host.emit_metric("inverter_l1_v", l1_v)
+    host.emit_metric("inverter_l2_v", l2_v)
+    host.emit_metric("inverter_l3_v", l3_v)
+    host.emit_metric("inverter_l1_a", l1_a)
+    host.emit_metric("inverter_l2_a", l2_a)
+    host.emit_metric("inverter_l3_a", l3_a)
+    host.emit_metric("inverter_temp_c", temp_c)
+    host.emit_metric("grid_hz", hz)
+    host.emit_metric("inverter_status", status)
+    host.emit_metric("inverter_mode", mode)
+
+    return 5000
+end
+
+function driver_command(action, power_w, cmd)
+    return false
+end
+
+function driver_default_mode()
+    -- Read-only PV driver; nothing to put back into autonomous mode.
+end
+
+function driver_cleanup()
+    sn_set = false
+end

--- a/go/internal/drivers/catalog_verification_test.go
+++ b/go/internal/drivers/catalog_verification_test.go
@@ -31,6 +31,7 @@ func TestCatalogVerificationStatus(t *testing.T) {
 		{"sourceful-zap", "beta"},
 		{"deye", "experimental"},
 		{"solis", "experimental"},
+		{"solis-string", "experimental"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.id, func(t *testing.T) {
@@ -73,14 +74,14 @@ func TestCatalogProductionDriversHaveVerifier(t *testing.T) {
 // "experimental" rather than propagate an invalid label to the UI.
 func TestNormalizeVerificationStatus(t *testing.T) {
 	cases := map[string]string{
-		"production":     "production",
-		"PRODUCTION":     "production",
-		"Beta":           "beta",
-		"experimental":   "experimental",
-		"":               "experimental",
-		"  ":             "experimental",
-		"prod":           "experimental", // typo → safest default
-		"alpha":          "experimental", // non-canonical → safest default
+		"production":   "production",
+		"PRODUCTION":   "production",
+		"Beta":         "beta",
+		"experimental": "experimental",
+		"":             "experimental",
+		"  ":           "experimental",
+		"prod":         "experimental", // typo → safest default
+		"alpha":        "experimental", // non-canonical → safest default
 	}
 	for in, want := range cases {
 		if got := normalizeVerificationStatus(in); got != want {

--- a/go/internal/drivers/solis_string_test.go
+++ b/go/internal/drivers/solis_string_test.go
@@ -1,0 +1,125 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+type solisStringModbus struct {
+	regs map[uint16][]uint16
+}
+
+func (m *solisStringModbus) Read(addr, count uint16, kind int32) ([]uint16, error) {
+	src := m.regs[addr]
+	if len(src) < int(count) {
+		out := make([]uint16, count)
+		copy(out, src)
+		return out, nil
+	}
+	out := make([]uint16, count)
+	copy(out, src[:count])
+	return out, nil
+}
+
+func (m *solisStringModbus) WriteSingle(addr, value uint16) error { return nil }
+func (m *solisStringModbus) WriteMulti(addr uint16, values []uint16) error {
+	return nil
+}
+func (m *solisStringModbus) Close() error { return nil }
+
+func TestSolisStringEmitsPVOnlyInSiteConvention(t *testing.T) {
+	tel := telemetry.NewStore()
+	env := NewHostEnv("solis-string", tel).WithModbus(&solisStringModbus{
+		regs: map[uint16][]uint16{
+			3004: {0, 4200, 0, 4400, 0, 12345},
+			3021: {3501, 82, 3562, 79, 0, 0, 0, 0},
+			3033: {2301, 0, 0, 183, 0, 0},
+			3040: {1, 423, 5001, 1},
+		},
+	})
+	d, err := NewLuaDriver("../../../drivers/solis_string.lua", env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), map[string]any{"serial": "SOLIS-STRING-42"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	make, sn := env.Identity()
+	if make != "Ginlong Solis" || sn != "SOLIS-STRING-42" {
+		t.Fatalf("identity = (%q, %q), want Ginlong Solis/SOLIS-STRING-42", make, sn)
+	}
+
+	pv := tel.Get("solis-string", telemetry.DerPV)
+	if pv == nil {
+		t.Fatal("expected pv telemetry")
+	}
+	if pv.RawW != -4200 {
+		t.Fatalf("pv RawW = %v, want -4200", pv.RawW)
+	}
+	if got := tel.Get("solis-string", telemetry.DerBattery); got != nil {
+		t.Fatalf("battery telemetry should not be emitted: %+v", got)
+	}
+	if got := tel.Get("solis-string", telemetry.DerMeter); got != nil {
+		t.Fatalf("meter telemetry should not be emitted: %+v", got)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(pv.Data, &data); err != nil {
+		t.Fatalf("pv data: %v", err)
+	}
+	if !near(data["mppt1_v"].(float64), 350.1) {
+		t.Errorf("mppt1_v = %v, want 350.1", data["mppt1_v"])
+	}
+	if !near(data["mppt1_a"].(float64), 8.2) {
+		t.Errorf("mppt1_a = %v, want 8.2", data["mppt1_a"])
+	}
+	if !near(data["dc_w"].(float64), 4400) {
+		t.Errorf("dc_w = %v, want 4400", data["dc_w"])
+	}
+	if !near(data["lifetime_wh"].(float64), 12345000) {
+		t.Errorf("lifetime_wh = %v, want 12345000", data["lifetime_wh"])
+	}
+	if !near(data["temp_c"].(float64), 42.3) {
+		t.Errorf("temp_c = %v, want 42.3", data["temp_c"])
+	}
+	if !near(data["hz"].(float64), 50.01) {
+		t.Errorf("hz = %v, want 50.01", data["hz"])
+	}
+}
+
+func near(got, want float64) bool {
+	return math.Abs(got-want) < 0.000001
+}
+
+func TestSolisStringCatalogEntry(t *testing.T) {
+	entries, err := LoadCatalog("../../../drivers")
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	var found *CatalogEntry
+	for i, e := range entries {
+		if e.ID == "solis-string" {
+			found = &entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("solis-string not in catalog")
+	}
+	if found.Manufacturer != "Ginlong Solis" {
+		t.Errorf("manufacturer = %q, want Ginlong Solis", found.Manufacturer)
+	}
+	if len(found.Capabilities) != 1 || found.Capabilities[0] != "pv" {
+		t.Errorf("capabilities = %v, want [pv]", found.Capabilities)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `drivers/solis_string.lua`, a read-only PV driver for non-hybrid Solis string inverters over Modbus TCP.
- Emit PV telemetry in site convention and expose inverter diagnostics as scalar metrics.
- Add driver package tests and catalog documentation/verification coverage.

## Notes
- This is PV-only and does not advertise battery or meter capabilities.
- The repository remote has `master` as its default branch; there is no `main` branch to target.

## Validation
- `go test ./internal/drivers`
- `go test ./...`