### PR TITLE
[codex] fix Lua HTTP redirect allowlist enforcement

### DIFF
--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -437,8 +437,6 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	// host.http_get(url, headers?) → (body, nil) or (nil, error_string)
 	// host.http_post(url, body, headers?) → (body, nil) or (nil, error_string)
 	// headers is an optional Lua table {["Content-Type"]="application/json", ...}
-	httpClient := &net_http.Client{Timeout: 15 * time.Second}
-
 	// hostAllowed checks the URL's host component against the
 	// per-driver allowlist. Empty allowlist = any host (legacy
 	// behaviour). Matched case-insensitively.
@@ -496,6 +494,19 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			}
 		}
 		return false, fmt.Sprintf("host %q (port %s) not in allowed_hosts", host, port)
+	}
+
+	httpClient := &net_http.Client{
+		Timeout: 15 * time.Second,
+		CheckRedirect: func(req *net_http.Request, via []*net_http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if ok, reason := hostAllowed(req.URL.String()); !ok {
+				return fmt.Errorf("redirect blocked: %s", reason)
+			}
+			return nil
+		},
 	}
 
 	applyHeaders := func(req *net_http.Request, L *lua.LState, argIdx int) {
@@ -716,4 +727,3 @@ func luaToGo(v lua.LValue) any {
 	}
 	return nil
 }
-

--- a/go/internal/drivers/lua_http_test.go
+++ b/go/internal/drivers/lua_http_test.go
@@ -98,6 +98,24 @@ func TestLuaHTTPAllowlistEnforcement(t *testing.T) {
 	}
 }
 
+func TestLuaHTTPAllowlistEnforcesRedirectTargets(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`redirected`))
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	allowedHostPort := strings.TrimPrefix(redirector.URL, "http://")
+	got, errMsg := runHTTPTestDriver(t, []string{allowedHostPort}, redirector.URL)
+	if got {
+		t.Fatalf("redirect target outside allowed_hosts was fetched (err=%s)", errMsg)
+	}
+}
+
 func TestLuaHTTPCapabilityNotGranted(t *testing.T) {
 	tel := telemetry.NewStore()
 	env := NewHostEnv("nohttp", tel) // NO WithHTTP()


### PR DESCRIPTION
## Summary

Fixes a Lua driver host security bug where `host.http_get` / `host.http_post` checked `capabilities.http.allowed_hosts` only for the original URL. The default Go HTTP client then followed redirects without re-checking the redirected target, so a driver allowed to call one host could be bounced to another host or port.

## Root Cause

The Lua host built a `net/http.Client` with only a timeout. The `hostAllowed` gate ran before `httpClient.Do`, but redirects were handled internally by the client and never passed through the allowlist logic.

## Changes

- Adds a regression test proving a redirect from an allowed host to an unallowed host is blocked.
- Adds `CheckRedirect` to the Lua HTTP client.
- Reuses the same `hostAllowed` logic for each redirect target.
- Preserves Go's default 10-redirect cap.

## Validation

- `go test ./internal/drivers -run 'TestLuaHTTPAllowlist' -count=1 -v`
- `go test ./...`
- `go test -race ./internal/drivers -run 'TestLuaHTTPAllowlist|TestLuaHTTPCapability|TestSplitHostPortLower' -count=1`

Note: full `go test -race ./internal/drivers` exposed a separate existing race in `TestRunLoopRecordsSuccessEvenWithoutEmits` / `DriverHealth.RecordTick`; that is outside this HTTP redirect fix and should be handled in its own PR.