### PR TITLE
[codex] reject negative site control config values

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -851,8 +851,26 @@ func (c *Config) Validate() error {
 		return errors.New("at least one driver must be is_site_meter: true")
 	}
 
+	if c.Site.ControlIntervalS < 0 {
+		return errors.New("site.control_interval_s must be >= 0")
+	}
+	if c.Site.GridToleranceW < 0 {
+		return errors.New("site.grid_tolerance_w must be >= 0")
+	}
+	if c.Site.WatchdogTimeoutS < 0 {
+		return errors.New("site.watchdog_timeout_s must be >= 0")
+	}
 	if c.Site.SmoothingAlpha <= 0 || c.Site.SmoothingAlpha > 1 {
 		return errors.New("site.smoothing_alpha must be in (0, 1]")
+	}
+	if c.Site.Gain < 0 {
+		return errors.New("site.gain must be >= 0")
+	}
+	if c.Site.SlewRateW < 0 {
+		return errors.New("site.slew_rate_w must be >= 0")
+	}
+	if c.Site.MinDispatchIntervalS < 0 {
+		return errors.New("site.min_dispatch_interval_s must be >= 0")
 	}
 	if c.Fuse.MaxAmps <= 0 {
 		return errors.New("fuse.max_amps must be > 0")

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -230,6 +230,37 @@ api: { port: 8080 }
 	}
 }
 
+func TestRejectsNegativeSiteControlValues(t *testing.T) {
+	cases := []struct {
+		field string
+		value string
+	}{
+		{"control_interval_s", "-1"},
+		{"grid_tolerance_w", "-1"},
+		{"watchdog_timeout_s", "-1"},
+		{"gain", "-0.1"},
+		{"slew_rate_w", "-500"},
+		{"min_dispatch_interval_s", "-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			yaml := fmt.Sprintf(`
+site: { name: x, %s: %s }
+fuse: { max_amps: 16 }
+drivers:
+  - name: a
+    lua: a.lua
+    is_site_meter: true
+    capabilities: { mqtt: { host: 1.1.1.1 } }
+api: { port: 8080 }
+`, tc.field, tc.value)
+			if _, err := Parse([]byte(yaml), "."); err == nil {
+				t.Fatalf("expected validation error for site.%s=%s", tc.field, tc.value)
+			}
+		})
+	}
+}
+
 func TestAllOptionalSectionsParse(t *testing.T) {
 	yaml := `
 site: { name: Full }


### PR DESCRIPTION
## Summary

Fixes a config validation bug where negative site control values were accepted from YAML/API-shaped configs.

## Root Cause

`applyDefaults` only fills defaults when fields are exactly zero, and `Validate` only checked `smoothing_alpha` plus fuse amps. Negative values for fields such as `control_interval_s` and `slew_rate_w` passed validation unchanged.

That can have real runtime effects:

- `control_interval_s: -1` reaches `time.NewTicker` during startup and panics.
- `slew_rate_w: -500` makes the slew limiter step in the wrong direction.
- Negative tolerance / holdoff / watchdog / gain values disable or distort control semantics.

## Changes

- Adds a regression test covering negative site control scalars.
- Rejects negative values for:
  - `site.control_interval_s`
  - `site.grid_tolerance_w`
  - `site.watchdog_timeout_s`
  - `site.gain`
  - `site.slew_rate_w`
  - `site.min_dispatch_interval_s`

Zero remains compatible with existing defaulting behaviour.

## Validation

- `go test ./internal/config -run TestRejectsNegativeSiteControlValues -count=1 -v`
- `go test ./internal/config -count=1`
- `go test -race ./internal/config`
- `go test ./...`