### PR TITLE
[codex] preserve driver config secrets with custom driver dirs

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -688,7 +688,15 @@ func (s *Server) driverSecretKeys() map[string][]string {
 		if len(e.ConfigSecrets) == 0 {
 			continue
 		}
-		out[e.Path] = e.ConfigSecrets
+		path := filepath.ToSlash(e.Path)
+		out[path] = e.ConfigSecrets
+		base := filepath.ToSlash(filepath.Base(dir))
+		if rel, ok := strings.CutPrefix(path, base+"/"); ok {
+			// Config round-trips paths resolved via -drivers as
+			// "drivers/<rel>" regardless of the actual directory name.
+			// Keep catalog secret matching on that portable alias too.
+			out[filepath.ToSlash(filepath.Join("drivers", rel))] = e.ConfigSecrets
+		}
 	}
 	return out
 }

--- a/go/internal/api/api_driver_secrets_test.go
+++ b/go/internal/api/api_driver_secrets_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+func TestDriverSecretKeysIncludePortableDriverPathAlias(t *testing.T) {
+	driverDir := filepath.Join(t.TempDir(), "custom-driver-dir")
+	if err := os.MkdirAll(driverDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	luaPath := filepath.Join(driverDir, "sonnen.lua")
+	if err := os.WriteFile(luaPath, []byte(`
+DRIVER = {
+  id = "sonnen",
+  name = "sonnen",
+  protocols = { "http" },
+  config_secrets = { "api_token" },
+}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(&Deps{
+		DriverDir:  driverDir,
+		ConfigPath: filepath.Join(t.TempDir(), "config.yaml"),
+	})
+	secrets := srv.driverSecretKeys()
+	cfg := &config.Config{Drivers: []config.Driver{{
+		Name: "sonnen",
+		Lua:  "drivers/sonnen.lua",
+		Config: map[string]any{
+			"api_token": "secret-token",
+		},
+	}}}
+
+	maskDriverConfigSecrets(cfg, secrets)
+
+	if got := cfg.Drivers[0].Config["api_token"]; got != maskedPlaceholder {
+		t.Fatalf("api_token = %q, want masked placeholder", got)
+	}
+
+	incoming := &config.Config{Drivers: []config.Driver{{
+		Name: "sonnen",
+		Lua:  "drivers/sonnen.lua",
+		Config: map[string]any{
+			"api_token": maskedPlaceholder,
+		},
+	}}}
+	existing := &config.Config{Drivers: []config.Driver{{
+		Name: "sonnen",
+		Config: map[string]any{
+			"api_token": "secret-token",
+		},
+	}}}
+	restoreDriverConfigSecrets(incoming, existing, secrets)
+	if got := incoming.Drivers[0].Config["api_token"]; got != "secret-token" {
+		t.Fatalf("restored api_token = %q, want original secret", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a config secret masking/preservation bug when the app runs with `-drivers` pointing at a directory whose basename is not `drivers`.

## Root Cause

`handleGetConfig` normalizes resolved driver paths back to portable `drivers/<file>.lua` paths before masking secrets. But `driverSecretKeys()` keyed catalog `config_secrets` by `drivers.LoadCatalog(dir)`'s path, which uses `filepath.Base(dir)`. For a custom directory such as `/opt/custom-driver-dir`, the catalog key became `custom-driver-dir/sonnen.lua`, while the config/UI path was `drivers/sonnen.lua`.

That mismatch meant catalog-declared secrets such as Sonnen `api_token` were not masked on GET and were not restored on POST if the UI sent back the masked placeholder.

## Changes

- Keeps the catalog path key for compatibility.
- Adds a portable `drivers/<rel>` alias for each catalog secret entry.
- Adds a regression test covering both masking and restore with a custom driver directory.

## Validation

- `go test ./internal/api -run TestDriverSecretKeysIncludePortableDriverPathAlias -count=1 -v`
- `go test -race ./internal/api -run TestDriverSecretKeysIncludePortableDriverPathAlias -count=1`
- `go test ./...`