### PR TITLE
[codex] serialize driver health updates

### DIFF
--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -185,7 +185,7 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 	// data the operator told us to ignore.
 	if t == telemetry.DerBattery && h.BatteryCapacityWh <= 0 {
 		if h.Telemetry != nil {
-			h.Telemetry.DriverHealthMut(h.DriverName).RecordSuccess()
+			h.Telemetry.RecordDriverSuccess(h.DriverName)
 		}
 		return nil
 	}
@@ -194,7 +194,7 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 	}
 	// Successful emit counts as a tick for health
 	if h.Telemetry != nil {
-		h.Telemetry.DriverHealthMut(h.DriverName).RecordSuccess()
+		h.Telemetry.RecordDriverSuccess(h.DriverName)
 	}
 	return nil
 }

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -164,7 +164,7 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	// arrived (which can be 30+ s for slow telemetry topics), and
 	// mis-presented an alive-but-waiting driver as a failed one.
 	if r.tel != nil {
-		r.tel.DriverHealthMut(cfg.Name)
+		r.tel.EnsureDriverHealth(cfg.Name)
 	}
 	go r.runLoop(rd)
 	slog.Info("driver added", "name", cfg.Name, "path", cfg.Lua)
@@ -210,7 +210,7 @@ func (r *Registry) runLoop(rd *runningDriver) {
 		case <-timer.C:
 			if _, err := rd.driver.Poll(ctx); err != nil {
 				slog.Warn("driver poll failed", "name", rd.cfg.Name, "err", err)
-				r.tel.DriverHealthMut(rd.cfg.Name).RecordError(err.Error())
+				r.tel.RecordDriverError(rd.cfg.Name, err.Error())
 			} else if r.tel != nil {
 				// Bump TickCount so the loop is visibly alive in
 				// /api/status, but DON'T touch LastSuccess — that
@@ -220,7 +220,7 @@ func (r *Registry) runLoop(rd *runningDriver) {
 				// stale cache after upstream death) needs to surface
 				// as stale to the watchdog; otherwise a dead ferroamp
 				// re-stamps LastSuccess every tick from cached values.
-				r.tel.DriverHealthMut(rd.cfg.Name).RecordTick()
+				r.tel.RecordDriverTick(rd.cfg.Name)
 			}
 			// Re-arm timer at driver's requested interval
 			interval = rd.env.PollInterval()

--- a/go/internal/ocpp/handlers.go
+++ b/go/internal/ocpp/handlers.go
@@ -91,7 +91,7 @@ type ChargerView struct {
 // connection callbacks, not part of CoreHandler.
 func (h *Handler) OnConnect(id string) {
 	slog.Info("OCPP charger connected", "charger", id)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 }
 
 func (h *Handler) OnDisconnect(id string) {
@@ -115,7 +115,7 @@ func (h *Handler) OnBootNotification(id string, req *core.BootNotificationReques
 		"vendor", req.ChargePointVendor,
 		"model", req.ChargePointModel,
 		"fw", req.FirmwareVersion)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewBootNotificationConfirmation(
 		types.NewDateTime(time.Now()),
 		h.heartbeatIntervalS,
@@ -124,7 +124,7 @@ func (h *Handler) OnBootNotification(id string, req *core.BootNotificationReques
 }
 
 func (h *Handler) OnHeartbeat(id string, _ *core.HeartbeatRequest) (*core.HeartbeatConfirmation, error) {
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewHeartbeatConfirmation(types.NewDateTime(time.Now())), nil
 }
 
@@ -174,7 +174,7 @@ func (h *Handler) OnStatusNotification(id string, req *core.StatusNotificationRe
 		"charger", id, "connector", req.ConnectorId, "status", req.Status)
 
 	h.pushReading(id, s)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewStatusNotificationConfirmation(), nil
 }
 
@@ -211,7 +211,7 @@ func (h *Handler) OnMeterValues(id string, req *core.MeterValuesRequest) (*core.
 	h.mu.Unlock()
 
 	h.pushReading(id, s)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewMeterValuesConfirmation(), nil
 }
 
@@ -230,7 +230,7 @@ func (h *Handler) OnStartTransaction(id string, req *core.StartTransactionReques
 	slog.Info("OCPP transaction started",
 		"charger", id, "txid", txID, "tag", req.IdTag, "meter_start_wh", req.MeterStart)
 	h.pushReading(id, s)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewStartTransactionConfirmation(
 		types.NewIdTagInfo(types.AuthorizationStatusAccepted),
 		txID,
@@ -252,7 +252,7 @@ func (h *Handler) OnStopTransaction(id string, req *core.StopTransactionRequest)
 		"session_wh", sessionWh, "reason", req.Reason)
 	h.pushReading(id, s)
 	h.tel.EmitMetric(id, "ev_session_wh", sessionWh)
-	h.tel.DriverHealthMut(id).RecordSuccess()
+	h.tel.RecordDriverSuccess(id)
 	return core.NewStopTransactionConfirmation(), nil
 }
 

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -366,22 +366,52 @@ func (s *Store) IsStale(driver string, t DerType, timeout time.Duration) bool {
 	return time.Since(r.UpdatedAt) > timeout
 }
 
-// DriverHealth returns the health record for a driver (or nil if unknown).
+// DriverHealth returns a snapshot of the health record for a driver
+// (or nil if unknown). Mutations must go through Store methods or
+// DriverHealthMut in single-threaded test setup.
 func (s *Store) DriverHealth(name string) *DriverHealth {
 	s.mu.RLock(); defer s.mu.RUnlock()
-	return s.health[name]
+	h := s.health[name]
+	if h == nil { return nil }
+	cp := *h
+	return &cp
 }
 
 // DriverHealthMut returns the (mutable) health record, creating if missing.
-// Holds no lock after return — callers shouldn't share the pointer across goroutines.
+// Holds no lock after return — callers must not share the pointer across
+// goroutines. Runtime code should use the Store RecordDriver* helpers.
 func (s *Store) DriverHealthMut(name string) *DriverHealth {
 	s.mu.Lock(); defer s.mu.Unlock()
+	return s.driverHealthLocked(name)
+}
+
+func (s *Store) driverHealthLocked(name string) *DriverHealth {
 	h, ok := s.health[name]
 	if !ok {
 		h = &DriverHealth{Name: name}
 		s.health[name] = h
 	}
 	return h
+}
+
+func (s *Store) EnsureDriverHealth(name string) {
+	s.mu.Lock(); defer s.mu.Unlock()
+	s.driverHealthLocked(name)
+}
+
+func (s *Store) RecordDriverSuccess(name string) {
+	s.mu.Lock(); defer s.mu.Unlock()
+	s.driverHealthLocked(name).RecordSuccess()
+}
+
+func (s *Store) RecordDriverTick(name string) {
+	s.mu.Lock(); defer s.mu.Unlock()
+	s.driverHealthLocked(name).RecordTick()
+}
+
+func (s *Store) RecordDriverError(name, err string) {
+	s.mu.Lock(); defer s.mu.Unlock()
+	s.driverHealthLocked(name).RecordError(err)
 }
 
 // Remove drops all in-memory state for a driver: readings, Kalman


### PR DESCRIPTION
## Summary

Fixes a data race in driver health state exposed by `go test -race ./internal/drivers`.

## Root Cause

`DriverHealthMut` returned a pointer to the store-owned health record and runtime code mutated that pointer after releasing the telemetry store mutex. At the same time, readers such as `DriverHealth` / `AllHealth` could read or snapshot the same fields. The existing `TestRunLoopRecordsSuccessEvenWithoutEmits` reproduced this under the race detector: the registry poll loop updated `TickCount` while the test read the health record.

## Changes

- Makes `DriverHealth` return a snapshot copy instead of the store-owned pointer.
- Adds telemetry-store helper methods for runtime health mutations:
  - `EnsureDriverHealth`
  - `RecordDriverSuccess`
  - `RecordDriverTick`
  - `RecordDriverError`
- Routes driver host, registry and OCPP runtime health updates through those locked helpers.
- Leaves `DriverHealthMut` available for single-threaded test setup, with a stricter comment.

## Validation

- Before the fix: `go test -race ./internal/drivers` failed in `TestRunLoopRecordsSuccessEvenWithoutEmits` with a `DriverHealth.TickCount` race.
- After the fix:
  - `go test -race ./internal/drivers`
  - `go test ./internal/telemetry ./internal/drivers ./internal/ocpp -count=1`
  - `go test -race ./internal/telemetry ./internal/ocpp`
  - `go test ./...`