### PR TITLE
fix(state): scope TSDB intern cache per store

### DIFF
--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -31,6 +31,7 @@ const (
 // Store is the persistent state DB (thin wrapper around *sql.DB).
 type Store struct {
 	db *sql.DB
+	ts *internCache
 }
 
 // Open initializes (or creates) the DB at path. Runs all migrations.
@@ -42,7 +43,7 @@ func Open(path string) (*Store, error) {
 	// Single connection — SQLite doesn't benefit from pooling
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	s := &Store{db: db}
+	s := &Store{db: db, ts: newInternCache()}
 	if err := s.migrate(); err != nil {
 		db.Close()
 		return nil, err

--- a/go/internal/state/store_test.go
+++ b/go/internal/state/store_test.go
@@ -18,6 +18,49 @@ func freshStore(t *testing.T) *Store {
 	return s
 }
 
+func TestTimeSeriesInternCacheIsPerStore(t *testing.T) {
+	dir := t.TempDir()
+	s1, err := Open(filepath.Join(dir, "one.db"))
+	if err != nil { t.Fatal(err) }
+	if err := s1.RecordSamples([]Sample{{Driver: "driver", Metric: "metric_w", TsMs: 1, Value: 10}}); err != nil {
+		t.Fatalf("record first store: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("close first store: %v", err)
+	}
+
+	secondPath := filepath.Join(dir, "two.db")
+	s2, err := Open(secondPath)
+	if err != nil { t.Fatal(err) }
+	if err := s2.RecordSamples([]Sample{{Driver: "driver", Metric: "metric_w", TsMs: 2, Value: 20}}); err != nil {
+		t.Fatalf("record second store: %v", err)
+	}
+	var driverRows, metricRows int
+	if err := s2.db.QueryRow(`SELECT COUNT(*) FROM ts_drivers`).Scan(&driverRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := s2.db.QueryRow(`SELECT COUNT(*) FROM ts_metrics`).Scan(&metricRows); err != nil {
+		t.Fatal(err)
+	}
+	if driverRows != 1 || metricRows != 1 {
+		t.Fatalf("second store intern rows: drivers=%d metrics=%d, want 1/1", driverRows, metricRows)
+	}
+	if err := s2.Close(); err != nil {
+		t.Fatalf("close second store: %v", err)
+	}
+
+	reopened, err := Open(secondPath)
+	if err != nil { t.Fatal(err) }
+	t.Cleanup(func() { reopened.Close() })
+	series, err := reopened.LoadSeries("driver", "metric_w", 0, 10, 0)
+	if err != nil {
+		t.Fatalf("load reopened series: %v", err)
+	}
+	if len(series) != 1 || series[0].TsMs != 2 || series[0].Value != 20 {
+		t.Fatalf("reopened series = %+v, want one persisted sample", series)
+	}
+}
+
 func TestConfigRoundtrip(t *testing.T) {
 	s := freshStore(t)
 	if err := s.SaveConfig("mode", "self_consumption"); err != nil {

--- a/go/internal/state/store_ts.go
+++ b/go/internal/state/store_ts.go
@@ -27,7 +27,7 @@ type Sample struct {
 	Value  float64
 }
 
-// internCache holds the in-memory id↔name maps shared across all writers.
+// internCache holds the in-memory id↔name maps for one Store.
 type internCache struct {
 	mu       sync.RWMutex
 	drivers  map[string]int64
@@ -35,13 +35,16 @@ type internCache struct {
 	loaded   bool
 }
 
-var ts = &internCache{
-	drivers: make(map[string]int64),
-	metrics: make(map[string]int64),
+func newInternCache() *internCache {
+	return &internCache{
+		drivers: make(map[string]int64),
+		metrics: make(map[string]int64),
+	}
 }
 
 // hydrate loads the existing id mappings from disk. Idempotent.
 func (s *Store) hydrateIntern() error {
+	ts := s.ts
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 	if ts.loaded { return nil }
@@ -68,6 +71,7 @@ func (s *Store) hydrateIntern() error {
 // driverID returns the id for a driver name, allocating one on first use.
 // Holds the intern mutex for the lookup; safe for concurrent calls.
 func (s *Store) driverID(name string) (int64, error) {
+	ts := s.ts
 	ts.mu.RLock()
 	if id, ok := ts.drivers[name]; ok {
 		ts.mu.RUnlock()
@@ -87,6 +91,7 @@ func (s *Store) driverID(name string) (int64, error) {
 
 // metricID returns the id for a metric name, allocating one on first use.
 func (s *Store) metricID(name string) (int64, error) {
+	ts := s.ts
 	ts.mu.RLock()
 	if id, ok := ts.metrics[name]; ok {
 		ts.mu.RUnlock()
@@ -148,6 +153,7 @@ func (s *Store) RecordSamples(samples []Sample) error {
 // returned rows are evenly downsampled to at most maxPoints.
 func (s *Store) LoadSeries(driver, metric string, sinceMs, untilMs int64, maxPoints int) ([]Sample, error) {
 	if err := s.hydrateIntern(); err != nil { return nil, err }
+	ts := s.ts
 	ts.mu.RLock()
 	dID, dOK := ts.drivers[driver]
 	mID, mOK := ts.metrics[metric]
@@ -184,6 +190,7 @@ func (s *Store) LoadSeries(driver, metric string, sinceMs, untilMs int64, maxPoi
 // Returns sql.ErrNoRows if nothing has been recorded.
 func (s *Store) LatestSample(driver, metric string) (Sample, error) {
 	if err := s.hydrateIntern(); err != nil { return Sample{}, err }
+	ts := s.ts
 	ts.mu.RLock()
 	dID, dOK := ts.drivers[driver]
 	mID, mOK := ts.metrics[metric]
@@ -201,6 +208,7 @@ func (s *Store) LatestSample(driver, metric string) (Sample, error) {
 // MetricNames returns all known metric names, sorted alphabetically.
 func (s *Store) MetricNames() ([]string, error) {
 	if err := s.hydrateIntern(); err != nil { return nil, err }
+	ts := s.ts
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	out := make([]string, 0, len(ts.metrics))
@@ -211,6 +219,7 @@ func (s *Store) MetricNames() ([]string, error) {
 // DriverNames returns all known driver names, sorted alphabetically.
 func (s *Store) DriverNames() ([]string, error) {
 	if err := s.hydrateIntern(); err != nil { return nil, err }
+	ts := s.ts
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
 	out := make([]string, 0, len(ts.drivers))
@@ -234,6 +243,7 @@ func (s *Store) SamplesBefore(ctx context.Context, cutoffMs int64, batchSize int
 	if err := s.hydrateIntern(); err != nil { return err }
 	if batchSize <= 0 { batchSize = 10000 }
 	// Rebuild reverse maps so we can return strings.
+	ts := s.ts
 	ts.mu.RLock()
 	dRev := make(map[int64]string, len(ts.drivers))
 	for n, id := range ts.drivers { dRev[id] = n }


### PR DESCRIPTION
## Bug
`go/internal/state/store_ts.go` kept the TSDB driver/metric intern cache in package-global state. After one `Store` recorded a driver/metric, a second `Store` in the same process could reuse the cached IDs without inserting rows into its own `ts_drivers` and `ts_metrics` tables. That left `ts_samples` rows in the second SQLite DB without matching intern rows, so the series became undiscoverable after reopening the DB.

## Reproduction
Added `TestTimeSeriesInternCacheIsPerStore`, which records the same driver/metric into two separate DB files in one process. Before the fix the second DB had `drivers=0 metrics=0` even though it had a sample row.

## Fix
Move the intern cache onto `Store` and initialize it in `Open`, so each SQLite DB hydrates and allocates intern IDs against its own tables.

## Tests
- `go test ./internal/state -run TestTimeSeriesInternCacheIsPerStore -count=1 -v`
- `go test -race ./internal/state`
- `go test ./...`