### PR TITLE
fix(control): apply configured site gain

### DIFF
--- a/go/cmd/forty-two-watts/control_state.go
+++ b/go/cmd/forty-two-watts/control_state.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+	"github.com/frahlg/forty-two-watts/go/internal/control"
+)
+
+func newControlStateFromConfig(cfg *config.Config) *control.State {
+	ctrl := control.NewState(cfg.Site.GridTargetW, cfg.Site.GridToleranceW, cfg.SiteMeterDriver())
+	if cfg.Site.Gain != 0 {
+		ctrl.PI.Kp = cfg.Site.Gain
+	}
+	ctrl.SlewRateW = cfg.Site.SlewRateW
+	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
+	ctrl.InverterGroups = inverterGroupsFrom(cfg.Drivers)
+	ctrl.SupportsPVCurtail = supportsPVCurtailFrom(cfg.Drivers)
+	ctrl.DriverLimits = driverLimitsFrom(cfg.Drivers, cfg.Batteries)
+	// Per-phase fuse params for the per-phase clamp inside applyFuseGuard
+	// + forceFuseDischarge. Reads l1_a/l2_a/l3_a from the meter driver
+	// when SiteFuseAmps > 0; otherwise the per-phase clamp is disabled.
+	ctrl.SiteFuseAmps = cfg.Fuse.MaxAmps
+	ctrl.SiteFuseVoltage = cfg.Fuse.Voltage
+	ctrl.SiteFusePhases = cfg.Fuse.Phases
+	// EffectiveSafetyMarginA distinguishes nil ("unset, use default")
+	// from explicit 0 ("operator chose to disable"). The earlier
+	// `<= 0 -> default` shortcut clobbered the disable case.
+	ctrl.SiteFuseSafetyA = cfg.Fuse.EffectiveSafetyMarginA()
+	return ctrl
+}

--- a/go/cmd/forty-two-watts/control_state_test.go
+++ b/go/cmd/forty-two-watts/control_state_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+func TestControlStateFromConfigAppliesSiteGain(t *testing.T) {
+	cfg := &config.Config{
+		Site: config.Site{
+			Gain:                 0.8,
+			GridToleranceW:       50,
+			SlewRateW:            500,
+			MinDispatchIntervalS: 5,
+		},
+	}
+	ctrl := newControlStateFromConfig(cfg)
+	if ctrl.PI.Kp != 0.8 {
+		t.Fatalf("PI.Kp = %f, want configured site.gain", ctrl.PI.Kp)
+	}
+}

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -161,22 +161,7 @@ func main() {
 	tel := telemetry.NewStore()
 
 	// ---- Control state ----
-	ctrl := control.NewState(cfg.Site.GridTargetW, cfg.Site.GridToleranceW, cfg.SiteMeterDriver())
-	ctrl.SlewRateW = cfg.Site.SlewRateW
-	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
-	ctrl.InverterGroups = inverterGroupsFrom(cfg.Drivers)
-	ctrl.SupportsPVCurtail = supportsPVCurtailFrom(cfg.Drivers)
-	ctrl.DriverLimits = driverLimitsFrom(cfg.Drivers, cfg.Batteries)
-	// Per-phase fuse params for the per-phase clamp inside applyFuseGuard
-	// + forceFuseDischarge. Reads l1_a/l2_a/l3_a from the meter driver
-	// when SiteFuseAmps > 0; otherwise the per-phase clamp is disabled.
-	ctrl.SiteFuseAmps = cfg.Fuse.MaxAmps
-	ctrl.SiteFuseVoltage = cfg.Fuse.Voltage
-	ctrl.SiteFusePhases = cfg.Fuse.Phases
-	// EffectiveSafetyMarginA distinguishes nil ("unset, use default")
-	// from explicit 0 ("operator chose to disable"). The earlier
-	// `<= 0 → default` shortcut clobbered the disable case.
-	ctrl.SiteFuseSafetyA = cfg.Fuse.EffectiveSafetyMarginA()
+	ctrl := newControlStateFromConfig(cfg)
 	// Restore persisted mode + target if present. The planner variants
 	// have to be listed too — without them the strategy the user picked in
 	// the UI (planner_self / planner_cheap / planner_arbitrage) is silently


### PR DESCRIPTION
## Bug
`site.gain` is defaulted, validated, and marked as restart-required, but startup always constructed the PI controller with the hard-coded default `Kp=0.5`. Operator-configured gain values therefore had no effect after restart.

## Reproduction
Added `TestControlStateFromConfigAppliesSiteGain`. Before the fix, a config with `site.gain=0.8` still produced `PI.Kp=0.5`.

## Fix
Factor startup control-state construction into `newControlStateFromConfig` and apply `cfg.Site.Gain` to the PI proportional gain when configured. Existing default behavior stays unchanged because config defaults `site.gain` to `0.5`.

## Tests
- `go test ./cmd/forty-two-watts -run TestControlStateFromConfigAppliesSiteGain -count=1 -v`
- `go test ./cmd/forty-two-watts -count=1`
- `go test -race ./cmd/forty-two-watts`
- `go test ./...`