### PR TITLE
fix(state): keep shared-timestamp samples during rolloff

### DIFF
--- a/go/internal/state/store_test.go
+++ b/go/internal/state/store_test.go
@@ -68,6 +68,39 @@ func TestEventsRecorded(t *testing.T) {
 	}
 }
 
+func TestSamplesBeforeKeepsSameTimestampAcrossBatches(t *testing.T) {
+	s := freshStore(t)
+	samples := []Sample{
+		{Driver: "a", Metric: "power_w", TsMs: 10, Value: 1},
+		{Driver: "b", Metric: "power_w", TsMs: 10, Value: 2},
+		{Driver: "c", Metric: "power_w", TsMs: 10, Value: 3},
+	}
+	if err := s.RecordSamples(samples); err != nil {
+		t.Fatalf("record samples: %v", err)
+	}
+
+	var got []Sample
+	err := s.SamplesBefore(context.Background(), 11, 2, func(batch []Sample) error {
+		got = append(got, batch...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("SamplesBefore: %v", err)
+	}
+	if len(got) != len(samples) {
+		t.Fatalf("SamplesBefore returned %d samples, want %d: %+v", len(got), len(samples), got)
+	}
+	seen := map[string]bool{}
+	for _, sm := range got {
+		seen[sm.Driver] = true
+	}
+	for _, driver := range []string{"a", "b", "c"} {
+		if !seen[driver] {
+			t.Fatalf("SamplesBefore skipped driver %q from shared timestamp batch: %+v", driver, got)
+		}
+	}
+}
+
 func TestBatteryModelStore(t *testing.T) {
 	s := freshStore(t)
 	if err := s.SaveBatteryModel("ferroamp", `{"a":0.7,"b":0.3}`); err != nil {

--- a/go/internal/state/store_ts.go
+++ b/go/internal/state/store_ts.go
@@ -241,19 +241,24 @@ func (s *Store) SamplesBefore(ctx context.Context, cutoffMs int64, batchSize int
 	for n, id := range ts.metrics { mRev[id] = n }
 	ts.mu.RUnlock()
 
-	var lastTs int64 = -1
+	var lastTs, lastDriverID, lastMetricID int64
+	cursorSet := 0
 	batch := make([]Sample, 0, batchSize)
 	for {
 		rows, err := s.db.QueryContext(ctx, `SELECT driver_id, metric_id, ts_ms, value
-			FROM ts_samples WHERE ts_ms < ? AND ts_ms > ?
-			ORDER BY ts_ms ASC LIMIT ?`, cutoffMs, lastTs, batchSize)
+			FROM ts_samples
+			WHERE ts_ms < ?
+			  AND (? = 0 OR ts_ms > ? OR (ts_ms = ? AND (driver_id > ? OR (driver_id = ? AND metric_id > ?))))
+			ORDER BY ts_ms ASC, driver_id ASC, metric_id ASC
+			LIMIT ?`, cutoffMs, cursorSet, lastTs, lastTs, lastDriverID, lastDriverID, lastMetricID, batchSize)
 		if err != nil { return err }
 		batch = batch[:0]
 		for rows.Next() {
 			var dID, mID, t int64; var v float64
 			if err := rows.Scan(&dID, &mID, &t, &v); err != nil { rows.Close(); return err }
 			batch = append(batch, Sample{Driver: dRev[dID], Metric: mRev[mID], TsMs: t, Value: v})
-			lastTs = t
+			lastTs, lastDriverID, lastMetricID = t, dID, mID
+			cursorSet = 1
 		}
 		rows.Close()
 		if len(batch) == 0 { return nil }


### PR DESCRIPTION
## Bug
`SamplesBefore` paginated recent TSDB rows with only `ts_ms > lastTs`. If a batch ended in the middle of multiple samples sharing the same timestamp, the next query skipped the remaining rows at that timestamp. Rolloff/export paths using small batches could silently drop samples.

## Reproduction
Added `TestSamplesBeforeKeepsSameTimestampAcrossBatches`, which records three samples at the same `ts_ms` and reads them with `batchSize=2`. Before the fix only two samples were returned.

## Fix
Use a stable cursor and sort order over `(ts_ms, driver_id, metric_id)`, so pagination resumes after the exact last row instead of after the entire timestamp.

## Tests
- `go test ./internal/state -run TestSamplesBeforeKeepsSameTimestampAcrossBatches -count=1 -v`
- `go test -race ./internal/state`
- `go test ./...`