### PR TITLE
fix(state): keep latest point when downsampling

### DIFF
--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -495,13 +495,12 @@ func (s *Store) LoadHistory(sinceMs, untilMs int64, maxPoints int) ([]HistoryPoi
 
 	// Downsample by evenly picking maxPoints rows
 	if maxPoints > 0 && len(all) > maxPoints {
-		step := float64(len(all)) / float64(maxPoints)
+		if maxPoints == 1 {
+			return []HistoryPoint{all[len(all)-1]}, nil
+		}
 		out := make([]HistoryPoint, 0, maxPoints)
 		for i := 0; i < maxPoints; i++ {
-			idx := int(float64(i) * step)
-			if idx >= len(all) {
-				idx = len(all) - 1
-			}
+			idx := i * (len(all) - 1) / (maxPoints - 1)
 			out = append(out, all[idx])
 		}
 		return out, nil

--- a/go/internal/state/store_test.go
+++ b/go/internal/state/store_test.go
@@ -68,6 +68,32 @@ func TestEventsRecorded(t *testing.T) {
 	}
 }
 
+func TestLoadSeriesDownsamplingIncludesLatestSample(t *testing.T) {
+	s := freshStore(t)
+	samples := make([]Sample, 0, 10)
+	for i := 0; i < 10; i++ {
+		samples = append(samples, Sample{
+			Driver: "meter",
+			Metric: "power_w",
+			TsMs:   int64(i),
+			Value:  float64(i),
+		})
+	}
+	if err := s.RecordSamples(samples); err != nil {
+		t.Fatalf("record samples: %v", err)
+	}
+	got, err := s.LoadSeries("meter", "power_w", 0, 9, 3)
+	if err != nil {
+		t.Fatalf("LoadSeries: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("LoadSeries returned %d points, want 3: %+v", len(got), got)
+	}
+	if got[0].TsMs != 0 || got[len(got)-1].TsMs != 9 {
+		t.Fatalf("downsampled series endpoints = %d..%d, want 0..9: %+v", got[0].TsMs, got[len(got)-1].TsMs, got)
+	}
+}
+
 func TestBatteryModelStore(t *testing.T) {
 	s := freshStore(t)
 	if err := s.SaveBatteryModel("ferroamp", `{"a":0.7,"b":0.3}`); err != nil {
@@ -130,6 +156,10 @@ func TestHistoryDownsampling(t *testing.T) {
 	if err != nil { t.Fatal(err) }
 	if len(pts) != 10 {
 		t.Errorf("expected 10 downsampled points, got %d", len(pts))
+	}
+	if pts[0].TsMs != now || pts[len(pts)-1].TsMs != now+99 {
+		t.Errorf("downsampled history endpoints = %d..%d, want %d..%d",
+			pts[0].TsMs, pts[len(pts)-1].TsMs, now, now+99)
 	}
 }
 

--- a/go/internal/state/store_ts.go
+++ b/go/internal/state/store_ts.go
@@ -168,11 +168,12 @@ func (s *Store) LoadSeries(driver, metric string, sinceMs, untilMs int64, maxPoi
 	}
 	if err := rows.Err(); err != nil { return out, err }
 	if maxPoints > 0 && len(out) > maxPoints {
-		step := float64(len(out)) / float64(maxPoints)
+		if maxPoints == 1 {
+			return []Sample{out[len(out)-1]}, nil
+		}
 		ds := make([]Sample, 0, maxPoints)
 		for i := 0; i < maxPoints; i++ {
-			idx := int(float64(i) * step)
-			if idx >= len(out) { idx = len(out) - 1 }
+			idx := i * (len(out) - 1) / (maxPoints - 1)
 			ds = append(ds, out[idx])
 		}
 		return ds, nil


### PR DESCRIPTION
## Bug
State downsampling used `idx = int(i * len / maxPoints)`, which never selected the final row when `len > maxPoints`. `LoadSeries(..., maxPoints)` and `LoadHistory(..., maxPoints)` could therefore omit the latest datapoint, making charts and recent-state views stale at the right edge.

## Reproduction
- Added `TestLoadSeriesDownsamplingIncludesLatestSample`: before the fix 10 points downsampled to 3 returned timestamps `0,3,6` instead of ending at `9`.
- Extended `TestHistoryDownsampling`: before the fix 100 history rows downsampled to 10 ended at `now+90` instead of `now+99`.

## Fix
Downsample across `0..len-1` using integer endpoint-preserving indices. For `maxPoints=1`, return the latest point.

## Tests
- `go test ./internal/state -run 'TestLoadSeriesDownsamplingIncludesLatestSample|TestHistoryDownsampling' -count=1 -v`
- `go test -race ./internal/state`
- `go test ./...`