### PR TITLE
fix(drivers): use portable catalog lua paths

### DIFF
--- a/go/internal/drivers/catalog.go
+++ b/go/internal/drivers/catalog.go
@@ -14,7 +14,7 @@ import (
 // directory. Populated from the DRIVER={…} table each .lua file declares
 // at the top. Missing fields are left empty.
 type CatalogEntry struct {
-	Path               string         `json:"path"`          // relative to config dir
+	Path               string         `json:"path"`          // portable config lua path
 	Filename           string         `json:"filename"`      // e.g. "ferroamp.lua"
 	ID                 string         `json:"id"`
 	Name               string         `json:"name"`
@@ -70,7 +70,7 @@ func LoadCatalog(dir string) ([]CatalogEntry, error) {
 			return nil // skip malformed
 		}
 		rel, _ := filepath.Rel(dir, path)
-		entry.Path = filepath.Join(filepath.Base(dir), rel)
+		entry.Path = filepath.ToSlash(filepath.Join("drivers", rel))
 		entry.Filename = filepath.Base(path)
 		out = append(out, entry)
 		return nil

--- a/go/internal/drivers/catalog_test.go
+++ b/go/internal/drivers/catalog_test.go
@@ -1,0 +1,32 @@
+package drivers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCatalogUsesPortableDriverPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "custom-driver-dir")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "custom.lua"), []byte(`DRIVER = {
+  id = "custom"
+  name = "Custom"
+}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := LoadCatalog(dir)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("LoadCatalog returned %d entries, want 1: %+v", len(entries), entries)
+	}
+	if entries[0].Path != "drivers/custom.lua" {
+		t.Fatalf("catalog path = %q, want portable drivers/custom.lua", entries[0].Path)
+	}
+}


### PR DESCRIPTION
## Bug
`drivers.LoadCatalog(dir)` built catalog paths from `filepath.Base(dir)`. With a custom `-drivers` directory whose basename is not `drivers`, the API exposed entries like `custom-driver-dir/foo.lua`. If the UI saved that into config, `ResolveDriverPaths` would not route it through `DriversDirOverride`, so the driver path resolved relative to the config directory and failed after save/restart.

## Reproduction
Added `TestLoadCatalogUsesPortableDriverPath`, which loads a temporary catalog from `custom-driver-dir`. Before the fix, the entry path was `custom-driver-dir/custom.lua` instead of `drivers/custom.lua`.

## Fix
Always expose catalog entries as the logical portable alias `drivers/<rel>`, independent of the physical directory scanned. That matches the config resolver and keeps YAML portable across default, Docker, and custom driver directories.

## Tests
- `go test ./internal/drivers -run TestLoadCatalogUsesPortableDriverPath -count=1 -v`
- `go test -race ./internal/drivers -run TestLoadCatalogUsesPortableDriverPath -count=1`
- `go test ./...`

## Race note
- `go test -race ./internal/drivers` still hits the pre-existing driver health race in `TestRunLoopRecordsSuccessEvenWithoutEmits`; that separate race is fixed in PR #252.