### PR TITLE
fix(config): preserve external driver paths on save

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -986,5 +986,8 @@ func relDriverPath(baseDir, p string) string {
 	if err != nil {
 		return p
 	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return p
+	}
 	return rel
 }

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -302,6 +302,27 @@ func TestSaveAtomicRoundtrip(t *testing.T) {
 	}
 }
 
+func TestSaveAtomicKeepsOutOfTreeDriverPathAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c.yaml")
+	c, err := Parse([]byte(minimalYAML), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "external.lua")
+	c.Drivers[0].Lua = outside
+	if err := SaveAtomic(path, c); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Drivers[0].Lua != outside {
+		t.Fatalf("driver path after save/load = %q, want original absolute %q", loaded.Drivers[0].Lua, outside)
+	}
+}
+
 func pretty(f float64) string {
 	return fmt.Sprintf("%g", f)
 }


### PR DESCRIPTION
## Bug
`SaveAtomic` converted every absolute driver path to `filepath.Rel(baseDir, path)`. If a driver lived outside the config directory and no `DriversDirOverride` matched it, YAML got `../outside/driver.lua`. On the next load, `ResolveDriverPaths` strips leading `../` for path-traversal hardening, so the path was silently re-anchored under the config directory.

## Reproduction
Added `TestSaveAtomicKeepsOutOfTreeDriverPathAbsolute`. Before the fix, saving and loading an absolute out-of-tree Lua path moved it from sibling temp dir `002/external.lua` to `001/002/external.lua`.

## Fix
When `relDriverPath` sees that `filepath.Rel` would escape `baseDir`, keep the original absolute path instead of writing a `../`-prefixed path.

## Tests
- `go test ./internal/config -run TestSaveAtomicKeepsOutOfTreeDriverPathAbsolute -count=1 -v`
- `go test ./internal/config -count=1`
- `go test -race ./internal/config`
- `go test ./...`