### PR TITLE
fix(telemetry): floor sub-watt EV sums so denormals can't sink discharge

### DIFF
--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 )
@@ -328,6 +329,16 @@ func (s *Store) ReadingsByType(t DerType) []*DerReading {
 // Offline drivers (stale telemetry, watchdog tripped) are skipped so a
 // dangling 3.6 kW last-known reading can't sneak into load or grid
 // accounting after the driver has actually stopped reporting.
+//
+// Sub-watt floor: when the Kalman residual decays toward zero (driver
+// reports a real 0 W), the smoothed value asymptotes to denormals like
+// 1e-77. Those leak through any `> 0` guard and corrupt downstream
+// arithmetic — most acutely the BatteryCoversEV cap in control/dispatch.go,
+// which on a non-zero EVChargingW flips a planned discharge target into
+// a charge command and trips applyPlanSignFloor for the whole tick.
+// Floor at 1 W: real EV chargers draw kW or zero; nothing in between
+// matters here, and forcing exact 0 keeps every consumer's `> 0` guard
+// honest.
 func (s *Store) SumOnlineEVW() float64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -341,6 +352,9 @@ func (s *Store) SumOnlineEVW() float64 {
 			continue
 		}
 		sum += r.SmoothedW
+	}
+	if math.Abs(sum) < 1.0 {
+		return 0
 	}
 	return sum
 }

--- a/go/internal/telemetry/telemetry_test.go
+++ b/go/internal/telemetry/telemetry_test.go
@@ -293,3 +293,36 @@ func TestSumOnlineEVWEmptyStore(t *testing.T) {
 		t.Errorf("want 0, got %f", got)
 	}
 }
+
+// Regression: a Kalman residual decaying toward zero produces smoothed
+// values like 1e-77 (subnormal). Without the sub-watt floor those leak
+// into State.EVChargingW via control/dispatch.go's `evSum > 0` guard,
+// then trip the BatteryCoversEV cap (dispatch.go:730) which inverts a
+// planned discharge into a charge command, which trips applyPlanSignFloor
+// and zeros every battery target — observed live as
+// `ev_charging_w: 1.09e-77` blocking a peak-price discharge slot.
+func TestSumOnlineEVWFloorsSubWattReadings(t *testing.T) {
+	s := NewStore()
+	s.Update("easee", DerEV, 1e-77, nil, nil)
+	s.DriverHealthMut("easee").RecordSuccess()
+	if got := s.SumOnlineEVW(); got != 0 {
+		t.Errorf("subnormal EV reading must floor to 0, got %g", got)
+	}
+	// Negative trash (e.g. 1e-300 sign-flipped by another path) must
+	// also clamp — any consumer's `> 0` guard is honest only when the
+	// floor is symmetric.
+	s.Update("easee", DerEV, -0.5, nil, nil)
+	if got := s.SumOnlineEVW(); got != 0 {
+		t.Errorf("sub-watt negative EV reading must floor to 0, got %g", got)
+	}
+	// Sanity: a real charger draw on a fresh store passes through (the
+	// Kalman seeds itself from the first measurement, so first-update
+	// equality is meaningful; subsequent updates are smoothed and not
+	// useful as an exact assertion).
+	s2 := NewStore()
+	s2.Update("easee", DerEV, 3600, nil, nil)
+	s2.DriverHealthMut("easee").RecordSuccess()
+	if got := s2.SumOnlineEVW(); got != 3600 {
+		t.Errorf("real EV reading must pass through, got %g", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Live observation: MPC plan said `battery_w = -9000 W` for a peak-price arbitrage slot, but the battery sat idle through the entire slot. `/api/status` showed `ev_charging_w: 1.09e-77` and `ev_w: 2.93e-78` — subnormal floats.
- Root cause chain:
  1. The Kalman residual on an EV reading that has decayed to a real zero produces a `SmoothedW` of ~`1e-77`.
  2. `SumOnlineEVW` returns that subnormal.
  3. `control/dispatch.go:583` (`if evSum > 0 { state.EVChargingW = evSum }`) admits it.
  4. `dispatch.go:730-736` (`BatteryCoversEV` safety net) fires because `state.EVChargingW > 0` — and inverts a planned `-5400 W` discharge into a `+2647 W` charge command.
  5. `applyPlanSignFloor` (`dispatch.go:1596-1628`) sees plan-intent = discharge, exec = charge → mismatch → zeros every battery target. Battery idle through the peak.
- Fix: floor `SumOnlineEVW` to `0` when `|sum| < 1 W` at the aggregation boundary. One change covers control, MPC, loadmodel, and the `/api/status` JSON in one place — instead of sprinkling thresholds at four call sites.

## Why the boundary, not the dispatch site

`SumOnlineEVW` has four callers (`api`, `control`, `loadmodel`, `mpc`) and all treat the result as "EV power right now" in the same domain. None benefit from a denormal. The api caller is literally how this bug was first observed (subnormal in the live status JSON).

A 1 W floor is below any real EV charger draw and matches the system's existing convention that anything below the per-driver Kalman noise floor is not load-bearing.

## Out of scope (deferred)

- Tighten the `BatteryCoversEV` cap at `dispatch.go:730-736` so it isn't load-bearing on a `> 0` guard against driver-sourced floats.
- Audit `applyPlanSignFloor`'s blast radius — silent zeroing through a peak-price slot is a financial event; loud-log on trigger.
- The Kalman/driver root cause: a charger that stops emitting non-zero observations should converge to true zero, not denormals. Driver- or filter-level fix.

## Test plan

- [x] `go test ./internal/telemetry/... -run SumOnlineEV -v` — added `TestSumOnlineEVWFloorsSubWattReadings` covering subnormal, sub-watt negative, and a real 3.6 kW reading on a fresh store.
- [x] `make test` — full suite green (control, mpc, loadmodel, api, e2e all passing).
- [ ] Live verification on the Pi: deploy, confirm `/api/status` no longer reports denormals in `ev_charging_w` / `ev_w`, watch the next planned discharge slot actually discharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)