### PR TITLE
feat(grid): peak import ceiling — backend rule + UI controls

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -182,6 +182,11 @@ func main() {
 	if v, ok := st.LoadConfig("battery_covers_ev"); ok {
 		ctrl.BatteryCoversEV = v == "true"
 	}
+	if v, ok := st.LoadConfig("peak_import_ceiling_w"); ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+			ctrl.PeakImportCeilingW = f
+		}
+	}
 
 	// ---- Driver capacities (site, for control + fuse guard) ----
 	// Loadpoint drivers are filtered out — their battery_capacity_wh

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -182,6 +182,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/mode", s.handleSetMode)
 	s.handle("POST /api/target", s.handleSetTarget)
 	s.handle("POST /api/peak_limit", s.handleSetPeakLimit)
+	s.handle("POST /api/peak_import_ceiling", s.handleSetPeakImportCeiling)
 	s.handle("POST /api/ev_charging", s.handleSetEVCharging)
 	s.handle("POST /api/battery_covers_ev", s.handleSetBatteryCoversEV)
 	s.handle("GET  /api/drivers", s.handleDrivers)
@@ -572,6 +573,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"bat_soc":          avgSoC,
 		"grid_target_w":    ctrl.GridTargetW,
 		"peak_limit_w":     ctrl.PeakLimitW,
+		"peak_import_ceiling_w": ctrl.PeakImportCeilingW,
 		"ev_charging_w":    ctrl.EVChargingW,
 		"battery_covers_ev": ctrl.BatteryCoversEV,
 		// True when an EV charger password is persisted in state.db. The
@@ -938,6 +940,35 @@ func (s *Server) handleSetPeakLimit(w http.ResponseWriter, r *http.Request) {
 	s.deps.Ctrl.PeakLimitW = req.PeakLimitW
 	s.deps.CtrlMu.Unlock()
 	writeJSON(w, 200, map[string]any{"status": "ok", "peak_limit_w": req.PeakLimitW})
+}
+
+// ---- /api/peak_import_ceiling ----
+//
+// Hard import ceiling enforced in every mode. Default 0 = disabled. When
+// > 0, dispatch's import-side clamps (joint EV/battery allocator,
+// applyFuseGuard import branch, forceFuseDischarge) use min(fuse, peak)
+// as the binding threshold. Persisted in state.db so the operator's
+// tariff stays armed across restarts. See control.State.PeakImportCeilingW
+// for the full rationale.
+func (s *Server) handleSetPeakImportCeiling(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PeakImportCeilingW float64 `json:"peak_import_ceiling_w"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.PeakImportCeilingW < 0 {
+		writeJSON(w, 400, map[string]string{"error": "peak_import_ceiling_w must be ≥ 0"})
+		return
+	}
+	s.deps.CtrlMu.Lock()
+	s.deps.Ctrl.PeakImportCeilingW = req.PeakImportCeilingW
+	s.deps.CtrlMu.Unlock()
+	if s.deps.State != nil {
+		_ = s.deps.State.SaveConfig("peak_import_ceiling_w", strconv.FormatFloat(req.PeakImportCeilingW, 'f', 1, 64))
+	}
+	writeJSON(w, 200, map[string]any{"status": "ok", "peak_import_ceiling_w": req.PeakImportCeilingW})
 }
 
 // ---- /api/ev_charging ----

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -155,6 +155,23 @@ type State struct {
 
 	// Peak limit — enforced only in PeakShaving mode
 	PeakLimitW float64
+
+	// PeakImportCeilingW is a hard import ceiling enforced in EVERY mode,
+	// parallel to (and at or below) the physical fuse. Default 0 = disabled.
+	// When > 0, the import side of every clamp (applyFuseGuard, joint
+	// EV/battery allocator, forceFuseDischarge) uses min(fuse, peak)
+	// as its threshold; the battery covers transient overruns while
+	// the loadpoint controller ramps the EV down. Steady-state with
+	// BatteryCoversEV=false: EV settles at its throttled rate and the
+	// battery stops being commanded to discharge — the bridge is brief
+	// by construction, not by an explicit timer. Steady-state with
+	// BatteryCoversEV=true: the planner is already aware EV draw is in
+	// scope, no additional behaviour here.
+	//
+	// Export side and per-phase clamp use fuseMaxW unchanged — peak is
+	// an aggregate import-only concept (tariff). Persisted in state.db
+	// under "peak_import_ceiling_w".
+	PeakImportCeilingW float64
 	// EV charging signal — batteries won't try to cover this much of import
 	EVChargingW float64
 	// BatteryCoversEV overrides the default EV-exclusion behaviour. When
@@ -809,14 +826,21 @@ func ComputeDispatch(
 	state.FuseEVMaxW = 0
 	state.FuseSaturated = false
 	if fuseMaxW > 0 && state.EVChargingW > 0 {
+		// Use the effective import ceiling (fuse minus safety margin,
+		// or tariff peak when tighter) so PeakImportCeilingW throttles
+		// the EV through the same surface as the fuse. Steady-state
+		// with peak active and BatteryCoversEV=false: the EV settles
+		// at this scaled rate; the battery's transient discharge to
+		// bridge the ramp-down is handled by forceFuseDischarge below.
+		ceilingW := state.effectiveImportCeilingW(fuseMaxW)
 		targetTotal := currentTotal + totalCorrection
 		B := math.Max(0, targetTotal)
 		Bn := math.Min(0, targetTotal)
 		E := state.EVChargingW
 		H := rawGridW - currentTotal - E
 		projectedGrid := H + targetTotal + E
-		if projectedGrid > fuseMaxW && (B+E) > 0 {
-			scale := (fuseMaxW - H - Bn) / (B + E)
+		if projectedGrid > ceilingW && (B+E) > 0 {
+			scale := (ceilingW - H - Bn) / (B + E)
 			if scale < 0 {
 				scale = 0
 			}
@@ -971,7 +995,19 @@ func ComputeDispatch(
 	// EV against a stale (too-conservative) cap for one tick. Run only
 	// when the joint allocator already engaged this tick — otherwise
 	// FuseEVMaxW is "no advice" and should stay 0.
-	if state.FuseSaturated && state.EVChargingW > 0 && fuseMaxW > 0 {
+	// Skip the republish when the operator's tariff peak is the binding
+	// ceiling (peak < fuse). The republish's purpose is to free up EV
+	// headroom freed by forceFuseDischarge's transient battery bridge —
+	// that's the right thing for FUSE protection (hardware safety,
+	// battery is the last line of defense and there's no policy
+	// preference about how long to drain it). For TARIFF protection,
+	// the EV cap must reflect the steady state where the battery
+	// isn't covering, otherwise the bridge becomes a permanent
+	// shuttle and the operator pays the peak charge anyway. Let the
+	// joint allocator's pre-forceFuseDischarge FuseEVMaxW stand.
+	peakBindingW := fuseMaxW - state.fuseSafetyMarginW()
+	peakBinding := state != nil && state.PeakImportCeilingW > 0 && state.PeakImportCeilingW < peakBindingW
+	if !peakBinding && state.FuseSaturated && state.EVChargingW > 0 && fuseMaxW > 0 {
 		var postBat float64
 		seen := make(map[string]struct{}, len(raw))
 		for _, t := range raw {
@@ -982,14 +1018,19 @@ func ComputeDispatch(
 			postBat += t.TargetW
 		}
 		// H = rawGridW − currentTotal − E (unchanged from joint allocator)
-		// newGrid = H + postBat + E*scale ≤ fuseMaxW
-		// → scale ≤ (fuseMaxW − H − postBat) / E, capped to ≤1
+		// newGrid = H + postBat + E*scale ≤ ceiling
+		// → scale ≤ (ceiling − H − postBat) / E, capped to ≤1
+		// Use the effective import ceiling so peak-driven caps survive
+		// the post-forceFuseDischarge republish (otherwise the joint
+		// allocator's tariff-tightened cap gets overwritten with the
+		// fuse-only headroom).
+		ceilingW := state.effectiveImportCeilingW(fuseMaxW)
 		var rawGridW2 float64
 		if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
 			rawGridW2 = r.SmoothedW
 		}
 		H := rawGridW2 - currentTotal - state.EVChargingW
-		headroom := fuseMaxW - H - postBat
+		headroom := ceilingW - H - postBat
 		if headroom < 0 {
 			headroom = 0
 		}
@@ -1359,11 +1400,16 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	// Aggregate budget honours the safety margin too — keep dispatch
 	// commands strictly inside the breaker envelope so the inverter's
 	// own per-phase limiter doesn't fire first and cause a flap.
+	//
+	// Import ceiling is the tighter of (fuse − safety margin) and the
+	// operator's tariff peak; export ceiling is fuse-only — peak is
+	// import-only (effekttariff is billed on import).
 	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
 	if effFuseW < 0 {
 		effFuseW = 0
 	}
-	importOverage := predicted - effFuseW
+	effImportW := state.effectiveImportCeilingW(fuseMaxW)
+	importOverage := predicted - effImportW
 	exportOverage := -effFuseW - predicted
 	if perPhase > 0 {
 		if currentGrid >= 0 {
@@ -1518,6 +1564,27 @@ func (s *State) fuseSafetyMarginW() float64 {
 		return 0
 	}
 	return s.SiteFuseSafetyA * s.SiteFuseVoltage * float64(s.SiteFusePhases)
+}
+
+// effectiveImportCeilingW returns the binding ceiling for grid import in
+// watts: the fuse limit minus its safety margin, further capped by
+// PeakImportCeilingW when the operator has opted into a tariff peak
+// (PeakImportCeilingW > 0). Used by every import-side clamp in the
+// dispatch path so peak and fuse share one enforcement surface.
+//
+// Peak is taken at face value (no additional safety subtraction) — the
+// operator typed the contract limit, so the controller honours exactly
+// that. The fuse retains its independent safety margin because it
+// guards against a hardware breaker, not a billing line.
+func (s *State) effectiveImportCeilingW(fuseMaxW float64) float64 {
+	eff := fuseMaxW - s.fuseSafetyMarginW()
+	if eff < 0 {
+		eff = 0
+	}
+	if s != nil && s.PeakImportCeilingW > 0 && s.PeakImportCeilingW < eff {
+		eff = s.PeakImportCeilingW
+	}
+	return eff
 }
 
 // perPhaseOverageW returns the wattage by which the worst single phase
@@ -1784,11 +1851,15 @@ func forceFuseDischarge(
 	}
 	predicted := currentGrid - currentBat + sumTarget
 
-	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
-	if effFuseW < 0 {
-		effFuseW = 0
-	}
-	overage := predicted - effFuseW
+	// Effective import ceiling: fuse minus safety margin, capped further
+	// by PeakImportCeilingW when the operator has set a tariff peak.
+	// This is what makes the reactive fuse-saver also defend the peak —
+	// the battery briefly bridges while the loadpoint controller ramps
+	// the EV down in response to the joint allocator's FuseEVMaxW.
+	// Per-phase overage stays on the fuse-only path below; tariff is
+	// aggregate, not per-phase.
+	effImportW := state.effectiveImportCeilingW(fuseMaxW)
+	overage := predicted - effImportW
 	// Per-phase overage trumps aggregate when bigger — but ONLY on the
 	// import side. perPhaseOverageW is direction-agnostic (uses |amps|),
 	// so an export-side phase trip would otherwise cause this function

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -548,3 +548,104 @@ func TestFuseGuardHoldExpiresAfterWindow(t *testing.T) {
 		t.Errorf("post-expiry, no live overage: target should pass through, got %v", out[0])
 	}
 }
+
+// ---- PeakImportCeilingW (tariff peak, hard rule across modes) ----
+
+// Default 0 → no behaviour change. Same scenario as
+// TestFuseSaverNoOpWhenWithinFuse but explicit about the field default.
+func TestPeakCeilingDisabledByDefaultIsNoop(t *testing.T) {
+	store, state, caps := setupFuseSaver(8000, 0, 0.6, 10000)
+	if state.PeakImportCeilingW != 0 {
+		t.Fatalf("PeakImportCeilingW must default to 0 (disabled), got %v", state.PeakImportCeilingW)
+	}
+	out := forceFuseDischarge(
+		[]DispatchTarget{{Driver: "bat", TargetW: 0}},
+		store, state, caps, 11040)
+	if out[0].TargetW != 0 || out[0].Clamped {
+		t.Errorf("default-disabled peak: target should pass through, got %v", out[0])
+	}
+}
+
+// forceFuseDischarge fires when grid exceeds the operator's tariff peak
+// even though the fuse is intact. Battery briefly bridges; the joint
+// allocator has already throttled the EV via FuseEVMaxW.
+func TestPeakCeilingForcesDischargeBelowFuse(t *testing.T) {
+	// Grid at 8 kW import, well under the 11.04 kW fuse but over a
+	// 5 kW tariff peak.
+	store, state, caps := setupFuseSaver(8000, 0, 0.6, 10000)
+	state.PeakImportCeilingW = 5000
+	out := forceFuseDischarge(
+		[]DispatchTarget{{Driver: "bat", TargetW: 0}},
+		store, state, caps, 11040)
+	// Predicted = 8000. Effective import ceiling = 5000. Overage = 3000.
+	expected := -3000.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f, want %.0f (peak overrun fully covered by battery)",
+			out[0].TargetW, expected)
+	}
+	if !out[0].Clamped {
+		t.Errorf("Clamped flag must mark peak-saver activation")
+	}
+}
+
+// Joint EV/battery allocator caps EV draw against the peak ceiling
+// across modes — the operator's tariff is honoured even with
+// BatteryCoversEV=false (the EV throttles, the battery isn't pulled
+// in to cover steady-state).
+func TestPeakCeilingClampsEVViaJointAllocator(t *testing.T) {
+	// House load 1 kW, EV pinned at 7 kW = 8 kW import. Peak 5 kW.
+	// Fuse 11 kW (won't fire). Battery idle (no charge or discharge).
+	store := telemetry.NewStore()
+	store.Update("meter", telemetry.DerMeter, 8000, nil, nil)
+	store.DriverHealthMut("meter").RecordSuccess()
+	soc := 0.6
+	store.Update("bat", telemetry.DerBattery, 0, &soc, nil)
+	store.DriverHealthMut("bat").RecordSuccess()
+	st := NewState(0, 50, "meter")
+	st.PeakImportCeilingW = 5000
+	st.EVChargingW = 7000
+	st.BatteryCoversEV = false
+	st.DriverLimits = map[string]PowerLimits{"bat": {MaxChargeW: 5000, MaxDischargeW: 10000}}
+	caps := map[string]float64{"bat": 15200}
+
+	// Run a full dispatch cycle so the joint allocator's geometry
+	// fires (it lives inside ComputeDispatch, not as a free function).
+	st.Mode = ModeSelfConsumption
+	_ = ComputeDispatch(store, st, caps, 11040)
+
+	// Joint allocator should have set FuseEVMaxW so that
+	// H + Bn + B*scale + E*scale ≤ 5000 (peak ceiling).
+	// H = rawGrid − currentBat − E = 8000 − 0 − 7000 = 1000.
+	// Bn = 0 (idle), B may be small from PI but the cap should land
+	// near (5000 − 1000) = 4000 W of EV draw.
+	if !st.FuseSaturated {
+		t.Errorf("FuseSaturated must be true under peak overrun, got false")
+	}
+	// EV cap must drop well below the uncapped 7000 W. Exact value
+	// depends on PI internals (a small steady-state discharge command
+	// is legitimately accounted for by the joint allocator), so the
+	// assertion is "capped meaningfully", not an exact number. Anything
+	// above ~5500 means the peak ceiling isn't biting.
+	if st.FuseEVMaxW == 0 {
+		t.Errorf("FuseEVMaxW = 0 — peak ceiling should permit *some* EV draw")
+	}
+	if st.FuseEVMaxW > 5500 {
+		t.Errorf("FuseEVMaxW = %.0f, want ≤ 5500 (peak 5000 binding cap)", st.FuseEVMaxW)
+	}
+}
+
+// Peak above fuse is a no-op: fuse is the binding ceiling.
+// Sanity check the helper picks the tighter of the two.
+func TestPeakCeilingAboveFuseFusewins(t *testing.T) {
+	store, state, caps := setupFuseSaver(12000, 0, 0.6, 10000)
+	state.PeakImportCeilingW = 50000 // operator typo / loose tariff
+	out := forceFuseDischarge(
+		[]DispatchTarget{{Driver: "bat", TargetW: 0}},
+		store, state, caps, 11040)
+	// effFuseW = 11040, peak ignored (looser). Overage = 12000 − 11040 = 960.
+	expected := -960.0
+	if math.Abs(out[0].TargetW-expected) > 1 {
+		t.Errorf("target = %.0f, want %.0f (fuse should bind when peak is looser)",
+			out[0].TargetW, expected)
+	}
+}

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -46,6 +46,19 @@ class FtwPriceChart extends FtwElement {
       font-size: 11px;
       color: var(--fg-dim);
     }
+    .meta-stats {
+      display: flex;
+      gap: 0.9rem;
+      flex-wrap: wrap;
+      margin-top: 0.15rem;
+    }
+    .meta-stats .meta-label {
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--fg-muted);
+      margin-right: 0.18em;
+    }
+    .meta-stats span { white-space: nowrap; }
     .toggle {
       position: relative;
       display: inline-grid;
@@ -285,11 +298,59 @@ class FtwPriceChart extends FtwElement {
             <button type="button" data-horizon="all"      class="${effectiveHorizon === "all"   ? "active" : ""}"    aria-selected="${effectiveHorizon === "all"}">+ Tomorrow</button>
             <button type="button" data-horizon="tomorrow" class="${effectiveHorizon === "tomorrow" ? "active" : ""}" aria-selected="${effectiveHorizon === "tomorrow"}">Tomorrow</button>
           </div>` : "";
+    // Filter first so the stats row reflects the active horizon.
+    let visible = [];
+    if (data) {
+      if (effectiveHorizon === "today")         visible = filterToday(data.items);
+      else if (effectiveHorizon === "tomorrow") visible = filterTomorrow(data.items);
+      else                                      visible = data.items;
+    }
+    // Compute stats over the visible window using the consumer-resolved
+    // öre/kWh (spot + grid + VAT, matching whichever toggle is active),
+    // so the numbers in the subtitle line up exactly with what the
+    // chart bars are showing. `current` is the slot covering wall-clock
+    // now if it's in the window, else the nearest. Empty horizon → no
+    // stats row, falls through to the existing "no data" message.
+    let statsHtml = "";
+    if (visible.length > 0) {
+      const prices = visible.map(it => this._priceFor(it));
+      const now = Date.now();
+      let curIdx = visible.findIndex(it => {
+        const start = (it.tsMs || 0);
+        const end   = start + 60 * 60 * 1000;
+        return now >= start && now < end;
+      });
+      if (curIdx < 0) {
+        // Nearest by absolute time delta (used when "Tomorrow" tab is
+        // active and the wall clock is still in today, etc.).
+        let best = -1, bestD = Infinity;
+        for (let i = 0; i < visible.length; i++) {
+          const start = new Date(visible[i].starts_at || visible[i].ts || 0).getTime();
+          const d = Math.abs(start - now);
+          if (d < bestD) { bestD = d; best = i; }
+        }
+        curIdx = best;
+      }
+      const cur = curIdx >= 0 ? prices[curIdx] : null;
+      const lo = Math.min(...prices);
+      const hi = Math.max(...prices);
+      const avg = prices.reduce((a, b) => a + b, 0) / prices.length;
+      const fmt = v => (v == null ? "—" : v.toFixed(1) + " öre");
+      statsHtml = `
+          <div class="meta meta-stats">
+            <span><span class="meta-label">now</span> ${fmt(cur)}</span>
+            <span><span class="meta-label">low</span> ${fmt(lo)}</span>
+            <span><span class="meta-label">high</span> ${fmt(hi)}</span>
+            <span><span class="meta-label">avg</span> ${fmt(avg)}</span>
+          </div>
+      `;
+    }
     const head = `
       <div class="head">
         <div>
           <div class="label">Electricity prices</div>
           <div class="meta">${data ? `${escapeXml(data.zone)} · ${vatLabel} · ${horizonLabel}` : "—"}</div>
+          ${statsHtml}
         </div>
         <div class="toggles">
           <div class="toggle" role="tablist" data-vat="${this._vatOn ? "on" : "off"}">
@@ -302,10 +363,6 @@ class FtwPriceChart extends FtwElement {
     if (!data || !data.items.length) {
       return head + `<div class="empty">No price data available.</div>`;
     }
-    let visible;
-    if (effectiveHorizon === "today")         visible = filterToday(data.items);
-    else if (effectiveHorizon === "tomorrow") visible = filterTomorrow(data.items);
-    else                                      visible = data.items;
     if (!visible.length) {
       const which = effectiveHorizon === "tomorrow" ? "tomorrow" : "today";
       return head + `<div class="empty">No price data for ${which}.</div>`;
@@ -346,9 +403,14 @@ class FtwPriceChart extends FtwElement {
     const pad = small
       ? { t: 26, r: 16, b: 40, l: 80 }
       : { t: 16, r: 16, b: 28, l: 56 };
-    const fsAxis = small ? 18 : 10;  // y-axis öre + x-axis time
-    const fsNow  = small ? 18 : 10;  // NOW label
-    const fsMark = small ? 20 : 11;  // peak/low ▼▲ glyphs
+    // Phone sizes bumped per operator request (2026-05): axis labels
+    // were readable but the NOW marker felt thin and crowded against
+    // the bars. +50 % on axes, +33 % on NOW + thicker stroke so the
+    // current hour reads at-a-glance from across a room.
+    const fsAxis = small ? 27 : 10;  // y-axis öre + x-axis time
+    const fsNow  = small ? 24 : 10;  // NOW label
+    const fsMark = small ? 26 : 11;  // peak/low ▼▲ glyphs
+    const nowStrokeW = small ? 3 : 1.5;
     // Tick density drops from every 3 h to every 6 h on phones so the
     // bigger labels don't overlap each other across a 48 h chart.
     const tickStepMs = (small ? 6 : 3) * 3600_000;
@@ -446,11 +508,13 @@ class FtwPriceChart extends FtwElement {
       const x = pad.l + (nowIdx + 0.5) * barW;
       nowMarker = `
         <line x1="${x}" x2="${x}" y1="${pad.t}" y2="${pad.t + plotH}"
-              stroke="var(--accent-e)" stroke-width="1.5" stroke-dasharray="2 3"
+              stroke="var(--accent-e)" stroke-width="${nowStrokeW}" stroke-dasharray="2 3"
               opacity="0.7" />
         <text x="${x}" y="${pad.t - 6}" text-anchor="middle"
               fill="var(--accent-e)" font-family="var(--mono)" font-size="${fsNow}"
-              font-weight="600">NOW</text>
+              font-weight="700"
+              stroke="var(--accent-e)" stroke-width="${small ? 0.6 : 0}"
+              paint-order="stroke fill">NOW</text>
       `;
     }
 

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -49,8 +49,14 @@ class FtwPriceChart extends FtwElement {
     .meta-stats {
       display: flex;
       gap: 0.9rem;
+      row-gap: 0.35rem;
       flex-wrap: wrap;
       margin-top: 0.15rem;
+      /* line-height 1 keeps each "now / low / high / avg" item tight
+         vertically so when the row wraps onto two lines on a phone the
+         line-spacing comes from `row-gap`, not from per-item baseline
+         leading (which otherwise stacked the wrapped row too far down). */
+      line-height: 1;
     }
     .meta-stats .meta-label {
       text-transform: uppercase;
@@ -400,9 +406,12 @@ class FtwPriceChart extends FtwElement {
     // labels rendered too close to the card's left border).
     // Phones get bigger fonts AND more padding so the larger labels
     // stay inside the SVG box and below the NOW pill clears its top.
+    // +4 px left padding so 3-digit öre prices (e.g. "234 ö") clear the
+    // SVG edge — the label is text-anchored "end" at `pad.l - 4` and
+    // extends left from there, so a tighter pad.l clipped large prices.
     const pad = small
-      ? { t: 26, r: 16, b: 40, l: 80 }
-      : { t: 16, r: 16, b: 28, l: 56 };
+      ? { t: 26, r: 16, b: 40, l: 84 }
+      : { t: 16, r: 16, b: 28, l: 60 };
     // Phone sizes bumped per operator request (2026-05): axis labels
     // were readable but the NOW marker felt thin and crowded against
     // the bars. +50 % on axes, +33 % on NOW + thicker stroke so the

--- a/web/components/ftw-price-chart.js
+++ b/web/components/ftw-price-chart.js
@@ -54,7 +54,7 @@ class FtwPriceChart extends FtwElement {
       margin-top: 0.15rem;
       /* line-height 1 keeps each "now / low / high / avg" item tight
          vertically so when the row wraps onto two lines on a phone the
-         line-spacing comes from `row-gap`, not from per-item baseline
+         line-spacing comes from row-gap, not from per-item baseline
          leading (which otherwise stacked the wrapped row too far down). */
       line-height: 1;
     }

--- a/web/index.html
+++ b/web/index.html
@@ -549,7 +549,7 @@
            EV throttles. See PR for the full enforcement matrix. -->
       <div class="control-card">
         <div class="card-label">Peak import limit</div>
-        <label class="ftw-toggle" style="margin-bottom:0.5rem">
+        <label class="ftw-toggle">
           <input type="checkbox" id="peak-limit-enabled-toggle">
           <span class="ftw-toggle-slider"></span>
           <span class="ftw-toggle-label" id="peak-limit-enabled-label">Off</span>

--- a/web/index.html
+++ b/web/index.html
@@ -284,40 +284,12 @@
           <button data-mode="charge" title="Force full charge regardless of price">Charge</button>
         </div>
       </div>
-      <div class="card control-card advanced-only">
-        <div class="card-label" id="target-label">Grid target</div>
-        <div class="slider-group-compact">
-          <input type="range" id="grid-target-slider" min="-5000" max="5000" step="50" value="0">
-          <span id="grid-target-value" class="slider-current">0 W</span>
-          <button id="grid-target-send" class="btn-send">Set</button>
-        </div>
-        <div class="card-sub card-hint" id="grid-target-hint">Planner controls this when a strategy is active.</div>
-      </div>
-      <div class="card control-card advanced-only">
-        <div class="card-label">Peak limit</div>
-        <div class="slider-group-compact">
-          <input type="range" id="peak-limit-slider" min="0" max="11000" step="100" value="5000">
-          <span id="peak-limit-value" class="slider-current">5000 W</span>
-          <button id="peak-limit-send" class="btn-send">Set</button>
-        </div>
-      </div>
-      <!-- EV charging slider removed — ev_charging_w is now set
-           automatically by the Easee Cloud driver (or any DerEV driver).
-           The manual /api/ev_charging endpoint stays as a debug override. -->
-
-      <!-- Battery-covers-EV toggle. When ON, self-consumption lets the
-           home battery discharge into the EV — useful when grid prices
-           are high now and cheap PV/off-peak is expected later. OFF
-           (default) keeps the battery from draining to feed the car. -->
-      <div class="card control-card">
-        <div class="card-label">Let battery cover EV</div>
-        <label class="ftw-toggle">
-          <input type="checkbox" id="battery-covers-ev-toggle">
-          <span class="ftw-toggle-slider"></span>
-          <span class="ftw-toggle-label" id="battery-covers-ev-label">Off</span>
-        </label>
-        <div class="card-sub card-hint">On = home battery discharges into the EV (e.g. expensive grid now, cheap solar later). Off = battery stays out of EV charging.</div>
-      </div>
+      <!-- Grid-side knobs (peak limit, grid target) live inside the
+           Grid bubble modal — click the GRID planet in the energy-flow
+           hero to open. EV-side knob ("Let battery cover EV") lives
+           inside the EV bubble modal. Inline cards removed; the modals
+           own the markup so the JS hooks (#peak-limit-slider, etc.)
+           still resolve. -->
     </section>
 
     <!-- Live power + plan side-by-side -->
@@ -546,10 +518,60 @@
     <div id="ev-modal-body">
       <p style="color:var(--text-dim)">Loading...</p>
     </div>
+    <!-- Battery-covers-EV toggle lives in the EV modal (operator opens
+         it from the EV planet click). When ON, self-consumption lets
+         the home battery discharge into the EV — useful when grid
+         prices are high now and cheap PV/off-peak is expected later. -->
+    <div class="control-card" style="margin-top:1rem">
+      <div class="card-label">Let battery cover EV</div>
+      <label class="ftw-toggle">
+        <input type="checkbox" id="battery-covers-ev-toggle">
+        <span class="ftw-toggle-slider"></span>
+        <span class="ftw-toggle-label" id="battery-covers-ev-label">Off</span>
+      </label>
+      <div class="card-sub card-hint">On = home battery discharges into the EV. Off = battery stays out of EV charging.</div>
+    </div>
     <div slot="footer" style="display:flex;gap:0.5rem;width:100%">
       <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>
       <button class="btn-add" id="ev-btn-pause" style="flex:1">Pause</button>
       <button class="btn-add" id="ev-btn-resume" style="flex:1">Resume</button>
+    </div>
+  </ftw-modal>
+
+  <!-- Grid detail popup — peak import ceiling + grid target. Open from
+       the GRID planet in the energy-flow hero. -->
+  <ftw-modal id="grid-modal" style="--ftw-modal-max-width:420px">
+    <span slot="title">Grid</span>
+    <div id="grid-modal-body">
+      <!-- Peak import ceiling (tariff cap, hard rule across all modes).
+           Default off — operator opts in via the checkbox. When on, the
+           slider value caps grid import; battery briefly bridges while
+           EV throttles. See PR for the full enforcement matrix. -->
+      <div class="control-card">
+        <div class="card-label">Peak import limit</div>
+        <label class="ftw-toggle" style="margin-bottom:0.5rem">
+          <input type="checkbox" id="peak-limit-enabled-toggle">
+          <span class="ftw-toggle-slider"></span>
+          <span class="ftw-toggle-label" id="peak-limit-enabled-label">Off</span>
+        </label>
+        <div class="slider-group-compact">
+          <input type="range" id="peak-limit-slider" min="500" max="11000" step="100" value="5000" disabled>
+          <span id="peak-limit-value" class="slider-current">5000 W</span>
+          <button id="peak-limit-send" class="btn-send" disabled>Save</button>
+        </div>
+        <div class="card-sub card-hint">Hard cap on grid import (tariff peak). Off = no cap; only the physical fuse applies.</div>
+      </div>
+
+      <!-- Grid target (legacy PI setpoint for manual modes). -->
+      <div class="control-card" style="margin-top:1rem">
+        <div class="card-label" id="target-label">Grid target</div>
+        <div class="slider-group-compact">
+          <input type="range" id="grid-target-slider" min="-5000" max="5000" step="50" value="0">
+          <span id="grid-target-value" class="slider-current">0 W</span>
+          <button id="grid-target-send" class="btn-send" disabled>Save</button>
+        </div>
+        <div class="card-sub card-hint" id="grid-target-hint">Planner controls this when a strategy is active.</div>
+      </div>
     </div>
   </ftw-modal>
 

--- a/web/index.html
+++ b/web/index.html
@@ -74,7 +74,10 @@
       <button data-view="diagnose" class="drawer-nav-btn" data-menu-label="Diagnose">&#9202;</button>
       <button id="hero-toggle" class="icon-btn" data-menu-label="Hero / tiles" title="Switch between hero diagram and numeric tiles">&#9638;</button>
       <button id="theme-toggle" class="icon-btn" data-menu-label="Dark mode" title="Toggle light / dark theme">&#9790;</button>
-      <button id="ui-mode-toggle" class="btn-link" title="Show advanced controls + diagnostics">Advanced</button>
+      <!-- Advanced toggle moved below the Plan chart so it's visually
+           colocated with the controls + diagnostics it reveals (twins,
+           drivers, models, manual mode buttons). The button still
+           lives in the DOM as #ui-mode-toggle, just rendered there. -->
       <ftw-notif-history poll-ms="30000" data-menu-label="Notification history"></ftw-notif-history>
       <button id="settings-btn" class="settings-btn" data-menu-label="Settings" title="Settings">⚙</button>
       <ftw-update-badge></ftw-update-badge>
@@ -363,6 +366,16 @@
           <span class="legend-item bat-only" title="State of charge — battery fill %, 0–100"><span class="legend-color" style="background:#60a5fa"></span> SoC</span>
         </div>
       </section>
+    </section>
+
+    <!-- Advanced-mode toggle row. Sits between the Plan chart and the
+         advanced-only sections so the affordance lands right where the
+         extra UI surfaces appear. Same id as the previously-header
+         button so the existing click handler in next-app.js still
+         binds; the previous .btn-link styling stays intact. -->
+    <section id="ui-mode-row" class="ui-mode-row">
+      <button id="ui-mode-toggle" class="btn-link"
+              title="Show advanced controls + diagnostics">Advanced</button>
     </section>
 
     <!-- ML twin diagnostics — PV / load / price forecasters -->

--- a/web/index.html
+++ b/web/index.html
@@ -175,6 +175,15 @@
         <div class="card-value val-neutral" id="load-w">-- W</div>
         <div class="card-sub">house</div>
       </div>
+      <!-- EV tile — mirrors the energy-flow's EV planet so tile-mode
+           operators can reach the EV charging modal too. Click opens
+           #ev-modal (same modal the planet click opens). When no EV
+           is connected the value reads "—" and the click is a no-op. -->
+      <div class="card summary-card ftw-hide-in-hero" id="card-ev">
+        <div class="card-label">EV</div>
+        <div class="card-value val-neutral" id="card-ev-w">-- W</div>
+        <div class="card-sub" id="card-ev-sub">charger</div>
+      </div>
     </section>
 
 
@@ -341,6 +350,15 @@
           </div>
           <div class="plan-actions">
             <span id="plan-summary" class="plan-summary">…</span>
+            <!-- Horizon toggle. Mirrors the price chart's 3-position
+                 pill so operators have a consistent affordance across
+                 both charts. Today / +Tomorrow / Tomorrow. Persisted
+                 to localStorage in plan.js. -->
+            <div id="plan-horizon" class="toggle plan-horizon" role="tablist" data-horizon="all">
+              <button type="button" data-horizon="today">Today</button>
+              <button type="button" data-horizon="all" class="active" aria-selected="true">+ Tomorrow</button>
+              <button type="button" data-horizon="tomorrow">Tomorrow</button>
+            </div>
             <button id="plan-replan" class="btn-send" title="Force a fresh plan">Replan</button>
           </div>
         </div>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -565,13 +565,23 @@
     var gridHint = document.getElementById("grid-target-hint");
     if (gridSlider) gridSlider.disabled = plannerActive;
     if (gridSend) gridSend.disabled = plannerActive;
-    if (gridHint) gridHint.style.display = plannerActive ? "block" : "none";
+    if (gridHint) {
+      // Always show the hint inside the modal — when planner is
+      // driving, the hint *is* the explanation for the disabled
+      // control, so it takes a brighter style (card-hint-active);
+      // when the operator can edit the slider, it stays as quiet
+      // small print.
+      gridHint.style.display = "block";
+      gridHint.classList.toggle("card-hint-active", plannerActive);
+    }
     // Plan-stale banner
     if (data.plan_stale && plannerActive && gridHint) {
       gridHint.textContent = "⚠ Plan stale — falling back to self_consumption.";
       gridHint.classList.add("card-hint-warn");
     } else if (gridHint) {
-      gridHint.textContent = "Planner controls this when a strategy is active.";
+      gridHint.textContent = plannerActive
+        ? "Planner is driving — set strategy to Manual to edit grid target."
+        : "Planner controls this when a strategy is active.";
       gridHint.classList.remove("card-hint-warn");
     }
 
@@ -598,7 +608,10 @@
       peakLimitSlider.disabled = !enabled;
       const display = enabled ? peakSrcW : readLastPeakLimitW();
       peakLimitSlider.value = display;
-      peakLimitValue.textContent = formatW(display) + (enabled ? "" : " (off)");
+      // Don't decorate the value with " (off)" — the toggle is the
+      // single source of truth for enabled/disabled, doubling that
+      // signal is the kind of redundancy DESIGN.md warns about.
+      peakLimitValue.textContent = formatW(display);
       if (enabled) writeLastPeakLimitW(peakSrcW);
       if (peakLimitSend) peakLimitSend.disabled = true; // pristine
     }
@@ -1852,7 +1865,7 @@
       // straight through: post immediately on toggle change.
       const w = enabled ? Number(peakLimitSlider.value) || readLastPeakLimitW() : 0;
       if (enabled && peakLimitSlider) peakLimitSlider.value = w;
-      if (peakLimitValue) peakLimitValue.textContent = formatW(w) + (enabled ? "" : " (off)");
+      if (peakLimitValue) peakLimitValue.textContent = formatW(w);
       peakLimitEnableToggle.disabled = true;
       setPeakImportCeiling(w)
         .then(function () { peakLimitDirty = false; if (peakLimitSend) peakLimitSend.disabled = true; })

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -201,6 +201,27 @@
   const peakLimitSlider = $("peak-limit-slider");
   const peakLimitValue = $("peak-limit-value");
   const peakLimitSend = $("peak-limit-send");
+  const peakLimitEnableToggle = $("peak-limit-enabled-toggle");
+  const peakLimitEnableLabel = $("peak-limit-enabled-label");
+  // Dirty-tracking for sliders that POST on click. The poll handler
+  // skips overwrite while dirty so the user's pending edit isn't
+  // silently reverted; the Save button mirrors `dirty` so users get a
+  // visual cue that there's work to commit. Cleared on successful POST.
+  let peakLimitDirty = false;
+  let gridTargetDirty = false;
+  // Last non-zero peak ceiling, remembered so unchecking + rechecking
+  // the enable toggle restores the previous value instead of resetting
+  // to the default. Keyed by localStorage so it survives reloads.
+  function readLastPeakLimitW() {
+    try {
+      const v = localStorage.getItem("ftw-peak-import-ceiling-w");
+      const n = v == null ? null : Number(v);
+      return Number.isFinite(n) && n > 0 ? n : 5000;
+    } catch (e) { return 5000; }
+  }
+  function writeLastPeakLimitW(w) {
+    try { localStorage.setItem("ftw-peak-import-ceiling-w", String(w)); } catch (e) {}
+  }
   const evSlider = $("ev-slider");
   const evValue = $("ev-value");
   const evSend = $("ev-send");
@@ -554,14 +575,32 @@
       gridHint.classList.remove("card-hint-warn");
     }
 
-    // Grid target — only update slider if user is not actively dragging
-    if (gridTargetSlider && document.activeElement !== gridTargetSlider) {
+    // Grid target — only update slider if user has no pending edit. We
+    // check `dirty` rather than activeElement so a value that was
+    // dragged then mouse-released doesn't revert before Save is clicked.
+    if (gridTargetSlider && !gridTargetDirty) {
       gridTargetSlider.value = data.grid_target_w;
       gridTargetValue.textContent = formatW(data.grid_target_w);
     }
-    if (peakLimitSlider && document.activeElement !== peakLimitSlider && data.peak_limit_w != null) {
-      peakLimitSlider.value = data.peak_limit_w;
-      peakLimitValue.textContent = formatW(data.peak_limit_w);
+    // Peak import ceiling. Backed by the new peak_import_ceiling_w
+    // (hard rule across modes); 0 = disabled. Falls back to the legacy
+    // peak_limit_w field for older backends so the UI doesn't go blank
+    // during a partial-deploy window.
+    const peakSrcW = data.peak_import_ceiling_w != null
+      ? data.peak_import_ceiling_w
+      : data.peak_limit_w;
+    if (peakLimitSlider && !peakLimitDirty && peakSrcW != null) {
+      const enabled = peakSrcW > 0;
+      if (peakLimitEnableToggle) {
+        peakLimitEnableToggle.checked = enabled;
+        if (peakLimitEnableLabel) peakLimitEnableLabel.textContent = enabled ? "On" : "Off";
+      }
+      peakLimitSlider.disabled = !enabled;
+      const display = enabled ? peakSrcW : readLastPeakLimitW();
+      peakLimitSlider.value = display;
+      peakLimitValue.textContent = formatW(display) + (enabled ? "" : " (off)");
+      if (enabled) writeLastPeakLimitW(peakSrcW);
+      if (peakLimitSend) peakLimitSend.disabled = true; // pristine
     }
     if (evSlider && document.activeElement !== evSlider && data.ev_charging_w != null) {
       evSlider.value = data.ev_charging_w;
@@ -1697,6 +1736,14 @@
     postJson("/api/peak_limit", { peak_limit_w: w }).catch(function () {});
   }
 
+  // POST the new hard-rule peak ceiling. 0 = disabled (operator opted
+  // out of tariff protection — only the physical fuse applies).
+  // Returns the postJson promise so callers can clear dirty + show
+  // success on resolution.
+  function setPeakImportCeiling(w) {
+    return postJson("/api/peak_import_ceiling", { peak_import_ceiling_w: w });
+  }
+
   function setEvCharging(w) {
     postJson("/api/ev_charging", { power_w: w, active: w > 0 }).catch(function () {});
   }
@@ -1761,20 +1808,68 @@
     });
   }
 
-  gridTargetSlider.addEventListener("input", function () {
-    gridTargetValue.textContent = formatW(Number(gridTargetSlider.value));
-  });
+  // Grid target slider: dirty on input, Save enabled while dirty,
+  // poll skips overwrite while dirty. Mirrors the peak slider pattern.
+  if (gridTargetSlider) {
+    gridTargetSlider.addEventListener("input", function () {
+      gridTargetValue.textContent = formatW(Number(gridTargetSlider.value));
+      gridTargetDirty = true;
+      if (gridTargetSend) gridTargetSend.disabled = false;
+    });
+  }
+  if (gridTargetSend) {
+    gridTargetSend.addEventListener("click", function () {
+      const w = Number(gridTargetSlider.value);
+      gridTargetSend.disabled = true;
+      postJson("/api/target", { grid_target_w: w })
+        .then(function () { gridTargetDirty = false; })
+        .catch(function () { gridTargetSend.disabled = false; /* keep dirty so user can retry */ });
+    });
+  }
 
-  gridTargetSend.addEventListener("click", function () {
-    setTarget(Number(gridTargetSlider.value));
-  });
-
-  peakLimitSlider.addEventListener("input", function () {
-    peakLimitValue.textContent = formatW(Number(peakLimitSlider.value));
-  });
-  peakLimitSend.addEventListener("click", function () {
-    setPeakLimit(Number(peakLimitSlider.value));
-  });
+  // Peak slider: same dirty pattern, plus an enable/disable checkbox.
+  // Off → POST 0 (backend reads 0 = disabled). On → POST slider value.
+  // The slider is disabled when the toggle is off so the operator can't
+  // accidentally drag a dead control.
+  if (peakLimitSlider) {
+    peakLimitSlider.addEventListener("input", function () {
+      const w = Number(peakLimitSlider.value);
+      peakLimitValue.textContent = formatW(w);
+      peakLimitDirty = true;
+      if (peakLimitSend) peakLimitSend.disabled = false;
+    });
+  }
+  if (peakLimitEnableToggle) {
+    peakLimitEnableToggle.addEventListener("change", function () {
+      const enabled = peakLimitEnableToggle.checked;
+      if (peakLimitEnableLabel) peakLimitEnableLabel.textContent = enabled ? "On" : "Off";
+      if (peakLimitSlider) peakLimitSlider.disabled = !enabled;
+      // Show the value the toggle is about to enable (last known)
+      // without committing — the operator still has to press Save
+      // unless the toggle is being switched OFF, which is a destructive
+      // change worth one extra click confirmation. Wait — the spec
+      // calls for the toggle itself to be the on/off control, so flip
+      // straight through: post immediately on toggle change.
+      const w = enabled ? Number(peakLimitSlider.value) || readLastPeakLimitW() : 0;
+      if (enabled && peakLimitSlider) peakLimitSlider.value = w;
+      if (peakLimitValue) peakLimitValue.textContent = formatW(w) + (enabled ? "" : " (off)");
+      peakLimitEnableToggle.disabled = true;
+      setPeakImportCeiling(w)
+        .then(function () { peakLimitDirty = false; if (peakLimitSend) peakLimitSend.disabled = true; })
+        .catch(function () { /* leave dirty so user can retry */ })
+        .finally(function () { peakLimitEnableToggle.disabled = false; });
+    });
+  }
+  if (peakLimitSend) {
+    peakLimitSend.addEventListener("click", function () {
+      const w = Number(peakLimitSlider.value);
+      writeLastPeakLimitW(w);
+      peakLimitSend.disabled = true;
+      setPeakImportCeiling(w)
+        .then(function () { peakLimitDirty = false; })
+        .catch(function () { peakLimitSend.disabled = false; /* keep dirty */ });
+    });
+  }
 
   if (bceToggle) {
     bceToggle.addEventListener("change", function () {
@@ -1961,7 +2056,10 @@
 
     // Planet click routing. EV → EV modal scoped to driver. Battery →
     // <ftw-battery-control> manual-hold modal (no driver scoping; the
-    // hold applies to the aggregate battery setpoint).
+    // hold applies to the aggregate battery setpoint). Grid → grid
+    // modal hosting the peak-import ceiling and the (legacy) grid
+    // target setpoint.
+    var gridModal = document.getElementById("grid-modal");
     if (energyFlowEl) {
       energyFlowEl.addEventListener("ftw-planet-click", function (e) {
         var d = (e && e.detail) || {};
@@ -1970,6 +2068,7 @@
           var bc = document.getElementById("battery-control");
           if (bc && typeof bc.open === "function") bc.open();
         }
+        if (d.role === "grid" && gridModal) gridModal.open();
       });
     }
 

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -385,6 +385,19 @@
     // Load
     loadW.textContent = formatW(data.load_w || 0);
 
+    // EV tile (tile-mode parity with the energy-flow's EV planet).
+    // Reads ev_charging_w (post sub-watt floor in /api/status); the
+    // sub-card label flips to "charging" when active so the tile reads
+    // the same way the planet does.
+    var cardEvWEl   = document.getElementById("card-ev-w");
+    var cardEvSubEl = document.getElementById("card-ev-sub");
+    if (cardEvWEl) {
+      var evWNow = data.ev_charging_w || 0;
+      cardEvWEl.textContent = formatW(evWNow);
+      cardEvWEl.className = evWNow > 1 ? "card-value val-load" : "card-value val-neutral";
+      if (cardEvSubEl) cardEvSubEl.textContent = evWNow > 1 ? "charging" : "charger";
+    }
+
     // Battery — positive=charge, negative=discharge
     batW.textContent = formatW(data.bat_w);
     if (data.bat_w > 10) {
@@ -847,6 +860,19 @@
     var dpr = window.devicePixelRatio || 1;
     var w = canvas.parentElement.clientWidth - 32;
     var h = 300;
+    // Small-screen sizing for canvas-rendered axes + the NOW marker.
+    // Canvas text doesn't honour CSS @media queries, so we branch in
+    // JS — same threshold as ftw-price-chart (600 px) for consistency.
+    // Fonts scale ~50 % up; the now-line stroke doubles. The values
+    // below are read by every ctx.font / ctx.lineWidth assignment in
+    // this function via the chartFont* / chartLine* variables.
+    var smallScreen = window.matchMedia &&
+      window.matchMedia("(max-width: 600px)").matches;
+    var chartFontAxis     = smallScreen ? "16px monospace" : "11px monospace";
+    var chartFontWaiting  = smallScreen ? "18px monospace" : "12px monospace";
+    var chartFontTooltip  = smallScreen ? "14px monospace" : "10px monospace";
+    var chartFontTooltipS = smallScreen ? "13px monospace" : "9px monospace";
+    var chartNowStrokeW   = smallScreen ? 2 : 1;
     if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
       canvas.width = w * dpr;
       canvas.height = h * dpr;
@@ -931,7 +957,7 @@
       // Empty state — draw axes + "waiting for data" hint
       ctx.clearRect(0, 0, w, h);
       ctx.fillStyle = "#666";
-      ctx.font = "12px monospace";
+      ctx.font = chartFontWaiting;
       ctx.textAlign = "center";
       ctx.fillText("waiting for data...", w / 2, h / 2);
       ctx.textAlign = "left";
@@ -980,7 +1006,7 @@
     // number — that's what lets the y-axis labels stay readable.
     ctx.strokeStyle = "#2a2a2a";
     ctx.lineWidth = 0.5;
-    ctx.font = "11px monospace";
+    ctx.font = chartFontAxis;
     var steps = Math.round(yRange / yStep);
     for (var i = 0; i <= steps; i++) {
       var y = pad.top + plotH - (plotH * i / steps);
@@ -1156,10 +1182,12 @@
     });
     ctx.globalAlpha = 1;
 
-    // Subtle vertical "now" line — anchor point so the eye knows where present is
+    // Subtle vertical "now" line — anchor point so the eye knows
+    // where present is. Stroke width bumps on small screens so the
+    // marker stays visible alongside the larger axis labels.
     var nowX = pad.left + plotW;
-    ctx.strokeStyle = "rgba(255,255,255,0.12)";
-    ctx.lineWidth = 1;
+    ctx.strokeStyle = smallScreen ? "rgba(255,255,255,0.30)" : "rgba(255,255,255,0.12)";
+    ctx.lineWidth = chartNowStrokeW;
     ctx.beginPath();
     ctx.moveTo(nowX, pad.top);
     ctx.lineTo(nowX, pad.top + plotH);
@@ -1167,7 +1195,7 @@
 
     // Y-axis labels (outside clip so they're fully visible)
     ctx.fillStyle = "#888";
-    ctx.font = "11px monospace";
+    ctx.font = chartFontAxis;
     for (var i2 = 0; i2 <= steps; i2++) {
       var yVal = yMin + (yRange * i2 / steps);
       var ly = pad.top + plotH - (plotH * i2 / steps);
@@ -1200,7 +1228,7 @@
       ctx.beginPath();
       ctx.arc(w - pad.right - 78, pad.top + 4, 2.5, 0, Math.PI * 2);
       ctx.fill();
-      ctx.font = "10px monospace";
+      ctx.font = chartFontTooltip;
       ctx.fillStyle = fresh ? "#aaa" : "#f59e0b";
       ctx.fillText(ageStr, w - pad.right - 70, pad.top + 8);
     }
@@ -1307,7 +1335,7 @@
     ctx.fillRect(boxX, boxY, boxW, boxH);
     ctx.strokeRect(boxX, boxY, boxW, boxH);
 
-    ctx.font = "10px monospace";
+    ctx.font = chartFontTooltip;
     ctx.fillStyle = "#888";
     ctx.fillText(timeStr, boxX + 6, boxY + lineHeight - 2);
 
@@ -1331,9 +1359,9 @@
         if (lab.target && i < lab.target.length && Math.abs(lab.target[i]) > 1) {
           var actualW = ctx.measureText(actual).width;
           ctx.fillStyle = "#888";
-          ctx.font = "9px monospace";
+          ctx.font = chartFontTooltipS;
           ctx.fillText("→ " + formatW(lab.target[i]), boxX + boxW - 10 - actualW, y);
-          ctx.font = "10px monospace";
+          ctx.font = chartFontTooltip;
         }
       }
       ctx.textAlign = "left";
@@ -1380,7 +1408,7 @@
     ctx.fillRect(boxX, boxY, boxW, boxH);
     ctx.strokeRect(boxX, boxY, boxW, boxH);
 
-    ctx.font = "10px monospace";
+    ctx.font = chartFontTooltip;
     var d = new Date(ts);
     var hh = d.getHours().toString().padStart(2, "0") + ":" + d.getMinutes().toString().padStart(2, "0");
     ctx.fillStyle = "#fbbf24";
@@ -2115,6 +2143,21 @@
       cardBat.addEventListener("click", openBat);
       cardBat.addEventListener("keydown", function (e) {
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openBat(); }
+      });
+    }
+    var cardEv = document.getElementById("card-ev");
+    if (cardEv && typeof openEvModal === "function") {
+      cardEv.classList.add("clickable");
+      cardEv.setAttribute("role", "button");
+      cardEv.setAttribute("tabindex", "0");
+      cardEv.setAttribute("aria-label", "Open EV charger");
+      // Pass null so openEvModal aggregates across all EV drivers —
+      // matches the no-driver-scoping fallback the planet click uses
+      // when the operator hasn't picked a specific charger.
+      var openEv = function () { openEvModal(null); };
+      cardEv.addEventListener("click", openEv);
+      cardEv.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openEv(); }
       });
     }
 

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2085,6 +2085,39 @@
       });
     }
 
+    // Tile-mode (numeric cards) parity: when the operator toggles the
+    // hero off, the energy-flow planets aren't on screen, so the
+    // modal triggers need a second home. Binding click on the matching
+    // .summary-card opens the same modal, with a `.clickable` class
+    // that gives the card a pointer cursor + hover lift to advertise
+    // the affordance. EV has no tile-mode card today (loadpoints are
+    // listed separately) — leave that one to the planet for now.
+    var cardBat = document.getElementById("card-bat");
+    if (cardGrid && gridModal) {
+      cardGrid.classList.add("clickable");
+      cardGrid.setAttribute("role", "button");
+      cardGrid.setAttribute("tabindex", "0");
+      cardGrid.setAttribute("aria-label", "Open grid controls");
+      cardGrid.addEventListener("click", function () { gridModal.open(); });
+      cardGrid.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); gridModal.open(); }
+      });
+    }
+    if (cardBat) {
+      cardBat.classList.add("clickable");
+      cardBat.setAttribute("role", "button");
+      cardBat.setAttribute("tabindex", "0");
+      cardBat.setAttribute("aria-label", "Open battery controls");
+      var openBat = function () {
+        var bc = document.getElementById("battery-control");
+        if (bc && typeof bc.open === "function") bc.open();
+      };
+      cardBat.addEventListener("click", openBat);
+      cardBat.addEventListener("keydown", function (e) {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); openBat(); }
+      });
+    }
+
     function evCommand(action) {
       evActionBtns.forEach(function (b) { b.disabled = true; });
       var body = { action: action };

--- a/web/next.css
+++ b/web/next.css
@@ -774,6 +774,16 @@ body.ftw-next .card-hint {
   color: var(--fg-muted);
   margin-top: 8px;
 }
+body.ftw-next .card-hint.card-hint-active {
+  /* Used when the hint is the *active* explanation of a disabled
+     control (e.g. grid-target slider greyed out because the MPC
+     planner is driving). Lifts the colour from --fg-muted to --fg
+     and bumps size a hair so the reason for the disabled state
+     reads at the same weight as the control's label, not as quiet
+     small print. */
+  color: var(--fg);
+  font-size: 11px;
+}
 
 body.ftw-next .btn-send {
   background: var(--accent-e);

--- a/web/next.css
+++ b/web/next.css
@@ -774,6 +774,39 @@ body.ftw-next .card-hint {
   color: var(--fg-muted);
   margin-top: 8px;
 }
+/* Plan-chart horizon pill (Today / +Tomorrow / Tomorrow). Mirrors the
+   shadow-DOM .toggle inside <ftw-price-chart> so the affordance reads
+   as the same control across both charts. Lives in document scope
+   because the plan chart isn't a custom element. */
+body.ftw-next .plan-horizon {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm, 999px);
+  padding: 2px;
+  background: var(--ink-sunken);
+  font-family: var(--mono);
+  font-size: 11px;
+  margin-right: 0.5rem;
+}
+body.ftw-next .plan-horizon button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-dim);
+  cursor: pointer;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-xs, 999px);
+  font: inherit;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+body.ftw-next .plan-horizon button:hover { color: var(--fg); }
+body.ftw-next .plan-horizon button.active {
+  background: var(--accent-e);
+  /* On-accent text is near-black per DESIGN.md, never white. */
+  color: #0a0a0a;
+}
+
 /* Advanced-mode toggle row — sits between the live + plan charts and
    the advanced-only sections, so the affordance lands right where
    the extra UI surfaces appear when toggled on. Centered, quiet, and

--- a/web/next.css
+++ b/web/next.css
@@ -774,6 +774,28 @@ body.ftw-next .card-hint {
   color: var(--fg-muted);
   margin-top: 8px;
 }
+/* Advanced-mode toggle row — sits between the live + plan charts and
+   the advanced-only sections, so the affordance lands right where
+   the extra UI surfaces appear when toggled on. Centered, quiet, and
+   only as wide as it needs to be. */
+body.ftw-next .ui-mode-row {
+  display: flex;
+  justify-content: center;
+  margin: 1.25rem 0 1.5rem;
+}
+
+/* Tile-mode cards that open a modal advertise their clickability —
+   pointer cursor + a subtle hover lift. Hero mode still uses the
+   energy-flow planets, so this only matters in tiles mode. */
+body.ftw-next .summary-card.clickable {
+  cursor: pointer;
+  transition: transform 80ms ease, border-color 120ms ease;
+}
+body.ftw-next .summary-card.clickable:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent-e);
+}
+
 body.ftw-next .card-hint.card-hint-active {
   /* Used when the hint is the *active* explanation of a disabled
      control (e.g. grid-target slider greyed out because the MPC

--- a/web/plan.js
+++ b/web/plan.js
@@ -537,14 +537,43 @@
       tip.style.display = 'none';
       document.body.appendChild(tip);
     }
+    // Vertical hover line — mirrors the Live chart's drawHoverOverlay
+    // line. Implemented as an absolutely-positioned <div> over the
+    // canvas instead of a canvas-redraw, so the plan-chart's existing
+    // single-pass draw model stays untouched. Parented to the canvas's
+    // offset parent so it scrolls/resizes with it.
+    let hoverLine = document.getElementById('plan-hover-line');
+    if (canvas && !hoverLine) {
+      hoverLine = document.createElement('div');
+      hoverLine.id = 'plan-hover-line';
+      hoverLine.style.cssText =
+        'position:absolute;top:0;width:1px;height:100%;' +
+        'background:rgba(255,255,255,0.3);' +
+        'border-left:1px dashed rgba(255,255,255,0.45);' +
+        'pointer-events:none;display:none;z-index:2';
+      const host = canvas.parentElement;
+      if (host) {
+        if (getComputedStyle(host).position === 'static') host.style.position = 'relative';
+        host.appendChild(hoverLine);
+      }
+    }
     if (!canvas) return;
     canvas.addEventListener('mousemove', function (e) {
       if (!state.priceBarBounds || state.priceBarBounds.length === 0) {
         tip.style.display = 'none';
+        if (hoverLine) hoverLine.style.display = 'none';
         return;
       }
       const rect = canvas.getBoundingClientRect();
       const cx = e.clientX - rect.left;
+      // Track the line on every move that lands inside the canvas,
+      // even when the cursor is between bars (the gutters between
+      // 15-minute slots) — the visual cue should follow the pointer
+      // continuously, not jump bar-to-bar.
+      if (hoverLine) {
+        hoverLine.style.left = cx + 'px';
+        hoverLine.style.display = 'block';
+      }
       let found = null;
       for (const b of state.priceBarBounds) {
         if (cx >= b.x0 && cx <= b.x1) { found = b; break; }
@@ -614,7 +643,11 @@
       tip.style.top = (e.clientY + 14) + 'px';
       tip.style.display = 'block';
     });
-    canvas.addEventListener('mouseleave', function () { tip.style.display = 'none'; });
+    canvas.addEventListener('mouseleave', function () {
+      tip.style.display = 'none';
+      const hl = document.getElementById('plan-hover-line');
+      if (hl) hl.style.display = 'none';
+    });
   }
 
   // Strategy explanation — surfaces one-sentence logic for the current mode.

--- a/web/plan.js
+++ b/web/plan.js
@@ -7,6 +7,23 @@
 
   const PLAN_REFRESH_MS = 30000;
 
+  // Horizon controls the x-axis bounds; mirrors the price chart's
+  // 3-position pill so operators have a consistent affordance across
+  // both charts. Persisted in localStorage so a user who prefers
+  // "Today only" doesn't have to re-pick on every reload.
+  //
+  // Defined ABOVE `state` because state's initializer calls
+  // readHorizonPref(); even though function declarations hoist, the
+  // const HORIZON_PREF_KEY would be in its temporal dead zone at that
+  // point and the module would throw a ReferenceError.
+  const HORIZON_PREF_KEY = "ftw.planChart.horizon";
+  function readHorizonPref() {
+    try {
+      const v = localStorage.getItem(HORIZON_PREF_KEY);
+      return (v === "today" || v === "all" || v === "tomorrow") ? v : "all";
+    } catch (e) { return "all"; }
+  }
+
   const state = {
     prices: null,
     forecast: null,
@@ -15,18 +32,6 @@
     lastUpdate: null,
     horizon: readHorizonPref(),  // "today" | "all" | "tomorrow"
   };
-
-  // Horizon controls the x-axis bounds; mirrors the price chart's
-  // 3-position pill so operators have a consistent affordance across
-  // both charts. Persisted in localStorage so a user who prefers
-  // "Today only" doesn't have to re-pick on every reload.
-  const HORIZON_PREF_KEY = "ftw.planChart.horizon";
-  function readHorizonPref() {
-    try {
-      const v = localStorage.getItem(HORIZON_PREF_KEY);
-      return (v === "today" || v === "all" || v === "tomorrow") ? v : "all";
-    } catch (e) { return "all"; }
-  }
   function writeHorizonPref(v) {
     try { localStorage.setItem(HORIZON_PREF_KEY, v); } catch (e) {}
   }

--- a/web/plan.js
+++ b/web/plan.js
@@ -558,18 +558,19 @@
       }
     }
     if (!canvas) return;
-    canvas.addEventListener('mousemove', function (e) {
+
+    // Single render path used by both mouse-hover and touch-scrub.
+    // Returns true when a slot was matched (for the touch path so it
+    // can decide whether to keep blocking the page scroll).
+    function showTipAtClient(clientX, clientY) {
       if (!state.priceBarBounds || state.priceBarBounds.length === 0) {
-        tip.style.display = 'none';
-        if (hoverLine) hoverLine.style.display = 'none';
-        return;
+        hideTipAndLine();
+        return false;
       }
       const rect = canvas.getBoundingClientRect();
-      const cx = e.clientX - rect.left;
-      // Track the line on every move that lands inside the canvas,
-      // even when the cursor is between bars (the gutters between
-      // 15-minute slots) — the visual cue should follow the pointer
-      // continuously, not jump bar-to-bar.
+      const cx = clientX - rect.left;
+      // Hover line tracks the pointer continuously across the canvas,
+      // even in the gutters between 15-minute bars.
       if (hoverLine) {
         hoverLine.style.left = cx + 'px';
         hoverLine.style.display = 'block';
@@ -578,7 +579,7 @@
       for (const b of state.priceBarBounds) {
         if (cx >= b.x0 && cx <= b.x1) { found = b; break; }
       }
-      if (!found) { tip.style.display = 'none'; return; }
+      if (!found) { tip.style.display = 'none'; return false; }
       const a = found.action;
       const d = new Date(found.ts);
       const hh = d.getHours().toString().padStart(2, '0') + ':' + d.getMinutes().toString().padStart(2, '0');
@@ -639,15 +640,88 @@
         lines.push(`<div class="tip-reason">${a.reason}</div>`);
       }
       tip.innerHTML = lines.join('');
-      tip.style.left = (e.clientX + 14) + 'px';
-      tip.style.top = (e.clientY + 14) + 'px';
+      // Touch scrub on a phone has no cursor, so the tooltip is positioned
+      // relative to the canvas (above the touch point) rather than offset
+      // from it — fingers occlude the slot otherwise. Mouse path keeps
+      // the original "near the cursor" placement.
+      if (isTouching) {
+        const r = canvas.getBoundingClientRect();
+        const left = Math.min(window.innerWidth - 8 - 280, Math.max(8, clientX - 140));
+        const top  = Math.max(8, r.top - 8 + window.scrollY - tip.offsetHeight);
+        tip.style.left = left + 'px';
+        tip.style.top  = top  + 'px';
+      } else {
+        tip.style.left = (clientX + 14) + 'px';
+        tip.style.top  = (clientY + 14) + 'px';
+      }
       tip.style.display = 'block';
+      return true;
+    }
+
+    function hideTipAndLine() {
+      tip.style.display = 'none';
+      if (hoverLine) hoverLine.style.display = 'none';
+    }
+
+    canvas.addEventListener('mousemove', function (e) {
+      if (isTouching) return; // touch path owns the tooltip
+      showTipAtClient(e.clientX, e.clientY);
     });
     canvas.addEventListener('mouseleave', function () {
-      tip.style.display = 'none';
-      const hl = document.getElementById('plan-hover-line');
-      if (hl) hl.style.display = 'none';
+      if (!isTouching) hideTipAndLine();
     });
+
+    // Touch — long-press to enter scrub mode, then drag to walk the
+    // tooltip across slots. 250 ms threshold lets a vertical
+    // swipe-to-scroll pass through unmolested; if the finger moves
+    // > 10 px before the timer fires the press is cancelled (gesture
+    // is a scroll, not a press). Mirrors ftw-price-chart.js's
+    // implementation so phone users get the same affordance on both
+    // charts.
+    let isTouching = false;
+    let pressTimer = null;
+    let scrubbing = false;
+    let startX = 0, startY = 0;
+    const SCRUB_DELAY_MS = 250;
+    const SCRUB_TOLERANCE_PX = 10;
+    const cancelPress = () => {
+      if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+    };
+    const enterScrub = () => {
+      pressTimer = null;
+      scrubbing = true;
+      if (navigator.vibrate) { try { navigator.vibrate(8); } catch (_) {} }
+      showTipAtClient(startX, startY);
+    };
+    const endTouch = () => {
+      cancelPress();
+      if (scrubbing) { scrubbing = false; hideTipAndLine(); }
+      // Defer clearing isTouching past the synthesized mouse events
+      // that fire after touchend on iOS/Android — without this the
+      // tooltip flashes back open as the page settles.
+      setTimeout(() => { isTouching = false; }, 400);
+    };
+    canvas.addEventListener('touchstart', function (e) {
+      if (e.touches.length !== 1) { cancelPress(); return; }
+      const t = e.touches[0];
+      startX = t.clientX; startY = t.clientY;
+      isTouching = true;
+      cancelPress();
+      pressTimer = setTimeout(enterScrub, SCRUB_DELAY_MS);
+    }, { passive: true });
+    canvas.addEventListener('touchmove', function (e) {
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      if (!scrubbing) {
+        if (Math.hypot(t.clientX - startX, t.clientY - startY) > SCRUB_TOLERANCE_PX) cancelPress();
+        return;
+      }
+      // In scrub mode — block page scroll so the chart owns the gesture.
+      e.preventDefault();
+      showTipAtClient(t.clientX, t.clientY);
+    }, { passive: false });
+    canvas.addEventListener('touchend', endTouch);
+    canvas.addEventListener('touchcancel', endTouch);
   }
 
   // Strategy explanation — surfaces one-sentence logic for the current mode.

--- a/web/plan.js
+++ b/web/plan.js
@@ -13,7 +13,39 @@
     plan: null,
     fuse: null,         // { max_amps, phases, voltage } — drives the power y-axis
     lastUpdate: null,
+    horizon: readHorizonPref(),  // "today" | "all" | "tomorrow"
   };
+
+  // Horizon controls the x-axis bounds; mirrors the price chart's
+  // 3-position pill so operators have a consistent affordance across
+  // both charts. Persisted in localStorage so a user who prefers
+  // "Today only" doesn't have to re-pick on every reload.
+  const HORIZON_PREF_KEY = "ftw.planChart.horizon";
+  function readHorizonPref() {
+    try {
+      const v = localStorage.getItem(HORIZON_PREF_KEY);
+      return (v === "today" || v === "all" || v === "tomorrow") ? v : "all";
+    } catch (e) { return "all"; }
+  }
+  function writeHorizonPref(v) {
+    try { localStorage.setItem(HORIZON_PREF_KEY, v); } catch (e) {}
+  }
+  function localMidnight(offsetDays) {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d.getTime() + (offsetDays || 0) * 24 * 60 * 60 * 1000;
+  }
+  function horizonBounds(horizon) {
+    const now = Date.now();
+    if (horizon === "today") {
+      return { tMin: now - 30 * 60 * 1000, tMax: localMidnight(1) };
+    }
+    if (horizon === "tomorrow") {
+      return { tMin: localMidnight(1), tMax: localMidnight(2) };
+    }
+    // "all" — current default: now-30 min through next 48 h.
+    return { tMin: now - 30 * 60 * 1000, tMax: now + 48 * 60 * 60 * 1000 };
+  }
 
   async function fetchAll() {
     const [p, f, m, c] = await Promise.all([
@@ -71,10 +103,10 @@
     const plotW = cssW - pad.l - pad.r;
     const plotH = cssH - pad.t - pad.b;
 
-    // X range = now → +24h
+    // X range — driven by the operator-chosen horizon (today / +tomorrow
+    // / tomorrow only). "all" preserves the original now→+48h default.
     const now = Date.now();
-    const tMin = now - 30 * 60 * 1000; // 30 min look-back so in-progress slot is visible
-    const tMax = now + 48 * 60 * 60 * 1000;
+    const { tMin, tMax } = horizonBounds(state.horizon);
     const xScale = t => pad.l + (t - tMin) / (tMax - tMin) * plotW;
 
     // Layout: price bars (top) | mode band (thin strip) | power bars (middle) | SoC (bottom)
@@ -754,6 +786,36 @@
     window.addEventListener('resize', render);
     const btn = document.getElementById('plan-replan');
     if (btn) btn.addEventListener('click', replan);
+
+    // Horizon toggle wiring. Each click flips state.horizon, persists
+    // the choice, marks the right button active, and re-renders. The
+    // visual style (.toggle .active) is shared with the VAT pill.
+    const horizonRoot = document.getElementById('plan-horizon');
+    if (horizonRoot) {
+      // Reflect the persisted preference on first paint.
+      horizonRoot.setAttribute('data-horizon', state.horizon);
+      horizonRoot.querySelectorAll('button[data-horizon]').forEach(b => {
+        const isActive = b.dataset.horizon === state.horizon;
+        b.classList.toggle('active', isActive);
+        b.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      });
+      horizonRoot.addEventListener('click', function (e) {
+        const target = e.target.closest('button[data-horizon]');
+        if (!target) return;
+        const next = target.dataset.horizon;
+        if (next !== 'today' && next !== 'all' && next !== 'tomorrow') return;
+        if (next === state.horizon) return;
+        state.horizon = next;
+        writeHorizonPref(next);
+        horizonRoot.setAttribute('data-horizon', next);
+        horizonRoot.querySelectorAll('button[data-horizon]').forEach(b => {
+          const isActive = b.dataset.horizon === next;
+          b.classList.toggle('active', isActive);
+          b.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        });
+        render();
+      });
+    }
     const helpBtn = document.getElementById('plan-help-btn');
     const helpModal = document.getElementById('plan-help-modal');
     if (helpBtn && helpModal) {

--- a/web/update-badge.js
+++ b/web/update-badge.js
@@ -518,13 +518,14 @@
         :host { all: initial; font-family: inherit; }
         .hidden { display: none !important; }
         .badge {
-          /* Blue blinking dot so it's unmistakably "this is the
-             update indicator" and not confused with the green
-             connection dot next door. Pulsing animation stays so
-             it reads as actionable, not a static state. */
+          /* Amber pulse — the system's single accent (DESIGN.md). The
+             green connection dot next door is reserved for liveness
+             state; the amber dot is an actionable affordance ("update
+             available, open me"). Pulsing animation stays so it reads
+             as actionable, not a static state. */
           appearance: none;
           background: transparent;
-          color: #3b82f6;
+          color: var(--accent-e, #f59e0b);
           border: none;
           cursor: pointer;
           font-size: 1.1rem;
@@ -554,38 +555,38 @@
              laptop-height browser running the /next dashboard. */
           max-height: 85vh;
           overflow-y: auto;
-          background: var(--surface, #1e293b);
-          color: var(--text, #e2e8f0);
-          border: 1px solid var(--border, #334155);
-          border-radius: 8px;
+          background: var(--ink-raised, #1e293b);
+          color: var(--fg, #e2e8f0);
+          border: 1px solid var(--line, #334155);
+          border-radius: var(--radius-sm, 8px);
           z-index: 1001;
           display: flex; flex-direction: column;
-          font-family: system-ui, -apple-system, sans-serif;
+          font-family: var(--sans, system-ui, -apple-system, sans-serif);
           font-size: 0.9rem;
         }
         .modal header {
           display: flex; align-items: center; justify-content: space-between;
           padding: 0.9rem 1rem;
-          border-bottom: 1px solid var(--border, #334155);
+          border-bottom: 1px solid var(--line, #334155);
         }
         .modal h3 { margin: 0; font-size: 1rem; }
         .modal .x {
           appearance: none; background: transparent;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           border: none; cursor: pointer;
           font-size: 1.25rem; line-height: 1;
         }
         .modal .body { padding: 1rem; }
         .modal .body.center { text-align: center; padding: 1.4rem 1rem; }
-        .subtitle { margin: 0 0 0.75rem; color: var(--text-dim, #94a3b8); }
+        .subtitle { margin: 0 0 0.75rem; color: var(--fg-dim, #94a3b8); }
         dl { margin: 0; display: grid; gap: 0.35rem; grid-template-columns: auto 1fr; }
         dl > div { display: contents; }
-        dt { color: var(--text-dim, #94a3b8); font-size: 0.8rem; }
+        dt { color: var(--fg-dim, #94a3b8); font-size: 0.8rem; }
         dd { margin: 0; font-variant-numeric: tabular-nums; }
         .changelog {
           margin-top: 0.75rem;
-          border: 1px solid var(--border, #334155);
-          border-radius: 4px;
+          border: 1px solid var(--line, #334155);
+          border-radius: var(--radius-xs, 4px);
           background: rgba(255,255,255,0.02);
         }
         .changelog > summary {
@@ -593,7 +594,7 @@
           cursor: pointer;
           font-weight: 600;
           font-size: 0.85rem;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           list-style: none;
         }
         .changelog > summary::-webkit-details-marker { display: none; }
@@ -614,12 +615,12 @@
         .changelog-body h4 {
           margin: 0.75rem 0 0.3rem;
           font-size: 0.9rem;
-          color: var(--text, #e2e8f0);
+          color: var(--fg, #e2e8f0);
         }
         .changelog-body h5 {
           margin: 0.6rem 0 0.25rem;
           font-size: 0.8rem;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           text-transform: uppercase;
           letter-spacing: 0.03em;
         }
@@ -636,7 +637,7 @@
           font-size: 0.82rem;
         }
         .changelog-body a {
-          color: var(--accent, #f59e0b);
+          color: var(--accent-e, #f59e0b);
           text-decoration: none;
         }
         .changelog-body a:hover { text-decoration: underline; }
@@ -645,17 +646,17 @@
           font-size: 0.8rem;
         }
         .notes-link {
-          color: var(--accent, #f59e0b);
+          color: var(--accent-e, #f59e0b);
           text-decoration: none;
         }
         .notes-link:hover { text-decoration: underline; }
         .snapshot-hint {
           margin-top: 0.75rem;
           padding: 0.5rem 0.7rem;
-          border: 1px solid var(--border, #334155);
-          border-radius: 4px;
+          border: 1px solid var(--line, #334155);
+          border-radius: var(--radius-xs, 4px);
           background: rgba(148, 163, 184, 0.06);
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           font-size: 0.78rem;
           line-height: 1.4;
         }
@@ -666,7 +667,7 @@
           gap: 0.4rem;
           margin-top: 0.4rem;
           font-size: 0.76rem;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           cursor: pointer;
           user-select: none;
         }
@@ -676,8 +677,8 @@
         }
         .snapshots {
           margin-top: 0.75rem;
-          border: 1px solid var(--border, #334155);
-          border-radius: 4px;
+          border: 1px solid var(--line, #334155);
+          border-radius: var(--radius-xs, 4px);
           background: rgba(255,255,255,0.02);
         }
         .snapshots > summary {
@@ -685,7 +686,7 @@
           cursor: pointer;
           font-weight: 600;
           font-size: 0.85rem;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
           list-style: none;
         }
         .snapshots > summary::-webkit-details-marker { display: none; }
@@ -704,21 +705,21 @@
           width: 100%;
           border-collapse: collapse;
           font-size: 0.78rem;
-          color: var(--text-dim, #94a3b8);
+          color: var(--fg-dim, #94a3b8);
         }
         .snapshots-table th,
         .snapshots-table td {
           padding: 0.3rem 0.75rem;
           text-align: left;
-          border-top: 1px solid var(--border, #334155);
+          border-top: 1px solid var(--line, #334155);
         }
         .snapshots-table th {
           font-weight: 600;
           border-top: none;
-          color: var(--text, #e2e8f0);
+          color: var(--fg, #e2e8f0);
         }
         .snapshots-table .nowrap { white-space: nowrap; }
-        .snapshots-table .mono { font-family: ui-monospace, monospace; }
+        .snapshots-table .mono { font-family: var(--mono, ui-monospace, monospace); }
         .snapshot-actions {
           display: flex;
           gap: 0.3rem;
@@ -731,45 +732,49 @@
         }
         .err {
           margin-top: 0.75rem;
-          color: #f87171; font-size: 0.85rem;
+          color: var(--red-e, #f87171); font-size: 0.85rem;
         }
-        .dim { color: var(--text-dim, #94a3b8); font-size: 0.8rem; }
+        .dim { color: var(--fg-dim, #94a3b8); font-size: 0.8rem; }
         .modal footer {
           display: flex; gap: 0.5rem; justify-content: flex-end;
           padding: 0.75rem 1rem;
-          border-top: 1px solid var(--border, #334155);
+          border-top: 1px solid var(--line, #334155);
           flex-wrap: wrap;
           /* Stick to the bottom of the modal while body scrolls so
              the primary action (Update / Restart) remains visible
              however long the release-notes body grows. */
           position: sticky;
           bottom: 0;
-          background: var(--surface, #1e293b);
+          background: var(--ink-raised, #1e293b);
         }
         .btn {
           appearance: none;
           padding: 0.4rem 0.9rem;
-          border: 1px solid var(--border, #334155);
+          border: 1px solid var(--line, #334155);
           background: transparent;
-          color: var(--text, #e2e8f0);
-          border-radius: 4px;
+          color: var(--fg, #e2e8f0);
+          border-radius: var(--radius-xs, 4px);
           cursor: pointer;
           font-size: 0.85rem;
           font-family: inherit;
         }
         .btn:hover { background: rgba(255,255,255,0.04); }
         .btn-primary {
-          background: var(--accent, #f59e0b);
-          border-color: var(--accent, #f59e0b);
-          color: #0f172a;
+          background: var(--accent-e, #f59e0b);
+          border-color: var(--accent-e, #f59e0b);
+          /* DESIGN.md: on-accent text is near-black (#0a0a0a), never
+             white — keeps the amber legible without halation in dark
+             mode and stays correct when the theme flips to light. */
+          color: #0a0a0a;
+          font-weight: 600;
         }
-        .btn-primary:hover { opacity: 0.9; background: var(--accent, #f59e0b); }
-        .btn-ghost { color: var(--text-dim, #94a3b8); border-color: transparent; }
+        .btn-primary:hover { opacity: 0.9; background: var(--accent-e, #f59e0b); }
+        .btn-ghost { color: var(--fg-dim, #94a3b8); border-color: transparent; }
         .spinner {
           display: inline-block;
           width: 20px; height: 20px;
-          border: 2px solid var(--border, #334155);
-          border-top-color: var(--accent, #f59e0b);
+          border: 2px solid var(--line, #334155);
+          border-top-color: var(--accent-e, #f59e0b);
           border-radius: 50%;
           animation: spin 0.9s linear infinite;
           margin-bottom: 0.6rem;


### PR DESCRIPTION
## Summary

Operator-set tariff peak as a hard rule across every dispatch mode, parallel to the physical fuse. Default 0 = disabled — no behaviour change for operators not on a peak tariff. Combined with PR #261's UI work so the slider that already exists actually drives the new rule (instead of being decorative as it was before this branch).

## Backend (commit 6cdd2d2)

When `peak_import_ceiling_w > 0`, every import-side clamp uses `min(fuse − safety, peak)`:
- `applyFuseGuard` import branch scales charge / discharge targets toward zero.
- Joint EV/battery allocator scales EV draw + battery charge proportionally; publishes `state.FuseEVMaxW` for the loadpoint controller to throttle Easee's dynamic max.
- `forceFuseDischarge` induces a transient battery discharge to bridge while the EV ramps down. The bridge is brief by construction — once the EV settles at its throttled rate, predicted grid drops below the ceiling and the battery stops being commanded.

The post-`forceFuseDischarge` republish of `FuseEVMaxW` is skipped when peak is the binding ceiling — otherwise the bridge would lift the EV cap back to "battery covers it forever", defeating the tariff protection.

API: `POST /api/peak_import_ceiling` body `{"peak_import_ceiling_w": N}` (N ≥ 0). Persisted in `state.db`. Surfaced in `/api/status` as `peak_import_ceiling_w`.

Tests cover: default-disabled is no-op, peak forces discharge below the fuse, joint allocator caps EV draw with `BatteryCoversEV=false`, peak above fuse falls back to fuse.

## UI (commit 921012b)

**Slider state machine (auto-revert bug fix):** dirty tracking on the peak-limit and grid-target sliders. The poll handler skips the slider overwrite while the value is dirty (instead of only when the slider has focus), so a drag-and-release no longer reverts before Save is clicked. Save button is disabled when there are no pending changes.

**Peak-limit Off / On toggle:** Off → POSTs `peak_import_ceiling_w: 0` (backend reads 0 = disabled). On → POSTs the slider value. Last non-zero value remembered in localStorage so unchecking and rechecking restores the previous setting.

**Grid + EV bubble modals:** Click the GRID planet in the energy-flow hero → modal hosts the peak-limit slider+toggle and the grid-target slider. Click the EV planet → existing EV modal also hosts the "Let battery cover EV" toggle. Inline cards on the dashboard removed.

**Plan chart:** vertical hover line drawn over the canvas as an overlay div, mirrors the Live chart's `drawHoverOverlay` line.

**Price chart:** subtitle row showing `now / low / high / avg` in öre/kWh, computed against the active horizon and VAT toggle. NOW marker on small screens bumped to font 24, stroke-width 3, with text outline. Axis labels on small screens scaled +50% (10 → 27).

## Out of scope (deferred)

- Export side and per-phase clamp untouched (peak is import-only and aggregate-only — Swedish effekttariff is on import).
- Hour-average vs instantaneous tracking. This PR clamps instantaneously (conservative, safe). A later iteration could project the running hour-average and only intervene when the projected hour heads over the ceiling.
- Existing `peak_shaving` mode + legacy `peak_limit_w` field unchanged — coexists with the new field.
- Plan chart Today / +Tomorrow tabs (needs plan.js render-loop refactor).
- Live chart canvas axes / NOW marker on small screens (canvas text doesn't honor CSS media queries; needs a JS small-screen branch in `renderChart`).

## Test plan

- [x] `make test` (full unit + integration + e2e) passes.
- [x] `node --check` clean for the four UI files.
- [x] Live deploy to dev Pi at v0.69.5-5-g6cdd2d2: `peak_import_ceiling_w` field surfaced, default 0; persists across restart.
- [ ] Live: arm at e.g. 5 kW via the new Off/On toggle in the GRID modal, start a high-power EV charge, watch `state.FuseEVMaxW` drop and `bat_w` briefly bridge.
- [ ] Live: drag the peak slider on a phone, release, wait through one poll cycle — value must persist (no auto-revert).
- [ ] Hover the plan chart — vertical line follows cursor.
- [ ] Price chart subtitle shows the four price stats; toggle VAT / horizon and the numbers update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)