### PR TITLE
feat(selfupdate): gzip-compress snapshot state.db (closes #147)

### DIFF
--- a/go/cmd/ftw-updater/main.go
+++ b/go/cmd/ftw-updater/main.go
@@ -13,10 +13,12 @@
 package main
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -362,9 +364,35 @@ func (s *server) runRollback(snapshotID string, files []string) {
 			slog.Info("rollback: source missing, skipping", "file", f, "err", err)
 			continue
 		}
-		dst := "/app/data/" + f
-		cpArgs := []string{"cp", src, mainServiceName + ":" + dst}
-		if err := s.runner(ctx, nil, cpArgs...); err != nil {
+		// Gzipped entries (state.db.gz from #147) are decompressed
+		// to a sibling temp before docker cp so the container side
+		// receives the same bytes the historic uncompressed path did.
+		// We delete the temp eagerly after the copy regardless of
+		// outcome; a leftover would be cleaned by the next rollback
+		// anyway, but eagerness keeps the snapshots dir tidy.
+		copySrc := src
+		copyName := f
+		var tempToRemove string
+		if strings.HasSuffix(f, ".gz") {
+			plain := strings.TrimSuffix(f, ".gz")
+			tmp := filepath.Join(hostSnapDir, plain+".rollback.tmp")
+			if err := decompressGzipFile(src, tmp); err != nil {
+				slog.Error("rollback gunzip failed", "file", f, "err", err)
+				s.writeState(State{State: "failed", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "gunzip " + f + " failed: " + err.Error()})
+				_ = s.runner(ctx, nil, s.composeArgs("up", "-d", mainServiceName)...)
+				return
+			}
+			copySrc = tmp
+			copyName = plain
+			tempToRemove = tmp
+		}
+		dst := "/app/data/" + copyName
+		cpArgs := []string{"cp", copySrc, mainServiceName + ":" + dst}
+		err := s.runner(ctx, nil, cpArgs...)
+		if tempToRemove != "" {
+			_ = os.Remove(tempToRemove)
+		}
+		if err != nil {
 			// File-swap failure is serious. Try to bring the
 			// service back anyway so the operator isn't stranded.
 			slog.Error("rollback docker cp failed", "file", f, "err", err)
@@ -384,6 +412,38 @@ func (s *server) runRollback(snapshotID string, files []string) {
 		return
 	}
 	s.writeState(State{State: "done", Action: base.Action, Snapshot: base.Snapshot, StartedAt: now, UpdatedAt: time.Now(), Message: "rollback complete"})
+}
+
+// decompressGzipFile expands src (a gzip stream) into dst, refusing to
+// overwrite an existing dst. Used by the rollback path to materialise an
+// uncompressed file from a *.gz snapshot entry before docker cp hands it
+// to the main container, which still expects raw state.db on its side.
+func decompressGzipFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	gz, err := gzip.NewReader(in)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, gz); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return fmt.Errorf("decompress %s: %w", src, err)
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	return out.Close()
 }
 
 func (s *server) writeState(st State) {

--- a/go/cmd/ftw-updater/main_test.go
+++ b/go/cmd/ftw-updater/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -290,6 +291,81 @@ func TestHandleUpdate_RollbackRestoresFiles(t *testing.T) {
 	up := strings.Join(calls[3], " ")
 	if !strings.Contains(up, "up -d") || !strings.Contains(up, "--force-recreate") {
 		t.Errorf("final call must be compose up -d --force-recreate: %v", calls[3])
+	}
+}
+
+// Gzipped state.db.gz from #147 must be decompressed in the snapshot
+// dir before docker cp, and the container destination path must drop
+// the .gz suffix so the main service still finds plain state.db.
+func TestHandleUpdate_RollbackDecompressesGz(t *testing.T) {
+	s, runner := newTestServer(t)
+
+	composeDir := filepath.Dir(s.composeFile)
+	snapID := "2026-04-20T10-00-00Z_0.30.0_to_0.31.0"
+	snapDir := filepath.Join(composeDir, "data", "snapshots", snapID)
+	if err := os.MkdirAll(snapDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// state.db.gz holds the canonical gzip of the bytes "fakedb".
+	const payload = "fakedb"
+	gzPath := filepath.Join(snapDir, "state.db.gz")
+	gzFile, err := os.Create(gzPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(gzFile)
+	if _, err := gw.Write([]byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(snapDir, "config.yaml"), []byte("config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"action":"rollback","snapshot":"` + snapID + `","files":["state.db.gz","config.yaml"]}`
+	req := httptest.NewRequest(http.MethodPost, "/update", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.handleUpdate(rr, req)
+	if rr.Code != 202 {
+		t.Fatalf("rollback 202 expected, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	st := waitForState(t, s, "done")
+	if st.Action != "rollback" || st.Snapshot != snapID {
+		t.Errorf("state should track rollback + snapshot id: %+v", st)
+	}
+
+	calls := runner.snapshot()
+	if len(calls) != 4 {
+		t.Fatalf("want 4 docker calls, got %d: %v", len(calls), calls)
+	}
+	// docker cp arg for the gz entry must reference a decompressed temp
+	// file (NOT the .gz on disk) and target /app/data/state.db, not
+	// /app/data/state.db.gz.
+	cpDB := strings.Join(calls[1], " ")
+	if !strings.Contains(cpDB, mainServiceName+":/app/data/state.db") {
+		t.Errorf("state.db cp must drop .gz suffix on container side: %v", calls[1])
+	}
+	if strings.Contains(cpDB, "state.db.gz") {
+		t.Errorf("state.db cp source must be the decompressed temp, not the .gz: %v", calls[1])
+	}
+	// Decompressed temp must NOT linger after the rollback completes.
+	leftovers, err := filepath.Glob(filepath.Join(snapDir, "*.rollback.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("decompressed rollback temp leaked: %v", leftovers)
+	}
+
+	// config.yaml (non-gz) takes the legacy direct-cp path.
+	cpCfg := strings.Join(calls[2], " ")
+	if !strings.Contains(cpCfg, mainServiceName+":/app/data/config.yaml") {
+		t.Errorf("config.yaml cp should target /app/data/config.yaml: %v", calls[2])
 	}
 }
 

--- a/go/internal/api/api_selfupdate_test.go
+++ b/go/internal/api/api_selfupdate_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"compress/gzip"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -195,18 +197,44 @@ func TestVersionUpdate_CreatesSnapshotBeforeTrigger(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("want 1 snapshot dir, got %d", len(entries))
 	}
-	// Snapshot dir should contain state.db + meta.json (no config.yaml
-	// because ConfigPath was empty).
+	// Snapshot dir should contain state.db.gz + meta.json (no config.yaml
+	// because ConfigPath was empty). The compressed snapshot from #147
+	// also keeps no raw state.db on disk.
 	snapPath := filepath.Join(snapDir, entries[0].Name())
-	for _, f := range []string{"state.db", "meta.json"} {
+	for _, f := range []string{"state.db.gz", "meta.json"} {
 		if _, err := os.Stat(filepath.Join(snapPath, f)); err != nil {
 			t.Errorf("snapshot missing %s: %v", f, err)
 		}
 	}
-	// state.db in the snapshot must be usable.
-	snap, err := state.Open(filepath.Join(snapPath, "state.db"))
+	if _, err := os.Stat(filepath.Join(snapPath, "state.db")); !os.IsNotExist(err) {
+		t.Errorf("raw state.db should not be left in snapshot dir: stat err=%v", err)
+	}
+	// Decompressed state.db.gz must open as a valid SQLite DB and contain
+	// the seeded row.
+	gzFile, err := os.Open(filepath.Join(snapPath, "state.db.gz"))
 	if err != nil {
-		t.Fatalf("snapshot state.db unusable: %v", err)
+		t.Fatalf("open state.db.gz: %v", err)
+	}
+	defer gzFile.Close()
+	gzr, err := gzip.NewReader(gzFile)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gzr.Close()
+	rawPath := filepath.Join(t.TempDir(), "restored.db")
+	rawFile, err := os.Create(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(rawFile, gzr); err != nil {
+		t.Fatalf("decompress state.db.gz: %v", err)
+	}
+	if err := rawFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := state.Open(rawPath)
+	if err != nil {
+		t.Fatalf("decompressed snapshot state.db unusable: %v", err)
 	}
 	if v, ok := snap.LoadConfig("mode"); !ok || v != "planner_self" {
 		t.Errorf("snapshot missing seeded mode config: %q ok=%v", v, ok)

--- a/go/internal/api/snapshots.go
+++ b/go/internal/api/snapshots.go
@@ -90,12 +90,14 @@ func (s *Server) createPreUpdateSnapshot(action, fromVersion, toVersion string) 
 
 	captured := []string{}
 
-	// 1. state.db via VACUUM INTO — point-in-time consistent even under
-	// live writes, no need to pause anything.
-	if err := s.deps.State.SnapshotTo(filepath.Join(dir, "state.db")); err != nil {
+	// 1. state.db via VACUUM INTO + gzip — point-in-time consistent even
+	// under live writes, and ~5–10× smaller on disk than the raw file
+	// (#147). Stored as state.db.gz; the rollback sidecar decompresses
+	// any *.gz entry transparently before docker cp.
+	if err := s.deps.State.SnapshotToCompressed(filepath.Join(dir, "state.db.gz")); err != nil {
 		return SnapshotInfo{}, fmt.Errorf("state snapshot: %w", err)
 	}
-	captured = append(captured, "state.db")
+	captured = append(captured, "state.db.gz")
 
 	// 2. config.yaml — plain file copy. Missing/empty path means the
 	// caller wasn't wired with one; log and move on without failing

--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -7,10 +7,13 @@
 package state
 
 import (
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -78,6 +81,68 @@ func (s *Store) SnapshotTo(dstPath string) error {
 	escaped := strings.ReplaceAll(dstPath, "'", "''")
 	if _, err := s.db.Exec(fmt.Sprintf("VACUUM INTO '%s'", escaped)); err != nil {
 		return fmt.Errorf("snapshot to %s: %w", dstPath, err)
+	}
+	return nil
+}
+
+// SnapshotToCompressed writes a gzip-compressed VACUUM INTO snapshot to
+// dstPath. Internally it materialises an uncompressed temp DB next to
+// dstPath (SQLite's VACUUM INTO can't stream), gzip-streams it into the
+// final path, and removes the temp on success. SQLite hot-tier tables
+// compress 5–10× — the typical 200 MB raw snapshot lands at ~25–40 MB,
+// which keeps the five-slot retention budget under ~200 MB instead of
+// ~1 GB on a mature site.
+//
+// dstPath must not exist. The caller is responsible for the .gz suffix
+// convention; this function does not enforce it but `state.db.gz` is what
+// the rollback path expects.
+func (s *Store) SnapshotToCompressed(dstPath string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("store: snapshot on nil store")
+	}
+	if _, err := os.Stat(dstPath); err == nil {
+		return fmt.Errorf("snapshot to %s: destination exists", dstPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("snapshot to %s: %w", dstPath, err)
+	}
+	tmp := dstPath + ".raw.tmp"
+	// Pre-clean any leftover temp from a prior crashed run — VACUUM INTO
+	// would otherwise refuse with "file exists".
+	_ = os.Remove(tmp)
+	if err := s.SnapshotTo(tmp); err != nil {
+		return err
+	}
+	defer os.Remove(tmp)
+
+	in, err := os.Open(tmp)
+	if err != nil {
+		return fmt.Errorf("open vacuum temp: %w", err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("create gz dst: %w", err)
+	}
+	gz := gzip.NewWriter(out)
+	if _, err := io.Copy(gz, in); err != nil {
+		_ = gz.Close()
+		_ = out.Close()
+		_ = os.Remove(dstPath)
+		return fmt.Errorf("gzip snapshot: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dstPath)
+		return fmt.Errorf("gzip close: %w", err)
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dstPath)
+		return fmt.Errorf("gz dst sync: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dstPath)
+		return fmt.Errorf("gz dst close: %w", err)
 	}
 	return nil
 }

--- a/go/internal/state/store_test.go
+++ b/go/internal/state/store_test.go
@@ -1,7 +1,10 @@
 package state
 
 import (
+	"compress/gzip"
 	"context"
+	"io"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -368,6 +371,74 @@ func TestSnapshotToRefusesExistingFile(t *testing.T) {
 	// bug.
 	if err := s.SnapshotTo(dst); err == nil {
 		t.Error("second SnapshotTo to existing path should fail")
+	}
+}
+
+func TestSnapshotToCompressedRoundTrip(t *testing.T) {
+	s := freshStore(t)
+	if err := s.SaveConfig("mode", "planner_self"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveTelemetry("ferroamp:battery", `{"w":1500,"soc":0.42}`); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	gzPath := filepath.Join(dir, "state.db.gz")
+	if err := s.SnapshotToCompressed(gzPath); err != nil {
+		t.Fatalf("SnapshotToCompressed: %v", err)
+	}
+
+	// Temp file from VACUUM INTO must not be left behind.
+	if _, err := os.Stat(gzPath + ".raw.tmp"); !os.IsNotExist(err) {
+		t.Errorf("vacuum temp leaked next to snapshot: err=%v", err)
+	}
+
+	// Decompressing the snapshot to a sibling file must yield a valid
+	// SQLite DB containing the seeded rows.
+	gzFile, err := os.Open(gzPath)
+	if err != nil {
+		t.Fatalf("open gz snapshot: %v", err)
+	}
+	defer gzFile.Close()
+	gzr, err := gzip.NewReader(gzFile)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer gzr.Close()
+	rawPath := filepath.Join(dir, "restored.db")
+	rawFile, err := os.Create(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(rawFile, gzr); err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if err := rawFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := Open(rawPath)
+	if err != nil {
+		t.Fatalf("open decompressed snapshot: %v", err)
+	}
+	t.Cleanup(func() { snap.Close() })
+	if v, ok := snap.LoadConfig("mode"); !ok || v != "planner_self" {
+		t.Errorf("decompressed snapshot missing config row: got %q ok=%v", v, ok)
+	}
+	if v, ok := snap.LoadTelemetry("ferroamp:battery"); !ok || v != `{"w":1500,"soc":0.42}` {
+		t.Errorf("decompressed snapshot missing telemetry row: got %q ok=%v", v, ok)
+	}
+}
+
+func TestSnapshotToCompressedRefusesExistingFile(t *testing.T) {
+	s := freshStore(t)
+	gzPath := filepath.Join(t.TempDir(), "state.db.gz")
+	if err := s.SnapshotToCompressed(gzPath); err != nil {
+		t.Fatalf("first compressed snapshot: %v", err)
+	}
+	if err := s.SnapshotToCompressed(gzPath); err == nil {
+		t.Error("second SnapshotToCompressed to existing path should fail")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #147. Pre-update snapshots used to land at ~200 MB raw on a mature site, making the five-slot retention budget ~1 GB on disk. SQLite's hot-tier tables compress 5–10× with gzip, so we now `VACUUM INTO` a temp file and gzip-stream it into `snapshots/<id>/state.db.gz`. Expected steady-state on the same site: ~25–40 MB per snapshot, ~150–200 MB total for five slots.

## What changes

- **`state.SnapshotToCompressed(dst)`** (`go/internal/state/store.go`) — wraps the existing `SnapshotTo` (which can't stream — SQLite's `VACUUM INTO` requires a file path) with a gzip stream into the final `.gz` path. The intermediate raw temp is removed on success and on every error path. Refuses to overwrite an existing destination, matching `SnapshotTo`.
- **`Server.createPreUpdateSnapshot`** (`go/internal/api/snapshots.go`) now writes `state.db.gz` and records that name in `meta.json#files`, so the existing `meta.Files`-driven rollback flow picks up the new format with no code change in `selfupdate.TriggerRollback`.
- **`ftw-updater` rollback** (`go/cmd/ftw-updater/main.go`) — for each entry in `Files` that ends with `.gz`, decompress to a sibling `<plain>.rollback.tmp` in the snapshot dir, `docker cp` that into the container at `/app/data/<plain>` (suffix stripped), then unconditionally remove the temp. Files without `.gz` take the legacy direct-cp path unchanged, so older snapshots still restore.

The schema version in `SnapshotMeta` doesn't change because nothing in the snapshot dir layout is renamed — the file list is data, and readers already iterate it.

## Tests

- `state.TestSnapshotToCompressedRoundTrip` — gzip → gunzip → reopen, asserts seeded rows survive and the raw temp is cleaned up.
- `state.TestSnapshotToCompressedRefusesExistingFile` — second call to the same path errors instead of stomping.
- `ftw-updater.TestHandleUpdate_RollbackDecompressesGz` — end-to-end: a `state.db.gz` entry in the snapshot is decompressed, `docker cp` targets `/app/data/state.db` (no `.gz` on the container side), and no `*.rollback.tmp` leaks after the rollback completes.
- `api.TestVersionUpdate_CreatesSnapshotBeforeTrigger` updated to look for `state.db.gz` and assert that the raw `state.db` is NOT left next to it. The test also gunzips the snapshot in-process and reopens it as a `state.Store` to prove the bytes round-trip.

## Verified

- `go build ./...` clean
- `go vet ./internal/state/ ./internal/api/ ./cmd/ftw-updater/` clean
- `go test ./... -count=1 -short` — full module green (state, api, ftw-updater + e2e)

## Test plan

- [x] Unit tests for the new compressed snapshot path.
- [x] Unit test for the rollback decompression path.
- [x] Existing pre-update snapshot test updated for the new filename.
- [ ] On a real device: run a self-update, verify `du -sh snapshots/` is ~5–10× smaller than before; trigger a rollback, verify the main service comes up on the restored state.

## Out of scope

- Migrating older `state.db` (uncompressed) snapshots already on disk. Existing snapshots stay valid because the rollback path falls through to the legacy direct-cp branch when the file list lacks `.gz` entries; we don't rewrite history.
- The "sidecar-free" preference from the issue stays: `gzip` is stdlib, no new dependency.

https://claude.ai/code/session_01SQtNeXFhRoEiwjLghE69KR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQtNeXFhRoEiwjLghE69KR)_