### PR TITLE
fix(control,pixii): stop self-flap when site-meter driver IS a battery

### DIFF
--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -387,6 +387,9 @@ end
 
 local function write_setpoint_w(pixii_w)
     local hi, lo = encode_i32_be(pixii_w)
+    host.log("info", "Pixii: modbus_write_multi addr=" .. REG_SETPOINT_HI
+        .. " hi=" .. tostring(hi) .. " lo=" .. tostring(lo)
+        .. " (pixii_w=" .. tostring(pixii_w) .. ")")
     local err = host.modbus_write_multi(REG_SETPOINT_HI, { hi, lo })
     if err ~= nil and err ~= "" then
         host.log("warn", "Pixii: setpoint write failed: " .. tostring(err))
@@ -403,7 +406,7 @@ end
 local function set_battery_power(power_w)
     -- Flip EMS → generator frame.
     local pixii_w = -power_w
-    host.log("debug", "Pixii: setpoint ems_w=" .. tostring(power_w)
+    host.log("info", "Pixii: setpoint ems_w=" .. tostring(power_w)
         .. " pixii_w=" .. tostring(pixii_w))
     return write_setpoint_w(pixii_w)
 end

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1399,6 +1399,19 @@ func main() {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
 					"driver", ctrl.SiteMeterDriver)
 				for _, n := range reg.Names() {
+					// Skip the site-meter driver itself: when it's both
+					// the meter AND a battery (e.g. Pixii), its meter
+					// going stale is usually because its own modbus poll
+					// stalled. Writing setpoint 0 into that same hung
+					// session disrupts whatever it was already doing
+					// and creates a flap loop — the symptom the user
+					// actually sees is the battery cutting in/out
+					// every minute. The protection rationale (don't
+					// charge from a stale grid signal) only applies to
+					// OTHER batteries, not the meter owner itself.
+					if n == ctrl.SiteMeterDriver {
+						continue
+					}
 					_ = reg.SendDefault(ctx, n)
 				}
 				continue


### PR DESCRIPTION
## Summary

When the configured site-meter driver also owns a battery (e.g. Pixii PowerShaper), an occasional ~30 s modbus poll stall on its side ages the meter telemetry past the watchdog timeout. The site-meter-stale safety in `main.go`'s control loop then writes `setpoint 0` to **all** drivers — including the meter owner itself — and the inverter flaps in/out for as long as the stall lasts.

## Live evidence (forty-two.watts on a Pixii site, 2026-05-09)

```
site meter telemetry stale — idling batteries this cycle  driver=pixii
site meter telemetry stale — idling batteries this cycle  driver=pixii
[...35 seconds, every dispatch tick...]
Pixii: setpoint ems_w=-2324 pixii_w=2324    ← planner had been ramping discharge
Pixii: watchdog → setpoint 0                ← self-flap from main.go:1402
Pixii: setpoint ems_w=-2122 pixii_w=2122    ← resume after meter recovers
```

The defensive idle is correct for **other** batteries (don't charge from a stale grid signal), but counterproductive against the meter owner: the 0-setpoint write contends with the same hung modbus session that's causing the staleness, and disrupts whatever setpoint the inverter was already executing.

## Fix

`main.go:1393-1410` — skip the site-meter driver itself in the `SendDefault` loop. Other batteries still get the safety idle; the meter owner keeps its current setpoint and recovers naturally when the next poll succeeds.

## Driver-side log polish

`drivers/pixii.lua:406` — bump the setpoint diagnostic log from \`debug\` → \`info\`. Was essential for visualising this flap (the \`Pixii: watchdog → setpoint 0\` line is what made it diagnose-able). Cost is one log line per ~5 s tick — well below noise floor — and any operator filing a bug now sees the exact register/value sequence on the wire.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/control/\` passes (existing dispatch + watchdog tests)
- [x] Live verified on the affected Pi:
  - 90 s post-fix: zero \`site meter telemetry stale\` warnings
  - \`manual_hold discharge 4 kW\` ramps cleanly: -1031 → -1374 → -2277 → -3440 → -4000 W (held 15 s)
  - \`manual_hold charge 3 kW\` ramps cleanly: +771 → +1293 → +1813 → +2457 → +3000 W (held 20 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)