### PR TITLE
feat(drivers): auto-include config.host in HTTP allowed_hosts

### DIFF
--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -124,7 +126,8 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 	if cfg.Capabilities.HTTP != nil {
 		env.WithHTTP()
-		if hosts := cfg.Capabilities.HTTP.AllowedHosts; len(hosts) > 0 {
+		hosts := mergeAllowedHosts(cfg.Capabilities.HTTP.AllowedHosts, cfg.Config)
+		if len(hosts) > 0 {
 			env.WithHTTPAllowedHosts(hosts)
 		}
 	}
@@ -388,6 +391,41 @@ func (r *Registry) RestartByName(ctx context.Context, name string) error {
 	}
 	cfg := rd.cfg
 	return r.Restart(ctx, cfg)
+}
+
+// mergeAllowedHosts returns the explicit allowlist plus any host implied
+// by the driver's free-form config (`host` or `url` keys), deduplicated.
+// Saves the user from listing the same IP under both `config.host` and
+// `capabilities.http.allowed_hosts` — the common foot-gun when a driver
+// only talks to one device.
+func mergeAllowedHosts(explicit []string, drvCfg map[string]any) []string {
+	seen := make(map[string]struct{}, len(explicit)+2)
+	out := make([]string, 0, len(explicit)+2)
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, h := range explicit {
+		add(h)
+	}
+	if drvCfg != nil {
+		if v, ok := drvCfg["host"].(string); ok {
+			add(v)
+		}
+		if v, ok := drvCfg["url"].(string); ok {
+			if u, err := url.Parse(v); err == nil && u.Host != "" {
+				add(u.Host)
+			}
+		}
+	}
+	return out
 }
 
 func findDriver(list []config.Driver, name string) (config.Driver, bool) {

--- a/go/internal/drivers/registry_allowlist_test.go
+++ b/go/internal/drivers/registry_allowlist_test.go
@@ -1,0 +1,81 @@
+package drivers
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeAllowedHosts(t *testing.T) {
+	cases := []struct {
+		name     string
+		explicit []string
+		cfg      map[string]any
+		want     []string
+	}{
+		{
+			name:     "explicit only",
+			explicit: []string{"10.0.0.1"},
+			cfg:      nil,
+			want:     []string{"10.0.0.1"},
+		},
+		{
+			name:     "config.host folded in",
+			explicit: nil,
+			cfg:      map[string]any{"host": "192.168.1.248"},
+			want:     []string{"192.168.1.248"},
+		},
+		{
+			name:     "config.host already listed — no duplicate",
+			explicit: []string{"192.168.1.248"},
+			cfg:      map[string]any{"host": "192.168.1.248"},
+			want:     []string{"192.168.1.248"},
+		},
+		{
+			name:     "config.host adds to explicit list",
+			explicit: []string{"10.0.0.1"},
+			cfg:      map[string]any{"host": "192.168.1.248"},
+			want:     []string{"10.0.0.1", "192.168.1.248"},
+		},
+		{
+			name:     "config.url host extracted",
+			explicit: nil,
+			cfg:      map[string]any{"url": "http://meter.local:8080/api"},
+			want:     []string{"meter.local:8080"},
+		},
+		{
+			name:     "config.host with whitespace trimmed",
+			explicit: nil,
+			cfg:      map[string]any{"host": "  192.168.1.248  "},
+			want:     []string{"192.168.1.248"},
+		},
+		{
+			name:     "non-string host ignored",
+			explicit: []string{"10.0.0.1"},
+			cfg:      map[string]any{"host": 12345},
+			want:     []string{"10.0.0.1"},
+		},
+		{
+			name:     "empty host ignored",
+			explicit: nil,
+			cfg:      map[string]any{"host": ""},
+			want:     []string{},
+		},
+		{
+			name:     "nil cfg returns explicit unchanged",
+			explicit: []string{"a", "b"},
+			cfg:      nil,
+			want:     []string{"a", "b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeAllowedHosts(tc.explicit, tc.cfg)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeAllowedHosts() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Drivers that talk HTTP to one device end up writing the same IP twice in the YAML — once under `config.host` (where the driver reads it) and once under `capabilities.http.allowed_hosts` (where the host's SSRF gate enforces it). Forgetting either one is a silent foot-gun:

```
WARN  Zap: discovery failed: http: host "192.168.1.248" (port 80) not in allowed_hosts (retry in 2000ms)
```

…even though the operator did configure that exact host, just in the wrong block.

## Fix

When wiring the HTTP capability in `registry.Add`, fold the driver's `config.host` (and `config.url`'s host) into the allowlist, deduplicated. The capability still has to be declared at all (no auto-grant of HTTP on drivers that didn't ask for it), so the SSRF surface is unchanged — operators just stop having to repeat themselves.

```yaml
# before — error-prone double declaration
- name: zap
  capabilities:
    http:
      allowed_hosts: [192.168.1.248]   # easy to forget
  config:
    host: 192.168.1.248

# after — config.host is enough
- name: zap
  capabilities:
    http: {}                            # still required to grant the cap
  config:
    host: 192.168.1.248
```

`mergeAllowedHosts()`:
- preserves explicit `allowed_hosts` entries verbatim (order + content)
- folds in `cfg.Config["host"]` (string) when present
- folds in `cfg.Config["url"]`'s `url.URL.Host` when parseable
- skips empty / whitespace-only / non-string values
- dedups so the explicit entry wins when both sources agree

## Test plan
- [x] 9-case unit test in `registry_allowlist_test.go` covers each path + nil-cfg no-op
- [x] Existing HTTP allowlist tests (\`TestLuaHTTPAllowlistEnforcement\`, redirect-target test, capability-not-granted test) all still pass
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)