### PR TITLE
fix(control): clamp legacy PI dispatch against live meter

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2250,3 +2250,78 @@ func TestBatteryManualHoldBypassesHoldoff(t *testing.T) {
 		t.Errorf("got %f, want 1500", targets[0].TargetW)
 	}
 }
+
+// ---- Meter clamp on the legacy PI dispatch arm ----
+//
+// The reactive PI path commits a charge/discharge magnitude based on
+// gridW vs GridTargetW. When the upstream load forecast (or the
+// operator slider) is wrong, PI can demand a battery action that would
+// flip the meter past zero in the opposite direction — discharging
+// more than the site imports (causing unwanted export), or charging
+// from grid when the site is already importing. The live-meter clamp
+// inside the default arm caps |targetTotal| by the current grid
+// magnitude in the matching direction.
+
+func TestMeterClampStopsExportOnLoadOverPrediction(t *testing.T) {
+	// Live meter: importing +2000 W (small house load).
+	// Battery: currently discharging at -5000 W (forecast said load was
+	// much higher than reality). Reactive PI in ModeSelfConsumption will
+	// want to continue discharging hard to drive gridW → 0, but doing so
+	// would flip the meter into export. The clamp must cap the total
+	// battery target at -|rawGridW| = -2000.
+	store := seedStore(2000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -5000, 0.6},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000 // big so slew doesn't mask the clamp
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	var sum float64
+	for _, tg := range targets {
+		sum += tg.TargetW
+	}
+	// Magnitude of discharge must not exceed live import (2000 W).
+	if sum < -2000-1e-6 {
+		t.Errorf("meter clamp should cap discharge at -|rawGridW|=-2000, got sum=%f", sum)
+	}
+	// Direction sanity: should still be discharging (or zero), never
+	// charging when importing.
+	if sum > 0 {
+		t.Errorf("import case should not produce a charge command, got sum=%f", sum)
+	}
+}
+
+func TestMeterClampStopsImportOnLoadUnderPrediction(t *testing.T) {
+	// Live meter: importing +1000 W. Battery idle. Operator (or planner)
+	// has set GridTargetW = -5000 (wants to export 5 kW), so the PI will
+	// demand a large positive (charge) correction. That command would
+	// pull additional power from the grid, deepening the import — the
+	// opposite of what self_consumption should ever do. Since the meter
+	// is importing, charge headroom is zero, so the clamp must zero the
+	// battery total.
+	store := seedStore(1000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(-5000, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	var sum float64
+	for _, tg := range targets {
+		sum += tg.TargetW
+	}
+	// With the site already importing, the clamp drops charge headroom
+	// to zero. Sum must not exceed 0 (allow a tiny tolerance for fp).
+	if sum > 1e-6 {
+		t.Errorf("meter clamp should zero charge when importing, got sum=%f", sum)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -794,6 +794,55 @@ func ComputeDispatch(
 		}
 		out := state.PI.Update(piMeasurement)
 		totalCorrection = out.Output
+
+		// Live-meter clamp on the legacy PI path: plan decides charge or
+		// discharge direction; the meter decides magnitude. Prevents the
+		// load-twin over-prediction case where reactive PI commands a
+		// discharge larger than the live import. Scoped to this default
+		// arm only — manualHold, useEnergyPath, and plannerSelfIdleGate
+		// each have their own contracts that intentionally cross the
+		// zero-grid line.
+		//
+		// Deadband (state.GridToleranceW) is a threshold (do not fire
+		// below it), not a haircut (do not subtract from the headroom):
+		// the deadband already gates entry to this arm at line 763.
+		targetTotal := currentTotal + totalCorrection
+		dead := state.GridToleranceW
+		var allowed float64
+		switch {
+		case targetTotal > 0: // plan says charge → cap at current export
+			headroom := -rawGridW
+			if headroom < dead {
+				headroom = 0
+			}
+			if targetTotal > headroom {
+				allowed = headroom
+			} else {
+				allowed = targetTotal
+			}
+		case targetTotal < 0: // plan says discharge → cap at current import
+			headroom := rawGridW
+			if headroom < dead {
+				headroom = 0
+			}
+			if -targetTotal > headroom {
+				allowed = -headroom
+			} else {
+				allowed = targetTotal
+			}
+		default:
+			allowed = 0
+		}
+		if allowed != targetTotal {
+			slog.Warn("dispatch: meter clamp reduced battery target",
+				"requested_total_w", targetTotal,
+				"clamped_total_w", allowed,
+				"raw_grid_w", rawGridW,
+				"current_total_w", currentTotal,
+				"deadband_w", dead,
+				"mode", string(effectiveMode))
+		}
+		totalCorrection = allowed - currentTotal
 	}
 
 	// ---- Joint fuse-budget allocator ----


### PR DESCRIPTION
## Summary

**Incident**: load twin predicted 5.4 kW load, actual was 2.1 kW. The reactive PI loop in the legacy `default:` arm of `ComputeDispatch` commanded the battery to discharge at -5 kW; the surplus ~3 kW exported to the grid.

**Fix**: clamp `totalCorrection` against the live grid meter inside the `default:` arm. Plan decides charge/discharge direction; meter decides magnitude.

- New clamp at `dispatch.go:779`, right after `totalCorrection = out.Output`.
- Charge intent: cap at current export. Discharge intent: cap at current import.
- `GridToleranceW` (42 W default) is a **threshold** (don't fire below it), not a haircut (don't subtract from headroom).
- Uses `rawGridW` (physical meter), not the EV-subtracted `gridW`.
- Clamp reduces magnitude or zeros the command; never flips the sign of `totalCorrection`.
- `slog.Warn` on activation with `requested_total_w`, `clamped_total_w`, `raw_grid_w`, `current_total_w`, `deadband_w`, `mode`.

## Scope is structural

The clamp lives inside the `default:` arm only, so the other branches keep their codified contracts:

- `manualHold` — operator override executes exactly.
- `useEnergyPath` (planner_arbitrage / planner_cheap) — Wh-budgeted slots cross the zero-grid line on purpose; that's the arbitrage product.
- `plannerSelfIdleGate` — must drive to 0 regardless of grid.

No extra boolean guard required. An earlier universal version of this clamp regressed 14 existing tests precisely because it touched those paths.

## Why not duplicate an existing clamp

`docs/safety.md` enumerates seven clamps. None cover this risk:

- Fuse guard fires only above the fuse rating (~11-25 kW); 3 kW unwanted export is well under.
- `applyPlanSignFloor` protects against sign disagreement, not magnitude with matching signs.
- Slew slows the ramp toward a bad target but does not stop it.

This is a new, quantifiable risk — load-twin / forecast error within fuse headroom.

## Tests

- `TestMeterClampStopsExportOnLoadOverPrediction` reproduces the incident: meter +2 kW, battery -5 kW, `ModeSelfConsumption`. Asserts total discharge does not exceed live import.
- `TestMeterClampStopsImportOnLoadUnderPrediction` mirrors: meter +1 kW, plan demands large charge. Asserts charge stays at zero (no import headroom).

## Test plan

- [x] `cd go && go test ./internal/control/...` → 113/113 (was 111 + 2 new)
- [x] `make test` → 29/29 packages, e2e 26.9 s
- [x] `go vet ./...` clean
- [x] `TestSlewRespectsRateWhenTracking` still passes (was the canary for the threshold-vs-haircut bug)
- [ ] Field-tester rig: confirm Live chart no longer shows surprise exports on the next load-twin over-prediction.

## Saturation-feedback path closed

PI consumes `gridW` (live meter), not the clamped command, so the loop opens naturally. Slew anchors on `SmoothedW`. Saturation curves observe battery `SmoothedW` with `MinSatSeedW=1000` guard. No path replicates the saturation-curve feedback bug from `docs/safety.md`.

## Follow-ups (out of scope)

- Add a line to `go/internal/control/CLAUDE.md` "What NOT to do": *"Do NOT hoist the meter clamp out of the `default:` branch."* (Prevents the next contributor from re-triggering the 14 regressions.)
- Add this clamp as the 8th entry in `docs/safety.md`.
- Operational watch: PI integral windup under persistent clamp activation is bounded by `IntegralLimit=3000` and was explicitly accepted; flag in field telemetry if slow unwind shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)