### PR TITLE
feat(loadpoint): EV schedules + bat-SoC surplus unlock + Easee surplus-only fixes

### DIFF
--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -59,6 +59,22 @@ local pending_amp_resend = false
 local pending_amp_resend_at_ms = 0
 local last_amps_set = nil
 
+-- paused_state tracks whether the LAST command we successfully sent was
+-- ev_pause. Easee's REST API has no way to query "are you currently
+-- in user-pause" — op_mode 2 ("awaiting start") covers both "paused"
+-- and "plugged in but car hasn't started a session yet". Without this
+-- flag, after a controller pause + re-offer, we'd write
+-- dynamicChargerCurrent=6 successfully but the contactor stays open
+-- because we never sent resume_charging. We saw this in the field as
+-- "easee_a=6, easee_chg=false, ev_w=0, reason=100/52" stuck states.
+local paused_state = false
+
+-- command_stalled_since_ms tracks when we last wrote a non-zero amps
+-- offer that did NOT translate into actual charging. Used to surface
+-- a derived diagnostic for the controller / UI so a stuck Easee
+-- (firmware error, EV-side reject) is observable rather than silent.
+local command_stalled_since_ms = 0
+
 -- Easee charger physical limits. These are the manufacturer's hard
 -- bounds, not operator preferences — `dynamicChargerCurrent` written
 -- below the minimum is silently rejected by the unit (returns success
@@ -303,7 +319,13 @@ local REASON_LABELS = {
     [79]  = "car not drawing current",
     [80]  = "current ramping",
     [81]  = "limited by car",
-    [100] = "undefined error",
+    -- Easee's public enumeration doesn't define 100. Field observation:
+    -- we see it when the EV is the side rejecting the offer (Tesla
+    -- charge-on-solar window, charge limit reached, scheduled charging
+    -- still active, transient handshake hiccup). Labelling it
+    -- "undefined error" misleads operators into chasing a charger
+    -- problem when the wallbox is fine.
+    [100] = "EV not accepting current",
 }
 
 local email, password, configured_max_a
@@ -473,6 +495,26 @@ function driver_poll()
         actual_amps_per_phase = power_w / vv / phases
     end
 
+    -- command_stalled: true when we've been offering >0 A for >30 s but
+    -- the charger isn't drawing AND Easee is reporting an EV-side or
+    -- "max dynamic too low" reason. Lets the controller / UI tell the
+    -- difference between "EV declined" (legitimate, e.g. Tesla SoC
+    -- limit reached) and "wallbox accepted but contactor stuck"
+    -- (needs operator attention). Note: connected==true is required so
+    -- a disconnected cable doesn't latch the flag.
+    local command_stalled = false
+    local now = host.millis()
+    local stalled_reason = (reason_code == 52) or (reason_code == 53) or (reason_code == 100)
+    if connected and (last_amps_set or 0) > 0 and not charging and stalled_reason then
+        if command_stalled_since_ms == 0 then
+            command_stalled_since_ms = now
+        elseif (now - command_stalled_since_ms) >= 30000 then
+            command_stalled = true
+        end
+    else
+        command_stalled_since_ms = 0
+    end
+
     host.emit("ev", {
         w                       = power_w,
         connected               = connected,
@@ -487,6 +529,7 @@ function driver_poll()
         max_a                   = dyn_current,                 -- last-set dynamic limit (echoes our write, may lag)
         actual_amps_per_phase   = actual_amps_per_phase,       -- live per-phase A derived from totalPower
         phases                  = phases,                      -- our committed phase count (1 or 3)
+        command_stalled         = command_stalled,             -- offer>0 but contactor open >30s on stall reason
     })
 
     -- Defense against Easee's post-phaseMode reset of dynamicChargerCurrent
@@ -540,11 +583,17 @@ function driver_command(action, power_w, cmd)
     if not charger_serial or not ensure_auth(email, password) then return false end
 
     if action == "ev_start" then
-        return post_command("/commands/start_charging")
+        local ok = post_command("/commands/start_charging")
+        if ok then paused_state = false end
+        return ok
     elseif action == "ev_pause" then
-        return post_command("/commands/pause_charging")
+        local ok = post_command("/commands/pause_charging")
+        if ok then paused_state = true end
+        return ok
     elseif action == "ev_resume" then
-        return post_command("/commands/resume_charging")
+        local ok = post_command("/commands/resume_charging")
+        if ok then paused_state = false end
+        return ok
     elseif action == "ev_set_current" then
         -- Driver-level phase decision: read the operator's preferences
         -- + site fuse from the cmd, decide 1Φ vs 3Φ here based on
@@ -596,6 +645,25 @@ function driver_command(action, power_w, cmd)
             if phase_changed then
                 pending_amp_resend = true
                 pending_amp_resend_at_ms = now_ms + 5000
+            end
+            -- Auto-resume after pause. The controller's contract used
+            -- to be: ev_pause → (later) ev_resume → ev_set_current.
+            -- In practice the controller drops ev_resume in some
+            -- transitions and just re-issues ev_set_current with a
+            -- non-zero offer — Easee accepts the new
+            -- dynamicChargerCurrent but the contactor stays open
+            -- because pause is still active (op_mode=2,
+            -- reason_no_current=52 or 100, ev_w=0). Defensively
+            -- send resume_charging when we know we're paused and
+            -- the new offer is > 0. Idempotent on the Easee side;
+            -- a failure here doesn't fail the command (the offer
+            -- itself succeeded, controller will retry next tick).
+            if amps > 0 and paused_state then
+                if post_command("/commands/resume_charging") then
+                    paused_state = false
+                    host.log("info", "Easee: auto-resumed after pause (offer=" ..
+                        tostring(amps) .. " A)")
+                end
             end
         end
         return err == nil

--- a/go/cmd/forty-two-watts/bootstrap.go
+++ b/go/cmd/forty-two-watts/bootstrap.go
@@ -140,38 +140,43 @@ func runBootstrap(configPath, webDir, driverDir string) {
 		writeBootstrapJSON(w, 200, selfUpdater.Status())
 	})
 
-	// POST /api/ev/chargers — authenticate with an EV cloud provider and
-	// list chargers. Mirror of the full-app handler so the setup wizard
-	// can offer a picker instead of asking the operator to transcribe a
-	// serial. No state store here, so password comes only from the body
-	// (no fallback to the persisted ev_charger.password).
+	// GET /api/ev/providers — descriptor list for the wizard's field
+	// renderer. Mirrors the full-app endpoint.
+	mux.HandleFunc("GET /api/ev/providers", func(w http.ResponseWriter, r *http.Request) {
+		writeBootstrapJSON(w, 200, evcloud.Describe())
+	})
+
+	// POST /api/ev/chargers — probe a provider for the chargers reachable
+	// from the supplied config. Mirror of the full-app handler so the
+	// setup wizard can offer a picker instead of asking the operator to
+	// transcribe a serial. No state store here, so password (when
+	// required) comes only from the body — no fallback to the persisted
+	// ev_charger_password.
 	mux.HandleFunc("POST /api/ev/chargers", func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			Provider string `json:"provider"`
-			Email    string `json:"email"`
-			Password string `json:"password"`
-		}
-		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		var cfg config.EVCharger
+		if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&cfg); err != nil {
 			writeBootstrapJSON(w, 400, map[string]string{"error": "invalid request"})
 			return
 		}
-		if req.Provider == "" {
-			req.Provider = "easee"
+		cfg.Normalize()
+		if cfg.Provider == "" {
+			cfg.Provider = "easee"
 		}
-		if req.Email == "" {
-			writeBootstrapJSON(w, 400, map[string]string{"error": "email required"})
-			return
-		}
-		if req.Password == "" {
-			writeBootstrapJSON(w, 400, map[string]string{"error": "password required"})
-			return
-		}
-		p, err := evcloud.Get(req.Provider)
+		p, err := evcloud.Get(cfg.Provider)
 		if err != nil {
 			writeBootstrapJSON(w, 400, map[string]string{"error": err.Error()})
 			return
 		}
-		chargers, err := p.ListChargers(req.Email, req.Password)
+		desc := p.Describe()
+		if err := cfg.Validate(); err != nil {
+			writeBootstrapJSON(w, 400, map[string]string{"error": err.Error()})
+			return
+		}
+		if desc.NeedsAuth && cfg.Password == "" {
+			writeBootstrapJSON(w, 400, map[string]string{"error": "password required"})
+			return
+		}
+		chargers, err := p.ListChargers(&cfg)
 		if err != nil {
 			writeBootstrapJSON(w, 502, map[string]string{"error": err.Error()})
 			return

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -750,10 +750,45 @@ func main() {
 				if initSoC > maxPct {
 					maxPct = initSoC
 				}
+				// Defer grid-funded EV planning when the deadline lies
+				// past the last published price slot AND is more than ~3 h
+				// out. Without this, MPC commits today's afternoon grid
+				// (today's prices are confirmed) instead of waiting for
+				// tomorrow's pre-dawn slots (typically published ~13:00 UTC
+				// for next-day Nordpool). The user-facing intent is "burn
+				// surplus PV during day, only plan grid at night when the
+				// real cheap window is known". Setting LoadpointSpec.SurplusOnly
+				// makes MPC's DP refuse grid-import EV actions; the runtime
+				// loadpoint controller still grabs PV via the bat-SoC unlock
+				// path. Once tomorrow's prices land, MPC's next replan
+				// rebuilds the spec without this guard and proper grid
+				// planning kicks in.
+				deferGridPlan := false
+				if priceSvc != nil {
+					end := time.Now().Add(72 * time.Hour)
+					pts, _ := priceSvc.Load(time.Now().UnixMilli(), end.UnixMilli())
+					var latestEnd time.Time
+					for _, p := range pts {
+						slotEnd := time.UnixMilli(p.SlotTsMs).Add(time.Duration(p.SlotLenMin) * time.Minute)
+						if slotEnd.After(latestEnd) {
+							latestEnd = slotEnd
+						}
+					}
+					if !latestEnd.IsZero() &&
+						st.TargetTime.After(latestEnd) &&
+						time.Until(st.TargetTime) > 3*time.Hour {
+						deferGridPlan = true
+					}
+				}
 				slog.Debug("mpc: loadpoint spec",
 					"id", st.ID, "soc_pct", initSoC, "soc_source", socSource,
 					"target_pct", st.TargetSoCPct, "target_slot", targetSlot,
-					"max_pct", maxPct, "vehicle_limit_pct", vehicleChargeLimit)
+					"max_pct", maxPct, "vehicle_limit_pct", vehicleChargeLimit,
+					"defer_grid_plan", deferGridPlan)
+				if deferGridPlan {
+					slog.Info("mpc: LP grid-funded planning deferred — target past published prices",
+						"lp", st.ID, "target", st.TargetTime, "hours_to_target", time.Until(st.TargetTime).Hours())
+				}
 				return &mpc.LoadpointSpec{
 					ID:              st.ID,
 					CapacityWh:      capWh,
@@ -767,7 +802,10 @@ func main() {
 					MaxChargeW:      st.MaxChargeW,
 					AllowedStepsW:   st.AllowedStepsW,
 					ChargeEfficiency: 0.9,
-					SurplusOnly:     st.SurplusOnly,
+					// Either operator-configured surplus_only OR our
+					// "wait for tomorrow's prices" defer triggers MPC's
+					// no-grid constraint for this LP.
+					SurplusOnly: st.SurplusOnly || deferGridPlan,
 				}
 			}
 			return nil

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1058,12 +1058,16 @@ func main() {
 			// has taken its share: -gridW + max(0, -batW) (battery
 			// counts only if it's discharging, contributing to
 			// site supply).
+			// A bat-SoC-armed loadpoint is just as much a "PV-priority"
+			// claimant as a configured surplus_only LP — both want PV
+			// routed to the EV ahead of the home battery. Counting
+			// either via the controller's combined view (configured OR
+			// armed) keeps the flap-avoidance protection symmetric and
+			// closes the loophole where an armed LP would inflate the
+			// apparent surplus by the battery's PV-charge rate.
 			surplusOnlyActive := false
-			for _, st := range lpMgr.States() {
-				if st.SurplusOnly {
-					surplusOnlyActive = true
-					break
-				}
+			if lpController != nil && lpController.AnyLoadpointSurplusActive() {
+				surplusOnlyActive = true
 			}
 			if surplusOnlyActive && batW > 0 {
 				batW = 0

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -313,6 +313,45 @@ func main() {
 		lpMgr.Load(buildLoadpointConfigs(cfg.Loadpoints))
 		slog.Info("loadpoints configured", "count", len(cfg.Loadpoints))
 	}
+	// Persist operator schedules in the existing state.config k/v.
+	// One row per LP keyed `loadpoint_schedule:<id>`. Clearing a
+	// schedule writes the empty JSON ("{}"), which HydrateSchedules
+	// treats as no-config so a future reload doesn't resurrect it.
+	const lpSchedKeyPrefix = "loadpoint_schedule:"
+	lpMgr.SetScheduleSaver(func(id string, s loadpoint.Schedule) {
+		key := lpSchedKeyPrefix + id
+		if s.Empty() {
+			if err := st.SaveConfig(key, "{}"); err != nil {
+				slog.Warn("failed to clear loadpoint schedule", "lp", id, "err", err)
+			}
+			return
+		}
+		b, err := json.Marshal(s)
+		if err != nil {
+			slog.Warn("failed to marshal loadpoint schedule", "lp", id, "err", err)
+			return
+		}
+		if err := st.SaveConfig(key, string(b)); err != nil {
+			slog.Warn("failed to persist loadpoint schedule", "lp", id, "err", err)
+		}
+	})
+	lpMgr.HydrateSchedules(func(id string) (loadpoint.Schedule, bool) {
+		v, ok := st.LoadConfig(lpSchedKeyPrefix + id)
+		if !ok || v == "" || v == "{}" {
+			return loadpoint.Schedule{}, false
+		}
+		var s loadpoint.Schedule
+		if err := json.Unmarshal([]byte(v), &s); err != nil {
+			slog.Warn("failed to parse persisted loadpoint schedule",
+				"lp", id, "err", err)
+			return loadpoint.Schedule{}, false
+		}
+		return s, !s.Empty()
+	})
+	// Seed any recurring deadlines from boot — without this the first
+	// dispatch tick would race with an empty target_time and might
+	// miss the deadline penalty for ~5 s.
+	lpMgr.RollSchedules(time.Now().UTC())
 
 	// Forward-declared so the hot-reload closure below can push
 	// capacity changes into the running planner. Assigned at line
@@ -1038,6 +1077,30 @@ func main() {
 			// match. Tracked separately to keep this change focused.
 			return -gridW + batW + evW, true
 		})
+
+		// Bat-SoC surplus-unlock: feed the controller a live home-battery
+		// SoC reading so a loadpoint with a `surplus_unlock_bat_soc_pct`
+		// schedule can flip into surplus-snap mode when the battery is
+		// already comfortable. Sums online battery readings; (_, false)
+		// when no battery driver is online so the controller leaves the
+		// arm state untouched (hysteresis preserved across blips).
+		lpController.SetBatSoCProvider(func() (float64, bool) {
+			var total, count float64
+			for _, r := range tel.ReadingsByType(telemetry.DerBattery) {
+				if h := tel.DriverHealth(r.Driver); h == nil || h.Status == telemetry.StatusOffline {
+					continue
+				}
+				if r.SoC == nil || *r.SoC <= 0 {
+					continue
+				}
+				total += *r.SoC
+				count++
+			}
+			if count == 0 {
+				return 0, false
+			}
+			return total / count, true
+		})
 	}
 
 	// ---- Self-update checker ----
@@ -1531,6 +1594,9 @@ func main() {
 			// The per-loadpoint state machine (observe → plan lookup
 			// → snap → send) is owned by loadpoint.Controller so the
 			// main tick stays a thin orchestrator. See issue #172.
+			// Recurring schedules: roll deadlines forward when the
+			// current target_time has passed. Idempotent within a day.
+			lpMgr.RollSchedules(time.Now().UTC())
 			lpController.Tick(ctx, time.Now())
 
 			// ---- Trigger MPC replan on fuse-saturation rising edge ----

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1005,6 +1005,37 @@ func main() {
 				batW += r.SmoothedW
 			}
 			evW := tel.SumOnlineEVW()
+			// Surplus-only EV priority: when any loadpoint is in
+			// surplus-only mode, battery charging power is NOT
+			// available for the EV. The original formula assumed
+			// "if I told the battery to stop, that surplus would
+			// free up for the EV" — but the MPC, even with the
+			// grid-charge ban now in place, may still legitimately
+			// charge the battery from PV surplus. If we hand that
+			// power back to the EV, the controller commands the EV
+			// on, the battery loses its share, the planner re-budgets
+			// the EV down → flap. The truthful surplus for an EV
+			// under surplus-only is what's left AFTER the battery
+			// has taken its share: -gridW + max(0, -batW) (battery
+			// counts only if it's discharging, contributing to
+			// site supply).
+			surplusOnlyActive := false
+			for _, st := range lpMgr.States() {
+				if st.SurplusOnly {
+					surplusOnlyActive = true
+					break
+				}
+			}
+			if surplusOnlyActive && batW > 0 {
+				batW = 0
+			}
+			// Open follow-up: in self-consumption / planner_self mode,
+			// the dispatch PI absorbs PV into the battery before the
+			// EV controller sees it, defeating surplus-only priority.
+			// The MPC arbitrage path is covered by the new mpc.go
+			// feasibility constraint; the self-consumption fallback
+			// needs a battery-charge cap in control/dispatch.go to
+			// match. Tracked separately to keep this change focused.
 			return -gridW + batW + evW, true
 		})
 	}
@@ -1426,7 +1457,23 @@ func main() {
 			for k, v := range capacities { capsSnap[k] = v }
 			capMu.RUnlock()
 
+			// Surplus-only EV reserve: walk all loadpoints and sum
+			// MaxChargeW for any LP that is surplus_only AND has an EV
+			// plugged in. Result is injected into ctrl.EVSurplusOnlyReserveW
+			// so dispatch caps battery charge to leave that much PV
+			// headroom for the EV controller to claim. See
+			// dispatch.go EVSurplusOnlyReserveW + the (energy/legacy) cap
+			// blocks. Computed every tick so toggling surplus_only or
+			// plugging/unplugging an EV takes effect immediately.
+			var evReserveW float64
+			for _, st := range lpMgr.States() {
+				if st.SurplusOnly && st.PluggedIn {
+					evReserveW += st.MaxChargeW
+				}
+			}
+
 			ctrlMu.Lock()
+			ctrl.EVSurplusOnlyReserveW = evReserveW
 			fuseMaxW := ctrl.SiteFuseAmps * ctrl.SiteFuseVoltage * float64(ctrl.SiteFusePhases)
 			targets := control.ComputeDispatch(tel, ctrl, capsSnap, fuseMaxW)
 			ctrlMu.Unlock()

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -749,6 +749,22 @@ func main() {
 				if vehicleChargeLimit > 0 && vehicleChargeLimit < maxPct {
 					maxPct = vehicleChargeLimit
 				}
+				// Effective deadline target: when the operator asked
+				// for 100% but the vehicle (Tesla via TeslaBLEProxy
+				// etc.) is hard-capped at, say, 60%, the DP must plan
+				// against the cap — otherwise the deadline-shortfall
+				// penalty stays elevated forever (the SoC grid maxes
+				// at the cap, can never reach the operator target),
+				// and MPC keeps committing grid charging chasing an
+				// unreachable goal. Cap target_pct to whatever the
+				// car will physically accept.
+				targetPct := st.TargetSoCPct
+				if vehicleChargeLimit > 0 && vehicleChargeLimit < targetPct {
+					targetPct = vehicleChargeLimit
+					slog.Info("mpc: target capped to vehicle charge limit",
+						"lp", st.ID, "operator_target_pct", st.TargetSoCPct,
+						"vehicle_limit_pct", vehicleChargeLimit)
+				}
 				// Guard against degenerate grids: if current SoC > maxPct
 				// (already over target), grow the ceiling to current so
 				// the DP can at least represent it (no charging will be
@@ -812,7 +828,7 @@ func main() {
 					MaxPct:          maxPct,
 					InitialSoCPct:   initSoC,
 					PluggedIn:       true,
-					TargetSoCPct:    st.TargetSoCPct,
+					TargetSoCPct:    targetPct,
 					TargetSlotIdx:   targetSlot,
 					MaxChargeW:      st.MaxChargeW,
 					AllowedStepsW:   st.AllowedStepsW,

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1491,11 +1491,35 @@ func main() {
 			// rules without the control loop knowing about them.
 			bus.Publish(events.HealthTick{Health: tel.AllHealth(), Now: time.Now()})
 
+			// ---- EV dispatch first — independent of the site meter ----
+			// Loadpoint Observe() reads its own telemetry (the EV
+			// charger driver), so it MUST run before the site-meter
+			// staleness guard below — otherwise a missing/stale site
+			// meter silently freezes the LP manager's plugged_in
+			// state, MPC never extends the DP with the EV dimension,
+			// and the operator sees "schedule set but EV never
+			// charges". The surplus-only clamp inside the LP controller
+			// already returns 0 when site surplus is unknown, so this
+			// is safe: bad grid signal → LP paused, but at least the
+			// LP state machine is alive.
+			lpMgr.RollSchedules(time.Now().UTC())
+			lpController.Tick(ctx, time.Now())
+
 			// ---- Safety: site meter stale → idle everything this cycle ----
 			// Otherwise stale grid readings cause one battery to charge another.
+			// Only meaningful when a site meter is actually configured;
+			// without one, IsStale("", DerMeter) is permanently true and
+			// the SendDefault loop below would fire on every tick — and
+			// SendDefault is a blocking send into each driver's cmdCh,
+			// which deadlocks the dispatch loop the first time any
+			// driver's channel buffer fills.
 			ctrlMu.Lock()
-			siteMeterStale := tel.IsStale(ctrl.SiteMeterDriver, telemetry.DerMeter, watchdogTimeout)
+			siteMeterDriver := ctrl.SiteMeterDriver
 			ctrlMu.Unlock()
+			siteMeterStale := false
+			if siteMeterDriver != "" {
+				siteMeterStale = tel.IsStale(siteMeterDriver, telemetry.DerMeter, watchdogTimeout)
+			}
 			if siteMeterStale {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
 					"driver", ctrl.SiteMeterDriver)
@@ -1594,14 +1618,8 @@ func main() {
 				}
 			}
 
-			// ---- EV dispatch: per-loadpoint observe + command ----
-			// The per-loadpoint state machine (observe → plan lookup
-			// → snap → send) is owned by loadpoint.Controller so the
-			// main tick stays a thin orchestrator. See issue #172.
-			// Recurring schedules: roll deadlines forward when the
-			// current target_time has passed. Idempotent within a day.
-			lpMgr.RollSchedules(time.Now().UTC())
-			lpController.Tick(ctx, time.Now())
+			// LP dispatch ran at the top of this tick — see the
+			// "EV dispatch first" block above.
 
 			// ---- Trigger MPC replan on fuse-saturation rising edge ----
 			// The joint allocator (control.dispatch) just throttled

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -656,6 +656,12 @@ func main() {
 	defer loadSvc.Stop()
 	slog.Info("loadmodel started", "peak_w", loadPeakW, "quality", loadSvc.Model().Quality())
 
+	// Forward-declared so the MPC spec builder closure (set below) can
+	// push grid-deferred state into the runtime controller. The
+	// controller itself is constructed further down once its
+	// dependencies (planAdapter, telAdapter, registry) are wired.
+	var lpController *loadpoint.Controller
+
 	// ---- Start MPC planner (optional) ----
 	mpcSvc = buildMPC(cfg, st, tel, capacities)
 	if mpcSvc != nil {
@@ -788,6 +794,15 @@ func main() {
 				if deferGridPlan {
 					slog.Info("mpc: LP grid-funded planning deferred — target past published prices",
 						"lp", st.ID, "target", st.TargetTime, "hours_to_target", time.Until(st.TargetTime).Hours())
+				}
+				// Mirror the deferral into the runtime controller so live
+				// dispatch enforces "no grid import" too. Without this,
+				// MPC's plan would still record a small EV budget per slot
+				// (snapped to forecast surplus); when forecast PV
+				// undershoots reality, the runtime controller would
+				// happily import grid to fulfil the cached plan budget.
+				if lpController != nil {
+					lpController.SetGridDeferred(st.ID, deferGridPlan)
 				}
 				return &mpc.LoadpointSpec{
 					ID:              st.ID,
@@ -922,7 +937,8 @@ func main() {
 	//
 	// Adapters here keep loadpoint independent of mpc/telemetry
 	// (mpc already imports loadpoint — the cycle must go this way).
-	var lpController *loadpoint.Controller
+	// lpController is forward-declared earlier so the MPC spec builder
+	// closure can push grid-deferred state into it.
 	if mpcSvc != nil {
 		planAdapter := func(now time.Time) (loadpoint.Directive, bool) {
 			d, ok := mpcSvc.SlotDirectiveAt(now)

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -2147,15 +2147,42 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	surplusDisabled := false
 	if req.SurplusOnly != nil {
-		if !s.deps.Loadpoints.SetSurplusOnly(id, *req.SurplusOnly) {
+		prev, ok := s.deps.Loadpoints.SetSurplusOnly(id, *req.SurplusOnly)
+		if !ok {
 			writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
 			return
 		}
+		// Disabling surplus_only is a planner regime change: the
+		// terminal SoC credit flips from self-consumption back to the
+		// arbitrage default (much higher), the grid-charge ban lifts,
+		// and the LP may now be eligible for grid-arbitrage scheduling
+		// (when target_soc_pct > 0). Force a synchronous replan with a
+		// tagged reason so the new schedule is in place by the time
+		// this HTTP response returns and the diagnose snapshot records
+		// "why" the plan changed at this timestamp.
+		if prev && !*req.SurplusOnly {
+			surplusDisabled = true
+		}
 	}
-	// Trigger replan so the new target lands in the schedule fast.
 	if s.deps.MPC != nil {
-		go s.deps.MPC.Replan(r.Context())
+		if surplusDisabled {
+			slog.Info("loadpoint surplus_only disabled — forcing replan",
+				"lp", id)
+			// Synchronous + fresh context (the request context dies the
+			// moment we writeJSON). Replan typically completes in
+			// <100ms for current grid sizes; the API caller blocks
+			// briefly and returns to a UI that can immediately fetch
+			// /api/mpc/plan and see the new schedule.
+			s.deps.MPC.ReplanWithReason(context.Background(), "surplus_only_disabled")
+		} else {
+			// Other field changes: replan is helpful but not load-
+			// bearing — kick it off in the background so the API stays
+			// snappy. The goroutine uses a fresh context for the same
+			// reason as above (request ctx cancellation).
+			go s.deps.MPC.ReplanWithReason(context.Background(), "loadpoint_target_changed")
+		}
 	}
 	writeJSON(w, 200, map[string]any{"ok": true})
 }

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -233,6 +234,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/ev/status", s.handleEVStatus)
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
+	s.handle("GET  /api/ev/providers", s.handleEVProviders)
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
 	s.handle("POST /api/loadpoints/{id}/soc", s.handleLoadpointSoC)
@@ -1965,40 +1967,49 @@ func (s *Server) handleEVCommand(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"status": "ok"})
 }
 
-// POST /api/ev/chargers — authenticate with an EV cloud provider and list chargers.
+// GET /api/ev/providers — return the descriptor for every registered EV
+// charger provider. The wizard reads this to decide which transport +
+// auth fields to render for the user's pick.
+func (s *Server) handleEVProviders(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, 200, evcloud.Describe())
+}
+
+// POST /api/ev/chargers — probe a provider for the chargers reachable
+// from the supplied config. Body is the EVCharger shape (provider +
+// transport block + optional auth). For providers that need auth and
+// the body omits Password, we fall back to the persisted
+// ev_charger_password so the operator doesn't have to re-type it when
+// they're just refreshing the picker.
 func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Provider string `json:"provider"`
-		Email    string `json:"email"`
-		Password string `json:"password"`
-	}
-	if err := readJSON(r, &req); err != nil {
+	var cfg config.EVCharger
+	if err := readJSON(r, &cfg); err != nil {
 		writeJSON(w, 400, map[string]string{"error": "invalid request"})
 		return
 	}
-	if req.Provider == "" {
-		req.Provider = "easee"
+	cfg.Normalize()
+	if cfg.Provider == "" {
+		cfg.Provider = "easee"
 	}
-	if req.Email == "" {
-		writeJSON(w, 400, map[string]string{"error": "email required"})
-		return
-	}
-	if req.Password == "" {
-		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
-			req.Password = pw
-		}
-	}
-	if req.Password == "" {
-		writeJSON(w, 400, map[string]string{"error": "password required"})
-		return
-	}
-
-	p, err := evcloud.Get(req.Provider)
+	p, err := evcloud.Get(cfg.Provider)
 	if err != nil {
 		writeJSON(w, 400, map[string]string{"error": err.Error()})
 		return
 	}
-	chargers, err := p.ListChargers(req.Email, req.Password)
+	desc := p.Describe()
+	if desc.NeedsAuth && cfg.Password == "" {
+		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			cfg.Password = pw
+		}
+	}
+	if err := cfg.Validate(); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	if desc.NeedsAuth && cfg.Password == "" {
+		writeJSON(w, 400, map[string]string{"error": "password required"})
+		return
+	}
+	chargers, err := p.ListChargers(&cfg)
 	if err != nil {
 		writeJSON(w, 502, map[string]string{"error": err.Error()})
 		return
@@ -2106,18 +2117,54 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 	// the target the way the legacy client does, pass an explicit
 	// `{"soc_pct": 0, "target_time_ms": 0}` — pointers to zero are
 	// distinct from nil here.
+	// Schedule uses json.RawMessage so the handler can distinguish three
+	// states the regular struct-pointer trick can't: absent (leave alone),
+	// null (clear), or object (set). encoding/json collapses absent/null
+	// to nil for *struct pointers, which would lose the explicit-clear
+	// signal the UI needs.
 	var req struct {
-		SoCPct       *float64 `json:"soc_pct,omitempty"`
-		TargetTimeMs *int64   `json:"target_time_ms,omitempty"`
-		SurplusOnly  *bool    `json:"surplus_only,omitempty"`
+		SoCPct       *float64        `json:"soc_pct,omitempty"`
+		TargetTimeMs *int64          `json:"target_time_ms,omitempty"`
+		SurplusOnly  *bool           `json:"surplus_only,omitempty"`
+		Schedule     json.RawMessage `json:"schedule,omitempty"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		writeJSON(w, 400, map[string]string{"error": err.Error()})
 		return
 	}
-	if req.SoCPct == nil && req.TargetTimeMs == nil && req.SurplusOnly == nil {
+	if req.SoCPct == nil && req.TargetTimeMs == nil && req.SurplusOnly == nil && len(req.Schedule) == 0 {
 		writeJSON(w, 400, map[string]string{"error": "no fields to update"})
 		return
+	}
+
+	// Schedule first: when set, it implies target_soc_pct + target_time
+	// values that SetTarget below will read back, so apply order matters.
+	scheduleChanged := false
+	if len(req.Schedule) > 0 {
+		if bytes.Equal(bytes.TrimSpace(req.Schedule), []byte("null")) {
+			if !s.deps.Loadpoints.ClearSchedule(id) {
+				writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
+				return
+			}
+		} else {
+			var sched loadpoint.Schedule
+			if err := json.Unmarshal(req.Schedule, &sched); err != nil {
+				writeJSON(w, 400, map[string]string{"error": "invalid schedule: " + err.Error()})
+				return
+			}
+			if sched.TimeOfDayMinUTC < 0 || sched.TimeOfDayMinUTC >= 1440 {
+				writeJSON(w, 400, map[string]string{"error": "time_of_day_min_utc must be 0..1439"})
+				return
+			}
+			if !s.deps.Loadpoints.SetSchedule(id, sched) {
+				writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
+				return
+			}
+			// Roll immediately so the upcoming SetTarget read-modify-write
+			// sees the schedule-implied deadline, not stale state.
+			s.deps.Loadpoints.RollSchedules(time.Now().UTC())
+		}
+		scheduleChanged = true
 	}
 	if req.SoCPct != nil || req.TargetTimeMs != nil {
 		// SetTarget always takes both fields, so when the caller
@@ -2176,6 +2223,9 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 			// briefly and returns to a UI that can immediately fetch
 			// /api/mpc/plan and see the new schedule.
 			s.deps.MPC.ReplanWithReason(context.Background(), "surplus_only_disabled")
+		} else if scheduleChanged {
+			slog.Info("loadpoint schedule changed — forcing replan", "lp", id)
+			s.deps.MPC.ReplanWithReason(context.Background(), "loadpoint_schedule_changed")
 		} else {
 			// Other field changes: replan is helpful but not load-
 			// bearing — kick it off in the background so the API stays

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1987,8 +1987,13 @@ func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cfg.Normalize()
+	// Provider must come from the caller. The api stays vendor-agnostic
+	// — the wizard's GET /api/ev/providers enumerates the registry, the
+	// operator picks one, and that choice is what arrives here. Defaulting
+	// to a specific brand would silently couple the api to one vendor.
 	if cfg.Provider == "" {
-		cfg.Provider = "easee"
+		writeJSON(w, 400, map[string]string{"error": "provider required"})
+		return
 	}
 	p, err := evcloud.Get(cfg.Provider)
 	if err != nil {
@@ -2238,8 +2243,8 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST /api/loadpoints/{id}/soc lets the operator correct the
-// inferred vehicle SoC. Easee (and most chargers) are blind to the
-// vehicle's BMS — without a vehicle API integration (Tesla, VW, …)
+// inferred vehicle SoC. Most EV chargers are blind to the
+// vehicle's BMS — without a vehicle-side API integration
 // we have no way to know actual SoC. We infer from
 // `plugin_soc_pct + delivered_wh / capacity`, but if the plug-in
 // anchor was wrong the estimate drifts. This endpoint re-anchors so

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -234,7 +234,6 @@ func (s *Server) routes() {
 	s.handle("GET  /api/ev/status", s.handleEVStatus)
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
-	s.handle("GET  /api/ev/providers", s.handleEVProviders)
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
 	s.handle("POST /api/loadpoints/{id}/soc", s.handleLoadpointSoC)
@@ -1967,49 +1966,40 @@ func (s *Server) handleEVCommand(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"status": "ok"})
 }
 
-// GET /api/ev/providers — return the descriptor for every registered EV
-// charger provider. The wizard reads this to decide which transport +
-// auth fields to render for the user's pick.
-func (s *Server) handleEVProviders(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, 200, evcloud.Describe())
-}
-
-// POST /api/ev/chargers — probe a provider for the chargers reachable
-// from the supplied config. Body is the EVCharger shape (provider +
-// transport block + optional auth). For providers that need auth and
-// the body omits Password, we fall back to the persisted
-// ev_charger_password so the operator doesn't have to re-type it when
-// they're just refreshing the picker.
+// POST /api/ev/chargers — authenticate with an EV cloud provider and list chargers.
 func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
-	var cfg config.EVCharger
-	if err := readJSON(r, &cfg); err != nil {
+	var req struct {
+		Provider string `json:"provider"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := readJSON(r, &req); err != nil {
 		writeJSON(w, 400, map[string]string{"error": "invalid request"})
 		return
 	}
-	cfg.Normalize()
-	if cfg.Provider == "" {
-		cfg.Provider = "easee"
+	if req.Provider == "" {
+		req.Provider = "easee"
 	}
-	p, err := evcloud.Get(cfg.Provider)
+	if req.Email == "" {
+		writeJSON(w, 400, map[string]string{"error": "email required"})
+		return
+	}
+	if req.Password == "" {
+		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			req.Password = pw
+		}
+	}
+	if req.Password == "" {
+		writeJSON(w, 400, map[string]string{"error": "password required"})
+		return
+	}
+
+	p, err := evcloud.Get(req.Provider)
 	if err != nil {
 		writeJSON(w, 400, map[string]string{"error": err.Error()})
 		return
 	}
-	desc := p.Describe()
-	if desc.NeedsAuth && cfg.Password == "" {
-		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
-			cfg.Password = pw
-		}
-	}
-	if err := cfg.Validate(); err != nil {
-		writeJSON(w, 400, map[string]string{"error": err.Error()})
-		return
-	}
-	if desc.NeedsAuth && cfg.Password == "" {
-		writeJSON(w, 400, map[string]string{"error": "password required"})
-		return
-	}
-	chargers, err := p.ListChargers(&cfg)
+	chargers, err := p.ListChargers(req.Email, req.Password)
 	if err != nil {
 		writeJSON(w, 502, map[string]string{"error": err.Error()})
 		return

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -234,6 +234,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/ev/status", s.handleEVStatus)
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)
+	s.handle("GET  /api/ev/providers", s.handleEVProviders)
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
 	s.handle("POST /api/loadpoints/{id}/soc", s.handleLoadpointSoC)
@@ -1966,40 +1967,49 @@ func (s *Server) handleEVCommand(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, map[string]string{"status": "ok"})
 }
 
-// POST /api/ev/chargers — authenticate with an EV cloud provider and list chargers.
+// GET /api/ev/providers — return the descriptor for every registered EV
+// charger provider. The wizard reads this to decide which transport +
+// auth fields to render for the user's pick.
+func (s *Server) handleEVProviders(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, 200, evcloud.Describe())
+}
+
+// POST /api/ev/chargers — probe a provider for the chargers reachable
+// from the supplied config. Body is the EVCharger shape (provider +
+// transport block + optional auth). For providers that need auth and
+// the body omits Password, we fall back to the persisted
+// ev_charger_password so the operator doesn't have to re-type it when
+// they're just refreshing the picker.
 func (s *Server) handleEVChargers(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Provider string `json:"provider"`
-		Email    string `json:"email"`
-		Password string `json:"password"`
-	}
-	if err := readJSON(r, &req); err != nil {
+	var cfg config.EVCharger
+	if err := readJSON(r, &cfg); err != nil {
 		writeJSON(w, 400, map[string]string{"error": "invalid request"})
 		return
 	}
-	if req.Provider == "" {
-		req.Provider = "easee"
+	cfg.Normalize()
+	if cfg.Provider == "" {
+		cfg.Provider = "easee"
 	}
-	if req.Email == "" {
-		writeJSON(w, 400, map[string]string{"error": "email required"})
-		return
-	}
-	if req.Password == "" {
-		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
-			req.Password = pw
-		}
-	}
-	if req.Password == "" {
-		writeJSON(w, 400, map[string]string{"error": "password required"})
-		return
-	}
-
-	p, err := evcloud.Get(req.Provider)
+	p, err := evcloud.Get(cfg.Provider)
 	if err != nil {
 		writeJSON(w, 400, map[string]string{"error": err.Error()})
 		return
 	}
-	chargers, err := p.ListChargers(req.Email, req.Password)
+	desc := p.Describe()
+	if desc.NeedsAuth && cfg.Password == "" {
+		if pw, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			cfg.Password = pw
+		}
+	}
+	if err := cfg.Validate(); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	if desc.NeedsAuth && cfg.Password == "" {
+		writeJSON(w, 400, map[string]string{"error": "password required"})
+		return
+	}
+	chargers, err := p.ListChargers(&cfg)
 	if err != nil {
 		writeJSON(w, 502, map[string]string{"error": err.Error()})
 		return

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -148,17 +148,102 @@ type OCPP struct {
 }
 
 // EVCharger is the high-level EV charger config written by the Settings UI.
-// The backend auto-generates a Lua driver entry from this on startup so
-// users never touch raw driver YAML for their EV charger.
+// Exactly one transport block (HTTP or Modbus) is meaningful per provider —
+// the runtime picks which to populate based on the provider's declared
+// transport in evcloud.Provider.
 //
 // Password is stored in state.db (key "ev_charger_password"), NOT in config.yaml.
 // It is populated at runtime by main.go after loading state and by the API
-// handler on POST /api/config.
+// handler on POST /api/config. Providers that don't need auth (e.g. local
+// Modbus) leave Username + Password empty.
 type EVCharger struct {
-	Provider string `yaml:"provider" json:"provider"` // "easee" (only option for now)
-	Email    string `yaml:"email" json:"email"`
-	Password string `yaml:"-" json:"password"` // persisted in state.db, not YAML
-	Serial   string `yaml:"serial,omitempty" json:"serial,omitempty"`
+	Provider string `yaml:"provider" json:"provider"` // "easee" | "ctek"
+
+	// Connection — populate the block matching the provider's transport.
+	HTTP   *EVChargerHTTP   `yaml:"http,omitempty" json:"http,omitempty"`
+	Modbus *EVChargerModbus `yaml:"modbus,omitempty" json:"modbus,omitempty"`
+
+	// Optional auth — required by cloud HTTP providers like Easee,
+	// unused by local Modbus providers like CTEK.
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	Password string `yaml:"-" json:"password,omitempty"` // persisted in state.db, not YAML
+
+	Serial string `yaml:"serial,omitempty" json:"serial,omitempty"`
+
+	// EmailLegacy preserves backward compatibility with the original
+	// `email:` field. Normalize() copies it into Username if Username
+	// is empty, so configs written before the generalization still load.
+	// New code should always read Username.
+	EmailLegacy string `yaml:"email,omitempty" json:"email,omitempty"`
+}
+
+// EVChargerHTTP is the HTTP/cloud connection block. BaseURL is optional —
+// when empty the provider uses its default (e.g. https://api.easee.com/api).
+type EVChargerHTTP struct {
+	BaseURL string `yaml:"base_url,omitempty" json:"base_url,omitempty"`
+}
+
+// EVChargerModbus is the Modbus/TCP connection block. Port defaults to 502
+// and UnitID defaults to 1 if zero — see provider-specific Validate.
+type EVChargerModbus struct {
+	Host   string `yaml:"host" json:"host"`
+	Port   int    `yaml:"port,omitempty" json:"port,omitempty"`
+	UnitID int    `yaml:"unit_id,omitempty" json:"unit_id,omitempty"`
+}
+
+// Normalize folds the legacy `email:` YAML key into Username and clears
+// it so subsequent writes use the canonical key. Idempotent.
+func (e *EVCharger) Normalize() {
+	if e == nil {
+		return
+	}
+	if e.Username == "" && e.EmailLegacy != "" {
+		e.Username = e.EmailLegacy
+	}
+	e.EmailLegacy = ""
+}
+
+// Validate enforces per-provider shape rules. Password is intentionally
+// not required here — it's loaded from state.db after YAML parse (see
+// main.go's ev_charger_password restore step), so at Validate() time
+// the field may be legitimately empty.
+func (e *EVCharger) Validate() error {
+	if e == nil {
+		return nil
+	}
+	switch e.Provider {
+	case "":
+		return errors.New("ev_charger.provider: required")
+	case "easee":
+		// Username/Password are NOT enforced here. The runtime easee
+		// driver logs + idles when creds are missing, and the API picker
+		// requires both before calling Easee Cloud. Letting a partial
+		// ev_charger block load is the original contract — the wizard
+		// writes provider intent first, then captures creds in a second
+		// API call.
+		if e.Modbus != nil {
+			return errors.New("ev_charger.modbus: not valid for provider easee (HTTP transport)")
+		}
+	case "ctek":
+		if e.Modbus == nil || e.Modbus.Host == "" {
+			return errors.New("ev_charger.modbus.host: required for provider ctek")
+		}
+		if e.Modbus.Port < 0 {
+			return errors.New("ev_charger.modbus.port: must be >= 0")
+		}
+		if e.Modbus.UnitID < 0 || e.Modbus.UnitID > 247 {
+			return errors.New("ev_charger.modbus.unit_id: must be in 0..247")
+		}
+		if e.HTTP != nil {
+			return errors.New("ev_charger.http: not valid for provider ctek (Modbus transport)")
+		}
+		if e.Username != "" || e.Password != "" {
+			return errors.New("ev_charger: username/password not valid for provider ctek")
+		}
+	default:
+		return fmt.Errorf("ev_charger.provider %q: not supported (valid: easee, ctek)", e.Provider)
+	}
+	return nil
 }
 
 // Planner configures the MPC scheduler (optional — disabled if omitted).
@@ -820,6 +905,13 @@ func applyDefaults(c *Config) {
 
 // Validate ensures the config is internally consistent and safe to run with.
 func (c *Config) Validate() error {
+	if c.EVCharger != nil {
+		c.EVCharger.Normalize()
+		if err := c.EVCharger.Validate(); err != nil {
+			return err
+		}
+	}
+
 	// Empty drivers list is a valid shape — e.g. an EV-only site that
 	// configured a cloud EV charger in the setup wizard and doesn't
 	// own local inverter/meter hardware. Control loop becomes a no-op

--- a/go/internal/config/evcharger_test.go
+++ b/go/internal/config/evcharger_test.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestEVChargerNormalizeFoldsLegacyEmail(t *testing.T) {
+	e := &EVCharger{Provider: "easee", EmailLegacy: "old@example.com"}
+	e.Normalize()
+	if e.Username != "old@example.com" {
+		t.Errorf("Username: got %q, want %q", e.Username, "old@example.com")
+	}
+	if e.EmailLegacy != "" {
+		t.Errorf("EmailLegacy should be cleared after Normalize, got %q", e.EmailLegacy)
+	}
+}
+
+func TestEVChargerNormalizePrefersExistingUsername(t *testing.T) {
+	e := &EVCharger{Provider: "easee", Username: "new@example.com", EmailLegacy: "old@example.com"}
+	e.Normalize()
+	if e.Username != "new@example.com" {
+		t.Errorf("Username should win over legacy email, got %q", e.Username)
+	}
+	if e.EmailLegacy != "" {
+		t.Errorf("EmailLegacy should be cleared, got %q", e.EmailLegacy)
+	}
+}
+
+func TestEVChargerYAMLRoundTripEmailAlias(t *testing.T) {
+	in := []byte("provider: easee\nemail: rickard@example.com\n")
+	var e EVCharger
+	if err := yaml.Unmarshal(in, &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	e.Normalize()
+	if e.Username != "rickard@example.com" {
+		t.Errorf("after Normalize Username should be populated from legacy email, got %q", e.Username)
+	}
+
+	// Re-marshal — should emit `username:`, not `email:`.
+	out, err := yaml.Marshal(&e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+	if strings.Contains(s, "email:") {
+		t.Errorf("re-marshaled YAML should not contain legacy email key: %s", s)
+	}
+	if !strings.Contains(s, "username: rickard@example.com") {
+		t.Errorf("re-marshaled YAML missing username: %s", s)
+	}
+}
+
+func TestEVChargerValidateEasee(t *testing.T) {
+	cases := []struct {
+		name    string
+		e       EVCharger
+		wantErr string // empty means no error
+	}{
+		{"happy", EVCharger{Provider: "easee", Username: "u@x"}, ""},
+		{"empty creds allowed (wizard placeholder)", EVCharger{Provider: "easee"}, ""},
+		{"modbus block rejected", EVCharger{Provider: "easee", Username: "u@x", Modbus: &EVChargerModbus{Host: "h"}}, "modbus"},
+		{"http block allowed", EVCharger{Provider: "easee", Username: "u@x", HTTP: &EVChargerHTTP{BaseURL: "https://staging"}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.e.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEVChargerValidateCTek(t *testing.T) {
+	cases := []struct {
+		name    string
+		e       EVCharger
+		wantErr string
+	}{
+		{"happy", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Host: "10.0.0.5"}}, ""},
+		{"modbus required", EVCharger{Provider: "ctek"}, "modbus.host"},
+		{"host required", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Port: 502}}, "modbus.host"},
+		{"http block rejected", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Host: "h"}, HTTP: &EVChargerHTTP{}}, "http"},
+		{"auth rejected", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Host: "h"}, Username: "u"}, "username/password"},
+		{"unit_id range high", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Host: "h", UnitID: 248}}, "unit_id"},
+		{"unit_id range negative", EVCharger{Provider: "ctek", Modbus: &EVChargerModbus{Host: "h", UnitID: -1}}, "unit_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.e.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEVChargerValidateUnknownProvider(t *testing.T) {
+	e := &EVCharger{Provider: "made-up"}
+	err := e.Validate()
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("error should mention 'not supported': %v", err)
+	}
+}
+
+func TestEVChargerValidateEmptyProvider(t *testing.T) {
+	e := &EVCharger{}
+	err := e.Validate()
+	if err == nil {
+		t.Fatal("expected error for empty provider")
+	}
+}
+
+func TestEVChargerValidateNilIsNoop(t *testing.T) {
+	var e *EVCharger
+	if err := e.Validate(); err != nil {
+		t.Errorf("nil receiver should return nil error, got %v", err)
+	}
+}

--- a/go/internal/config/restart_required_test.go
+++ b/go/internal/config/restart_required_test.go
@@ -80,7 +80,7 @@ func TestRestartRequiredFor_BootSections(t *testing.T) {
 		{"nova toggled", func(c *Config) { c.Nova = &Nova{Enabled: true, URL: "https://x"} }, "nova"},
 		{"ocpp toggled", func(c *Config) { c.OCPP = &OCPP{Enabled: true} }, "ocpp"},
 		{"ev_charger added", func(c *Config) {
-			c.EVCharger = &EVCharger{Provider: "easee", Email: "a@b.c"}
+			c.EVCharger = &EVCharger{Provider: "easee", Username: "a@b.c"}
 		}, "ev_charger"},
 		{"weather provider change", func(c *Config) {
 			c.Weather = &Weather{Provider: "open_meteo", Latitude: 59, Longitude: 18}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -174,6 +174,20 @@ type State struct {
 	PeakImportCeilingW float64
 	// EV charging signal — batteries won't try to cover this much of import
 	EVChargingW float64
+
+	// EVSurplusOnlyReserveW is the aggregate PV headroom that must be
+	// kept available for EVs under surplus_only loadpoints. When > 0:
+	//   - the energy-allocation path caps battery aggregate charge so
+	//     it doesn't consume PV that the EV could be claiming
+	//   - the legacy PI / self-consumption path biases the grid setpoint
+	//     so it leaves `reserveRemaining` of export untouched
+	// Where reserveRemaining = max(0, EVSurplusOnlyReserveW - EVChargingW)
+	// — once the EV has ramped up to the reserve, no further headroom is
+	// withheld from the battery. Populated each tick by main.go from
+	// loadpoint.Manager.States(): sum of MaxChargeW across LPs that are
+	// SurplusOnly && PluggedIn. Set to 0 when no such LP is connected,
+	// in which case all behaviour reverts to the pre-existing path.
+	EVSurplusOnlyReserveW float64
 	// BatteryCoversEV overrides the default EV-exclusion behaviour. When
 	// false (default), EVChargingW is subtracted from the meter reading
 	// before the PI runs so batteries don't shuffle energy through the
@@ -752,6 +766,29 @@ func ComputeDispatch(
 			}
 		}
 
+		// Surplus-only EV reserve (energy path): cap battery aggregate
+		// charge to leave PV headroom for an EV that's under a
+		// surplus_only loadpoint. The MPC's grid-charge ban handles the
+		// planning side; this enforces it on every tick (covers reactive
+		// drift, stale plan fallback, and the period before the next
+		// replan picks up the EV's needs). Discharge is unaffected — the
+		// reserve only matters when the battery is competing with the
+		// EV for the same surplus PV.
+		if state.EVSurplusOnlyReserveW > 0 && targetTotalW > 0 {
+			pvSurplus := -gridW + currentTotal
+			reserveRemaining := state.EVSurplusOnlyReserveW - state.EVChargingW
+			if reserveRemaining < 0 {
+				reserveRemaining = 0
+			}
+			ceiling := pvSurplus - reserveRemaining
+			if ceiling < 0 {
+				ceiling = 0
+			}
+			if targetTotalW > ceiling {
+				targetTotalW = ceiling
+			}
+		}
+
 		totalCorrection = targetTotalW - currentTotal
 	default:
 		// Legacy PI-on-grid-target path. Used by:
@@ -759,6 +796,45 @@ func ComputeDispatch(
 		//   - planner_self (the "participate reactively" branch — idle-gate
 		//     already handled above)
 		//   - planner_cheap / planner_arbitrage when UseEnergyDispatch=false
+
+		// Surplus-only EV reserve (legacy/reactive path): when an EV
+		// under a surplus_only loadpoint is connected, bias the grid
+		// signal so the PI leaves `reserveRemaining` of export untouched
+		// for the EV. Without this, the PI drives gridW→0 by absorbing
+		// every kW of surplus into the battery and the EV controller
+		// (which polls a separate surplus number) sees nothing left to
+		// claim — flap mode. The bias is only applied to the self-
+		// consumption flavour: PeakShaving has its own peak-relative
+		// error, and other modes (Charge, Priority, Weighted) are out
+		// of scope for surplus-only semantics.
+		//
+		// Three regions:
+		//   gridW < -reserveRemaining: exporting MORE than the reserve.
+		//     Bias so PI absorbs only the excess (export beyond reserve).
+		//     biasedGridW = gridW + reserveRemaining (still negative).
+		//   -reserveRemaining <= gridW <= 0: exporting within the reserve.
+		//     Idle the battery — let the EV claim the export. biasedGridW=0.
+		//   gridW > 0: importing. Unchanged — battery still covers
+		//     household imports normally (the EV isn't drawing on
+		//     surplus_only, so there's no double-counting concern).
+		// A naive bias of `gridW + reserve` over the whole range would
+		// flip sign in the within-reserve band and tell the PI to
+		// DISCHARGE battery into the EV's reserved export space — the
+		// opposite of what we want.
+		biasedGridW := gridW
+		if state.EVSurplusOnlyReserveW > 0 && effectiveMode == ModeSelfConsumption {
+			reserveRemaining := state.EVSurplusOnlyReserveW - state.EVChargingW
+			if reserveRemaining < 0 {
+				reserveRemaining = 0
+			}
+			if gridW < -reserveRemaining {
+				biasedGridW = gridW + reserveRemaining
+			} else if gridW < 0 {
+				biasedGridW = 0
+			}
+			// gridW >= 0: leave biasedGridW = gridW (import behavior).
+		}
+
 		var errW float64
 		switch effectiveMode {
 		case ModePeakShaving:
@@ -772,12 +848,21 @@ func ComputeDispatch(
 				errW = 0
 			}
 		default:
-			errW = gridW - state.GridTargetW
+			errW = biasedGridW - state.GridTargetW
 		}
 
 		// Deadband only applies to the legacy path — the energy formula
 		// produces small corrections naturally when close to target.
-		if math.Abs(errW) < state.GridToleranceW {
+		// Surplus-only EV reserve override: when reserve is active, do
+		// NOT short-circuit on small error. The bias above can collapse
+		// the error to zero in the within-reserve band, but the battery
+		// might be running on a stale higher setpoint from before the
+		// reserve kicked in. Returning nil here would leave the battery
+		// stuck at that previous level, defeating the whole point of
+		// the reserve. Falling through forces a fresh dispatch that
+		// drives the battery toward 0 (or the post-PI cap below).
+		surplusActive := state.EVSurplusOnlyReserveW > 0 && effectiveMode == ModeSelfConsumption
+		if !surplusActive && math.Abs(errW) < state.GridToleranceW {
 			return nil
 		}
 
@@ -790,10 +875,36 @@ func ComputeDispatch(
 		if effectiveMode == ModePeakShaving {
 			piMeasurement = state.GridTargetW + errW
 		} else {
-			piMeasurement = gridW
+			piMeasurement = biasedGridW
 		}
 		out := state.PI.Update(piMeasurement)
 		totalCorrection = out.Output
+
+		// Post-PI cap (legacy path): mirror the energy-path cap so the
+		// battery target on the legacy/reactive path also respects the
+		// surplus-only EV reserve. The PI bias above tries to steer the
+		// integrator the right way, but PI windup, deadband interaction,
+		// and the slow integrator unwind would otherwise leave the
+		// battery on a stale charge command for tens of seconds — long
+		// enough to starve the EV. This cap drives the aggregate target
+		// to the same ceiling the energy path uses.
+		if surplusActive {
+			targetTotal := currentTotal + totalCorrection
+			if targetTotal > 0 {
+				pvSurplus := -gridW + currentTotal
+				reserveRemaining := state.EVSurplusOnlyReserveW - state.EVChargingW
+				if reserveRemaining < 0 {
+					reserveRemaining = 0
+				}
+				ceiling := pvSurplus - reserveRemaining
+				if ceiling < 0 {
+					ceiling = 0
+				}
+				if targetTotal > ceiling {
+					totalCorrection = ceiling - currentTotal
+				}
+			}
+		}
 	}
 
 	// ---- Joint fuse-budget allocator ----

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -627,7 +627,26 @@ func ComputeDispatch(
 	// clamps (SoC, per-driver MaxDischargeW, fuse guard) still apply —
 	// exceeding battery capacity just means the residual comes from grid.
 	gridW := rawGridW
-	if !state.BatteryCoversEV {
+	// Surplus-only EV transient cover: when an LP is in surplus_only mode
+	// AND the EV is currently drawing AND the site is importing, the EV
+	// is drawing more than the available surplus. This typically happens
+	// during the 5–15 s window after surplus_only is freshly enabled
+	// (the EV ramps current down through Easee Cloud + the car's onboard
+	// charger — both are slow), or during a sudden cloud transient. The
+	// home battery (Pixii) responds in <1 s, so let it cover the import
+	// burst until the EV ramp-down completes. Mechanism: don't subtract
+	// EV from gridW, so the PI sees the real import and discharges
+	// battery accordingly. Self-deactivates the moment grid goes
+	// negative again — at that point EV draw matches surplus and there's
+	// no import to cover, so steady-state surplus_only behavior is
+	// unchanged. The pre-existing reserve cap on the CHARGE side still
+	// stops the battery from competing with the EV for surplus when PV
+	// exceeds load+EV.
+	coverEV := state.BatteryCoversEV
+	if !coverEV && state.EVSurplusOnlyReserveW > 0 && state.EVChargingW > 0 && rawGridW > 0 {
+		coverEV = true
+	}
+	if !coverEV {
 		gridW -= state.EVChargingW
 	}
 
@@ -758,7 +777,14 @@ func ComputeDispatch(
 		// Charging is left untouched. Mirrors the dispatch.go:453 rule on
 		// the legacy path. The MPC also gets a NoBatteryToEV constraint
 		// so the plan stops prescribing what dispatch then has to censor.
-		if !state.BatteryCoversEV && state.EVChargingW > 0 && targetTotalW < 0 {
+		// EXCEPTION: surplus-only transient cover. Same gate as the
+		// rawGridW-subtraction path above — when a surplus_only LP is
+		// drawing more than current surplus (site importing), the battery
+		// is allowed to bridge the EV ramp-down for ~10 s while the
+		// Easee/car-side current ramp completes. The cap reverts the
+		// moment grid goes negative.
+		surplusTransient := state.EVSurplusOnlyReserveW > 0 && state.EVChargingW > 0 && rawGridW > 0
+		if !state.BatteryCoversEV && !surplusTransient && state.EVChargingW > 0 && targetTotalW < 0 {
 			houseGridW := rawGridW - state.EVChargingW
 			reactiveTotal := currentTotal - houseGridW
 			if targetTotalW < reactiveTotal {

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -288,14 +288,23 @@ func (r *Registry) Send(ctx context.Context, name string, payload []byte) error 
 	}
 }
 
-// SendDefault sends the default/watchdog command to a driver.
+// SendDefault sends the default/watchdog command to a driver. Symmetric
+// with Send: both the channel-push and the result-wait honour ctx. A
+// driver whose cmdCh is full (because its goroutine is slow / stuck mid
+// I/O) would otherwise block the caller forever; the watchdog-fallback
+// path runs on every dispatch tick, so an unblocked send into a wedged
+// driver deadlocks the entire control loop.
 func (r *Registry) SendDefault(ctx context.Context, name string) error {
 	r.mu.Lock()
 	rd, ok := r.rec[name]
 	r.mu.Unlock()
 	if !ok { return fmt.Errorf("driver %q not found", name) }
 	resCh := make(chan error, 1)
-	rd.cmdCh <- driverCmd{kind: "default", result: resCh}
+	select {
+	case rd.cmdCh <- driverCmd{kind: "default", result: resCh}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	select {
 	case err := <-resCh: return err
 	case <-ctx.Done(): return ctx.Err()

--- a/go/internal/evcloud/ctek.go
+++ b/go/internal/evcloud/ctek.go
@@ -1,0 +1,172 @@
+package evcloud
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	sv "github.com/simonvetter/modbus"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+// ctekDefaultPort is the standard Modbus/TCP port. Overridable via
+// EVCharger.Modbus.Port when the device is behind NAT or on a custom
+// listener.
+const ctekDefaultPort = 502
+
+// ctekDefaultUnitID is what CSOS uses for the first outlet on
+// single-outlet stations. Dual-outlet stations expose EVSE2 on unit 2.
+const ctekDefaultUnitID = 1
+
+// ctekProbeTimeout bounds the one-shot dial + serial read so a wedged
+// LAN can't tie up the wizard request goroutine. The probe is purely
+// for the charger-picker UX, not the driver's polling loop, so 5 s is
+// generous.
+const ctekProbeTimeout = 5 * time.Second
+
+// CTEK register addresses for identity. Same as drivers/ctek.lua for
+// API v1. The picker only needs the serial; the runtime driver does
+// the rest at poll time.
+const (
+	ctekRegSerialBase  = 0x1003 // 6 regs → 12 ASCII chars, big-endian byte order
+	ctekRegSerialCount = 6
+)
+
+// ctekDialFn is injectable for tests — production code dials a real
+// modbus socket via simonvetter; tests substitute a fake.
+type ctekDialFn func(host string, port, unitID int) (ctekClient, error)
+
+// ctekClient is the minimal surface the picker needs from a modbus
+// client. simonvetter.ModbusClient satisfies this; tests can swap in
+// a fake without standing up a real Modbus server.
+type ctekClient interface {
+	ReadHolding(addr, count uint16) ([]uint16, error)
+	Close() error
+}
+
+func init() { Register("ctek", NewCTEK()) }
+
+// CTEK implements Provider for CTEK Chargestorm Connected 2/3 wallboxes
+// reached over Modbus/TCP (Automation API v1). The picker probes the
+// identity registers (0x1003..0x1008) to read the serial; the actual
+// telemetry + control path lives in drivers/ctek.lua.
+type CTEK struct {
+	dial ctekDialFn
+}
+
+// NewCTEK builds a CTEK provider using the production simonvetter dialer.
+func NewCTEK() *CTEK {
+	return &CTEK{dial: ctekDialReal}
+}
+
+// WithDialer returns a copy of c using the supplied dialer. For tests.
+func (c *CTEK) WithDialer(d ctekDialFn) *CTEK {
+	cp := *c
+	cp.dial = d
+	return &cp
+}
+
+// Describe is the wizard's hook for rendering a CTEK-flavored form
+// (Modbus transport, no auth, port 502 / unit 1 defaults).
+func (c *CTEK) Describe() Descriptor {
+	return Descriptor{
+		Name:          "ctek",
+		Label:         "CTEK Chargestorm",
+		Transport:     TransportModbus,
+		NeedsAuth:     false,
+		DefaultPort:   ctekDefaultPort,
+		DefaultUnitID: ctekDefaultUnitID,
+		LuaDriver:     "drivers/ctek.lua",
+	}
+}
+
+// ListChargers dials the configured Modbus host and reads the identity
+// registers. Returns one Charger entry — CTEK exposes a single outlet
+// per unit ID; multi-outlet stations are picked by configuring two
+// EVCharger blocks (different unit_id) in two separate setups.
+func (c *CTEK) ListChargers(cfg *config.EVCharger) ([]Charger, error) {
+	if cfg == nil || cfg.Modbus == nil {
+		return nil, errors.New("ctek: modbus block required")
+	}
+	host := cfg.Modbus.Host
+	if host == "" {
+		return nil, errors.New("ctek: modbus.host required")
+	}
+	port := cfg.Modbus.Port
+	if port == 0 {
+		port = ctekDefaultPort
+	}
+	unitID := cfg.Modbus.UnitID
+	if unitID == 0 {
+		unitID = ctekDefaultUnitID
+	}
+
+	cli, err := c.dial(host, port, unitID)
+	if err != nil {
+		return nil, fmt.Errorf("ctek: dial %s:%d (unit %d): %w", host, port, unitID, err)
+	}
+	defer cli.Close()
+
+	regs, err := cli.ReadHolding(ctekRegSerialBase, ctekRegSerialCount)
+	if err != nil {
+		return nil, fmt.Errorf("ctek: read serial: %w", err)
+	}
+	serial := decodeCTEKSerial(regs)
+	if serial == "" {
+		return nil, errors.New("ctek: empty serial — wrong API version or wrong unit_id?")
+	}
+	return []Charger{{ID: serial, Name: "CTEK Chargestorm " + serial}}, nil
+}
+
+// decodeCTEKSerial unpacks 6 big-endian u16 registers into 12 ASCII chars.
+// Trailing NULs and spaces are trimmed since some firmware right-pads.
+func decodeCTEKSerial(regs []uint16) string {
+	if len(regs) != ctekRegSerialCount {
+		return ""
+	}
+	buf := make([]byte, 0, 12)
+	for _, r := range regs {
+		hi := byte(r >> 8)
+		lo := byte(r & 0xff)
+		if hi == 0 && lo == 0 {
+			break
+		}
+		buf = append(buf, hi)
+		if lo == 0 {
+			break
+		}
+		buf = append(buf, lo)
+	}
+	return strings.TrimRight(strings.TrimSpace(string(buf)), "\x00")
+}
+
+// ctekDialReal is the production dialer — opens a real Modbus/TCP socket
+// via simonvetter, sets the unit ID, and returns a thin adapter that
+// implements ctekClient.
+func ctekDialReal(host string, port, unitID int) (ctekClient, error) {
+	url := fmt.Sprintf("tcp://%s:%d", host, port)
+	cli, err := sv.NewClient(&sv.ClientConfiguration{
+		URL:     url,
+		Timeout: ctekProbeTimeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := cli.Open(); err != nil {
+		return nil, err
+	}
+	if unitID > 0 {
+		_ = cli.SetUnitId(uint8(unitID))
+	}
+	return &ctekRealClient{cli: cli}, nil
+}
+
+type ctekRealClient struct{ cli *sv.ModbusClient }
+
+func (r *ctekRealClient) ReadHolding(addr, count uint16) ([]uint16, error) {
+	return r.cli.ReadRegisters(addr, count, sv.HOLDING_REGISTER)
+}
+
+func (r *ctekRealClient) Close() error { return r.cli.Close() }

--- a/go/internal/evcloud/ctek_test.go
+++ b/go/internal/evcloud/ctek_test.go
@@ -1,0 +1,157 @@
+package evcloud
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+// fakeCTekClient is a stub ctekClient that returns canned register
+// content. Lets us test the picker without standing up a real Modbus
+// server.
+type fakeCTekClient struct {
+	regs []uint16
+	err  error
+}
+
+func (f *fakeCTekClient) ReadHolding(addr, count uint16) ([]uint16, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if int(count) != len(f.regs) {
+		return nil, errors.New("count mismatch")
+	}
+	return f.regs, nil
+}
+
+func (f *fakeCTekClient) Close() error { return nil }
+
+// asciiRegs packs an ASCII serial into 6 big-endian u16 registers, padding
+// with NUL when the input is shorter than 12 chars.
+func asciiRegs(s string) []uint16 {
+	b := []byte(s)
+	if len(b) < 12 {
+		b = append(b, make([]byte, 12-len(b))...)
+	}
+	out := make([]uint16, 6)
+	for i := 0; i < 6; i++ {
+		out[i] = uint16(b[2*i])<<8 | uint16(b[2*i+1])
+	}
+	return out
+}
+
+func TestCTekListChargersHappyPath(t *testing.T) {
+	dialed := struct {
+		host   string
+		port   int
+		unitID int
+	}{}
+	dialer := func(host string, port, unitID int) (ctekClient, error) {
+		dialed.host = host
+		dialed.port = port
+		dialed.unitID = unitID
+		return &fakeCTekClient{regs: asciiRegs("123456789012")}, nil
+	}
+
+	c := NewCTEK().WithDialer(dialer)
+	got, err := c.ListChargers(&config.EVCharger{
+		Provider: "ctek",
+		Modbus:   &config.EVChargerModbus{Host: "10.0.0.5", Port: 1502, UnitID: 2},
+	})
+	if err != nil {
+		t.Fatalf("ListChargers: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("chargers: got %d, want 1", len(got))
+	}
+	if got[0].ID != "123456789012" {
+		t.Errorf("serial: got %q, want %q", got[0].ID, "123456789012")
+	}
+	if dialed.host != "10.0.0.5" || dialed.port != 1502 || dialed.unitID != 2 {
+		t.Errorf("dialer args: got %+v, want {10.0.0.5 1502 2}", dialed)
+	}
+}
+
+func TestCTekListChargersDefaultsPortAndUnit(t *testing.T) {
+	var seenPort, seenUnit int
+	dialer := func(host string, port, unitID int) (ctekClient, error) {
+		seenPort = port
+		seenUnit = unitID
+		return &fakeCTekClient{regs: asciiRegs("SN-ABC")}, nil
+	}
+	c := NewCTEK().WithDialer(dialer)
+	_, err := c.ListChargers(&config.EVCharger{
+		Provider: "ctek",
+		Modbus:   &config.EVChargerModbus{Host: "host"},
+	})
+	if err != nil {
+		t.Fatalf("ListChargers: %v", err)
+	}
+	if seenPort != 502 || seenUnit != 1 {
+		t.Errorf("defaults: got port=%d unit=%d, want 502/1", seenPort, seenUnit)
+	}
+}
+
+func TestCTekListChargersRequiresHost(t *testing.T) {
+	c := NewCTEK()
+	_, err := c.ListChargers(&config.EVCharger{
+		Provider: "ctek",
+		Modbus:   &config.EVChargerModbus{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty host")
+	}
+	if !strings.Contains(err.Error(), "host") {
+		t.Errorf("error should mention host: %v", err)
+	}
+}
+
+func TestCTekListChargersDialFailure(t *testing.T) {
+	dialer := func(host string, port, unitID int) (ctekClient, error) {
+		return nil, errors.New("connection refused")
+	}
+	c := NewCTEK().WithDialer(dialer)
+	_, err := c.ListChargers(&config.EVCharger{
+		Provider: "ctek",
+		Modbus:   &config.EVChargerModbus{Host: "host"},
+	})
+	if err == nil {
+		t.Fatal("expected dial error")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("dial error not wrapped: %v", err)
+	}
+}
+
+func TestCTekListChargersEmptySerialIsError(t *testing.T) {
+	dialer := func(host string, port, unitID int) (ctekClient, error) {
+		return &fakeCTekClient{regs: []uint16{0, 0, 0, 0, 0, 0}}, nil
+	}
+	c := NewCTEK().WithDialer(dialer)
+	_, err := c.ListChargers(&config.EVCharger{
+		Provider: "ctek",
+		Modbus:   &config.EVChargerModbus{Host: "host"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty serial")
+	}
+}
+
+func TestDecodeCTEKSerialTrimsNulAndSpace(t *testing.T) {
+	got := decodeCTEKSerial(asciiRegs("AB12  "))
+	if got != "AB12" {
+		t.Errorf("decoded: got %q, want %q", got, "AB12")
+	}
+}
+
+func TestCTekDescribe(t *testing.T) {
+	d := NewCTEK().Describe()
+	if d.Name != "ctek" || d.Transport != TransportModbus || d.NeedsAuth {
+		t.Errorf("descriptor: got %+v", d)
+	}
+	if d.DefaultPort != 502 || d.DefaultUnitID != 1 {
+		t.Errorf("defaults: got port=%d unit=%d, want 502/1", d.DefaultPort, d.DefaultUnitID)
+	}
+}

--- a/go/internal/evcloud/easee.go
+++ b/go/internal/evcloud/easee.go
@@ -3,10 +3,13 @@ package evcloud
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
 )
 
 // easeeDefaultBaseURL is the Easee cloud API base URL. Split out so
@@ -56,14 +59,42 @@ func (e *Easee) WithBaseURL(u string) *Easee {
 	return &cp
 }
 
-// ListChargers logs in with the given credentials and returns the
-// chargers on the account.
-func (e *Easee) ListChargers(email, password string) ([]Charger, error) {
-	token, err := e.login(email, password)
+// Describe is the wizard's hook for rendering an Easee-flavored form
+// (HTTP transport, "Email" as the username label).
+func (e *Easee) Describe() Descriptor {
+	return Descriptor{
+		Name:          "easee",
+		Label:         "Easee",
+		Transport:     TransportHTTP,
+		NeedsAuth:     true,
+		UsernameLabel: "Email",
+		LuaDriver:     "drivers/easee_cloud.lua",
+	}
+}
+
+// ListChargers logs in with the credentials from cfg and returns the
+// chargers on the account. cfg.HTTP.BaseURL overrides the default base
+// URL when set, which is mostly useful for staging or self-hosted
+// reverse proxies.
+func (e *Easee) ListChargers(cfg *config.EVCharger) ([]Charger, error) {
+	if cfg == nil {
+		return nil, errors.New("easee: nil config")
+	}
+	if cfg.Username == "" {
+		return nil, errors.New("easee: username required")
+	}
+	if cfg.Password == "" {
+		return nil, errors.New("easee: password required")
+	}
+	client := e
+	if cfg.HTTP != nil && cfg.HTTP.BaseURL != "" {
+		client = e.WithBaseURL(cfg.HTTP.BaseURL)
+	}
+	token, err := client.login(cfg.Username, cfg.Password)
 	if err != nil {
 		return nil, err
 	}
-	return e.listChargers(token)
+	return client.listChargers(token)
 }
 
 func (e *Easee) login(email, password string) (string, error) {

--- a/go/internal/evcloud/easee_test.go
+++ b/go/internal/evcloud/easee_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
 )
 
 // TestEaseeListChargers covers the happy path end-to-end against an
@@ -41,7 +43,11 @@ func TestEaseeListChargers(t *testing.T) {
 	defer srv.Close()
 
 	e := NewEasee().WithHTTPClient(srv.Client()).WithBaseURL(srv.URL)
-	got, err := e.ListChargers("user@example.com", "hunter2")
+	got, err := e.ListChargers(&config.EVCharger{
+		Provider: "easee",
+		Username: "user@example.com",
+		Password: "hunter2",
+	})
 	if err != nil {
 		t.Fatalf("ListChargers: %v", err)
 	}
@@ -72,7 +78,11 @@ func TestEaseeLoginRejectsBadCreds(t *testing.T) {
 	defer srv.Close()
 
 	e := NewEasee().WithHTTPClient(srv.Client()).WithBaseURL(srv.URL)
-	_, err := e.ListChargers("user@example.com", "supersecret")
+	_, err := e.ListChargers(&config.EVCharger{
+		Provider: "easee",
+		Username: "user@example.com",
+		Password: "supersecret",
+	})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -106,7 +116,11 @@ func TestEaseeTimeoutBounded(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := e.ListChargers("a@b", "c")
+		_, err := e.ListChargers(&config.EVCharger{
+			Provider: "easee",
+			Username: "a@b",
+			Password: "c",
+		})
 		done <- err
 	}()
 	select {

--- a/go/internal/evcloud/evcloud.go
+++ b/go/internal/evcloud/evcloud.go
@@ -1,6 +1,19 @@
 package evcloud
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+// Transport identifies the wire protocol a provider speaks. Drives the
+// wizard's field renderer and the runtime's connection wiring.
+type Transport string
+
+const (
+	TransportHTTP   Transport = "http"
+	TransportModbus Transport = "modbus"
+)
 
 // Charger is the common representation returned by all providers.
 type Charger struct {
@@ -8,10 +21,24 @@ type Charger struct {
 	Name string `json:"name,omitempty"`
 }
 
-// Provider can authenticate with a cloud EV charger service and list
-// the chargers on the account.
+// Descriptor is the self-description a provider hands to the UI so the
+// wizard can render the right form fields. Returned by GET /api/ev/providers.
+type Descriptor struct {
+	Name          string    `json:"name"`                    // canonical id, e.g. "easee"
+	Label         string    `json:"label"`                   // human-facing, e.g. "Easee"
+	Transport     Transport `json:"transport"`               // "http" | "modbus"
+	NeedsAuth     bool      `json:"needs_auth"`              // true → wizard shows username+password
+	UsernameLabel string    `json:"username_label,omitempty"` // e.g. "Email"; empty → "Username"
+	DefaultPort   int       `json:"default_port,omitempty"`   // Modbus: typically 502
+	DefaultUnitID int       `json:"default_unit_id,omitempty"` // Modbus: typically 1
+	LuaDriver     string    `json:"lua_driver,omitempty"`     // hint for wizard: the drivers/*.lua entry to write alongside
+}
+
+// Provider can authenticate (if required) with an EV charger service
+// and list the chargers reachable via the supplied EVCharger config.
 type Provider interface {
-	ListChargers(email, password string) ([]Charger, error)
+	Describe() Descriptor
+	ListChargers(*config.EVCharger) ([]Charger, error)
 }
 
 var providers = map[string]Provider{}
@@ -35,16 +62,26 @@ func Register(name string, p Provider) {
 func Get(name string) (Provider, error) {
 	p, ok := providers[name]
 	if !ok {
-		return nil, fmt.Errorf("unknown ev cloud provider: %q", name)
+		return nil, fmt.Errorf("unknown ev provider: %q", name)
 	}
 	return p, nil
 }
 
-// Names returns all registered provider names.
+// Names returns all registered provider names in arbitrary order.
 func Names() []string {
 	out := make([]string, 0, len(providers))
 	for k := range providers {
 		out = append(out, k)
+	}
+	return out
+}
+
+// Describe returns the descriptor for every registered provider. Order
+// is unspecified — the UI sorts by Label if it cares.
+func Describe() []Descriptor {
+	out := make([]Descriptor, 0, len(providers))
+	for _, p := range providers {
+		out = append(out, p.Describe())
 	}
 	return out
 }

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -118,6 +118,17 @@ type Controller struct {
 	wakeLast      map[string]time.Time
 	wakeKickUntil map[string]time.Time
 	wakeAttempts  map[string]int
+
+	// batSoC reports the home battery's current state-of-charge (0..1
+	// fraction) for the bat-SoC surplus-unlock feature. nil disables
+	// the feature entirely — the LP behaves exactly as today.
+	batSoC func() (float64, bool)
+
+	// batSoCArmed tracks the per-LP arm/release state for the bat-SoC
+	// hysteresis. Without per-LP state a noisy bat_soc reading right
+	// at the threshold would flap the contactor every tick.
+	batSoCArmedMu sync.Mutex
+	batSoCArmed   map[string]bool
 }
 
 // wakeKickDuration is how long a wake-kick forces the EV charger to
@@ -317,6 +328,65 @@ func (c *Controller) SetPeakRemainingSurplusW(f func() (float64, bool)) {
 	c.peakRemainingSurplusW = f
 }
 
+// SetBatSoCProvider wires the home-battery SoC reader used by the
+// bat-SoC surplus-unlock feature. The function returns the current
+// SoC as a 0..1 fraction. (_, false) disables the feature for this
+// tick; nil disables it permanently. Called once at startup from
+// main.go.
+func (c *Controller) SetBatSoCProvider(f func() (float64, bool)) {
+	if c == nil {
+		return
+	}
+	c.batSoC = f
+}
+
+// evalBatSoCArm decides whether the bat-SoC surplus unlock is armed
+// for the given loadpoint this tick. Arms at threshold, releases at
+// (threshold − BatSoCUnlockHystPp). In the deadband it preserves the
+// previous tick's state — that's the hysteresis. Returns false when
+// no threshold is configured or the bat_soc reader is missing/stale.
+func (c *Controller) evalBatSoCArm(lpID string, threshold float64) bool {
+	if c == nil || c.batSoC == nil || threshold <= 0 {
+		return false
+	}
+	soc, ok := c.batSoC()
+	if !ok {
+		// Stale telemetry: don't change the arm state. A momentary
+		// blip shouldn't release the unlock during peak surplus.
+		c.batSoCArmedMu.Lock()
+		defer c.batSoCArmedMu.Unlock()
+		return c.batSoCArmed[lpID]
+	}
+	socPct := soc * 100
+	c.batSoCArmedMu.Lock()
+	defer c.batSoCArmedMu.Unlock()
+	if c.batSoCArmed == nil {
+		c.batSoCArmed = map[string]bool{}
+	}
+	prev := c.batSoCArmed[lpID]
+	armed := prev
+	switch {
+	case socPct >= threshold:
+		armed = true
+	case socPct < threshold-BatSoCUnlockHystPp:
+		armed = false
+	}
+	c.batSoCArmed[lpID] = armed
+	return armed
+}
+
+// surplusActive reports whether surplus-only dispatch semantics apply
+// to this loadpoint right now. True when the configured SurplusOnly
+// flag is on, OR when the bat-SoC unlock is armed for this LP. The
+// caller passes the loadpoint's schedule so we read the threshold
+// without re-locking the Manager.
+func (c *Controller) surplusActive(lpCfg Config, sched Schedule) bool {
+	if lpCfg.SurplusOnly {
+		return true
+	}
+	return c.evalBatSoCArm(lpCfg.ID, sched.SurplusUnlockBatSoCPct)
+}
+
 // SetSiteFuse installs the grid-boundary fuse so the controller can
 // pass voltage + per-phase amperage to drivers in every command.
 // Called once at startup from main.go after config load. A zero-value
@@ -421,6 +491,14 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	if c.tel != nil {
 		sample, _ = c.tel(lpCfg.DriverName)
 	}
+	// Resolve the schedule once per tick — used for bat-SoC unlock
+	// (surplusActive) below. Zero value when no schedule is set,
+	// which makes evalBatSoCArm a no-op.
+	var sched Schedule
+	if c.manager != nil {
+		sched, _ = c.manager.GetSchedule(lpCfg.ID)
+	}
+	surplusOn := c.surplusActive(lpCfg, sched)
 	// Detect the disconnected→connected edge (state.PluggedIn flips
 	// from false to true) so we can reset session-scoped state
 	// before the new session's first dispatch tick. Without this
@@ -453,7 +531,7 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		// The hold's other fields (phase mode, hold time) are still
 		// honoured — only the W setpoint is clamped, and we log it so
 		// the operator notices the conflict.
-		if lpCfg.SurplusOnly && holdW > 0 {
+		if surplusOn && holdW > 0 {
 			clamped := c.computeSurplusCmd(now, lpCfg, holdW, sample.PowerW)
 			if clamped < holdW {
 				slog.Warn("loadpoint manual hold clamped by surplus_only",
@@ -533,7 +611,7 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		// surplus clamp was previously gated on cmdW > 0. The
 		// wallbox will silently report what the EV does (op_mode
 		// stays at 2 if the car declines) without grid import.
-		if lpCfg.SurplusOnly {
+		if surplusOn {
 			wantW := cmdW
 			if wantW <= 0 {
 				wantW = lpCfg.MaxChargeW
@@ -632,16 +710,17 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	//      The 90 s cooldown caps Tesla BLE wear; if the car is
 	//      genuinely asleep at night the proxy returns 503 and we
 	//      back off.
-	c.maybeWakeVehicle(ctx, now, lpCfg.ID, lpCfg, cmd)
+	c.maybeWakeVehicle(ctx, now, lpCfg, surplusOn, cmd)
 }
 
-func (c *Controller) maybeWakeVehicle(ctx context.Context, now time.Time, lpID string, lpCfg Config, cmd map[string]any) {
+func (c *Controller) maybeWakeVehicle(ctx context.Context, now time.Time, lpCfg Config, surplusOn bool, cmd map[string]any) {
+	lpID := lpCfg.ID
 	if c == nil || c.vehicleStatus == nil || c.send == nil {
 		return
 	}
 	pw, _ := cmd["power_w"].(float64)
 	wantWake := pw > 0
-	if lpCfg.SurplusOnly {
+	if surplusOn {
 		wantWake = true
 	}
 	if !wantWake {

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -517,8 +517,28 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		// PV is naturally absorbed by the home battery via the
 		// reactive self_consumption PI in dispatch.go — that's the
 		// "battery smooths PV transients for ~1-2 min" path.
-		if lpCfg.SurplusOnly && cmdW > 0 {
-			cmdW = c.computeSurplusCmd(now, lpCfg, cmdW, sample.PowerW)
+		//
+		// Opportunistic start: when surplus_only is on but the MPC
+		// has no plan budget for this LP (cmdW = 0) — typical when
+		// the LP isn't in the planner's view because the vehicle
+		// driver is offline / has no SoC, or the user has no
+		// deadline set — fall through to the surplus clamp anyway
+		// with the LP's MaxChargeW as the requested ceiling. The
+		// clamp returns 0 if there's no PV surplus, or a snapped
+		// step otherwise. Without this, surplus_only LPs without an
+		// active vehicle telemetry source (Easee + no Tesla, or
+		// any third-party EV without a Go-side vehicle driver)
+		// would never start because (a) MPC won't allocate without
+		// a target, (b) auto-wake requires vehicleStatus, (c) the
+		// surplus clamp was previously gated on cmdW > 0. The
+		// wallbox will silently report what the EV does (op_mode
+		// stays at 2 if the car declines) without grid import.
+		if lpCfg.SurplusOnly {
+			wantW := cmdW
+			if wantW <= 0 {
+				wantW = lpCfg.MaxChargeW
+			}
+			cmdW = c.computeSurplusCmd(now, lpCfg, wantW, sample.PowerW)
 		}
 		// Wake-kick AFTER the surplus clamp: when an auto-wake just
 		// fired and the surplus clamp paused us to 0, force the

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -364,6 +364,21 @@ func (c *Controller) evalBatSoCArm(lpID string, threshold float64) bool {
 	if c == nil || c.batSoC == nil || threshold <= 0 {
 		return false
 	}
+	// Read the live inputs (bat SoC + site surplus) OUTSIDE the arm
+	// mutex — siteSurplusForEVW is a closure wired in main.go that
+	// itself calls back into AnyLoadpointSurplusActive, which needs
+	// to acquire batSoCArmedMu. Calling it under that lock would
+	// recursively self-deadlock the dispatch loop (debugged: every
+	// tickOne hung on the first LP after we shipped this feature).
+	// Order: gather facts → take lock → mutate the small state map.
+	soc, socOK := c.batSoC()
+	pvGone := true
+	if c.siteSurplusForEVW != nil {
+		if s, ok := c.siteSurplusForEVW(); ok && s > 0 {
+			pvGone = false
+		}
+	}
+
 	c.batSoCArmedMu.Lock()
 	defer c.batSoCArmedMu.Unlock()
 	if c.batSoCArmed == nil {
@@ -371,30 +386,16 @@ func (c *Controller) evalBatSoCArm(lpID string, threshold float64) bool {
 		c.batSoCNoPV = map[string]int{}
 	}
 	prev := c.batSoCArmed[lpID]
-
-	soc, ok := c.batSoC()
-	if !ok {
+	if !socOK {
 		// Stale telemetry: don't change the arm state. A momentary
 		// blip shouldn't release the unlock during peak surplus.
 		return prev
-	}
-
-	// PV-availability gate: live site surplus must be positive to
-	// count as "PV to grab". A negative surplus means PV − load is
-	// in deficit and any apparent battery discharge is covering the
-	// gap — not real surplus, no matter how full the battery is.
-	pvGone := true
-	if c.siteSurplusForEVW != nil {
-		if s, ok := c.siteSurplusForEVW(); ok && s > 0 {
-			pvGone = false
-		}
 	}
 	if pvGone {
 		c.batSoCNoPV[lpID]++
 	} else {
 		c.batSoCNoPV[lpID] = 0
 	}
-
 	socPct := soc * 100
 	armed := prev
 	switch {

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -125,11 +125,21 @@ type Controller struct {
 	batSoC func() (float64, bool)
 
 	// batSoCArmed tracks the per-LP arm/release state for the bat-SoC
-	// hysteresis. Without per-LP state a noisy bat_soc reading right
-	// at the threshold would flap the contactor every tick.
+	// hysteresis. batSoCNoPV counts consecutive ticks where the live
+	// site surplus dropped to zero — a sustained no-PV run releases
+	// the arm even when the home battery is still above the SoC
+	// threshold, because battery discharge isn't surplus and we don't
+	// want to ride a high-SoC arm through the night kicking the EV.
 	batSoCArmedMu sync.Mutex
 	batSoCArmed   map[string]bool
+	batSoCNoPV    map[string]int
 }
+
+// batSoCPVGoneTicks is the consecutive-tick threshold (at the 5 s
+// dispatch cadence ≈ 30 s) of zero/negative live surplus before the
+// bat-SoC unlock disarms. Long enough to swallow a passing cloud
+// without flap; short enough that evening transition releases promptly.
+const batSoCPVGoneTicks = 6
 
 // wakeKickDuration is how long a wake-kick forces the EV charger to
 // signal min 3Φ current after a charge_start fires. The wallbox must
@@ -341,34 +351,61 @@ func (c *Controller) SetBatSoCProvider(f func() (float64, bool)) {
 }
 
 // evalBatSoCArm decides whether the bat-SoC surplus unlock is armed
-// for the given loadpoint this tick. Arms at threshold, releases at
-// (threshold − BatSoCUnlockHystPp). In the deadband it preserves the
-// previous tick's state — that's the hysteresis. Returns false when
-// no threshold is configured or the bat_soc reader is missing/stale.
+// for the given loadpoint this tick. Arms when SoC is at/above the
+// threshold AND there's live PV to grab (battery discharge alone is
+// not surplus — that's just self-consumption or arbitrage the planner
+// is already orchestrating). Releases when SoC drops below
+// (threshold − BatSoCUnlockHystPp), or after a sustained run of
+// zero/negative live surplus (batSoCPVGoneTicks).
+//
+// Returns false when no threshold is configured or the bat_soc reader
+// is missing.
 func (c *Controller) evalBatSoCArm(lpID string, threshold float64) bool {
 	if c == nil || c.batSoC == nil || threshold <= 0 {
 		return false
 	}
-	soc, ok := c.batSoC()
-	if !ok {
-		// Stale telemetry: don't change the arm state. A momentary
-		// blip shouldn't release the unlock during peak surplus.
-		c.batSoCArmedMu.Lock()
-		defer c.batSoCArmedMu.Unlock()
-		return c.batSoCArmed[lpID]
-	}
-	socPct := soc * 100
 	c.batSoCArmedMu.Lock()
 	defer c.batSoCArmedMu.Unlock()
 	if c.batSoCArmed == nil {
 		c.batSoCArmed = map[string]bool{}
+		c.batSoCNoPV = map[string]int{}
 	}
 	prev := c.batSoCArmed[lpID]
+
+	soc, ok := c.batSoC()
+	if !ok {
+		// Stale telemetry: don't change the arm state. A momentary
+		// blip shouldn't release the unlock during peak surplus.
+		return prev
+	}
+
+	// PV-availability gate: live site surplus must be positive to
+	// count as "PV to grab". A negative surplus means PV − load is
+	// in deficit and any apparent battery discharge is covering the
+	// gap — not real surplus, no matter how full the battery is.
+	pvGone := true
+	if c.siteSurplusForEVW != nil {
+		if s, ok := c.siteSurplusForEVW(); ok && s > 0 {
+			pvGone = false
+		}
+	}
+	if pvGone {
+		c.batSoCNoPV[lpID]++
+	} else {
+		c.batSoCNoPV[lpID] = 0
+	}
+
+	socPct := soc * 100
 	armed := prev
 	switch {
-	case socPct >= threshold:
-		armed = true
 	case socPct < threshold-BatSoCUnlockHystPp:
+		armed = false
+	case socPct >= threshold && !pvGone:
+		armed = true
+	case c.batSoCNoPV[lpID] >= batSoCPVGoneTicks:
+		// SoC may still be high but PV has been gone long enough that
+		// staying armed would just trickle from battery/grid via the
+		// surplus path's auto-wake. Release.
 		armed = false
 	}
 	c.batSoCArmed[lpID] = armed
@@ -385,6 +422,36 @@ func (c *Controller) surplusActive(lpCfg Config, sched Schedule) bool {
 		return true
 	}
 	return c.evalBatSoCArm(lpCfg.ID, sched.SurplusUnlockBatSoCPct)
+}
+
+// AnyLoadpointSurplusActive reports whether any configured loadpoint
+// is currently treating PV surplus as priority — either via the
+// configured SurplusOnly flag or via a runtime-armed bat-SoC unlock.
+// main.go's siteSurplusForEVW reader uses this to zero out the
+// home-battery's PV-charge contribution from the EV's apparent
+// surplus, which prevents the EV from stealing PV that the planner
+// already routed to the home battery (the flap-avoidance rule).
+//
+// Safe to call before Tick has ever run — returns false in that case.
+func (c *Controller) AnyLoadpointSurplusActive() bool {
+	if c == nil || c.manager == nil {
+		return false
+	}
+	for _, cfg := range c.manager.Configs() {
+		if cfg.SurplusOnly {
+			return true
+		}
+		sched, _ := c.manager.GetSchedule(cfg.ID)
+		if sched.SurplusUnlockBatSoCPct > 0 {
+			c.batSoCArmedMu.Lock()
+			armed := c.batSoCArmed[cfg.ID]
+			c.batSoCArmedMu.Unlock()
+			if armed {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // SetSiteFuse installs the grid-boundary fuse so the controller can
@@ -710,7 +777,13 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	//      The 90 s cooldown caps Tesla BLE wear; if the car is
 	//      genuinely asleep at night the proxy returns 503 and we
 	//      back off.
-	c.maybeWakeVehicle(ctx, now, lpCfg, surplusOn, cmd)
+	// Forced-wake belongs to the configured surplus_only contract — the
+	// "kick the EV periodically so the car negotiates with the wallbox
+	// even when the surplus clamp paused us" behaviour. The bat-SoC
+	// unlock is opportunistic and tick-level; it must not poke a sleeping
+	// car at night just because the bat is full. Pass the configured flag,
+	// not the runtime-armed one.
+	c.maybeWakeVehicle(ctx, now, lpCfg, lpCfg.SurplusOnly, cmd)
 }
 
 func (c *Controller) maybeWakeVehicle(ctx context.Context, now time.Time, lpCfg Config, surplusOn bool, cmd map[string]any) {
@@ -1011,6 +1084,17 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 	}
 	if peak >= minStep3 {
 		return steps3
+	}
+	// The day-long 1Φ lock is a commitment that belongs to *configured*
+	// surplus_only operators: they've opted into "no grid import for this
+	// LP", and a low-PV day means trickle-charge instead of pausing.
+	// The bat-SoC unlock is opportunistic and tick-level — it should not
+	// inherit a day-long phase lock just because it was armed once. Skip
+	// the lock-set when SurplusOnly isn't actually configured; return all
+	// allowed steps so the driver can pick whichever phase the live
+	// surplus suits this tick.
+	if !lpCfg.SurplusOnly {
+		return lpCfg.AllowedStepsW
 	}
 	// Lock to 1Φ for the rest of the day.
 	c.phaseLockMu.Lock()

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -124,6 +124,16 @@ type Controller struct {
 	// the feature entirely — the LP behaves exactly as today.
 	batSoC func() (float64, bool)
 
+	// gridDeferredMu protects gridDeferred. The map is set by main.go's
+	// MPC spec builder when it decides to suppress grid-funded EV
+	// planning (because the deadline lies past the last published price
+	// slot). Runtime dispatch reads it to ALSO enforce surplus-only
+	// behaviour at the tick — so when forecast PV undershoots reality
+	// the EV pauses rather than silently importing from grid against a
+	// plan budget that assumed sun.
+	gridDeferredMu sync.Mutex
+	gridDeferred   map[string]bool
+
 	// batSoCArmed tracks the per-LP arm/release state for the bat-SoC
 	// hysteresis. batSoCNoPV counts consecutive ticks where the live
 	// site surplus dropped to zero — a sustained no-PV run releases
@@ -413,25 +423,67 @@ func (c *Controller) evalBatSoCArm(lpID string, threshold float64) bool {
 	return armed
 }
 
+// SetGridDeferred records that MPC has suppressed grid-funded EV
+// planning for this LP (because the deadline lies past published
+// prices). Surplus dispatch semantics apply at runtime too: the EV's
+// commanded W is snapped to live surplus only, with no grid import,
+// regardless of what the cached MPC plan budget says. Cleared when
+// MPC's next replan finds prices for the deadline window. Safe to
+// call concurrently with the dispatch tick.
+func (c *Controller) SetGridDeferred(lpID string, deferred bool) {
+	if c == nil {
+		return
+	}
+	c.gridDeferredMu.Lock()
+	defer c.gridDeferredMu.Unlock()
+	if c.gridDeferred == nil {
+		c.gridDeferred = map[string]bool{}
+	}
+	if deferred {
+		c.gridDeferred[lpID] = true
+	} else {
+		delete(c.gridDeferred, lpID)
+	}
+}
+
+// gridDeferredFor reads the per-LP deferral flag set by main.go's MPC
+// spec builder. Read-only accessor used inside surplusActive.
+func (c *Controller) gridDeferredFor(lpID string) bool {
+	if c == nil {
+		return false
+	}
+	c.gridDeferredMu.Lock()
+	defer c.gridDeferredMu.Unlock()
+	return c.gridDeferred[lpID]
+}
+
 // surplusActive reports whether surplus-only dispatch semantics apply
-// to this loadpoint right now. True when the configured SurplusOnly
-// flag is on, OR when the bat-SoC unlock is armed for this LP. The
-// caller passes the loadpoint's schedule so we read the threshold
+// to this loadpoint right now. True when ANY of:
+//   - the operator's configured SurplusOnly flag is on
+//   - MPC has deferred grid-funded planning (forecast-vs-real divergence
+//     guard: even if the cached plan said "charge 2 kW now", live PV
+//     might have collapsed since the last replan)
+//   - the bat-SoC unlock is armed for this LP
+//
+// The caller passes the loadpoint's schedule so we read the threshold
 // without re-locking the Manager.
 func (c *Controller) surplusActive(lpCfg Config, sched Schedule) bool {
 	if lpCfg.SurplusOnly {
+		return true
+	}
+	if c.gridDeferredFor(lpCfg.ID) {
 		return true
 	}
 	return c.evalBatSoCArm(lpCfg.ID, sched.SurplusUnlockBatSoCPct)
 }
 
 // AnyLoadpointSurplusActive reports whether any configured loadpoint
-// is currently treating PV surplus as priority — either via the
-// configured SurplusOnly flag or via a runtime-armed bat-SoC unlock.
-// main.go's siteSurplusForEVW reader uses this to zero out the
-// home-battery's PV-charge contribution from the EV's apparent
-// surplus, which prevents the EV from stealing PV that the planner
-// already routed to the home battery (the flap-avoidance rule).
+// is currently treating PV surplus as priority — via the configured
+// SurplusOnly flag, the MPC grid-deferral flag, or a runtime-armed
+// bat-SoC unlock. main.go's siteSurplusForEVW reader uses this to
+// zero out the home-battery's PV-charge contribution from the EV's
+// apparent surplus, which prevents the EV from stealing PV that the
+// planner already routed to the home battery (the flap-avoidance rule).
 //
 // Safe to call before Tick has ever run — returns false in that case.
 func (c *Controller) AnyLoadpointSurplusActive() bool {
@@ -440,6 +492,9 @@ func (c *Controller) AnyLoadpointSurplusActive() bool {
 	}
 	for _, cfg := range c.manager.Configs() {
 		if cfg.SurplusOnly {
+			return true
+		}
+		if c.gridDeferredFor(cfg.ID) {
 			return true
 		}
 		sched, _ := c.manager.GetSchedule(cfg.ID)

--- a/go/internal/loadpoint/controller_bat_soc_unlock_test.go
+++ b/go/internal/loadpoint/controller_bat_soc_unlock_test.go
@@ -1,0 +1,82 @@
+package loadpoint
+
+import "testing"
+
+// TestEvalBatSoCArm_Hysteresis covers the arm-at / release-below
+// behaviour the surplus-unlock relies on.
+func TestEvalBatSoCArm_Hysteresis(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	var soc float64
+	c.SetBatSoCProvider(func() (float64, bool) { return soc, true })
+
+	cases := []struct {
+		name      string
+		soc       float64
+		threshold float64
+		wantArmed bool
+	}{
+		{"below arm threshold starts disarmed", 0.70, 80, false},
+		{"reaches threshold arms", 0.80, 80, true},
+		{"slight dip stays armed (deadband)", 0.78, 80, true},
+		{"drops to release boundary stays armed", 0.75, 80, true}, // 80-5 = 75, inclusive armed
+		{"drops below release disarms", 0.749, 80, false},
+		{"climbs back into deadband stays disarmed", 0.78, 80, false},
+		{"climbs back above threshold re-arms", 0.80, 80, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			soc = tc.soc
+			got := c.evalBatSoCArm("garage", tc.threshold)
+			if got != tc.wantArmed {
+				t.Errorf("soc=%v threshold=%v: got armed=%v want %v",
+					tc.soc, tc.threshold, got, tc.wantArmed)
+			}
+		})
+	}
+}
+
+// TestEvalBatSoCArm_ZeroThresholdDisables verifies the off switch.
+func TestEvalBatSoCArm_ZeroThresholdDisables(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	c.SetBatSoCProvider(func() (float64, bool) { return 0.99, true })
+	if c.evalBatSoCArm("garage", 0) {
+		t.Error("threshold=0 must disable the unlock")
+	}
+}
+
+// TestEvalBatSoCArm_StalePreservesState — a missing/stale reading
+// must NOT change the arm state. Otherwise a one-tick blip during
+// peak surplus would release the unlock.
+func TestEvalBatSoCArm_StalePreservesState(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	stale := false
+	c.SetBatSoCProvider(func() (float64, bool) {
+		if stale {
+			return 0, false
+		}
+		return 0.85, true
+	})
+	if !c.evalBatSoCArm("garage", 80) {
+		t.Fatal("should arm on first call with soc=85")
+	}
+	stale = true
+	if !c.evalBatSoCArm("garage", 80) {
+		t.Error("stale reading must preserve armed state")
+	}
+}
+
+// TestSurplusActive_NilProviderGracefullyOff makes sure a controller
+// without a bat-soc provider behaves exactly as today: only the
+// configured SurplusOnly flag matters.
+func TestSurplusActive_NilProviderGracefullyOff(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	cfg := Config{ID: "garage", SurplusOnly: false}
+	sched := Schedule{SurplusUnlockBatSoCPct: 80}
+	if c.surplusActive(cfg, sched) {
+		t.Error("nil bat-soc provider: surplusActive should be false when SurplusOnly is off")
+	}
+	cfg.SurplusOnly = true
+	if !c.surplusActive(cfg, sched) {
+		t.Error("SurplusOnly=true must always be surplusActive=true")
+	}
+}

--- a/go/internal/loadpoint/controller_bat_soc_unlock_test.go
+++ b/go/internal/loadpoint/controller_bat_soc_unlock_test.go
@@ -1,73 +1,99 @@
 package loadpoint
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-// TestEvalBatSoCArm_Hysteresis covers the arm-at / release-below
-// behaviour the surplus-unlock relies on.
-func TestEvalBatSoCArm_Hysteresis(t *testing.T) {
+// armCtrl wires a Controller with a bat-SoC reader and a surplus
+// reader for the tests below. surplusW=>0 means "PV is producing
+// enough to count as live surplus"; <=0 means "no PV".
+func armCtrl(soc, surplusW *float64) *Controller {
 	c := NewController(NewManager(), nil, nil, nil)
-	var soc float64
-	c.SetBatSoCProvider(func() (float64, bool) { return soc, true })
+	c.SetBatSoCProvider(func() (float64, bool) {
+		if soc == nil {
+			return 0, false
+		}
+		return *soc, true
+	})
+	c.SetSiteSurplusForEV(func() (float64, bool) {
+		if surplusW == nil {
+			return 0, false
+		}
+		return *surplusW, true
+	})
+	return c
+}
 
-	cases := []struct {
-		name      string
-		soc       float64
-		threshold float64
-		wantArmed bool
-	}{
-		{"below arm threshold starts disarmed", 0.70, 80, false},
-		{"reaches threshold arms", 0.80, 80, true},
-		{"slight dip stays armed (deadband)", 0.78, 80, true},
-		{"drops to release boundary stays armed", 0.75, 80, true}, // 80-5 = 75, inclusive armed
-		{"drops below release disarms", 0.749, 80, false},
-		{"climbs back into deadband stays disarmed", 0.78, 80, false},
-		{"climbs back above threshold re-arms", 0.80, 80, true},
+func TestEvalBatSoCArm_RequiresLivePV(t *testing.T) {
+	soc := 0.85
+	surplus := 1500.0 // PV producing
+	c := armCtrl(&soc, &surplus)
+	if !c.evalBatSoCArm("garage", 80) {
+		t.Fatal("should arm: bat 85% >= threshold AND PV > 0")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			soc = tc.soc
-			got := c.evalBatSoCArm("garage", tc.threshold)
-			if got != tc.wantArmed {
-				t.Errorf("soc=%v threshold=%v: got armed=%v want %v",
-					tc.soc, tc.threshold, got, tc.wantArmed)
-			}
-		})
+	// PV gone — staying armed for a few ticks (hysteresis), then released.
+	surplus = -100
+	for i := 0; i < batSoCPVGoneTicks-1; i++ {
+		if !c.evalBatSoCArm("garage", 80) {
+			t.Errorf("tick %d: should still be armed during PV-gone hysteresis", i)
+		}
+	}
+	if c.evalBatSoCArm("garage", 80) {
+		t.Error("after PV-gone hysteresis ticks expired, should release")
 	}
 }
 
-// TestEvalBatSoCArm_ZeroThresholdDisables verifies the off switch.
+func TestEvalBatSoCArm_PVReturnRearms(t *testing.T) {
+	soc := 0.85
+	surplus := 1500.0
+	c := armCtrl(&soc, &surplus)
+	c.evalBatSoCArm("garage", 80) // arm
+
+	// Brief PV dip: 3 ticks no PV (below batSoCPVGoneTicks threshold)
+	surplus = 0
+	for i := 0; i < 3; i++ {
+		c.evalBatSoCArm("garage", 80)
+	}
+	// PV comes back before hysteresis expires
+	surplus = 1500
+	if !c.evalBatSoCArm("garage", 80) {
+		t.Error("brief PV dip must not disarm before hysteresis ticks expire")
+	}
+}
+
+func TestEvalBatSoCArm_SoCBelowReleaseDisarms(t *testing.T) {
+	soc := 0.85
+	surplus := 1500.0
+	c := armCtrl(&soc, &surplus)
+	c.evalBatSoCArm("garage", 80) // arm
+	soc = 0.74                    // below threshold-hyst (80-5=75) → release
+	if c.evalBatSoCArm("garage", 80) {
+		t.Error("soc 74% < 75% release floor must disarm regardless of PV")
+	}
+}
+
+func TestEvalBatSoCArm_StalePreservesState(t *testing.T) {
+	soc := 0.85
+	surplus := 1500.0
+	c := armCtrl(&soc, &surplus)
+	c.evalBatSoCArm("garage", 80) // arm
+	// Stale bat_soc — must preserve.
+	c.SetBatSoCProvider(func() (float64, bool) { return 0, false })
+	if !c.evalBatSoCArm("garage", 80) {
+		t.Error("stale bat_soc reading must preserve previous arm state")
+	}
+}
+
 func TestEvalBatSoCArm_ZeroThresholdDisables(t *testing.T) {
-	c := NewController(NewManager(), nil, nil, nil)
-	c.SetBatSoCProvider(func() (float64, bool) { return 0.99, true })
+	soc := 0.99
+	surplus := 5000.0
+	c := armCtrl(&soc, &surplus)
 	if c.evalBatSoCArm("garage", 0) {
 		t.Error("threshold=0 must disable the unlock")
 	}
 }
 
-// TestEvalBatSoCArm_StalePreservesState — a missing/stale reading
-// must NOT change the arm state. Otherwise a one-tick blip during
-// peak surplus would release the unlock.
-func TestEvalBatSoCArm_StalePreservesState(t *testing.T) {
-	c := NewController(NewManager(), nil, nil, nil)
-	stale := false
-	c.SetBatSoCProvider(func() (float64, bool) {
-		if stale {
-			return 0, false
-		}
-		return 0.85, true
-	})
-	if !c.evalBatSoCArm("garage", 80) {
-		t.Fatal("should arm on first call with soc=85")
-	}
-	stale = true
-	if !c.evalBatSoCArm("garage", 80) {
-		t.Error("stale reading must preserve armed state")
-	}
-}
-
-// TestSurplusActive_NilProviderGracefullyOff makes sure a controller
-// without a bat-soc provider behaves exactly as today: only the
-// configured SurplusOnly flag matters.
 func TestSurplusActive_NilProviderGracefullyOff(t *testing.T) {
 	c := NewController(NewManager(), nil, nil, nil)
 	cfg := Config{ID: "garage", SurplusOnly: false}
@@ -78,5 +104,83 @@ func TestSurplusActive_NilProviderGracefullyOff(t *testing.T) {
 	cfg.SurplusOnly = true
 	if !c.surplusActive(cfg, sched) {
 		t.Error("SurplusOnly=true must always be surplusActive=true")
+	}
+}
+
+// TestPickSurplusSteps_BatSoCArmedSkipsDailyLock asserts the new
+// behaviour: when surplus dispatch is active *only* because of the
+// bat-SoC unlock (not the configured SurplusOnly flag), the day-long
+// 1Φ lock must NOT be set. That lock is an operator contract for
+// configured surplus_only LPs; the opportunistic unlock is tick-level.
+func TestPickSurplusSteps_BatSoCArmedSkipsDailyLock(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	// Force "peak surplus today is below the 3Φ min" so the original
+	// path would lock to 1Φ.
+	c.SetPeakRemainingSurplusW(func() (float64, bool) { return 100, true })
+	cfg := Config{
+		ID:            "garage",
+		SurplusOnly:   false, // NOT configured surplus-only
+		MinChargeW:    1380,
+		MaxChargeW:    11000,
+		AllowedStepsW: []float64{0, 1380, 4140, 6900, 11000},
+	}
+	now := time.Date(2026, 5, 11, 20, 0, 0, 0, time.UTC)
+	_ = c.pickSurplusSteps(now, cfg)
+	if c.surplusLockedTo1P(cfg.ID) {
+		t.Error("bat-SoC-armed surplus must NOT set the day-long 1Φ lock")
+	}
+}
+
+func TestPickSurplusSteps_ConfiguredSurplusOnlyDoesLock(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	c.SetPeakRemainingSurplusW(func() (float64, bool) { return 100, true })
+	cfg := Config{
+		ID:            "garage",
+		SurplusOnly:   true,
+		MinChargeW:    1380,
+		MaxChargeW:    11000,
+		AllowedStepsW: []float64{0, 1380, 4140, 6900, 11000},
+	}
+	now := time.Date(2026, 5, 11, 20, 0, 0, 0, time.UTC)
+	_ = c.pickSurplusSteps(now, cfg)
+	if !c.surplusLockedTo1P(cfg.ID) {
+		t.Error("configured surplus_only with insufficient peak forecast must lock to 1Φ")
+	}
+}
+
+// TestAnyLoadpointSurplusActive walks the combined-view aggregator
+// main.go uses to decide whether to zero out battery PV-charge from
+// the EV's apparent surplus (the flap protection).
+func TestAnyLoadpointSurplusActive(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	soc := 0.85
+	surplus := 1500.0
+	c := NewController(m, nil, nil, nil)
+	c.SetBatSoCProvider(func() (float64, bool) { return soc, true })
+	c.SetSiteSurplusForEV(func() (float64, bool) { return surplus, true })
+
+	// No schedule + SurplusOnly=false → false
+	if c.AnyLoadpointSurplusActive() {
+		t.Error("baseline: no surplus_only and no schedule → must be false")
+	}
+
+	// Schedule with bat-SoC unlock, but not yet evaluated (no Tick) → false
+	m.SetSchedule("garage", Schedule{SurplusUnlockBatSoCPct: 80})
+	if c.AnyLoadpointSurplusActive() {
+		t.Error("schedule alone (without evalBatSoCArm being called) must not flip true")
+	}
+
+	// Evaluate arm — bat 85% with PV > 0 should arm; then aggregator true.
+	c.evalBatSoCArm("garage", 80)
+	if !c.AnyLoadpointSurplusActive() {
+		t.Error("after arm via evalBatSoCArm, aggregator must report true")
+	}
+
+	// Disarm via SoC drop → aggregator back to false.
+	soc = 0.50
+	c.evalBatSoCArm("garage", 80)
+	if c.AnyLoadpointSurplusActive() {
+		t.Error("after disarm, aggregator must report false")
 	}
 }

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -364,16 +364,21 @@ func (m *Manager) SetTarget(id string, socPct float64, targetTime time.Time) boo
 // SetSurplusOnly toggles the runtime surplus_only flag for a loadpoint.
 // Mutates Config.SurplusOnly so subsequent Configs() calls reflect the
 // new value (both the MPC LoadpointSpec builder in main.go and the
-// dispatch controller read from there). Returns false for unknown IDs.
-func (m *Manager) SetSurplusOnly(id string, v bool) bool {
+// dispatch controller read from there). Returns (previous, ok) so a
+// caller can detect the transition direction — disabling surplus_only
+// is a regime change for the planner (terminal credit flips back to
+// the arbitrage default, the grid-charge ban lifts) and the API
+// handler forces a tagged replan in that case.
+func (m *Manager) SetSurplusOnly(id string, v bool) (prev bool, ok bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	lp, ok := m.byID[id]
 	if !ok {
-		return false
+		return false, false
 	}
+	prev = lp.Config.SurplusOnly
 	lp.Config.SurplusOnly = v
-	return true
+	return prev, true
 }
 
 // SetCurrentSoC lets an operator correct the inferred vehicle SoC

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -160,13 +160,24 @@ type State struct {
 	// omitempty) so a polling client can distinguish "explicitly off"
 	// from "field absent because the server is too old to know".
 	SurplusOnly bool `json:"surplus_only"`
+
+	// Schedule is the operator's recurring intent. Empty when no
+	// schedule is configured. Always emitted (object, possibly with
+	// zero fields) so the UI can rely on a stable shape — clients
+	// detect "no schedule" via Schedule.Empty() / soc_pct === 0.
+	Schedule Schedule `json:"schedule"`
 }
 
 // Manager holds the running set of loadpoints. Thread-safe.
 type Manager struct {
-	mu     sync.RWMutex
-	byID   map[string]*loadpointRuntime
-	order  []string // insertion-preserving id list for deterministic listing
+	mu    sync.RWMutex
+	byID  map[string]*loadpointRuntime
+	order []string // insertion-preserving id list for deterministic listing
+
+	// scheduleSaver, if non-nil, is invoked synchronously whenever a
+	// schedule is set or cleared. Wired by main.go to persist via
+	// state.SaveConfig. Left nil in tests / sites without storage.
+	scheduleSaver func(id string, s Schedule)
 }
 
 // loadpointRuntime is the in-memory representation. Its fields are the
@@ -189,6 +200,18 @@ type loadpointRuntime struct {
 	// even as session_wh grows. Reset to Config.PluginSoCPct on
 	// every plug-in transition (prev !pluggedIn → now pluggedIn).
 	sessionPluginSoCPct float64
+
+	// schedule carries the operator's persistent intent. Empty when
+	// none is set. Survives config hot-reload because Load() copies
+	// it across from the previous runtime row.
+	schedule Schedule
+
+	// lastRolledFor is the targetTime value that the most recent
+	// RollSchedules promotion produced. Used to keep the roll
+	// idempotent within a tick window — without this, a recurring
+	// schedule re-promotes its own freshly-set targetTime back to
+	// the day after that, racing the clock by 24 h every tick.
+	lastRolledFor time.Time
 }
 
 // NewManager returns an empty manager. Configure with Load().
@@ -223,6 +246,8 @@ func (m *Manager) Load(cfgs []Config) {
 			lp.targetTime = existing.targetTime
 			lp.updatedAtMs = existing.updatedAtMs
 			lp.sessionPluginSoCPct = existing.sessionPluginSoCPct
+			lp.schedule = existing.schedule
+			lp.lastRolledFor = existing.lastRolledFor
 		}
 		newByID[c.ID] = lp
 		newOrder = append(newOrder, c.ID)
@@ -443,5 +468,137 @@ func (lp *loadpointRuntime) snapshot() State {
 		MaxChargeW:         lp.MaxChargeW,
 		AllowedStepsW:      steps,
 		SurplusOnly:        lp.Config.SurplusOnly,
+		Schedule:           lp.schedule,
+	}
+}
+
+// SetScheduleSaver wires the persistence callback. Pass nil to disable.
+// Safe to call before or after Load().
+func (m *Manager) SetScheduleSaver(saver func(id string, s Schedule)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scheduleSaver = saver
+}
+
+// SetSchedule stores the operator's intent for a loadpoint. Empty
+// schedules clear (equivalent to ClearSchedule). Returns false for
+// unknown IDs. The persistence callback (if wired) is invoked outside
+// the lock so a slow disk doesn't block other readers.
+func (m *Manager) SetSchedule(id string, s Schedule) bool {
+	m.mu.Lock()
+	lp, ok := m.byID[id]
+	if !ok {
+		m.mu.Unlock()
+		return false
+	}
+	if s.SoCPct < 0 {
+		s.SoCPct = 0
+	}
+	if s.SoCPct > 100 {
+		s.SoCPct = 100
+	}
+	if s.SurplusUnlockBatSoCPct < 0 {
+		s.SurplusUnlockBatSoCPct = 0
+	}
+	if s.SurplusUnlockBatSoCPct > 100 {
+		s.SurplusUnlockBatSoCPct = 100
+	}
+	lp.schedule = s
+	// Force RollSchedules to re-evaluate on next call — operator just
+	// changed the contract so any previous idempotence cache is stale.
+	lp.lastRolledFor = time.Time{}
+	saver := m.scheduleSaver
+	m.mu.Unlock()
+	if saver != nil {
+		saver(id, s)
+	}
+	return true
+}
+
+// GetSchedule returns the current schedule and a found flag. The flag
+// is true only when an Empty()=false schedule is set for the ID — an
+// empty schedule is reported as "not configured".
+func (m *Manager) GetSchedule(id string) (Schedule, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return Schedule{}, false
+	}
+	if lp.schedule.Empty() {
+		return Schedule{}, false
+	}
+	return lp.schedule, true
+}
+
+// ClearSchedule removes the operator's intent. Persists Empty so a
+// reload doesn't resurrect the old schedule from disk. Returns false
+// for unknown IDs.
+func (m *Manager) ClearSchedule(id string) bool {
+	m.mu.Lock()
+	lp, ok := m.byID[id]
+	if !ok {
+		m.mu.Unlock()
+		return false
+	}
+	lp.schedule = Schedule{}
+	lp.lastRolledFor = time.Time{}
+	saver := m.scheduleSaver
+	m.mu.Unlock()
+	if saver != nil {
+		saver(id, Schedule{})
+	}
+	return true
+}
+
+// HydrateSchedules loads persisted schedules at boot. `loader(id)`
+// returns the stored schedule for each configured loadpoint; missing
+// entries return (Schedule{}, false). Unknown IDs in storage are
+// silently ignored — the operator may have renamed a loadpoint, and
+// resurrecting a schedule under the new ID would be surprising.
+//
+// Does NOT invoke the saver — this is a load path. Does NOT call
+// RollSchedules either; the controller's first tick will handle that.
+func (m *Manager) HydrateSchedules(loader func(id string) (Schedule, bool)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, id := range m.order {
+		lp, ok := m.byID[id]
+		if !ok {
+			continue
+		}
+		s, found := loader(id)
+		if !found || s.Empty() {
+			continue
+		}
+		lp.schedule = s
+	}
+}
+
+// RollSchedules advances recurring deadlines past `now`. For each LP
+// with `Recurring` schedule and a stale (or absent) targetTime, it
+// rewrites target_soc_pct/target_time to "next time-of-day after now".
+// Non-recurring schedules are left alone — they're one-shot.
+//
+// Idempotent: when a schedule has already been rolled to the future,
+// subsequent calls before that deadline are no-ops. Cheap to call on
+// every dispatch tick.
+func (m *Manager) RollSchedules(now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, lp := range m.byID {
+		if !lp.schedule.Recurring || lp.schedule.Empty() {
+			continue
+		}
+		// Already rolled past now; do nothing. Use targetTime as the
+		// authority — lastRolledFor is just a tiebreaker for the
+		// "first call after schedule change" case.
+		if !lp.targetTime.IsZero() && lp.targetTime.After(now) {
+			continue
+		}
+		next := NextDailyUTC(now, lp.schedule.TimeOfDayMinUTC)
+		lp.targetTime = next
+		lp.targetSoCPct = lp.schedule.SoCPct
+		lp.lastRolledFor = next
 	}
 }

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -575,30 +575,44 @@ func (m *Manager) HydrateSchedules(loader func(id string) (Schedule, bool)) {
 	}
 }
 
-// RollSchedules advances recurring deadlines past `now`. For each LP
-// with `Recurring` schedule and a stale (or absent) targetTime, it
-// rewrites target_soc_pct/target_time to "next time-of-day after now".
-// Non-recurring schedules are left alone — they're one-shot.
+// RollSchedules brings each loadpoint's one-shot target_soc / target_time
+// into line with its persisted schedule. Two cases:
 //
-// Idempotent: when a schedule has already been rolled to the future,
-// subsequent calls before that deadline are no-ops. Cheap to call on
-// every dispatch tick.
+//   - Recurring=true: refresh target_time forward each time the prior
+//     deadline passes, so the deadline penalty in MPC never goes stale.
+//   - Recurring=false: seed the one-shot target ONCE on the first roll
+//     after the schedule was saved (SetSchedule clears lastRolledFor as
+//     its sentinel). After the deadline passes, leave target_time in the
+//     past — MPC treats that as "no deadline" and the schedule expires
+//     quietly. The schedule itself stays for the operator to inspect or
+//     clear via the API.
+//
+// Idempotent on subsequent ticks. Cheap to call every dispatch cycle.
 func (m *Manager) RollSchedules(now time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, lp := range m.byID {
-		if !lp.schedule.Recurring || lp.schedule.Empty() {
+		s := lp.schedule
+		if s.Empty() {
 			continue
 		}
-		// Already rolled past now; do nothing. Use targetTime as the
-		// authority — lastRolledFor is just a tiebreaker for the
-		// "first call after schedule change" case.
-		if !lp.targetTime.IsZero() && lp.targetTime.After(now) {
+		next := NextDailyUTC(now, s.TimeOfDayMinUTC)
+		if s.Recurring {
+			if !lp.targetTime.IsZero() && lp.targetTime.After(now) {
+				continue
+			}
+			lp.targetTime = next
+			lp.targetSoCPct = s.SoCPct
+			lp.lastRolledFor = next
 			continue
 		}
-		next := NextDailyUTC(now, lp.schedule.TimeOfDayMinUTC)
-		lp.targetTime = next
-		lp.targetSoCPct = lp.schedule.SoCPct
-		lp.lastRolledFor = next
+		// Non-recurring: seed exactly once per SetSchedule. The Empty
+		// SetSchedule path (clear) also resets lastRolledFor, so a
+		// re-save with a non-recurring schedule re-seeds.
+		if lp.lastRolledFor.IsZero() {
+			lp.targetTime = next
+			lp.targetSoCPct = s.SoCPct
+			lp.lastRolledFor = next
+		}
 	}
 }

--- a/go/internal/loadpoint/schedule.go
+++ b/go/internal/loadpoint/schedule.go
@@ -1,0 +1,56 @@
+package loadpoint
+
+import "time"
+
+// Schedule is the user's persistent charging intent for one loadpoint:
+// "be at SoCPct by TimeOfDayMinUTC each day". When Recurring is true the
+// Manager rolls the loadpoint's targetTime forward to tomorrow once
+// today's deadline passes; when false the schedule still hydrates the
+// one-shot target_soc_pct/target_time fields on save but doesn't refresh
+// itself.
+//
+// SurplusUnlockBatSoCPct, if > 0, tells the dispatch controller to grab
+// PV surplus into this loadpoint whenever the home battery's SoC sits at
+// or above the threshold — even when SurplusOnly is off and the MPC has
+// nothing planned. Hysteresis (release at threshold − BatSoCUnlockHystPp)
+// keeps the contactor from flapping at the boundary.
+//
+// Zero value (Empty) means "no schedule configured". Persistence keys
+// off this — Empty schedules are not written to disk.
+type Schedule struct {
+	SoCPct                 float64 `json:"soc_pct"`
+	TimeOfDayMinUTC        int     `json:"time_of_day_min_utc"` // 0..1439
+	Recurring              bool    `json:"recurring"`
+	SurplusUnlockBatSoCPct float64 `json:"surplus_unlock_bat_soc_pct,omitempty"`
+}
+
+// BatSoCUnlockHystPp is the percentage-point gap between arm and release
+// for the bat-SoC surplus unlock. Armed at threshold, released at
+// threshold − 5 pp. Tuned to swallow normal Kalman noise on bat_soc
+// readings (~0.5–1 pp) without ever flapping the contactor.
+const BatSoCUnlockHystPp = 5.0
+
+// Empty reports whether the schedule carries no operator intent. The
+// persistence layer writes nothing on Empty so a stale-loadpoint
+// schedule on disk is naturally GC'd when the operator clears it via
+// the API.
+func (s Schedule) Empty() bool {
+	return s.SoCPct == 0 && s.TimeOfDayMinUTC == 0 && !s.Recurring && s.SurplusUnlockBatSoCPct == 0
+}
+
+// NextDailyUTC returns the next time-of-day deadline (in UTC) strictly
+// after `now`. If `now` is already past today's slot, returns
+// tomorrow's. Used by RollSchedules to keep recurring deadlines from
+// going stale.
+//
+// `minUTC` is interpreted mod 1440 to defend against UI overflow.
+func NextDailyUTC(now time.Time, minUTC int) time.Time {
+	minUTC = ((minUTC % 1440) + 1440) % 1440
+	now = now.UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(),
+		minUTC/60, minUTC%60, 0, 0, time.UTC)
+	if !today.After(now) {
+		today = today.Add(24 * time.Hour)
+	}
+	return today
+}

--- a/go/internal/loadpoint/schedule_test.go
+++ b/go/internal/loadpoint/schedule_test.go
@@ -104,26 +104,34 @@ func TestManager_RollSchedules_RecurringPromotes(t *testing.T) {
 	}
 }
 
-func TestManager_RollSchedules_NonRecurringExpiresQuietly(t *testing.T) {
+func TestManager_RollSchedules_NonRecurringSeedsOnce(t *testing.T) {
 	m := NewManager()
 	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
-	// Operator set a one-shot target via the legacy path: target_time
-	// is in the past. The non-recurring schedule shouldn't re-arm it.
-	past := time.Date(2026, 5, 11, 5, 0, 0, 0, time.UTC)
-	m.SetTarget("garage", 60, past)
 	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: false}
 	m.SetSchedule("garage", s)
 
+	// Now is 07:00; today's 06:00 has already passed → seed for tomorrow.
 	now := time.Date(2026, 5, 11, 7, 0, 0, 0, time.UTC)
 	m.RollSchedules(now)
-
 	st, _ := m.State("garage")
-	if !st.TargetTime.Equal(past) {
-		t.Errorf("non-recurring should leave existing target_time alone; got %v want %v",
-			st.TargetTime, past)
+	want := time.Date(2026, 5, 12, 6, 0, 0, 0, time.UTC)
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("non-recurring first seed: target_time = %v, want %v",
+			st.TargetTime, want)
 	}
-	if st.TargetSoCPct != 60 {
-		t.Errorf("non-recurring should leave target_soc_pct alone; got %v", st.TargetSoCPct)
+	if st.TargetSoCPct != 50 {
+		t.Errorf("non-recurring first seed: target_soc_pct = %v, want 50", st.TargetSoCPct)
+	}
+
+	// After the deadline passes, RollSchedules must NOT re-seed —
+	// non-recurring expires quietly. The schedule sticks around so
+	// the operator can inspect it, but target_time stays in the past.
+	after := want.Add(2 * time.Hour)
+	m.RollSchedules(after)
+	st, _ = m.State("garage")
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("non-recurring after deadline: target_time should stay at %v, got %v",
+			want, st.TargetTime)
 	}
 }
 

--- a/go/internal/loadpoint/schedule_test.go
+++ b/go/internal/loadpoint/schedule_test.go
@@ -1,0 +1,180 @@
+package loadpoint
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextDailyUTC(t *testing.T) {
+	base := time.Date(2026, 5, 10, 8, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		now   time.Time
+		min   int
+		wantH int
+		wantD int
+	}{
+		{"slot later today", base, 600, 10, 10}, // 10:00 today
+		{"slot earlier today rolls to tomorrow", base, 360, 6, 11},
+		{"slot at exact now rolls to tomorrow", base, 480, 8, 11},
+		{"negative minUTC normalises", base, -60, 23, 10}, // 23:00 today (1440-60=1380 → 23:00)
+		{"overflow minUTC normalises", base, 1500, 1, 11}, // 1500 mod 1440 = 60 = 01:00, < now → tomorrow
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := NextDailyUTC(c.now, c.min)
+			if got.Hour() != c.wantH || got.Day() != c.wantD {
+				t.Errorf("NextDailyUTC(%v,%d) = %v, want H=%d D=%d",
+					c.now, c.min, got, c.wantH, c.wantD)
+			}
+			if !got.After(c.now) {
+				t.Errorf("NextDailyUTC must return time strictly after now; got %v <= %v",
+					got, c.now)
+			}
+		})
+	}
+}
+
+func TestScheduleEmpty(t *testing.T) {
+	if !(Schedule{}).Empty() {
+		t.Error("zero Schedule should be Empty")
+	}
+	if (Schedule{SoCPct: 50}).Empty() {
+		t.Error("Schedule with SoCPct set should not be Empty")
+	}
+	if (Schedule{SurplusUnlockBatSoCPct: 80}).Empty() {
+		t.Error("Schedule with bat-soc unlock should not be Empty")
+	}
+}
+
+func TestManager_SetGetClearSchedule(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+
+	if _, ok := m.GetSchedule("garage"); ok {
+		t.Fatal("fresh manager should have no schedule")
+	}
+	if _, ok := m.GetSchedule("nope"); ok {
+		t.Fatal("unknown ID should return ok=false")
+	}
+
+	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: true, SurplusUnlockBatSoCPct: 80}
+	if !m.SetSchedule("garage", s) {
+		t.Fatal("SetSchedule should succeed for known ID")
+	}
+	got, ok := m.GetSchedule("garage")
+	if !ok || got != s {
+		t.Errorf("GetSchedule roundtrip mismatch: got %+v, want %+v", got, s)
+	}
+	if m.SetSchedule("nope", s) {
+		t.Error("SetSchedule should reject unknown ID")
+	}
+
+	if !m.ClearSchedule("garage") {
+		t.Fatal("ClearSchedule should succeed")
+	}
+	if _, ok := m.GetSchedule("garage"); ok {
+		t.Error("ClearSchedule should remove it")
+	}
+}
+
+func TestManager_RollSchedules_RecurringPromotes(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: true}
+	m.SetSchedule("garage", s)
+
+	now := time.Date(2026, 5, 11, 7, 0, 0, 0, time.UTC) // past 06:00
+	m.RollSchedules(now)
+
+	st, _ := m.State("garage")
+	if st.TargetSoCPct != 50 {
+		t.Errorf("expected target_soc_pct=50 after roll, got %v", st.TargetSoCPct)
+	}
+	want := time.Date(2026, 5, 12, 6, 0, 0, 0, time.UTC)
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("expected target_time=%v after roll, got %v", want, st.TargetTime)
+	}
+
+	// Idempotent: rolling again at the same time shouldn't push it again.
+	m.RollSchedules(now)
+	st, _ = m.State("garage")
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("RollSchedules should be idempotent within the same window; got %v", st.TargetTime)
+	}
+}
+
+func TestManager_RollSchedules_NonRecurringExpiresQuietly(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	// Operator set a one-shot target via the legacy path: target_time
+	// is in the past. The non-recurring schedule shouldn't re-arm it.
+	past := time.Date(2026, 5, 11, 5, 0, 0, 0, time.UTC)
+	m.SetTarget("garage", 60, past)
+	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: false}
+	m.SetSchedule("garage", s)
+
+	now := time.Date(2026, 5, 11, 7, 0, 0, 0, time.UTC)
+	m.RollSchedules(now)
+
+	st, _ := m.State("garage")
+	if !st.TargetTime.Equal(past) {
+		t.Errorf("non-recurring should leave existing target_time alone; got %v want %v",
+			st.TargetTime, past)
+	}
+	if st.TargetSoCPct != 60 {
+		t.Errorf("non-recurring should leave target_soc_pct alone; got %v", st.TargetSoCPct)
+	}
+}
+
+func TestManager_RollSchedules_RecurringSeedsFirstTarget(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	// No SetTarget called yet — schedule alone should populate it.
+	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: true}
+	m.SetSchedule("garage", s)
+
+	now := time.Date(2026, 5, 11, 7, 0, 0, 0, time.UTC)
+	m.RollSchedules(now)
+
+	st, _ := m.State("garage")
+	if st.TargetSoCPct != 50 {
+		t.Errorf("expected initial target_soc_pct=50 from schedule, got %v", st.TargetSoCPct)
+	}
+	want := time.Date(2026, 5, 12, 6, 0, 0, 0, time.UTC)
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("expected initial target_time=%v, got %v", want, st.TargetTime)
+	}
+}
+
+func TestManager_HydrateSchedules(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}, {ID: "street"}})
+	want := Schedule{SoCPct: 80, TimeOfDayMinUTC: 420, Recurring: true, SurplusUnlockBatSoCPct: 75}
+	m.HydrateSchedules(func(id string) (Schedule, bool) {
+		if id == "garage" {
+			return want, true
+		}
+		return Schedule{}, false
+	})
+	got, ok := m.GetSchedule("garage")
+	if !ok || got != want {
+		t.Errorf("HydrateSchedules: got=%+v ok=%v want=%+v", got, ok, want)
+	}
+	if _, ok := m.GetSchedule("street"); ok {
+		t.Error("HydrateSchedules should not invent schedules for non-loaded IDs")
+	}
+}
+
+func TestManager_LoadPreservesSchedule(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	s := Schedule{SoCPct: 50, TimeOfDayMinUTC: 360, Recurring: true}
+	m.SetSchedule("garage", s)
+	// Re-load (config hot reload): same id should keep its schedule.
+	m.Load([]Config{{ID: "garage", DriverName: "easee", MaxChargeW: 11000}})
+	got, ok := m.GetSchedule("garage")
+	if !ok || got != s {
+		t.Errorf("Load should preserve schedule across reload; got=%+v ok=%v", got, ok)
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -475,6 +475,29 @@ func Optimize(slots []Slot, p Params) Plan {
 							continue
 						}
 
+						// Surplus-only EV: the battery must not steal
+						// PV that the EV could use, and must not
+						// grid-charge for arbitrage while the EV is
+						// connected. Without this rule the planner
+						// "launders" cheap grid through the battery:
+						// import in slot N to charge battery, discharge
+						// to EV in slot N+1 — gridW in N+1 looks ~0,
+						// the EV-only constraint above doesn't catch
+						// it, and the EV ends up grid-fed at retail
+						// import price + roundtrip loss. Forbidding
+						// (battW > 0 AND gridW > 50) when a surplus-
+						// only LP is plugged in closes that loophole.
+						// Battery charging from genuine PV surplus
+						// (gridW ≤ 50) stays allowed — that just
+						// means PV exceeds load+EV+battery and the
+						// battery soaks up what would otherwise
+						// export. Discharge (battW < 0) is always
+						// allowed (peak shaving, fuse guard, self-
+						// consumption when EV not drawing).
+						if evActive && lp.SurplusOnly && battW > 0 && gridW > 50 {
+							continue
+						}
+
 						// Mode-based feasibility. Baseline includes
 						// EV so the mode check asks "is the extra
 						// battery action pulling the grid further

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -498,6 +498,24 @@ func Optimize(slots []Slot, p Params) Plan {
 							continue
 						}
 
+						// Don't simultaneously discharge the home battery
+						// for grid export AND charge the EV. Either the
+						// battery is being sold for arbitrage profit (and
+						// EV charging would erode the export), or it's a
+						// roundtrip-laundering loop (battery → AC → EV at
+						// 2× round-trip loss vs. just charging the EV
+						// from grid in a different slot). Letting both
+						// happen at once is strictly worse than picking a
+						// slot that does one or the other. The deadline
+						// shortfall penalty handles "but the EV needs to
+						// charge eventually" — the DP will move EV
+						// charging to a slot where battery isn't
+						// exporting. 50 W epsilon mirrors the surplus-
+						// only constraints above.
+						if evActive && evW > 0 && battW < 0 && gridW < -50 {
+							continue
+						}
+
 						// Mode-based feasibility. Baseline includes
 						// EV so the mode check asks "is the extra
 						// battery action pulling the grid further

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -139,6 +139,46 @@ func TestArbitrageDischargesToExpensive(t *testing.T) {
 	}
 }
 
+// Regression: don't simultaneously discharge the home battery for grid
+// export AND charge the EV in the same slot. Either is fine alone but
+// together it's strictly worse than picking a slot for one or the
+// other — the EV either erodes the export profit or laundered grid
+// through the battery at 2× round-trip loss.
+func TestArbitrageNoEVChargeWhileBatteryExporting(t *testing.T) {
+	// Two slots: slot 0 cheap-with-PV (battery should charge from PV,
+	// EV could too), slot 1 expensive (battery should discharge to
+	// export). With the constraint, slot 1 must NOT also charge the EV.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 50, LoadW: 500, PVW: -3000, Confidence: 1},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 800, SpotOre: 800, LoadW: 500, PVW: 0, Confidence: 1},
+	}
+	p := baseParams(ModeArbitrage)
+	p.InitialSoCPct = 80 // headroom for big discharge
+	p.ExportOrePerKWh = 700
+	p.Loadpoint = &LoadpointSpec{
+		ID:               "garage",
+		CapacityWh:       60000,
+		Levels:           11,
+		InitialSoCPct:    20,
+		PluggedIn:        true,
+		TargetSoCPct:     30,
+		TargetSlotIdx:    1, // deadline at slot 1 forces some EV charging
+		MaxChargeW:       11000,
+		AllowedStepsW:    []float64{0, 5000, 11000},
+		ChargeEfficiency: 0.9,
+	}
+	plan := Optimize(slots, p)
+
+	for i, a := range plan.Actions {
+		gridW := a.LoadW + a.PVW + a.BatteryW + a.LoadpointW
+		// gridW < -50 means real export this slot.
+		if a.LoadpointW > 0 && a.BatteryW < 0 && gridW < -50 {
+			t.Errorf("slot %d: EV charging at %fW while battery exports (battW=%f gridW=%f) — constraint violated",
+				i, a.LoadpointW, a.BatteryW, gridW)
+		}
+	}
+}
+
 // Regression: arbitrage at negative spot must NOT discharge battery to
 // grid. Real incident 2026-05-02: operator switched to planner_arbitrage
 // during −5 öre spot prices and watched batteries discharge full power

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -576,7 +576,9 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// "idle, import to cover load" over "discharge now, refill from PV
 	// tomorrow" (because discharging loses η_rt while the extra retail-
 	// priced terminal credit is never realised).
+	terminalDefaulted := false
 	if p.TerminalSoCPrice <= 0 {
+		terminalDefaulted = true
 		switch p.Mode {
 		case ModeSelfConsumption, ModeCheapCharge:
 			p.TerminalSoCPrice = selfConsumptionTerminalPrice(prices,
@@ -606,6 +608,24 @@ func (s *Service) replan(_ context.Context) *Plan {
 			p.Loadpoint = spec
 			loadpointID = spec.ID
 		}
+	}
+
+	// Surplus-only LP override: when an EV is connected to a surplus-
+	// only loadpoint, the battery is forbidden from grid-charging
+	// (mpc.go feasibility). The default arbitrage terminal credit
+	// (mean retail import price across the horizon) then becomes
+	// misleading — it tells the DP "stored energy is worth full
+	// retail" while the only realistic discharge path is local
+	// self-consumption (battery → house, battery → EV via the still-
+	// allowed PV-only charge). Re-evaluate the terminal credit using
+	// the self-consumption formula so the planner stops chasing a
+	// reward it can no longer earn through grid arbitrage. Only
+	// applies when we just defaulted above; an explicit caller-
+	// supplied TerminalSoCPrice is respected.
+	if terminalDefaulted && p.Loadpoint != nil && p.Loadpoint.SurplusOnly &&
+		p.Mode != ModeSelfConsumption && p.Mode != ModeCheapCharge {
+		p.TerminalSoCPrice = selfConsumptionTerminalPrice(prices,
+			s.ExportBonusOreKwh, s.ExportFeeOreKwh)
 	}
 
 	slog.Info("mpc: optimize params",

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -506,6 +506,22 @@ func (s *Service) checkDivergence(ctx context.Context) {
 // Exposed for tests and API triggers.
 func (s *Service) Replan(ctx context.Context) *Plan { return s.replan(ctx) }
 
+// ReplanWithReason is Replan with an explicit reason string that lands
+// in slog + the diagnose snapshot. Use it when an external event (API
+// mutation, settings change, mode flip) forces a replan — the default
+// "scheduled" reason loses that provenance, which makes time-travel
+// debugging harder when the operator asks "why did the plan change at
+// 12:34?". Reasons should be short kebab-style, e.g.
+// "surplus_only_disabled", "target_soc_changed", "mode_changed".
+func (s *Service) ReplanWithReason(ctx context.Context, reason string) *Plan {
+	if reason != "" {
+		s.mu.Lock()
+		s.lastReason = reason
+		s.mu.Unlock()
+	}
+	return s.replan(ctx)
+}
+
 func (s *Service) replan(_ context.Context) *Plan {
 	now := time.Now()
 	untilMs := now.Add(s.Horizon).UnixMilli()

--- a/web/index.html
+++ b/web/index.html
@@ -30,7 +30,7 @@
   <!-- Design tokens FIRST — every sheet and every <ftw-*> shadow root reads
        from :root declared in /components/theme.css. -->
   <link rel="stylesheet" href="/components/theme.css">
-  <link rel="stylesheet" href="/style.css?v=lp1">
+  <link rel="stylesheet" href="/style.css?v=lp2">
   <!-- /next-only visual redesign — layered on top of style.css and scoped
        to body.ftw-next so legacy /index.html is untouched. -->
   <link rel="stylesheet" href="/next.css?v=next2">

--- a/web/index.html
+++ b/web/index.html
@@ -30,7 +30,7 @@
   <!-- Design tokens FIRST — every sheet and every <ftw-*> shadow root reads
        from :root declared in /components/theme.css. -->
   <link rel="stylesheet" href="/components/theme.css">
-  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/style.css?v=lp1">
   <!-- /next-only visual redesign — layered on top of style.css and scoped
        to body.ftw-next so legacy /index.html is untouched. -->
   <link rel="stylesheet" href="/next.css?v=next2">
@@ -405,6 +405,15 @@
       <div class="twins-grid" id="twins-grid"></div>
     </section>
 
+    <!-- Loadpoints — EV charger configuration + planned schedule -->
+    <section id="loadpoints-section" class="advanced-only">
+      <div class="section-header">
+        <h2>Loadpoints</h2>
+        <span id="loadpoints-subtitle" class="plan-summary"></span>
+      </div>
+      <div id="loadpoints-grid"></div>
+    </section>
+
     <!-- Drivers — compact -->
     <section id="drivers-section" class="advanced-only">
       <div class="drivers-grid" id="drivers-grid"></div>
@@ -622,6 +631,7 @@
   <script src="/models.js?v=diag1"></script>
   <script src="/plan.js?v=diag1"></script>
   <script src="/twins.js?v=diag1"></script>
+  <script src="/loadpoints.js?v=lp1"></script>
   <script src="/diagnose.js?v=diag1"></script>
   <script src="/update-badge.js?v=modal1" defer></script>
   <script>

--- a/web/loadpoints.js
+++ b/web/loadpoints.js
@@ -1,0 +1,186 @@
+// loadpoints.js — advanced-mode panel: per-loadpoint configuration
+// summary + the planner's per-slot charging schedule. Refreshes every
+// 10 s. Mirrors twins.js's lifecycle: only visible when body.advanced
+// is set, but the fetches run regardless so toggling in is instant.
+//
+// Data sources:
+//   GET /api/loadpoints  — array of LP states (id, driver, surplus_only,
+//                          plugged_in, max_charge_w, allowed_steps_w,
+//                          current_soc_pct, target_soc_pct, target_time,
+//                          vehicle_*, soc_source).
+//   GET /api/mpc/plan    — current plan; actions[] include optional
+//                          loadpoint_w + loadpoint_soc_pct when an LP
+//                          is part of the DP. Only one LP at a time
+//                          today (mpc/service.go: "One loadpoint at a
+//                          time — multi-LP support is on the roadmap").
+
+(function () {
+  'use strict';
+
+  const REFRESH_MS = 10000;
+  // How many forward slots of the schedule to render. The plan is
+  // 193 slots × 15 min = 48 h; rendering the lot creates a wall of
+  // numbers nobody reads. 16 slots = next 4 h covers the operator's
+  // "what is this thing about to do?" question without obscuring it.
+  const SCHEDULE_SLOTS = 16;
+
+  async function fetchAll() {
+    const [lps, plan] = await Promise.all([
+      fetch('/api/loadpoints').then(r => r.json()).catch(() => ({ loadpoints: [] })),
+      fetch('/api/mpc/plan').then(r => r.json()).catch(() => null),
+    ]);
+    render(lps && lps.loadpoints ? lps.loadpoints : [], plan);
+  }
+
+  function fmtW(w) {
+    if (w == null || !isFinite(w)) return '—';
+    if (Math.abs(w) >= 1000) return (w / 1000).toFixed(2) + ' kW';
+    return Math.round(w) + ' W';
+  }
+
+  function fmtPct(p) {
+    if (p == null || !isFinite(p)) return '—';
+    return p.toFixed(1) + '%';
+  }
+
+  function fmtPriceOre(o) {
+    if (o == null || !isFinite(o)) return '—';
+    return o.toFixed(0);
+  }
+
+  function fmtSlotTime(ms) {
+    if (!ms) return '—';
+    const d = new Date(ms);
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `${hh}:${mm}`;
+  }
+
+  function fmtDeadline(iso) {
+    if (!iso || iso.startsWith('0001-')) return null;
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return null;
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    return `${d.toLocaleDateString()} ${hh}:${mm}`;
+  }
+
+  // Badge: small pill matching the existing .ftw-badge convention from
+  // ftw-badge.js / next.css. Uses theme tokens so light mode flips
+  // correctly. Two variants: "on" = amber accent (matches .accent-e
+  // affordance), "off" = muted hairline.
+  function badge(label, on) {
+    const cls = on ? 'lp-badge lp-badge-on' : 'lp-badge';
+    return `<span class="${cls}">${label}</span>`;
+  }
+
+  function configBlock(lp) {
+    const d = fmtDeadline(lp.target_time);
+    const target = (lp.target_soc_pct > 0)
+      ? `${lp.target_soc_pct.toFixed(0)}%${d ? ' by ' + d : ''}`
+      : 'opportunistic';
+    const vehicle = (lp.vehicle_driver)
+      ? `${lp.vehicle_driver}${lp.vehicle_charging_state ? ' · ' + lp.vehicle_charging_state : ''}${lp.vehicle_stale ? ' · stale' : ''}`
+      : '—';
+    const soc = (lp.current_soc_pct != null)
+      ? `${lp.current_soc_pct.toFixed(1)}%${lp.soc_source ? ' (' + lp.soc_source + ')' : ''}`
+      : '—';
+    const rows = [
+      ['Driver',       lp.driver_name || '—'],
+      ['Plugged in',   badge(lp.plugged_in ? 'YES' : 'NO', lp.plugged_in)],
+      ['Surplus only', badge(lp.surplus_only ? 'ON' : 'OFF', lp.surplus_only)],
+      ['Live power',   fmtW(lp.current_power_w)],
+      ['Max',          fmtW(lp.max_charge_w)],
+      ['Min',          fmtW(lp.min_charge_w)],
+      ['Target',       target],
+      ['Vehicle',      vehicle],
+      ['SoC',          soc],
+    ];
+    const html = rows.map(([k, v]) =>
+      `<div class="lp-cfg-row"><span class="lp-cfg-key">${k}</span><span class="lp-cfg-val">${v}</span></div>`
+    ).join('');
+    return `<div class="lp-cfg">${html}</div>`;
+  }
+
+  function scheduleTable(lp, plan) {
+    if (!plan || !plan.plan || !Array.isArray(plan.plan.actions)) {
+      return '<div class="lp-empty">No active plan.</div>';
+    }
+    // Plan only carries one LP today. Match by checking whether *any*
+    // action has a loadpoint_w / loadpoint_soc_pct field — if it does,
+    // assume those refer to this LP. Once multi-LP support lands the
+    // plan will need to namespace these by LP id; for now the comment
+    // in mpc/service.go is the source of truth.
+    const planLpId = plan.plan.loadpoint_id || null;
+    const isOurs = !planLpId || planLpId === lp.id;
+    if (!isOurs) {
+      return `<div class="lp-empty">Plan is scheduling <code>${planLpId}</code>, not this loadpoint.</div>`;
+    }
+    const slots = plan.plan.actions
+      .filter(a => a.loadpoint_w != null || a.loadpoint_soc_pct != null)
+      .slice(0, SCHEDULE_SLOTS);
+    if (slots.length === 0) {
+      return '<div class="lp-empty">Planner did not allocate this loadpoint in the current horizon ' +
+             '(no target SoC + no surplus_only opportunistic slots).</div>';
+    }
+    const rows = slots.map(a => {
+      const charging = a.loadpoint_w && a.loadpoint_w > 50;
+      const cls = charging ? 'lp-row-charging' : '';
+      return `<tr class="${cls}">` +
+        `<td>${fmtSlotTime(a.slot_start_ms)}</td>` +
+        `<td>${fmtPriceOre(a.price_ore)}</td>` +
+        `<td>${fmtW(a.loadpoint_w || 0)}</td>` +
+        `<td>${fmtPct(a.loadpoint_soc_pct)}</td>` +
+        `<td>${fmtW(a.battery_w)}</td>` +
+        `<td>${a.reason || ''}</td>` +
+        '</tr>';
+    }).join('');
+    return '<div class="lp-schedule-wrap">' +
+      '<table class="diag-table lp-schedule">' +
+      '<thead><tr>' +
+        '<th>Slot</th>' +
+        '<th>Price (öre)</th>' +
+        '<th>EV W</th>' +
+        '<th>EV SoC</th>' +
+        '<th>Battery W</th>' +
+        '<th>Reason</th>' +
+      '</tr></thead>' +
+      `<tbody>${rows}</tbody>` +
+      '</table></div>';
+  }
+
+  function loadpointCard(lp, plan) {
+    return '<div class="lp-card">' +
+      `<div class="lp-card-header"><h3>${lp.id}</h3></div>` +
+      '<div class="lp-card-body">' +
+      configBlock(lp) +
+      scheduleTable(lp, plan) +
+      '</div></div>';
+  }
+
+  function render(lps, plan) {
+    const grid = document.getElementById('loadpoints-grid');
+    if (!grid) return;
+    if (!lps || lps.length === 0) {
+      grid.innerHTML = '<div class="lp-empty">No loadpoints configured.</div>';
+    } else {
+      grid.innerHTML = lps.map(lp => loadpointCard(lp, plan)).join('');
+    }
+    const sub = document.getElementById('loadpoints-subtitle');
+    if (sub) {
+      const planMode = plan && plan.plan ? plan.plan.mode : 'no plan';
+      sub.textContent = `${lps.length} loadpoint${lps.length === 1 ? '' : 's'} · planner: ${planMode}`;
+    }
+  }
+
+  function init() {
+    fetchAll();
+    setInterval(fetchAll, REFRESH_MS);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/web/loadpoints.js
+++ b/web/loadpoints.js
@@ -151,7 +151,7 @@
   }
 
   function loadpointCard(lp, plan) {
-    return '<div class="lp-card">' +
+    return `<div class="lp-card" data-lp-id="${lp.id}">` +
       `<div class="lp-card-header"><h3>${lp.id}</h3></div>` +
       '<div class="lp-card-body">' +
       configBlock(lp) +
@@ -162,11 +162,45 @@
   function render(lps, plan) {
     const grid = document.getElementById('loadpoints-grid');
     if (!grid) return;
+
+    // Capture scroll positions BEFORE swapping innerHTML — otherwise the
+    // 5 s auto-refresh yanks the page (and any per-card schedule scroll)
+    // back to the top mid-read. Page scroll comes from the document's
+    // scrolling element; per-LP scrolls come from each `.lp-schedule-wrap`
+    // keyed by the card's data-lp-id so we restore to the right card even
+    // if LP order or count changes.
+    const scroller = document.scrollingElement || document.documentElement;
+    const pageScroll = { top: scroller.scrollTop, left: scroller.scrollLeft };
+    const wrapScrolls = {};
+    grid.querySelectorAll('.lp-card[data-lp-id]').forEach(card => {
+      const id = card.getAttribute('data-lp-id');
+      const wrap = card.querySelector('.lp-schedule-wrap');
+      if (id && wrap) {
+        wrapScrolls[id] = { top: wrap.scrollTop, left: wrap.scrollLeft };
+      }
+    });
+
     if (!lps || lps.length === 0) {
       grid.innerHTML = '<div class="lp-empty">No loadpoints configured.</div>';
     } else {
       grid.innerHTML = lps.map(lp => loadpointCard(lp, plan)).join('');
     }
+
+    // Restore per-LP wrap scrolls first, then the page. Restoring the
+    // page last avoids browsers re-anchoring the page scroll to the
+    // freshly-laid-out content height.
+    grid.querySelectorAll('.lp-card[data-lp-id]').forEach(card => {
+      const id = card.getAttribute('data-lp-id');
+      const prev = wrapScrolls[id];
+      const wrap = card.querySelector('.lp-schedule-wrap');
+      if (prev && wrap) {
+        wrap.scrollTop = prev.top;
+        wrap.scrollLeft = prev.left;
+      }
+    });
+    scroller.scrollTop = pageScroll.top;
+    scroller.scrollLeft = pageScroll.left;
+
     const sub = document.getElementById('loadpoints-subtitle');
     if (sub) {
       const planMode = plan && plan.plan ? plan.plan.mode : 'no plan';

--- a/web/loadpoints.js
+++ b/web/loadpoints.js
@@ -19,10 +19,11 @@
 
   const REFRESH_MS = 10000;
   // How many forward slots of the schedule to render. The plan is
-  // 193 slots × 15 min = 48 h; rendering the lot creates a wall of
-  // numbers nobody reads. 16 slots = next 4 h covers the operator's
-  // "what is this thing about to do?" question without obscuring it.
-  const SCHEDULE_SLOTS = 16;
+  // 193 slots × 15 min = 48 h. 4 h was too narrow — operators looking
+  // at "why does the plan chart show grid burst at 13:00 but my schedule
+  // table doesn't list it?" were confused. 96 slots = 24 h covers the
+  // typical overnight charging window plus the next afternoon.
+  const SCHEDULE_SLOTS = 96;
 
   async function fetchAll() {
     const [lps, plan] = await Promise.all([

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1976,6 +1976,16 @@
     evModalBody.appendChild(p);
   }
 
+  // Schedule-control persistence across the modal's auto-refresh tick.
+  // refreshEvModal wipes evModalBody every poll; without these the
+  // user's in-progress edits to the schedule inputs would be reset
+  // every few seconds. The cached element is re-attached as long as
+  // the user has touched any field and hasn't yet hit Save / Clear,
+  // and the LP id hasn't changed (different planet clicked).
+  var schedCacheEl = null;
+  var schedCacheLpId = null;
+  var schedDirty = false;
+
   function refreshEvModal() {
     // Pass driver query if known so the backend can scope the response
     // to the clicked planet (multi-EV setups). Falls back to whatever
@@ -2014,71 +2024,302 @@
         }
       }
       if (matched) {
-        evModalBody.appendChild(buildSurplusOnlyControl(matched));
+        if (schedDirty && schedCacheEl && schedCacheLpId === matched.id) {
+          // User is mid-edit: re-attach their dirty form instead of
+          // rebuilding it from server state and trampling input.
+          evModalBody.appendChild(schedCacheEl);
+        } else {
+          evModalBody.appendChild(buildScheduleControl(matched));
+        }
       }
     }).catch(function () {
       setEvModalMessage("Failed to load EV status");
     });
   }
 
-  // buildSurplusOnlyControl renders the "charge only from PV" toggle
-  // at the bottom of the EV modal. Ticking auto-targets 100 % by the
-  // next 16:00 UTC; unticking preserves the existing target/deadline
-  // and just clears the flag. Live state comes from /api/loadpoints
-  // so the checkbox always reflects server truth on modal refresh.
-  function buildSurplusOnlyControl(lp) {
+  // buildScheduleControl renders the persistent charging schedule
+  // section: target SoC + time (local; converted to UTC for the wire),
+  // recurring checkbox, and the bat-SoC surplus-unlock threshold.
+  // The backend persists this across restarts (state.config), rolls the
+  // deadline forward each day when Recurring is set, and arms the
+  // surplus-grab whenever the home battery sits at or above the
+  // threshold (with 5 pp release hysteresis).
+  function buildScheduleControl(lp) {
+    var sched = (lp && lp.schedule) || {};
+    // Convert "minutes-of-day-UTC" to a "HH:MM" string in the
+    // browser's local zone. The UI shows local time everywhere;
+    // we marshal back to UTC minutes on save.
+    var hasSched = !!(sched.soc_pct || sched.recurring || sched.surplus_unlock_bat_soc_pct);
+    var initLocalHHMM = utcMinsToLocalHHMM(typeof sched.time_of_day_min_utc === "number" ? sched.time_of_day_min_utc : 360);
+    var initSoC = typeof sched.soc_pct === "number" && sched.soc_pct > 0 ? sched.soc_pct : 50;
+    var initRec = !!sched.recurring;
+    var savedUnlock = typeof sched.surplus_unlock_bat_soc_pct === "number" ? sched.surplus_unlock_bat_soc_pct : 0;
+    // Surplus on/off is derived from the saved threshold: > 0 ⇒ enabled.
+    // The threshold input retains the last-used value (or defaults to 50)
+    // so unchecking + re-checking doesn't wipe the user's pick.
+    var initSurplus = savedUnlock > 0;
+    var initUnlock = savedUnlock > 0 ? savedUnlock : 50;
+
     var box = document.createElement("div");
     box.style.marginTop = "0.75rem";
     box.style.paddingTop = "0.6rem";
     box.style.borderTop = "1px solid var(--line)";
-    var label = document.createElement("label");
-    label.style.display = "flex";
-    label.style.alignItems = "center";
-    label.style.gap = "0.5rem";
-    label.style.cursor = "pointer";
-    label.style.fontSize = "0.85rem";
-    var cb = document.createElement("input");
-    cb.type = "checkbox";
-    cb.checked = !!lp.surplus_only;
-    cb.style.accentColor = "var(--accent-e)";
-    var text = document.createElement("span");
-    text.textContent = "Surplus-only · 100 % by 16:00 UTC";
-    label.appendChild(cb);
-    label.appendChild(text);
-    var hint = document.createElement("small");
-    hint.style.display = "block";
-    hint.style.marginTop = "0.35rem";
-    hint.style.color = "var(--text-dim)";
-    hint.textContent = "Charge only from PV surplus. Holds 3-phase. MPC won't plan grid-funded charging for this loadpoint.";
-    box.appendChild(label);
-    box.appendChild(hint);
-    cb.addEventListener("change", function () {
-      cb.disabled = true;
-      var body;
-      if (cb.checked) {
-        var now = new Date();
-        var t = new Date(Date.UTC(
-          now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
-          16, 0, 0));
-        if (t.getTime() <= now.getTime()) t.setUTCDate(t.getUTCDate() + 1);
-        body = { soc_pct: 100, target_time_ms: t.getTime(), surplus_only: true };
-      } else {
-        // Pointer/patch semantics on the backend: omitting fields
-        // preserves their existing values. Sending only surplus_only
-        // avoids overwriting the user's target/deadline with whatever
-        // (possibly stale or missing) snapshot we last fetched.
-        body = { surplus_only: false };
+
+    var eyebrow = document.createElement("div");
+    eyebrow.textContent = "Schedule";
+    eyebrow.style.fontFamily = "var(--mono)";
+    eyebrow.style.fontSize = "0.7rem";
+    eyebrow.style.letterSpacing = "0.18em";
+    eyebrow.style.textTransform = "uppercase";
+    eyebrow.style.color = "var(--text-dim)";
+    eyebrow.style.marginBottom = "0.55rem";
+    box.appendChild(eyebrow);
+
+    function row(labelText, controlEl) {
+      var r = document.createElement("div");
+      r.style.display = "flex";
+      r.style.alignItems = "center";
+      r.style.justifyContent = "space-between";
+      r.style.gap = "0.5rem";
+      r.style.marginBottom = "0.4rem";
+      var l = document.createElement("label");
+      l.textContent = labelText;
+      l.style.fontSize = "0.85rem";
+      l.style.color = "var(--fg)";
+      r.appendChild(l);
+      r.appendChild(controlEl);
+      return r;
+    }
+
+    function numInput(value, min, max, step, suffix) {
+      var wrap = document.createElement("div");
+      wrap.style.display = "inline-flex";
+      wrap.style.alignItems = "baseline";
+      wrap.style.gap = "0.25rem";
+      var inp = document.createElement("input");
+      inp.type = "number";
+      inp.value = String(value);
+      inp.min = String(min);
+      inp.max = String(max);
+      inp.step = String(step);
+      inp.style.width = "4.5rem";
+      inp.style.padding = "0.25rem 0.4rem";
+      inp.style.background = "var(--ink-raised)";
+      inp.style.color = "var(--fg)";
+      inp.style.border = "1px solid var(--line)";
+      inp.style.borderRadius = "3px";
+      inp.style.fontFamily = "var(--mono)";
+      inp.style.fontSize = "0.85rem";
+      inp.style.textAlign = "right";
+      wrap.appendChild(inp);
+      if (suffix) {
+        var s = document.createElement("span");
+        s.textContent = suffix;
+        s.style.color = "var(--text-dim)";
+        s.style.fontSize = "0.8rem";
+        wrap.appendChild(s);
       }
+      wrap.input = inp;
+      return wrap;
+    }
+
+    var socWrap = numInput(initSoC, 0, 100, 5, "%");
+    var unlockWrap = numInput(initUnlock, 0, 100, 5, "%");
+
+    var timeInp = document.createElement("input");
+    timeInp.type = "time";
+    timeInp.value = initLocalHHMM;
+    timeInp.style.padding = "0.25rem 0.4rem";
+    timeInp.style.background = "var(--ink-raised)";
+    timeInp.style.color = "var(--fg)";
+    timeInp.style.border = "1px solid var(--line)";
+    timeInp.style.borderRadius = "3px";
+    timeInp.style.fontFamily = "var(--mono)";
+    timeInp.style.fontSize = "0.85rem";
+
+    function checkbox(checked, labelText) {
+      var cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = checked;
+      cb.style.accentColor = "var(--accent-e)";
+      var wrap = document.createElement("label");
+      wrap.style.display = "inline-flex";
+      wrap.style.alignItems = "center";
+      wrap.style.gap = "0.4rem";
+      wrap.style.cursor = "pointer";
+      wrap.style.fontSize = "0.85rem";
+      wrap.appendChild(cb);
+      var txt = document.createElement("span");
+      txt.textContent = labelText;
+      wrap.appendChild(txt);
+      wrap.input = cb;
+      return wrap;
+    }
+
+    var recWrap = checkbox(initRec, "Recurring (every day)");
+    var surWrap = checkbox(initSurplus, "Surplus charge from home battery");
+    var recCb = recWrap.input;
+    var surCb = surWrap.input;
+
+    box.appendChild(row("Target SoC", socWrap));
+    box.appendChild(row("By", timeInp));
+
+    var checkRow = document.createElement("div");
+    checkRow.style.display = "flex";
+    checkRow.style.flexDirection = "column";
+    checkRow.style.gap = "0.35rem";
+    checkRow.style.marginBottom = "0.55rem";
+    checkRow.appendChild(recWrap);
+    checkRow.appendChild(surWrap);
+    box.appendChild(checkRow);
+
+    var unlockHint = document.createElement("small");
+    unlockHint.style.display = "block";
+    unlockHint.style.color = "var(--text-dim)";
+    unlockHint.style.marginTop = "0.2rem";
+    unlockHint.style.marginBottom = "0.3rem";
+    unlockHint.textContent = "Always grab PV surplus when home battery ≥ threshold.";
+    box.appendChild(unlockHint);
+
+    var thresholdRow = row("Threshold", unlockWrap);
+    box.appendChild(thresholdRow);
+
+    function applySurplusGate() {
+      var on = surCb.checked;
+      unlockWrap.input.disabled = !on;
+      thresholdRow.style.opacity = on ? "1" : "0.4";
+      thresholdRow.style.pointerEvents = on ? "auto" : "none";
+      unlockHint.style.opacity = on ? "1" : "0.55";
+    }
+    applySurplusGate();
+    surCb.addEventListener("change", applySurplusGate);
+
+    // Actions
+    var btnRow = document.createElement("div");
+    btnRow.style.display = "flex";
+    btnRow.style.gap = "0.5rem";
+    btnRow.style.marginTop = "0.55rem";
+    btnRow.style.justifyContent = "flex-end";
+
+    function mkBtn(label, primary) {
+      var b = document.createElement("button");
+      b.textContent = label;
+      b.style.padding = "0.3rem 0.8rem";
+      b.style.fontSize = "0.8rem";
+      b.style.fontFamily = "var(--mono)";
+      b.style.letterSpacing = "0.06em";
+      b.style.textTransform = "uppercase";
+      b.style.borderRadius = "3px";
+      b.style.cursor = "pointer";
+      b.style.border = "1px solid var(--line)";
+      if (primary) {
+        b.style.background = "var(--accent-e)";
+        b.style.color = "#0a0a0a";
+        b.style.borderColor = "var(--accent-e)";
+      } else {
+        b.style.background = "transparent";
+        b.style.color = "var(--fg)";
+      }
+      return b;
+    }
+    var clearBtn = mkBtn("Clear", false);
+    var saveBtn = mkBtn(hasSched ? "Update" : "Save", true);
+    clearBtn.disabled = !hasSched;
+    if (!hasSched) clearBtn.style.opacity = "0.4";
+    btnRow.appendChild(clearBtn);
+    btnRow.appendChild(saveBtn);
+    box.appendChild(btnRow);
+
+    var status = document.createElement("small");
+    status.style.display = "block";
+    status.style.color = "var(--text-dim)";
+    status.style.marginTop = "0.4rem";
+    status.style.minHeight = "1em";
+    box.appendChild(status);
+
+    // Cache + dirty wiring: each user edit flips schedDirty=true so
+    // the auto-refresh keeps THIS element on screen instead of
+    // rebuilding it from stale server state.
+    schedCacheEl = box;
+    schedCacheLpId = lp.id;
+    schedDirty = false;
+    function markDirty() { schedDirty = true; }
+    [socWrap.input, timeInp, unlockWrap.input].forEach(function (el) {
+      el.addEventListener("input", markDirty);
+      el.addEventListener("change", markDirty);
+    });
+    recCb.addEventListener("change", markDirty);
+
+    saveBtn.addEventListener("click", function () {
+      saveBtn.disabled = true;
+      clearBtn.disabled = true;
+      status.textContent = "Saving…";
+      var localHHMM = timeInp.value || initLocalHHMM;
+      var minUTC = localHHMMToUtcMins(localHHMM);
+      // Surplus checkbox gates the threshold: when off, the threshold
+      // is sent as 0 (the backend interprets 0 as "feature disabled").
+      var unlockVal = surCb.checked ? Number(unlockWrap.input.value) : 0;
+      var body = {
+        schedule: {
+          soc_pct: Number(socWrap.input.value),
+          time_of_day_min_utc: minUTC,
+          recurring: !!recCb.checked,
+          surplus_unlock_bat_soc_pct: unlockVal,
+        },
+      };
       fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/target", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
-      }).finally(function () {
-        if (cb.isConnected) cb.disabled = false;
+      }).then(function (r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        status.textContent = "Saved.";
+        schedDirty = false;
+        schedCacheEl = null;
         refreshEvModal();
+      }).catch(function (e) {
+        status.textContent = "Save failed: " + e.message;
+        saveBtn.disabled = false;
+        clearBtn.disabled = false;
       });
     });
+
+    clearBtn.addEventListener("click", function () {
+      saveBtn.disabled = true;
+      clearBtn.disabled = true;
+      status.textContent = "Clearing…";
+      fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/target", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ schedule: null }),
+      }).then(function (r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        status.textContent = "Cleared.";
+        schedDirty = false;
+        schedCacheEl = null;
+        refreshEvModal();
+      }).catch(function (e) {
+        status.textContent = "Clear failed: " + e.message;
+        saveBtn.disabled = false;
+      });
+    });
+
     return box;
+  }
+
+  function utcMinsToLocalHHMM(min) {
+    var d = new Date();
+    d.setUTCHours(Math.floor(min / 60), min % 60, 0, 0);
+    return String(d.getHours()).padStart(2, "0") + ":" + String(d.getMinutes()).padStart(2, "0");
+  }
+  function localHHMMToUtcMins(hhmm) {
+    var parts = String(hhmm).split(":");
+    if (parts.length !== 2) return 360;
+    var h = parseInt(parts[0], 10), m = parseInt(parts[1], 10);
+    if (isNaN(h) || isNaN(m)) return 360;
+    var d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d.getUTCHours() * 60 + d.getUTCMinutes();
   }
 
   var evRefreshTimer = null;

--- a/web/setup.html
+++ b/web/setup.html
@@ -693,17 +693,34 @@
         <label for="ev-provider">Provider</label>
         <select id="ev-provider">
           <option value="">None</option>
-          <option value="easee">Easee</option>
         </select>
       </div>
       <div id="ev-fields" style="display:none">
-        <div class="form-group">
-          <label for="ev-email">Email</label>
-          <input type="text" id="ev-email" placeholder="user@example.com">
+        <div id="ev-fields-http" style="display:none">
+          <div class="form-group">
+            <label for="ev-username" id="ev-username-label">Username</label>
+            <input type="text" id="ev-username" placeholder="user@example.com">
+          </div>
+          <div class="form-group">
+            <label for="ev-password">Password</label>
+            <input type="password" id="ev-password">
+          </div>
         </div>
-        <div class="form-group">
-          <label for="ev-password">Password</label>
-          <input type="password" id="ev-password">
+        <div id="ev-fields-modbus" style="display:none">
+          <div class="form-group">
+            <label for="ev-mb-host">IP address</label>
+            <input type="text" id="ev-mb-host" placeholder="192.168.1.190">
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="ev-mb-port">Port</label>
+              <input type="number" id="ev-mb-port">
+            </div>
+            <div class="form-group">
+              <label for="ev-mb-unit">Unit ID</label>
+              <input type="number" id="ev-mb-unit">
+            </div>
+          </div>
         </div>
         <div class="form-group">
           <button type="button" class="btn-secondary" id="ev-load-chargers" onclick="loadEVChargers()">Load chargers</button>

--- a/web/style.css
+++ b/web/style.css
@@ -1647,6 +1647,105 @@ body.advanced #ui-mode-toggle { color: #fbbf24; }
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 12px;
 }
+
+/* Loadpoints — advanced-mode panel. Mirrors .twin-card visual language
+   (1 px hairline border via --line where the modern theme is loaded,
+   subtle raised surface) but lays the body out as config-on-the-left,
+   schedule-table-on-the-right so an operator can read state + plan
+   side by side without scrolling. Wraps to a single column under
+   720 px so it stays readable on a tablet. */
+.lp-card {
+  background: var(--ink-raised, rgba(255,255,255,0.03));
+  border: 1px solid var(--line, rgba(255,255,255,0.08));
+  border-radius: 6px;
+  padding: 12px;
+  margin-top: 10px;
+}
+.lp-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0 0 10px 0;
+}
+.lp-card-header h3 {
+  font-family: var(--mono, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  margin: 0;
+  color: var(--fg-label, var(--text, #e2e8f0));
+}
+.lp-card-body {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 720px) {
+  .lp-card-body { grid-template-columns: 1fr; }
+}
+.lp-cfg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.lp-cfg-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.78rem;
+  padding: 2px 0;
+  border-bottom: 1px solid var(--line-soft, rgba(255,255,255,0.04));
+}
+.lp-cfg-row:last-child { border-bottom: 0; }
+.lp-cfg-key {
+  color: var(--fg-dim, var(--text-dim, #94a3b8));
+  font-family: var(--mono, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.68rem;
+}
+.lp-cfg-val {
+  color: var(--fg, var(--text, #e2e8f0));
+  font-variant-numeric: tabular-nums;
+}
+.lp-badge {
+  display: inline-block;
+  font-family: var(--mono, monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  padding: 1px 6px;
+  border: 1px solid var(--line, rgba(255,255,255,0.08));
+  border-radius: 3px;
+  color: var(--fg-dim, var(--text-dim, #94a3b8));
+  background: transparent;
+}
+.lp-badge-on {
+  /* On-accent text MUST be near-black per DESIGN.md, not white. */
+  color: #0a0a0a;
+  background: var(--amber, var(--accent, #5566ff));
+  border-color: transparent;
+}
+.lp-schedule-wrap {
+  /* Bound the table height so a 16-row plan doesn't push the card
+     off-screen on a small viewport. The diag-table inherits a sticky
+     thead so column headers stay visible while the operator scrolls. */
+  max-height: 360px;
+  overflow: auto;
+}
+.lp-schedule { font-size: 0.74rem; }
+.lp-schedule tbody tr.lp-row-charging td {
+  /* Highlight slots where the EV is actively scheduled. Subtle amber
+     wash so it reads as "this is the action" without screaming over
+     the rest of the schedule. */
+  background: color-mix(in oklch, var(--amber, #fbbf24) 14%, transparent);
+}
+.lp-empty {
+  color: var(--fg-muted, var(--text-dim, #94a3b8));
+  font-size: 0.78rem;
+  padding: 12px 0;
+  font-style: italic;
+}
 .model-card {
   background: var(--surface);
   border: 1px solid var(--border);

--- a/web/style.css
+++ b/web/style.css
@@ -1648,6 +1648,13 @@ body.advanced #ui-mode-toggle { color: #fbbf24; }
   gap: 12px;
 }
 
+/* Loadpoints section — match the inter-section spacing other advanced
+   sections use (#models-section: margin-top 20px). Without this the
+   .lp-card sits flush against the drivers-section below, which the
+   user reported as "loadpoints overlaps the devices". Add bottom
+   margin too so the model section after drivers stays readable. */
+#loadpoints-section { margin-top: 20px; margin-bottom: 20px; }
+
 /* Loadpoints — advanced-mode panel. Mirrors .twin-card visual language
    (1 px hairline border via --line where the modern theme is loaded,
    subtle raised surface) but lays the body out as config-on-the-left,


### PR DESCRIPTION
## Summary

Two interlocking bodies of work on the loadpoint / MPC stack:

1. **Easee surplus-only end-to-end fixes** (5 commits) — original branch purpose. surplus_only EV charging now actually works on a 3Φ Easee install: 1Φ-lock-for-the-day when peak forecast surplus < 4140 W, planner_arbitrage tagged-replan on surplus_only flip, and battery covers EV import bursts during surplus-only transients.

2. **First-class EV schedules + bat-SoC surplus unlock** (7 commits) — the new schedule UI + backend the operator drives via the EV charger popup. Persistent recurring deadlines, bat-SoC threshold for opportunistic surplus capture, MPC defers grid-funded EV planning until target-day prices land, and several MPC DP feasibility constraints that match operator intent.

## What's in the second group

- `loadpoint.Schedule` struct persisted in `state.config`. `Manager.RollSchedules` rolls recurring deadlines forward each tick; non-recurring schedules seed once and expire quietly.
- New `Controller.SetGridDeferred` so when MPC defers grid planning (target past published prices), the runtime dispatch ALSO clamps EV to live surplus — forecast undershoot doesn't silently import grid.
- New per-slot DP constraint: `evW > 0 AND battW < 0 AND gridW < -50` is infeasible (don't charge EV while battery exports for arbitrage).
- Cap `LoadpointSpec.TargetSoCPct` to the vehicle's `charge_limit_pct` so MPC stops chasing an unreachable goal when the Tesla is hard-capped at 70%.
- UI: schedule section in EV charger popup (target SoC, local-time picker, recurring, bat-SoC unlock); replaces the old "100 % by 16:00 UTC" toggle. Loadpoints panel schedule table widened from 4 h to 24 h.

## Bugs caught while shipping

Three interacting deadlock/hang bugs in the dispatch loop that surfaced once the schedule feature was live on the pi:

- Recursive self-lock in `evalBatSoCArm` (held `batSoCArmedMu` across `siteSurplusForEVW` → `AnyLoadpointSurplusActive` → same lock).
- Stale-meter guard fired on every tick when no `is_site_meter` driver was configured (`IsStale("", DerMeter, _)` returns true unconditionally).
- `Registry.SendDefault` blocked on full driver `cmdCh` without ctx-cancellation, deadlocking the control loop the moment any driver's channel filled.

## Test plan

- [x] `go test ./...` green incl. e2e (26 s)
- [x] new unit tests cover `RollSchedules` (recurring promote, non-recurring seed-once), `evalBatSoCArm` hysteresis incl. PV-gone release, `pickSurplusSteps` skip-1Φ-lock when only bat-SoC armed, and the no-EV-while-battery-exports DP constraint
- [x] shipped to home pi @ `192.168.1.139` end-to-end: schedule persists across restart, bat-SoC unlock arms / releases on PV signal, MPC plan reacts correctly to defer + price-publication boundary, `target capped to vehicle charge limit` log fires when Tesla limit < operator target

🤖 Generated with [Claude Code](https://claude.com/claude-code)