### PR TITLE
fix(control): clamp battery dispatch against GridTargetW, not raw meter

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2298,20 +2298,20 @@ func TestMeterClampStopsExportOnLoadOverPrediction(t *testing.T) {
 }
 
 func TestMeterClampStopsImportOnLoadUnderPrediction(t *testing.T) {
-	// Live meter: importing +1000 W. Battery idle. Operator (or planner)
-	// has set GridTargetW = -5000 (wants to export 5 kW), so the PI will
-	// demand a large positive (charge) correction. That command would
-	// pull additional power from the grid, deepening the import — the
-	// opposite of what self_consumption should ever do. Since the meter
-	// is importing, charge headroom is zero, so the clamp must zero the
-	// battery total.
-	store := seedStore(1000, []struct {
+	// Mirror of the over-prediction case. Live meter: exporting -2000 W
+	// (PV momentarily under-loaded relative to forecast). Battery is
+	// already charging at +5000 W. GridTargetW = 0. The reactive PI sees
+	// errW = -2000 and keeps demanding more charge to drive gridW → 0,
+	// but doing so would flip the meter into import. The clamp must cap
+	// the total battery target at +|errW| = +2000 so the site does not
+	// pull additional power from the grid to feed the battery.
+	store := seedStore(-2000, []struct {
 		name          string
 		currentW, soc float64
 	}{
-		{"ferroamp", 0, 0.5},
+		{"ferroamp", 5000, 0.5},
 	})
-	st := NewState(-5000, 50, "ferroamp")
+	st := NewState(0, 50, "ferroamp")
 	st.Mode = ModeSelfConsumption
 	st.SlewRateW = 100000
 	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
@@ -2319,9 +2319,51 @@ func TestMeterClampStopsImportOnLoadUnderPrediction(t *testing.T) {
 	for _, tg := range targets {
 		sum += tg.TargetW
 	}
-	// With the site already importing, the clamp drops charge headroom
-	// to zero. Sum must not exceed 0 (allow a tiny tolerance for fp).
-	if sum > 1e-6 {
-		t.Errorf("meter clamp should zero charge when importing, got sum=%f", sum)
+	// Magnitude of charge must not exceed live export (2000 W).
+	if sum > 2000+1e-6 {
+		t.Errorf("meter clamp should cap charge at +|errW|=+2000, got sum=%f", sum)
+	}
+	// Direction sanity: should still be charging (or zero), never
+	// discharging when exporting.
+	if sum < 0 {
+		t.Errorf("export case should not produce a discharge command, got sum=%f", sum)
+	}
+}
+
+func TestMeterClampRespectsNonZeroGridTarget(t *testing.T) {
+	// Regression guard for the e2e failure on master after the first
+	// clamp landed: ModeSelfConsumption with GridTargetW = -3000 means
+	// the operator wants the site to export 3 kW. Live meter at -1000
+	// (already exporting 1 kW). The reactive PI must be free to command
+	// additional discharge so gridW moves toward -3000; the clamp must
+	// NOT treat "we're already exporting" as zero discharge headroom.
+	//
+	// Headroom is expressed in errW space (gridW - GridTargetW):
+	//   errW = -1000 - (-3000) = +2000 → discharge headroom is 2000 W,
+	// so a discharge correction of up to 2 kW (toward the GridTargetW)
+	// should pass the clamp unchanged.
+	store := seedStore(-1000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(-3000, 50, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	var sum float64
+	for _, tg := range targets {
+		sum += tg.TargetW
+	}
+	// Sum must move meaningfully toward discharge — not get pinned at 0
+	// by a clamp that confuses "currently exporting" with "no headroom".
+	if sum >= -1.0 {
+		t.Errorf("clamp pinned dispatch instead of letting PI close the gap to GridTargetW=-3000, got sum=%f", sum)
+	}
+	// And it must not overshoot the target (i.e. don't discharge past
+	// |errW| = 2000 W).
+	if sum < -2000-1e-6 {
+		t.Errorf("clamp let discharge overshoot GridTargetW, got sum=%f", sum)
 	}
 }

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -796,22 +796,30 @@ func ComputeDispatch(
 		totalCorrection = out.Output
 
 		// Live-meter clamp on the legacy PI path: plan decides charge or
-		// discharge direction; the meter decides magnitude. Prevents the
-		// load-twin over-prediction case where reactive PI commands a
-		// discharge larger than the live import. Scoped to this default
-		// arm only — manualHold, useEnergyPath, and plannerSelfIdleGate
-		// each have their own contracts that intentionally cross the
-		// zero-grid line.
+		// discharge direction; the live error decides magnitude. Prevents
+		// the load-twin over-prediction case where reactive PI commands a
+		// discharge larger than what's needed to close errW. Scoped to
+		// this default arm only — manualHold, useEnergyPath, and
+		// plannerSelfIdleGate each have their own contracts that
+		// intentionally cross the GridTargetW line.
+		//
+		// "Don't overshoot": the resulting grid value should land near
+		// GridTargetW, not punch through it. Headroom is therefore the
+		// signed distance from gridW to GridTargetW in the dispatch
+		// direction. Expressed via the existing errW (gridW - GridTargetW)
+		// so the clamp tracks whatever measurement the active mode feeds
+		// the PI (gridW for self_consumption, EV-aware; the same errW
+		// drives the PI's piMeasurement above).
 		//
 		// Deadband (state.GridToleranceW) is a threshold (do not fire
 		// below it), not a haircut (do not subtract from the headroom):
-		// the deadband already gates entry to this arm at line 763.
+		// the deadband already gates entry to this arm at line 780.
 		targetTotal := currentTotal + totalCorrection
 		dead := state.GridToleranceW
 		var allowed float64
 		switch {
-		case targetTotal > 0: // plan says charge → cap at current export
-			headroom := -rawGridW
+		case targetTotal > 0: // plan says charge → cap so we don't push past GridTargetW
+			headroom := -errW // positive when grid is below target (room to charge up)
 			if headroom < dead {
 				headroom = 0
 			}
@@ -820,8 +828,8 @@ func ComputeDispatch(
 			} else {
 				allowed = targetTotal
 			}
-		case targetTotal < 0: // plan says discharge → cap at current import
-			headroom := rawGridW
+		case targetTotal < 0: // plan says discharge → cap so we don't push past GridTargetW
+			headroom := errW // positive when grid is above target (room to discharge down)
 			if headroom < dead {
 				headroom = 0
 			}
@@ -837,7 +845,9 @@ func ComputeDispatch(
 			slog.Warn("dispatch: meter clamp reduced battery target",
 				"requested_total_w", targetTotal,
 				"clamped_total_w", allowed,
-				"raw_grid_w", rawGridW,
+				"grid_w", gridW,
+				"grid_target_w", state.GridTargetW,
+				"err_w", errW,
 				"current_total_w", currentTotal,
 				"deadband_w", dead,
 				"mode", string(effectiveMode))


### PR DESCRIPTION
## Summary

Hotfix for the e2e regression on master from #270.

#270's clamp expressed headroom in raw-meter space (`rawGridW`). That worked when `GridTargetW = 0` (the original incident geometry) but broke `ModeSelfConsumption` with a non-zero grid target: the `TestE2E_FullStack` runs `GridTargetW = -3000` (operator wants 3 kW export); with `gridW` at -1091 the old formula said "no discharge headroom because already exporting" and pinned dispatch to zero, so the battery never moved toward the operator's target.

## Fix

Re-express headroom in `errW = gridW - GridTargetW` space — the same quantity the PI uses as its error. "Don't overshoot `GridTargetW`" is now the literal semantic. The deadband stays a threshold (do not fire below it), not a haircut.

Switched from `rawGridW` to `gridW` (EV-subtracted) so the clamp behaves correctly when `BatteryCoversEV=false`. The clamp's job is to keep the operator's grid target honest; that target is set against the same `gridW` the PI tracks.

Log fields updated to surface `grid_w`, `grid_target_w`, and `err_w` so the activation warning is diagnosable in production.

## Original incident still fixed

Load twin over-predicted (5.4 kW vs actual 2.1 kW). `GridTargetW = 0` (normal self-consumption), `gridW = +2100`. `errW = 2100`. Discharge case → headroom = 2100. PI's -5000 demand → clamped to -2100. Incident still prevented. (Covered by `TestMeterClampStopsExportOnLoadOverPrediction`, geometry unchanged from #270.)

## Tests

- **`TestMeterClampStopsExportOnLoadOverPrediction`** — unchanged. Original incident geometry, `GridTargetW = 0`.
- **`TestMeterClampStopsImportOnLoadUnderPrediction`** — rewritten as a clean mirror: `gridW = -2000` exporting, battery charging at +5 kW, `GridTargetW = 0`, assert charge not exceeding + |errW|.
- **`TestMeterClampRespectsNonZeroGridTarget`** — new regression guard for the e2e failure (`GridTargetW = -3000`, `gridW = -1000`; clamp must let PI close the gap, not pin dispatch to zero).

## Test plan

- [x] `make test` → 29/29 packages, e2e 27.3 s green.
- [x] `go test ./internal/control/... -run MeterClamp` → 3/3 pass.
- [x] `TestE2E_FullStack` passes locally (was the failing test on master).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)