### PR TITLE
feat(control,mpc): PV surplus absorber + planner/dispatch alignment fixes

### DIFF
--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -49,13 +49,32 @@ local STALE_AFTER_MS    = 900000
 -- Every WAKEUP_INTERVAL_MS we attach `wakeup=true` to ONE poll so the
 -- proxy forces a BLE wake. Without this the proxy serves cached data
 -- indefinitely while the car sleeps and our SoC slowly drifts from
--- reality. 30 min is a balance between freshness and not draining the
--- 12 V battery from constant BLE wakes.
-local WAKEUP_INTERVAL_MS = 1800000
+-- reality.
+--
+-- Two cadences: the conservative IDLE one (30 min) protects the 12 V
+-- battery from constant BLE wakes when the car is parked + asleep;
+-- the tighter CHARGING one (15 min) keeps SoC and charge_limit_pct
+-- fresh while the car is on the wall so the MPC's planning targets
+-- track the operator's in-app settings without 30-minute lag. The
+-- car is already drawing AC power during a session, so the BLE-wake
+-- battery-drain concern doesn't apply.
+local WAKEUP_INTERVAL_MS          = 1800000  -- 30 min, idle
+local WAKEUP_INTERVAL_CHARGING_MS = 900000   -- 15 min, while charging
+
+-- When a non-wake poll fails (timeout, connection refused, anything
+-- that isn't the proxy explicitly saying "BLE busy"), the most likely
+-- cause is "car asleep and proxy gave up". Don't wait for the 30-min
+-- periodic wake — arm a wake-retry on the very next poll. The retry
+-- only fires if we haven't already attempted a wake within the recent
+-- gap, so a flapping proxy can't trigger a wake storm.
+local FAILURE_RETRY_INTERVAL_MS = 5000   -- schedule the retry this soon
+local WAKE_RETRY_MIN_GAP_MS     = 10000  -- don't wake more than once per ~10 s
 
 local base_url = nil
 local vin = nil
 local last_wakeup_ms = 0
+local last_wake_attempt_ms = 0   -- includes both periodic + retry wakes
+local pending_wake_retry = false -- set by failed poll, consumed by next poll
 
 -- Cached last-known reading so we can keep publishing a value while
 -- the vehicle is asleep. Tesla returns 408 "vehicle unavailable" when
@@ -183,10 +202,25 @@ function driver_poll()
   -- operator can press "Verify connection" in settings to force a
   -- one-shot wake, or wait for the next scheduled 30-min wake.
   local now = host.millis()
-  local do_wakeup = (last_wakeup_ms > 0) and ((now - last_wakeup_ms) >= WAKEUP_INTERVAL_MS)
+  -- Cadence depends on whether the last-known state was Charging — see
+  -- WAKEUP_INTERVAL_CHARGING_MS comment above. "Charging" comes from
+  -- the Tesla payload's charge_state.charging_state field; anything
+  -- else (Stopped / Complete / Disconnected / unknown) uses the
+  -- conservative 30-min cadence.
+  local wake_cadence_ms = (last.charging_state == "Charging")
+    and WAKEUP_INTERVAL_CHARGING_MS or WAKEUP_INTERVAL_MS
+  local do_wakeup = false
+  if pending_wake_retry and ((now - last_wake_attempt_ms) >= WAKE_RETRY_MIN_GAP_MS) then
+    -- Previous poll failed; we armed a retry. Consume it.
+    do_wakeup = true
+    pending_wake_retry = false
+    host.log("info", "tesla: wake-retry firing after previous poll failure")
+  elseif (last_wakeup_ms > 0) and ((now - last_wakeup_ms) >= wake_cadence_ms) then
+    do_wakeup = true
+  end
   if last_wakeup_ms == 0 then
-    -- Anchor the cadence at "now" so the first FORCED wake fires
-    -- exactly WAKEUP_INTERVAL_MS after startup, not on first poll.
+    -- Anchor the periodic cadence at "now" so the first FORCED wake
+    -- fires exactly wake_cadence_ms after startup, not on first poll.
     last_wakeup_ms = now
   end
   local url = base_url .. "/api/1/vehicles/" .. vin ..
@@ -194,7 +228,10 @@ function driver_poll()
   if do_wakeup then
     url = url .. "&wakeup=true"
     last_wakeup_ms = now
-    host.log("info", "tesla: forcing BLE wakeup on this poll (30-min cadence)")
+    last_wake_attempt_ms = now
+    host.log("info", "tesla: forcing BLE wakeup on this poll" ..
+                     " (cadence=" .. tostring(wake_cadence_ms / 60000) .. "min" ..
+                     " charging=" .. tostring(last.charging_state == "Charging") .. ")")
   end
   -- host.http_get returns (body_string, nil) or (nil, error_string) —
   -- first return is the body directly, NOT a table with .body. The
@@ -210,15 +247,30 @@ function driver_poll()
     -- in this state piles onto the rate-limit and prolongs it.
     -- Recovery is automatic when the next emit succeeds:
     -- driver_poll resets to POLL_INTERVAL_MS at the top of the
-    -- next call.
+    -- next call. Don't arm a wake-retry for these — the radio is
+    -- already busy; adding another wake won't help.
     local es = tostring(err)
     if es:match("HTTP 503") or es:match("HTTP 408") or es:match("Command Disallowed") then
       host.log("debug", "tesla: proxy busy (BLE busy) — backing off 3 min")
       emit_last()
       return 180000  -- 3 min
     end
+    -- Any other error (most commonly the host's 15 s HTTP timeout
+    -- when the car is asleep and the proxy's read of charge_state
+    -- never returns) — the car is probably asleep and the next
+    -- ordinary poll would just time out again. Arm a wake-retry
+    -- so the next poll attaches `&wakeup=true` and forces the
+    -- proxy to BLE-wake before reading. We don't arm if THIS poll
+    -- already woke (no point retrying with another wake — that's
+    -- the case the proxy is genuinely failing) — fall back to the
+    -- normal interval and let the periodic cadence catch up.
     host.log("warn", "tesla: poll HTTP error: " .. es)
     emit_last()
+    if not do_wakeup then
+      pending_wake_retry = true
+      host.log("info", "tesla: wake-retry armed (next poll will force BLE wake)")
+      return FAILURE_RETRY_INTERVAL_MS
+    end
     return POLL_INTERVAL_MS
   end
   if not body or body == "" then
@@ -364,8 +416,8 @@ end
 function driver_cleanup()
   -- Reset every persistent piece of state so a hot-reload looks
   -- identical to a fresh process start (the `last_wakeup_ms` reset
-  -- in particular re-anchors the 30-min cadence so we don't fire a
-  -- wakeup the moment the reloaded driver runs its first poll).
+  -- in particular re-anchors the periodic cadence so we don't fire
+  -- a wakeup the moment the reloaded driver runs its first poll).
   last.soc                    = nil
   last.charge_limit           = nil
   last.charging_state         = nil
@@ -374,4 +426,6 @@ function driver_cleanup()
   last.charger_actual_current = nil
   last.ts_ms                  = 0
   last_wakeup_ms              = 0
+  last_wake_attempt_ms        = 0
+  pending_wake_retry          = false
 end

--- a/drivers/tesla_vehicle.lua
+++ b/drivers/tesla_vehicle.lua
@@ -366,6 +366,44 @@ function driver_poll()
 end
 
 function driver_command(action, _, _)
+  -- Generic vehicle wake. The Go side fires `wake_up` whenever it
+  -- wants fresh telemetry without side effects — schedule edits,
+  -- the rising edge of wallbox-delivering-power, operator clicks
+  -- "Refresh". Any vehicle driver can implement this against its
+  -- own back-end; nothing here is Tesla-specific at the protocol
+  -- level. We hit the proxy's dedicated wake endpoint (rather than
+  -- the GET-with-wake the poll uses) so the response confirms
+  -- "wake initiated" instead of returning vehicle data — cleaner
+  -- separation between "wake" and "read".
+  --
+  -- Reset the periodic-wake anchor so we don't immediately re-fire
+  -- a second wake on the next 30/15-min cadence right after the
+  -- caller already woke the car. Also clear any pending failure
+  -- retry — if a previous poll failed and armed a retry, the
+  -- caller's wake just supersedes it.
+  if action == "wake_up" or action == "ev_wake" then
+    if not base_url or not vin then
+      host.log("warn", "tesla: wake_up before init")
+      return false
+    end
+    local url = base_url .. "/api/1/vehicles/" .. vin .. "/command/wake_up"
+    local body, err = host.http_post(url, "{}", auth_headers())
+    if err then
+      local es = tostring(err)
+      if es:match("HTTP 503") or es:match("HTTP 408") then
+        host.log("debug", "tesla: wake_up busy, will retry on next caller: " .. es)
+        return false
+      end
+      host.log("warn", "tesla: wake_up failed: " .. es)
+      return false
+    end
+    last_wakeup_ms = host.millis()
+    last_wake_attempt_ms = last_wakeup_ms
+    pending_wake_retry = false
+    local snippet = (body and #body > 0) and body:sub(1, 200) or "(empty body)"
+    host.log("info", "tesla: wake_up sent: " .. snippet)
+    return true
+  end
   -- Wake-and-start support. The loadpoint controller fires the
   -- generic `charge_start` action (defined as a cross-driver
   -- protocol — any vehicle driver can implement it) when the

--- a/go/cmd/forty-two-watts/control_state.go
+++ b/go/cmd/forty-two-watts/control_state.go
@@ -25,5 +25,8 @@ func newControlStateFromConfig(cfg *config.Config) *control.State {
 	// from explicit 0 ("operator chose to disable"). The earlier
 	// `<= 0 -> default` shortcut clobbered the disable case.
 	ctrl.SiteFuseSafetyA = cfg.Fuse.EffectiveSafetyMarginA()
+	// PV surplus absorber underlay (opt-in). cap == 0 keeps it off.
+	ctrl.PVSurplusAbsorbSoCCapPct = cfg.Site.PVSurplusAbsorbSoCCapPct
+	ctrl.PVSurplusAbsorbThresholdW = cfg.Site.PVSurplusAbsorbThresholdW
 	return ctrl
 }

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -837,6 +837,17 @@ func main() {
 				if lpController != nil {
 					batSoCArmed = lpController.IsBatSoCArmed(st.ID)
 				}
+				// NoBatteryToEV mirrors the site-wide ctrl.BatteryCoversEV
+				// flag (inverted). Plumbing the constraint into the DP
+				// here means the planner stops scheduling battery→EV
+				// transfers that dispatch's safety net would just clamp
+				// at runtime; this closes the plan↔reality divergence
+				// where operators saw "plan: 7 kW discharge + 11 kW EV"
+				// while live execution held the battery at house-only
+				// levels. Take ctrlMu for the bool read.
+				ctrlMu.Lock()
+				noBatteryToEV := !ctrl.BatteryCoversEV
+				ctrlMu.Unlock()
 				return &mpc.LoadpointSpec{
 					ID:               st.ID,
 					CapacityWh:       capWh,
@@ -851,6 +862,7 @@ func main() {
 					AllowedStepsW:    st.AllowedStepsW,
 					ChargeEfficiency: 0.9,
 					SurplusOnly:      st.SurplusOnly || deferGridPlan || batSoCArmed,
+					NoBatteryToEV:    noBatteryToEV,
 				}
 			}
 			return nil

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -348,6 +348,29 @@ func main() {
 		}
 		return s, !s.Empty()
 	})
+	// Persist surplus_only toggles the same way schedules persist —
+	// state.config key `loadpoint_surplus_only:<id>` stores "true" or
+	// "false". Operators toggle this from the dashboard EV modal, not
+	// YAML, so the previous in-memory-only behaviour reverted the
+	// flag on every restart.
+	const lpSurplusKeyPrefix = "loadpoint_surplus_only:"
+	lpMgr.SetSurplusOnlySaver(func(id string, v bool) {
+		key := lpSurplusKeyPrefix + id
+		val := "false"
+		if v {
+			val = "true"
+		}
+		if err := st.SaveConfig(key, val); err != nil {
+			slog.Warn("failed to persist loadpoint surplus_only", "lp", id, "err", err)
+		}
+	})
+	lpMgr.HydrateSurplusOnly(func(id string) (bool, bool) {
+		v, ok := st.LoadConfig(lpSurplusKeyPrefix + id)
+		if !ok || v == "" {
+			return false, false
+		}
+		return v == "true", true
+	})
 	// Seed any recurring deadlines from boot — without this the first
 	// dispatch tick would race with an empty target_time and might
 	// miss the deadline penalty for ~5 s.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -820,23 +820,37 @@ func main() {
 				if lpController != nil {
 					lpController.SetGridDeferred(st.ID, deferGridPlan)
 				}
+				// Surplus-only sources, in order of precedence:
+				//   1. Operator's explicit surplus_only flag on the LP
+				//   2. MPC grid-funded planning deferral (target past
+				//      published prices)
+				//   3. Runtime bat-SoC unlock arming — when the home
+				//      battery is at/above the schedule's threshold AND
+				//      live PV surplus is available, the dispatch layer
+				//      already treats the LP as surplus-only. Without
+				//      threading it into the MPC spec here, the plan
+				//      would prescribe battery→EV transfers that
+				//      dispatch then has to censor — producing
+				//      misleading slot entries the operator sees in
+				//      /api/mpc/plan that never actually execute.
+				batSoCArmed := false
+				if lpController != nil {
+					batSoCArmed = lpController.IsBatSoCArmed(st.ID)
+				}
 				return &mpc.LoadpointSpec{
-					ID:              st.ID,
-					CapacityWh:      capWh,
-					Levels:          11,
-					MinPct:          0,
-					MaxPct:          maxPct,
-					InitialSoCPct:   initSoC,
-					PluggedIn:       true,
-					TargetSoCPct:    targetPct,
-					TargetSlotIdx:   targetSlot,
-					MaxChargeW:      st.MaxChargeW,
-					AllowedStepsW:   st.AllowedStepsW,
+					ID:               st.ID,
+					CapacityWh:       capWh,
+					Levels:           11,
+					MinPct:           0,
+					MaxPct:           maxPct,
+					InitialSoCPct:    initSoC,
+					PluggedIn:        true,
+					TargetSoCPct:     targetPct,
+					TargetSlotIdx:    targetSlot,
+					MaxChargeW:       st.MaxChargeW,
+					AllowedStepsW:    st.AllowedStepsW,
 					ChargeEfficiency: 0.9,
-					// Either operator-configured surplus_only OR our
-					// "wait for tomorrow's prices" defer triggers MPC's
-					// no-grid constraint for this LP.
-					SurplusOnly: st.SurplusOnly || deferGridPlan,
+					SurplusOnly:      st.SurplusOnly || deferGridPlan || batSoCArmed,
 				}
 			}
 			return nil

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1105,6 +1105,44 @@ func main() {
 			return peak, true
 		})
 
+		// Near-term peak surplus: same scan but capped at now + window.
+		// pickSurplusSteps consults this to decide if a 3Φ window is
+		// imminent enough to be worth waiting for. When near-term <
+		// 3Φ minimum but day-peak is, we'd rather charge 1Φ now and
+		// switch to 3Φ later than sit idle waiting.
+		lpController.SetNearTermPeakSurplusW(func(window time.Duration) (float64, bool) {
+			if mpcSvc == nil {
+				return 0, false
+			}
+			plan := mpcSvc.Latest()
+			if plan == nil || len(plan.Actions) == 0 {
+				return 0, false
+			}
+			now := time.Now()
+			horizon := now.Add(window)
+			var peak float64
+			any := false
+			for _, a := range plan.Actions {
+				slotEnd := time.UnixMilli(a.SlotStartMs).Add(
+					time.Duration(a.SlotLenMin) * time.Minute)
+				if slotEnd.Before(now) {
+					continue
+				}
+				if time.UnixMilli(a.SlotStartMs).After(horizon) {
+					break
+				}
+				surplus := -a.PVW - a.LoadW
+				if !any || surplus > peak {
+					peak = surplus
+					any = true
+				}
+			}
+			if !any {
+				return 0, false
+			}
+			return peak, true
+		})
+
 		lpController.SetSiteSurplusForEV(func() (float64, bool) {
 			meterDriver := cfg.SiteMeterDriver()
 			if meterDriver == "" {

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1705,20 +1705,21 @@ func main() {
 			for k, v := range capacities { capsSnap[k] = v }
 			capMu.RUnlock()
 
-			// Surplus-only EV reserve: walk all loadpoints and sum
-			// MaxChargeW for any LP that is surplus_only AND has an EV
-			// plugged in. Result is injected into ctrl.EVSurplusOnlyReserveW
-			// so dispatch caps battery charge to leave that much PV
-			// headroom for the EV controller to claim. See
-			// dispatch.go EVSurplusOnlyReserveW + the (energy/legacy) cap
-			// blocks. Computed every tick so toggling surplus_only or
-			// plugging/unplugging an EV takes effect immediately.
-			var evReserveW float64
-			for _, st := range lpMgr.States() {
-				if st.SurplusOnly && st.PluggedIn {
-					evReserveW += st.MaxChargeW
-				}
-			}
+			// Surplus-only EV reserve: aggregate PV headroom to leave
+			// for surplus_only loadpoints. Per LP, reserves
+			// min(MaxChargeW, CurrentPowerW + EVRampHeadroomW) so the
+			// figure tracks the EV's actual draw rather than its
+			// theoretical max — when an EV is physically holding at
+			// e.g. 2.5 kW (1Φ × 11 A under phase hysteresis), the prior
+			// "reserve = MaxChargeW = 11 kW" form ate ~8.5 kW of the
+			// available surplus and starved the battery on
+			// over-forecast PV slots even when the plan said charge.
+			// Result is injected into ctrl.EVSurplusOnlyReserveW and
+			// consumed by dispatch.go in both the energy and the
+			// legacy/reactive paths. Computed every tick so toggling
+			// surplus_only, plugging/unplugging, or an EV ramp picks
+			// up immediately.
+			evReserveW := loadpoint.SurplusReserveW(lpMgr.States())
 
 			ctrlMu.Lock()
 			ctrl.EVSurplusOnlyReserveW = evReserveW

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -853,6 +853,8 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	s.deps.Ctrl.GridToleranceW = newCfg.Site.GridToleranceW
 	s.deps.Ctrl.SlewRateW = newCfg.Site.SlewRateW
 	s.deps.Ctrl.MinDispatchIntervalS = newCfg.Site.MinDispatchIntervalS
+	s.deps.Ctrl.PVSurplusAbsorbSoCCapPct = newCfg.Site.PVSurplusAbsorbSoCCapPct
+	s.deps.Ctrl.PVSurplusAbsorbThresholdW = newCfg.Site.PVSurplusAbsorbThresholdW
 	s.deps.CtrlMu.Unlock()
 	// Update shared cfg pointer
 	s.deps.CfgMu.Lock()

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1961,12 +1961,67 @@ func (s *Server) handleEVCommand(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 503, map[string]string{"error": "driver registry not available"})
 		return
 	}
+	// Manual Start / Resume / Pause must "stick" against the next
+	// dispatch tick — otherwise the controller's MPC-budget check (or
+	// surplus-only clamp with no live PV) commands `power_w=0` on the
+	// very next 5 s tick and the operator's click looks like a no-op.
+	// Solution: set a no-expiry ManualHold on the matched loadpoint
+	// before forwarding the action to the driver. Pause clears the
+	// hold so the LP reverts to plan / PV-surplus / schedule. Pure
+	// driver-targeted actions (ev_set_current) skip the hold path —
+	// dispatch uses ev_set_current internally and a sticky hold there
+	// would defeat the whole control loop.
+	if req.Action == "ev_start" || req.Action == "ev_resume" || req.Action == "ev_pause" {
+		applyManualEVHold(s.deps, driverName, req.Action)
+	}
 	payload, _ := json.Marshal(map[string]any{"action": req.Action})
 	if err := s.deps.Registry.Send(r.Context(), driverName, payload); err != nil {
 		writeJSON(w, 500, map[string]string{"error": err.Error()})
 		return
 	}
 	writeJSON(w, 200, map[string]string{"status": "ok"})
+}
+
+// applyManualEVHold pins / releases the loadpoint matching the given
+// EV driver according to the operator action. Start / Resume install
+// a no-expiry hold at the loadpoint's MaxChargeW so the next dispatch
+// tick can't pull the wallbox back to 0. Pause clears the hold and
+// the loadpoint immediately reverts to plan / surplus rules. No-op
+// when no controller is wired or no loadpoint matches the driver —
+// the action still forwards to the driver in those cases.
+func applyManualEVHold(deps *Deps, driverName string, action string) {
+	if deps == nil || deps.LoadpointCtrl == nil || deps.Loadpoints == nil {
+		return
+	}
+	var lpID string
+	var maxW float64
+	for _, st := range deps.Loadpoints.States() {
+		if st.DriverName == driverName {
+			lpID = st.ID
+			maxW = st.MaxChargeW
+			break
+		}
+	}
+	if lpID == "" {
+		return
+	}
+	if action == "ev_pause" {
+		deps.LoadpointCtrl.ClearManualHold(lpID)
+		slog.Info("ev manual pause — cleared manual hold, reverting to plan", "lp", lpID)
+		return
+	}
+	if maxW <= 0 {
+		maxW = 11000 // 16 A × 3φ × 230 V fallback when the LP config didn't set it
+	}
+	// 100-year expiry serves as "sticky until the operator cancels".
+	// Using time.Now() + a long delta rather than time.Time{} because
+	// SetManualHold treats zero ExpiresAt as "delete" (controller.go:653).
+	deps.LoadpointCtrl.SetManualHold(lpID, loadpoint.ManualHold{
+		PowerW:    maxW,
+		ExpiresAt: time.Now().Add(100 * 365 * 24 * time.Hour),
+	})
+	slog.Info("ev manual start/resume — installed sticky hold",
+		"lp", lpID, "action", action, "hold_w", maxW)
 }
 
 // GET /api/ev/providers — return the descriptor for every registered EV

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -2218,6 +2218,23 @@ func (s *Server) handleLoadpointTarget(w http.ResponseWriter, r *http.Request) {
 			surplusDisabled = true
 		}
 	}
+	// Force-wake the bound vehicle on any schedule edit. Without this
+	// the next plan + dispatch tick reads stale vehicle state — the
+	// new schedule could be planning against an old SoC, old vehicle
+	// charge_limit, or a "Complete" status that no longer reflects
+	// reality. Fire-and-forget on a background goroutine so the API
+	// stays snappy even when the BLE proxy is slow / asleep. Bounded
+	// timeout so a hung wake never leaks. Bypasses the auto-wake
+	// cooldown — the operator just told us they want a fresh read.
+	if scheduleChanged && s.deps.LoadpointCtrl != nil {
+		go func(lpID string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := s.deps.LoadpointCtrl.RefreshVehicle(ctx, lpID); err != nil {
+				slog.Warn("loadpoint refresh-vehicle failed", "lp", lpID, "err", err)
+			}
+		}(id)
+	}
 	if s.deps.MPC != nil {
 		if surplusDisabled {
 			slog.Info("loadpoint surplus_only disabled — forcing replan",

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -287,6 +287,24 @@ type Site struct {
 	Gain                 float64 `yaml:"gain" json:"gain"`
 	SlewRateW            float64 `yaml:"slew_rate_w" json:"slew_rate_w"`
 	MinDispatchIntervalS int     `yaml:"min_dispatch_interval_s" json:"min_dispatch_interval_s"`
+
+	// PVSurplusAbsorbSoCCapPct enables the opt-in PV-surplus absorber
+	// underlay in the energy-dispatch path (planner_cheap /
+	// planner_arbitrage). When the planner's slot allocation would still
+	// leave grid exporting beyond pv_surplus_absorb_threshold_w AND
+	// average SoC is below this cap, the dispatch redirects the leftover
+	// export into the battery instead of crossing the meter. Never
+	// reverses a discharge plan. 0 = disabled (default).
+	//
+	// Suggested 88 — leaves 2 pp margin below the planner's typical
+	// soc_max_pct = 90 so the absorber doesn't slam into the wall.
+	PVSurplusAbsorbSoCCapPct float64 `yaml:"pv_surplus_absorb_soc_cap_pct,omitempty" json:"pv_surplus_absorb_soc_cap_pct,omitempty"`
+
+	// PVSurplusAbsorbThresholdW is the trigger threshold for the
+	// absorber: only fires when projected grid export exceeds this many
+	// watts after the plan's target. Defaults to 100 W when the cap is
+	// set but this isn't.
+	PVSurplusAbsorbThresholdW float64 `yaml:"pv_surplus_absorb_threshold_w,omitempty" json:"pv_surplus_absorb_threshold_w,omitempty"`
 }
 
 // DefaultFuseSafetyMarginA is the fall-back per-phase amp headroom

--- a/go/internal/configreload/watcher.go
+++ b/go/internal/configreload/watcher.go
@@ -124,6 +124,15 @@ func (w *Watcher) reload() {
 	if newCfg.Site.MinDispatchIntervalS != oldCfg.Site.MinDispatchIntervalS {
 		w.ctrl.MinDispatchIntervalS = newCfg.Site.MinDispatchIntervalS
 	}
+	if newCfg.Site.PVSurplusAbsorbSoCCapPct != oldCfg.Site.PVSurplusAbsorbSoCCapPct {
+		slog.Info("config reload: pv_surplus_absorb_soc_cap_pct",
+			"old", oldCfg.Site.PVSurplusAbsorbSoCCapPct,
+			"new", newCfg.Site.PVSurplusAbsorbSoCCapPct)
+		w.ctrl.PVSurplusAbsorbSoCCapPct = newCfg.Site.PVSurplusAbsorbSoCCapPct
+	}
+	if newCfg.Site.PVSurplusAbsorbThresholdW != oldCfg.Site.PVSurplusAbsorbThresholdW {
+		w.ctrl.PVSurplusAbsorbThresholdW = newCfg.Site.PVSurplusAbsorbThresholdW
+	}
 	w.ctrlMu.Unlock()
 
 	// Swap global pointer

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2485,6 +2485,82 @@ func TestPVSurplusAbsorberHoldsAtCap(t *testing.T) {
 	}
 }
 
+// BatteryCoversEV=false must NOT clamp a planned evening-peak discharge
+// when the EV is effectively idle (driver reporting <100 W of noise).
+// Pre-fix, EVChargingW > 0 was the gate and any tiny non-zero from
+// Easee (~1 W on a connected-but-idle cable) tripped the cap, leaving
+// the planner's -9000 W export pinned to "just enough to zero the
+// house" (~-1 kW on a typical evening). Regression: live state showed
+// plan=-9000 W → realised ≈-1.3 kW with ev_w=0, ev_charging_w=1.08.
+func TestEnergyDispatchIgnoresEVChargingWNoiseUnderThreshold(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -2250, // plan: -9 kW for the slot
+		Strategy:        "arbitrage",
+	}
+	// Evening: PV gone, house ~1.4 kW load, plan wants to export
+	// hard. Battery currently at 0; rawGridW reflects the no-battery
+	// case (house importing 1.4 kW).
+	store := seedStore(1400, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.85},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.BatteryCoversEV = false
+	st.EVChargingW = 1.08 // <-- driver noise; EV is plugged-idle, not drawing
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// With the noise threshold in place, the safety net stays off and
+	// the planner's -9 kW discharge runs. Allow generous slack — slew,
+	// fuse and per-driver clamps may still trim it, but it should be
+	// well below -3 kW (i.e. discharging hard, not just covering house).
+	if got > -3000 {
+		t.Errorf("TargetW = %.0f W — EVChargingW noise (1 W) clamped a -9 kW plan to house-only. Want ≤ -3000 W.", got)
+	}
+}
+
+// Counter-check: when the EV is genuinely drawing (>= threshold), the
+// safety net MUST still fire to prevent the planner's discharge from
+// feeding the EV via the battery. battery_covers_ev=false is a strong
+// promise; the noise threshold doesn't weaken it for real draws.
+func TestEnergyDispatchClampsDischargeWhenEVActuallyCharging(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -2250,
+		Strategy:        "arbitrage",
+	}
+	// House 1.4 kW load + EV drawing 4 kW = rawGridW 5.4 kW import.
+	store := seedStore(5400, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.85},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.BatteryCoversEV = false
+	st.EVChargingW = 4000 // real charging — safety net MUST fire
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	got := targets[0].TargetW
+	// Battery should cover ~the house (~-1.4 kW), NOT the EV.
+	if got < -2500 {
+		t.Errorf("TargetW = %.0f W — safety net failed: battery is feeding the EV (want ≈ -1.4 kW).", got)
+	}
+	if got > -500 {
+		t.Errorf("TargetW = %.0f W — house side not covered (want roughly -1.4 kW).", got)
+	}
+}
+
 // Don't reverse a discharge plan: if the planner is deliberately
 // discharging this slot (e.g. evening-peak export), the absorber stays
 // out of the way regardless of live grid sign.

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2367,3 +2367,152 @@ func TestMeterClampRespectsNonZeroGridTarget(t *testing.T) {
 		t.Errorf("clamp let discharge overshoot GridTargetW, got sum=%f", sum)
 	}
 }
+
+// ---- PV surplus absorber underlay ----
+//
+// Opt-in policy reversal of TestEnergyDispatchDoesNotAbsorbPVSurprise: when
+// the operator sets a SoC cap (PVSurplusAbsorbSoCCapPct > 0), the dispatch
+// catches the gap between the planner's 15-min slot allocation and the
+// live PV/load drift — additional export beyond plan flows into the
+// battery instead of out the meter at low spot price. Only kicks in
+// planner_cheap / planner_arbitrage (the modes whose energy path doesn't
+// react to live grid), only adds charge (never reverses a discharge plan),
+// only while SoC < cap. Otherwise the original "let it export" behavior
+// stands. See the operator-report cycle 2026-04-17 → 2026-05-15.
+
+// Same scenario as TestEnergyDispatchDoesNotAbsorbPVSurprise, but with the
+// absorber knob enabled and SoC below cap → battery absorbs the surprise.
+func TestPVSurplusAbsorberAbsorbsExtraExportWhenEnabled(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200, // plan: charge 200 Wh (~ 800 W)
+		Strategy:        "arbitrage",
+	}
+	// Grid exporting 4 kW (PV surprise — PV 4.8 kW, load 0.8 kW, battery 0).
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5}, // SoC 50%, well below 88% cap
+	})
+	store.Update("pv-1", telemetry.DerPV, -4800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.PVSurplusAbsorbSoCCapPct = 88 // enable
+	st.PVSurplusAbsorbThresholdW = 100
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	// Energy balance: grid = load + pv + battery, so -4000 = 800 + (-4800) + 0
+	// ⇒ load is 800 W, PV surplus over load is 4000 W. Plan wanted +800 W.
+	// Plan-as-is would leave -3200 W still exporting (rawGridW + planTarget).
+	// Absorber catches the 3200 W leftover and stacks on top of plan →
+	// target ≈ 800 + 3200 = 4000 W, projected grid → 0.
+	// Allow ±400 W slack for energy-formula time drift and threshold.
+	got := targets[0].TargetW
+	if got < 3600 {
+		t.Errorf("TargetW = %.0f W — absorber should be soaking PV surplus into battery (want ≈ 4000 W)", got)
+	}
+	if got > 4400 {
+		t.Errorf("TargetW = %.0f W — absorber overshoot (want ≈ 4000 W, fuse/cap should bound)", got)
+	}
+}
+
+// Defaults preserve back-compat: PVSurplusAbsorbSoCCapPct = 0 means
+// disabled; original "don't absorb surprise" behavior holds.
+func TestPVSurplusAbsorberDisabledByDefault(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -4800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	// No PVSurplusAbsorbSoCCapPct set → defaults to 0 → feature off.
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	got := targets[0].TargetW
+	// Same expectations as TestEnergyDispatchDoesNotAbsorbPVSurprise.
+	if got > 1500 {
+		t.Errorf("TargetW = %.0f W — absorber should be off by default; got runaway absorption", got)
+	}
+	if got < 100 {
+		t.Errorf("TargetW = %.0f W — plan intent (~800 W) should still run", got)
+	}
+}
+
+// At-cap: absorber must not push SoC above cap.
+func TestPVSurplusAbsorberHoldsAtCap(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 200,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.88}, // already at cap
+	})
+	store.Update("pv-1", telemetry.DerPV, -4800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.PVSurplusAbsorbSoCCapPct = 88
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	got := targets[0].TargetW
+	// SoC already at cap → no absorption beyond the plan's ~800 W intent.
+	if got > 1500 {
+		t.Errorf("TargetW = %.0f W — at cap, absorber should defer to plan (~800 W)", got)
+	}
+}
+
+// Don't reverse a discharge plan: if the planner is deliberately
+// discharging this slot (e.g. evening-peak export), the absorber stays
+// out of the way regardless of live grid sign.
+func TestPVSurplusAbsorberDoesNotReverseDischarge(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -1000, // plan: discharge ~4 kW
+		Strategy:        "arbitrage",
+	}
+	// Grid exporting hard (PV plus planned discharge), but plan is
+	// intentionally export-at-peak. Absorber must NOT flip the sign.
+	store := seedStore(-4000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -4800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.PVSurplusAbsorbSoCCapPct = 88
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	got := targets[0].TargetW
+	if got > -1500 {
+		t.Errorf("TargetW = %.0f W — absorber must not blunt a discharge plan (want ≈ -4000 W)", got)
+	}
+}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2564,6 +2564,96 @@ func TestEnergyDispatchClampsDischargeWhenEVActuallyCharging(t *testing.T) {
 // Don't reverse a discharge plan: if the planner is deliberately
 // discharging this slot (e.g. evening-peak export), the absorber stays
 // out of the way regardless of live grid sign.
+// Regression for the operator-reported "battery sits idle while
+// surplus exports under EV reserve". Energy path, plan dictates
+// charge battery, EV is on surplus_only at 2.5 kW with 11 kW max,
+// and 3 kW is currently exporting at the real meter.
+//
+// dispatch.go:685 subtracts EVChargingW from gridW before the home-
+// battery decision so the battery sees "what export would exist
+// without the EV", which is 3000 + 2500 = 5500 W in this scenario.
+// The reserve cap then carves out reserveRemaining for the EV to
+// step up into.
+//
+// Pre-fix (reserve = full MaxChargeW = 11000): reserveRemaining
+// = 11000 - 2500 = 8500. ceiling = 5500 - 8500 = -3000 → 0. Battery
+// idles; surplus dumps to grid.
+//
+// Post-fix (reserve = CurrentPowerW + EVRampHeadroomW = 4500):
+// reserveRemaining = 4500 - 2500 = 2000. ceiling = 5500 - 2000 =
+// 3500. Battery picks up the bulk of the surplus while leaving 2 kW
+// of headroom for the EV to ramp up.
+//
+// The test sets EVSurplusOnlyReserveW directly to the value
+// loadpoint.SurplusReserveW would produce; the helper itself is
+// unit-tested separately in internal/loadpoint.
+func TestEnergyDispatchAbsorbsSurplusBeyondEVReserveActualDraw(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1250, // plan: charge ~5 kW over the slot
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(-3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -6000, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 2500
+	st.EVSurplusOnlyReserveW = 2500 + 2000 // = SurplusReserveW for one LP at 2.5 kW
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Want ≈ 3500 W. Allow ±400 W slack for time drift / formula edge.
+	if got < 3100 {
+		t.Errorf("TargetW = %.0f W — battery should absorb the surplus that the EV's adaptive reserve no longer hoards (want ≈ 3500 W, was 0 pre-fix)", got)
+	}
+	if got > 3900 {
+		t.Errorf("TargetW = %.0f W — battery overshoot, must leave EVRampHeadroomW (2 kW) of headroom for EV ramp-up (want ≈ 3500 W)", got)
+	}
+}
+
+// Companion: same setup, but with the PRE-FIX reserve (= full
+// MaxChargeW). The battery should be capped at or near 0. Documents
+// the bug this PR fixed and prevents accidental re-regression if
+// someone later restores the old reserve formula.
+func TestEnergyDispatchPreFixReserveStarvesBattery(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1250,
+		Strategy:        "arbitrage",
+	}
+	store := seedStore(-3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -6000, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+	st.EVChargingW = 2500
+	st.EVSurplusOnlyReserveW = 11000 // simulate the old "reserve = MaxChargeW" formula
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	got := targets[0].TargetW
+	if got > 200 {
+		t.Errorf("TargetW = %.0f W — full-MaxChargeW reserve should starve the battery here; if you see a non-trivial target the dispatch reserve cap regressed", got)
+	}
+}
+
 func TestPVSurplusAbsorberDoesNotReverseDischarge(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -232,6 +232,30 @@ type State struct {
 	// and flipped via config. Default off preserves today's behavior.
 	UseEnergyDispatch bool
 
+	// PVSurplusAbsorbSoCCapPct is the opt-in PV-surplus absorber
+	// underlay: in planner_cheap / planner_arbitrage, when live grid is
+	// exporting more than PVSurplusAbsorbThresholdW BEYOND what the
+	// planner's slot allocation would produce, AND the fleet's average
+	// SoC is below this cap, the energy-path's targetTotalW is bumped
+	// up by min(extra_export, cap_headroom_W) so the surprise lands in
+	// the battery instead of crossing the meter at low spot price.
+	//
+	// 0 = disabled (default — preserves the pre-2026-05 behavior
+	// asserted by TestEnergyDispatchDoesNotAbsorbPVSurprise). >0 turns
+	// the feature on with that percentage as the SoC ceiling.
+	//
+	// Never reverses a discharge plan: when the planner has already
+	// committed to discharge this slot (targetTotalW < 0, e.g.
+	// evening-peak export), the absorber stays passive.
+	PVSurplusAbsorbSoCCapPct float64
+
+	// PVSurplusAbsorbThresholdW is the dead-band on the absorber: how
+	// much live export beyond plan we tolerate before charging the
+	// battery instead. Defaults to 100 W (smaller than the PI
+	// deadband, but large enough to ignore meter quantisation noise).
+	// Only consulted when PVSurplusAbsorbSoCCapPct > 0.
+	PVSurplusAbsorbThresholdW float64
+
 	// currentDirective + slotDelivered track the active slot's energy
 	// accounting. Reset when the slot rolls over (by SlotStart equality).
 	// Zero-valued until UseEnergyDispatch fires its first cycle.
@@ -792,6 +816,58 @@ func ComputeDispatch(
 			}
 		}
 
+		// PV surplus absorber underlay (opt-in). Catches the gap between
+		// the MPC's 15-min slot allocation and live PV/load drift: when
+		// the plan's target would still leave grid exporting beyond the
+		// threshold AND average SoC is below cap AND we're not already
+		// in a planned discharge, redirect the leftover export into the
+		// battery instead of crossing the meter at low spot price.
+		//
+		// Only adds charge — never reverses a discharge plan. The slot
+		// Wh accumulator (state.slotDelivered) sees the extra and the
+		// next replan reads true SoC, so the plan adapts naturally.
+		//
+		// Order: runs BEFORE the surplus-only EV reserve cap below, so
+		// any addition the absorber makes is then re-capped if an EV is
+		// reserving PV headroom for itself.
+		if state.PVSurplusAbsorbSoCCapPct > 0 && targetTotalW >= 0 {
+			threshold := state.PVSurplusAbsorbThresholdW
+			if threshold <= 0 {
+				threshold = 100
+			}
+			var sumSoCWh, totalCap float64
+			for _, b := range onlineBats {
+				sumSoCWh += b.soc * b.capacityWh
+				totalCap += b.capacityWh
+			}
+			var avgSoCPct float64
+			if totalCap > 0 {
+				avgSoCPct = (sumSoCWh / totalCap) * 100
+			}
+			if avgSoCPct < state.PVSurplusAbsorbSoCCapPct {
+				// Grid level if dispatch ran the plan as-is.
+				projectedGridW := rawGridW + (targetTotalW - currentTotal)
+				extraExportW := -projectedGridW
+				if extraExportW > threshold {
+					// Remaining headroom in Wh, converted to a power
+					// share over the rest of the slot. Floor remainingS
+					// at 60 s so the late-slot edge doesn't ask for
+					// implausibly high power.
+					socHeadroomWh := (state.PVSurplusAbsorbSoCCapPct - avgSoCPct) / 100 * totalCap
+					remainS := remainingS
+					if remainS < 60 {
+						remainS = 60
+					}
+					headroomW := socHeadroomWh * 3600 / remainS
+					addW := extraExportW
+					if addW > headroomW {
+						addW = headroomW
+					}
+					targetTotalW += addW
+				}
+			}
+		}
+
 		// Surplus-only EV reserve (energy path): cap battery aggregate
 		// charge to leave PV headroom for an EV that's under a
 		// surplus_only loadpoint. The MPC's grid-charge ban handles the
@@ -799,7 +875,8 @@ func ComputeDispatch(
 		// drift, stale plan fallback, and the period before the next
 		// replan picks up the EV's needs). Discharge is unaffected — the
 		// reserve only matters when the battery is competing with the
-		// EV for the same surplus PV.
+		// EV for the same surplus PV. Final cap — runs AFTER the PV
+		// surplus absorber so the absorber can't override an EV reserve.
 		if state.EVSurplusOnlyReserveW > 0 && targetTotalW > 0 {
 			pvSurplus := -gridW + currentTotal
 			reserveRemaining := state.EVSurplusOnlyReserveW - state.EVChargingW

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -78,6 +78,17 @@ type SlotDirectiveFunc func(now time.Time) (SlotDirective, bool)
 // `max_discharge_w` (see PowerLimits + State.DriverLimits, issue #145).
 const MaxCommandW = 5000
 
+// evActiveThresholdW is the floor below which state.EVChargingW is
+// treated as driver-side noise (a connected-but-idle wallbox bleeds a
+// few watts of last-known smoothed reading after the contactor
+// opens). Above the threshold, the BatteryCoversEV=false safety net
+// caps battery discharge to the house side so the planner doesn't
+// drain the battery into the EV. Below it, the EV is effectively
+// idle and the safety net stays off, letting the planner's evening-
+// peak export plan run unmolested. 100 W matches the deadband used
+// elsewhere in this package for sign decisions.
+const evActiveThresholdW = 100.0
+
 // PowerLimits holds the per-driver charge/discharge ceiling. Zero on
 // either field means "use the global MaxCommandW default" — the value
 // an unset config key carries through the YAML → Driver struct →
@@ -799,16 +810,27 @@ func ComputeDispatch(
 		// commanded discharge to the level the reactive path would target
 		// — i.e. enough to zero the *house* side, not to feed the EV.
 		// Charging is left untouched. Mirrors the dispatch.go:453 rule on
-		// the legacy path. The MPC also gets a NoBatteryToEV constraint
-		// so the plan stops prescribing what dispatch then has to censor.
+		// the legacy path.
+		//
+		// Use a real EV-active threshold (evActiveThresholdW) instead of
+		// `> 0`: connected-but-idle chargers report low-W noise (~1 W
+		// from Easee's last-known reading bleed) that would otherwise
+		// trip this safety net on every evening-peak slot — pinning a
+		// planned -9 kW discharge to just-cover-the-house. The threshold
+		// preserves the EV-protection guarantee for any real draw while
+		// letting noise pass through. Regression:
+		// TestEnergyDispatchIgnoresEVChargingWNoiseUnderThreshold,
+		// TestEnergyDispatchClampsDischargeWhenEVActuallyCharging.
+		//
 		// EXCEPTION: surplus-only transient cover. Same gate as the
 		// rawGridW-subtraction path above — when a surplus_only LP is
 		// drawing more than current surplus (site importing), the battery
 		// is allowed to bridge the EV ramp-down for ~10 s while the
 		// Easee/car-side current ramp completes. The cap reverts the
 		// moment grid goes negative.
-		surplusTransient := state.EVSurplusOnlyReserveW > 0 && state.EVChargingW > 0 && rawGridW > 0
-		if !state.BatteryCoversEV && !surplusTransient && state.EVChargingW > 0 && targetTotalW < 0 {
+		evActive := state.EVChargingW > evActiveThresholdW
+		surplusTransient := state.EVSurplusOnlyReserveW > 0 && evActive && rawGridW > 0
+		if !state.BatteryCoversEV && !surplusTransient && evActive && targetTotalW < 0 {
 			houseGridW := rawGridW - state.EVChargingW
 			reactiveTotal := currentTotal - houseGridW
 			if targetTotalW < reactiveTotal {

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -830,6 +830,15 @@ func ComputeDispatch(
 		// moment grid goes negative.
 		evActive := state.EVChargingW > evActiveThresholdW
 		surplusTransient := state.EVSurplusOnlyReserveW > 0 && evActive && rawGridW > 0
+		// CANONICAL "battery may not feed EV" accounting. The MPC's
+		// NoBatteryToEV DP feasibility rule (mpc.go, see the
+		// houseResidualW check inside the action loop) mirrors this
+		// computation so the planner stops emitting allocations that
+		// this clamp then has to censor. TODO(refactor): extract the
+		// houseResidualW math + the (battW<0, evW>0) feasibility
+		// predicate into a small helper consumed by both this clamp
+		// and the DP rule, so a future change to the accounting can't
+		// drift between plan and runtime.
 		if !state.BatteryCoversEV && !surplusTransient && evActive && targetTotalW < 0 {
 			houseGridW := rawGridW - state.EVChargingW
 			reactiveTotal := currentTotal - houseGridW

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -512,17 +512,20 @@ func (c *Controller) AnyLoadpointSurplusActive() bool {
 
 // RefreshVehicle sends a one-off wake command to the vehicle driver
 // bound to the given loadpoint, bypassing the auto-wake cooldown.
-// Used by the API when the operator edits the schedule — wakes Tesla
-// (or whichever vehicle driver is bound) so the next poll surfaces
-// any vehicle-side limit / SoC / connection changes immediately
-// rather than waiting up to the next natural wake window.
+// Used by the API when the operator edits the schedule — wakes
+// Tesla / BMW / whichever vehicle driver is bound so the next poll
+// surfaces any vehicle-side limit / SoC / connection changes
+// immediately rather than waiting up to the next natural wake
+// window.
 //
-// The wake action is the same `charge_start` the auto-wake loop uses;
-// Tesla treats it as "wake + (idempotently) start charging if not
-// already at limit", and the driver's normal poll cycle picks up the
-// fresh state. Returns nil if no vehicle driver is bound or the
-// controller isn't fully wired (no-op). Errors from the send hop are
-// returned for the caller to surface to the operator.
+// Sends the generic `wake_up` action (cross-driver protocol — any
+// vehicle driver implements it against its own back-end). Distinct
+// from `charge_start` (still used by the auto-wake loop when it's
+// trying to convince a detached car to actually start drawing
+// current) — `wake_up` is purely a telemetry refresh, no charge
+// side effects. Returns nil if no vehicle driver is bound or the
+// controller isn't fully wired (no-op). Errors from the send hop
+// are returned for the caller to surface to the operator.
 func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 	if c == nil || c.vehicleStatus == nil || c.send == nil {
 		return nil
@@ -531,7 +534,7 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 	if !ok || driver == "" {
 		return nil
 	}
-	payload, err := json.Marshal(map[string]any{"action": "charge_start"})
+	payload, err := json.Marshal(map[string]any{"action": "wake_up"})
 	if err != nil {
 		return err
 	}
@@ -550,6 +553,46 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 	c.wakeMu.Unlock()
 	slog.Info("loadpoint manual wake (schedule edit)", "lp", lpID, "vehicle_driver", driver)
 	return c.send(ctx, driver, payload)
+}
+
+// wakeVehicleAuto sends a `wake_up` to the loadpoint's bound vehicle
+// driver, gated by the same `vehicleWakeCooldown` (5 min) the
+// charge_start auto-wake loop uses. Used for event-triggered wakes
+// (e.g. the wallbox-delivering rising edge) where we want fresh
+// vehicle state but the trigger can flap — don't storm the BLE radio.
+// No-op when no vehicle is bound; logs but does not return errors
+// (the trigger is opportunistic; failure is fine).
+func (c *Controller) wakeVehicleAuto(ctx context.Context, lpID string, reason string) {
+	if c == nil || c.vehicleStatus == nil || c.send == nil {
+		return
+	}
+	driver, _, ok := c.vehicleStatus(lpID)
+	if !ok || driver == "" {
+		return
+	}
+	now := time.Now()
+	c.wakeMu.Lock()
+	if c.wakeLast == nil {
+		c.wakeLast = map[string]time.Time{}
+		c.wakeKickUntil = map[string]time.Time{}
+		c.wakeAttempts = map[string]int{}
+	}
+	if last, has := c.wakeLast[lpID]; has && now.Sub(last) < vehicleWakeCooldown {
+		c.wakeMu.Unlock()
+		return
+	}
+	c.wakeLast[lpID] = now
+	c.wakeMu.Unlock()
+	payload, err := json.Marshal(map[string]any{"action": "wake_up"})
+	if err != nil {
+		return
+	}
+	slog.Info("loadpoint auto-wake (vehicle telemetry refresh)",
+		"lp", lpID, "vehicle_driver", driver, "reason", reason)
+	if err := c.send(ctx, driver, payload); err != nil {
+		slog.Warn("loadpoint auto-wake send failed",
+			"lp", lpID, "vehicle_driver", driver, "err", err)
+	}
 }
 
 // IsBatSoCArmed reports whether the bat-SoC surplus unlock is
@@ -691,9 +734,18 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	// before the new session's first dispatch tick. Without this
 	// the rolling-avg buffer keeps stale samples from the previous
 	// session, biasing the first ~20 s of pause/resume decisions.
+	// Also detect the not-delivering→delivering edge separately so
+	// we can wake the bound vehicle for fresh telemetry the moment
+	// the wallbox actually starts pushing current — the planner
+	// otherwise has to wait for the next periodic vehicle poll
+	// (or the proxy's cache to refresh on its own) to learn the
+	// car's current charge_limit_pct + SoC, which costs accuracy
+	// on the first ~15 min of a new charging session.
 	wasPlugged := false
+	wasDelivering := false
 	if st, ok := c.manager.State(lpCfg.ID); ok {
 		wasPlugged = st.PluggedIn
+		wasDelivering = st.CurrentPowerW >= DeliveringW
 	}
 	c.manager.Observe(lpCfg.ID, sample.Connected, sample.PowerW, sample.SessionWh)
 	if !sample.Connected {
@@ -702,6 +754,16 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	}
 	if !wasPlugged {
 		c.resetSurplusSession(lpCfg.ID)
+	}
+	// Wallbox just started delivering current: fire a wake at the
+	// bound vehicle so the next vehicle-driver poll comes back with
+	// fresh charging_state / charge_limit_pct / SoC. Gated by
+	// vehicleWakeCooldown inside wakeVehicleAuto so a flapping
+	// pause/resume cycle can't storm the BLE radio. Fire-and-forget
+	// on a background goroutine so the dispatch tick isn't blocked
+	// by the wake HTTP roundtrip.
+	if sample.PowerW >= DeliveringW && !wasDelivering {
+		go c.wakeVehicleAuto(context.Background(), lpCfg.ID, "delivering_edge")
 	}
 
 	cmd := map[string]any{"action": "ev_set_current"}

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -110,6 +110,14 @@ type Controller struct {
 	// the entire afternoon. Optional; nil means no near-term gate.
 	nearTermPeakSurplusW func(window time.Duration) (float64, bool)
 
+	// nearTermLogLast throttles the "1Φ allowed (near-term 3Φ
+	// unreachable)" log line to once per nearTermLogCooldown per
+	// loadpoint so it doesn't spam every 5 s when the condition
+	// holds for hours. Reset on day rollover via the existing
+	// phase-lock release path.
+	nearTermLogMu   sync.Mutex
+	nearTermLogLast map[string]time.Time
+
 	// phaseLockMu protects phaseLocked1P + phaseLockedAt. The 1Φ
 	// lock is sticky for the rest of the day so a slowly recovering
 	// PV doesn't flip 1Φ ↔ 3Φ as clouds shift. It's automatically
@@ -215,6 +223,11 @@ const surplusResumeMarginW = 200.0
 // rolling-avg already smooths transients; this is a hard contactor-
 // protection backstop on top.
 const surplusMinPauseHold = 35 * time.Second
+
+// nearTermLogCooldown caps the rate of the "1Φ allowed (near-term 3Φ
+// unreachable)" log line so a long morning with sustained low surplus
+// produces one line per 10 min per LP instead of one per 5 s tick.
+const nearTermLogCooldown = 10 * time.Minute
 
 // defaultPhaseSplitW mirrors loadpoint.Config.PhaseSplitW's default —
 // 3680 W is a 16 A 1Φ ceiling at 230 V. Kept in sync with the comment
@@ -1292,6 +1305,21 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 	if c.nearTermPeakSurplusW != nil {
 		const nearTermWindow = 30 * time.Minute
 		if nearPeak, ok := c.nearTermPeakSurplusW(nearTermWindow); ok && nearPeak < minStep3 {
+			c.nearTermLogMu.Lock()
+			lastFor, has := c.nearTermLogLast[lpCfg.ID]
+			fireLog := !has || now.Sub(lastFor) > nearTermLogCooldown
+			if fireLog {
+				if c.nearTermLogLast == nil {
+					c.nearTermLogLast = map[string]time.Time{}
+				}
+				c.nearTermLogLast[lpCfg.ID] = now
+			}
+			c.nearTermLogMu.Unlock()
+			if fireLog {
+				slog.Info("loadpoint surplus: 1Φ steps allowed (near-term 3Φ unreachable)",
+					"lp", lpCfg.ID, "near_term_peak_w", nearPeak, "min_3p_step_w", minStep3,
+					"window", nearTermWindow.String())
+			}
 			return lpCfg.AllowedStepsW
 		}
 	}

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -118,6 +118,14 @@ type Controller struct {
 	nearTermLogMu   sync.Mutex
 	nearTermLogLast map[string]time.Time
 
+	// fusePauseUntil holds the wall-clock time before which an LP must
+	// stay paused after a fuse-clamp-induced full pause. Operator-stated
+	// behaviour: ramp down if possible, pause if the fuse cap is below
+	// the LP's min step, and keep paused for fusePauseCooldown so a
+	// transient doesn't flap. Cleared lazily when the cooldown expires.
+	fusePauseMu    sync.Mutex
+	fusePauseUntil map[string]time.Time
+
 	// phaseLockMu protects phaseLocked1P + phaseLockedAt. The 1Φ
 	// lock is sticky for the rest of the day so a slowly recovering
 	// PV doesn't flip 1Φ ↔ 3Φ as clouds shift. It's automatically
@@ -228,6 +236,15 @@ const surplusMinPauseHold = 35 * time.Second
 // unreachable)" log line so a long morning with sustained low surplus
 // produces one line per 10 min per LP instead of one per 5 s tick.
 const nearTermLogCooldown = 10 * time.Minute
+
+// fusePauseCooldown is how long an LP stays at 0 W after a fuse-over-
+// limit force-pause. Long enough that whatever house load caused the
+// overload (oven, EV from another LP, sauna…) has time to clear or for
+// the operator to notice; short enough that a transient inrush doesn't
+// stop charging for the rest of the day. 5 min is the operator-stated
+// preference; chosen vs. e.g. 1 min because the typical "did the oven
+// kick on?" disturbance lasts longer than a minute.
+const fusePauseCooldown = 5 * time.Minute
 
 // defaultPhaseSplitW mirrors loadpoint.Config.PhaseSplitW's default —
 // 3680 W is a 16 A 1Φ ceiling at 230 V. Kept in sync with the comment
@@ -369,6 +386,68 @@ func (c *Controller) SetPeakRemainingSurplusW(f func() (float64, bool)) {
 		return
 	}
 	c.peakRemainingSurplusW = f
+}
+
+// applyFuseClampAndCooldown enforces the joint fuse allocator's
+// FuseEVMax cap on a requested wattage and tracks the operator-stated
+// pause-cooldown semantics:
+//
+//   - In cooldown: force 0 regardless of wantW.
+//   - cap unset / cap >= wantW: pass-through.
+//   - cap < wantW but a snap-step exists at ≤ cap: ramp down to that step.
+//   - cap < min step (or snap returns 0): force 0 AND arm
+//     fusePauseUntil[lpID] = now + fusePauseCooldown.
+//
+// Both tickOne branches (manual hold + normal MPC dispatch) call this
+// just before writing cmd["power_w"] so the protection is uniform:
+// neither a sticky operator hold nor a stale MPC budget can drive
+// the fuse over limit, and the cooldown prevents fuse flap when a
+// transient overload clears momentarily.
+func (c *Controller) applyFuseClampAndCooldown(now time.Time, lpCfg Config, wantW float64) float64 {
+	if c == nil {
+		return wantW
+	}
+	c.fusePauseMu.Lock()
+	until, has := c.fusePauseUntil[lpCfg.ID]
+	if has && !now.Before(until) {
+		// Cooldown elapsed; release lazily so subsequent ticks see no
+		// hold and can re-attempt charging.
+		delete(c.fusePauseUntil, lpCfg.ID)
+		has = false
+	}
+	c.fusePauseMu.Unlock()
+	if has {
+		return 0
+	}
+	if c.fuseEVMax == nil {
+		return wantW
+	}
+	cap, ok := c.fuseEVMax()
+	if !ok || cap < 0 {
+		return wantW
+	}
+	if wantW <= cap {
+		return wantW
+	}
+	// Need to ramp down. Snap to the largest allowed step ≤ cap.
+	snapped := SnapChargeW(cap, lpCfg.MinChargeW, lpCfg.MaxChargeW, lpCfg.AllowedStepsW)
+	if snapped > 0 && snapped >= lpCfg.MinChargeW {
+		slog.Info("loadpoint fuse-clamp: ramped down",
+			"lp", lpCfg.ID, "want_w", wantW, "fuse_cap_w", cap, "snapped_w", snapped)
+		return snapped
+	}
+	// Cap is below the LP's min step → pause + arm cooldown.
+	c.fusePauseMu.Lock()
+	if c.fusePauseUntil == nil {
+		c.fusePauseUntil = map[string]time.Time{}
+	}
+	c.fusePauseUntil[lpCfg.ID] = now.Add(fusePauseCooldown)
+	c.fusePauseMu.Unlock()
+	slog.Warn("loadpoint fuse-clamp: paused for cooldown",
+		"lp", lpCfg.ID, "want_w", wantW, "fuse_cap_w", cap,
+		"min_step_w", lpCfg.MinChargeW,
+		"cooldown_s", int(fusePauseCooldown.Seconds()))
+	return 0
 }
 
 // SetNearTermPeakSurplusW wires the short-horizon "peak surplus over
@@ -824,6 +903,12 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 				holdW = clamped
 			}
 		}
+		// Fuse protection: even an operator-pinned hold must not bust
+		// the fuse. Apply the joint allocator's FuseEVMax cap and the
+		// pause-cooldown guard before sending. A sticky 11 kW Start
+		// hold + house drawing 7 A on one phase = fuse trip without
+		// this clamp.
+		holdW = c.applyFuseClampAndCooldown(now, lpCfg, holdW)
 		cmd["power_w"] = holdW
 		// Phase mode: explicit hold > explicit LP config > surplus
 		// default ("auto") > driver default. Same surplus-active fallback
@@ -932,6 +1017,13 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 				cmdW = minKick
 			}
 		}
+		// Fuse protection: applied LAST (after MPC budget, surplus
+		// clamp, wake-kick) so all upstream sources see their nominal
+		// wantW; only the actual ceiling we send to the wallbox is
+		// reduced when the fuse demands it. Partial ramp-downs are
+		// immediate; only "cap below min step → must pause" arms the
+		// 5-min cooldown.
+		cmdW = c.applyFuseClampAndCooldown(now, lpCfg, cmdW)
 		cmd["power_w"] = cmdW
 		// Pass operator's phase preferences through verbatim. The driver
 		// reads these and decides 1Φ vs 3Φ based on its own knowledge of

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -213,6 +213,15 @@ const wakeBackoffCooldown = 10 * time.Minute
 // detached sessions; charge_start is the secondary signal.
 const vehicleWakeCooldown = 5 * time.Minute
 
+// vehicleWakeTimeout caps the wake-send roundtrip when wakeVehicleAuto
+// is invoked fire-and-forget on a background goroutine (e.g. from the
+// wallbox-delivering rising edge in tickOne). Without it a stuck
+// vehicle-proxy HTTP call would leak the goroutine until the process
+// exits. 30 s is comfortably longer than the Tesla proxy's own ~15 s
+// host timeout while still bounded enough that a leaked routine per
+// cooldown window is the worst case.
+const vehicleWakeTimeout = 30 * time.Second
+
 // surplusWindowSize is the length of the rolling-average buffer used
 // for surplus_only pause/resume decisions. At a 5 s tick this is ~20 s
 // of smoothing — long enough to ride out single-tick cloud transients
@@ -677,6 +686,12 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 // vehicle state but the trigger can flap — don't storm the BLE radio.
 // No-op when no vehicle is bound; logs but does not return errors
 // (the trigger is opportunistic; failure is fine).
+//
+// Callers commonly invoke this as `go wakeVehicleAuto(...)` with a
+// background context, so the send is bounded internally by
+// `vehicleWakeTimeout` to keep a stuck HTTP roundtrip from leaking the
+// goroutine. The driver's own HTTP client also has a timeout — this is
+// just a belt-and-braces ceiling at the caller boundary.
 func (c *Controller) wakeVehicleAuto(ctx context.Context, lpID string, reason string) {
 	if c == nil || c.vehicleStatus == nil || c.send == nil {
 		return
@@ -704,7 +719,9 @@ func (c *Controller) wakeVehicleAuto(ctx context.Context, lpID string, reason st
 	}
 	slog.Info("loadpoint auto-wake (vehicle telemetry refresh)",
 		"lp", lpID, "vehicle_driver", driver, "reason", reason)
-	if err := c.send(ctx, driver, payload); err != nil {
+	sendCtx, cancel := context.WithTimeout(ctx, vehicleWakeTimeout)
+	defer cancel()
+	if err := c.send(sendCtx, driver, payload); err != nil {
 		slog.Warn("loadpoint auto-wake send failed",
 			"lp", lpID, "vehicle_driver", driver, "err", err)
 	}

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -825,11 +825,18 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 			}
 		}
 		cmd["power_w"] = holdW
+		// Phase mode: explicit hold > explicit LP config > surplus
+		// default ("auto") > driver default. Same surplus-active fallback
+		// as the non-hold branch so a sticky Start hold on a 1380 W
+		// surplus slot actually delivers instead of dying at the Easee
+		// driver's unset → "3p" interpretation.
 		switch {
 		case hold.PhaseMode != "":
 			cmd["phase_mode"] = hold.PhaseMode
 		case lpCfg.PhaseMode != "":
 			cmd["phase_mode"] = lpCfg.PhaseMode
+		case surplusOn:
+			cmd["phase_mode"] = "auto"
 		}
 		switch {
 		case hold.PhaseSplitW > 0:
@@ -935,9 +942,20 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		// pick_phases respects an operator-set "3p" lock over the
 		// dispatch's wantW. The 1Φ lock IS the operator's intent for
 		// this day.
+		//
+		// Default to "auto" when surplus is active and the operator
+		// didn't explicitly pick a phase mode. The Easee driver
+		// (drivers/easee_cloud.lua:105) interprets an UNSET phase_mode
+		// as "3p" — silently locking the wallbox to 3Φ and rejecting
+		// any 1Φ-eligible step the near-term branch passes through.
+		// Operators who picked surplus_only have clearly opted into
+		// "react to PV"; dynamic phase switching is the only way to
+		// actually deliver low-power surplus to the EV.
 		phaseMode := lpCfg.PhaseMode
 		if c.surplusLockedTo1P(lpCfg.ID) {
 			phaseMode = "1p"
+		} else if surplusOn && phaseMode == "" {
+			phaseMode = "auto"
 		}
 		if phaseMode != "" {
 			cmd["phase_mode"] = phaseMode

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -99,6 +99,16 @@ type Controller struct {
 	// shifts. nil disables this — the loadpoint then stays on 3Φ-
 	// only forever (matching the conservative original behaviour).
 	peakRemainingSurplusW func() (float64, bool)
+	// nearTermPeakSurplusW returns the peak PV-minus-load surplus
+	// over the next `window` from now (in plan slot resolution).
+	// pickSurplusSteps consults this *before* the whole-day peak so
+	// the LP can fall back to 1Φ when 3Φ isn't imminent — captures
+	// "we have 3 kW now and won't see 4.1 kW for the next 30 min,
+	// start charging at 1Φ instead of waiting." The day-peak gate
+	// still applies for the longer-term "lock 1Φ for the whole day"
+	// decision so a passing cloud doesn't commit the LP to 1Φ for
+	// the entire afternoon. Optional; nil means no near-term gate.
+	nearTermPeakSurplusW func(window time.Duration) (float64, bool)
 
 	// phaseLockMu protects phaseLocked1P + phaseLockedAt. The 1Φ
 	// lock is sticky for the rest of the day so a slowly recovering
@@ -346,6 +356,19 @@ func (c *Controller) SetPeakRemainingSurplusW(f func() (float64, bool)) {
 		return
 	}
 	c.peakRemainingSurplusW = f
+}
+
+// SetNearTermPeakSurplusW wires the short-horizon "peak surplus over
+// the next window" reader used by pickSurplusSteps to decide whether
+// a 3Φ start is imminent. Typical implementation iterates the MPC
+// plan's slots starting now and walks until `now + window`, returning
+// the max(−pvW − loadW) seen. Pass nil to keep the original "wait for
+// today's day-peak forecast" behaviour.
+func (c *Controller) SetNearTermPeakSurplusW(f func(window time.Duration) (float64, bool)) {
+	if c == nil {
+		return
+	}
+	c.nearTermPeakSurplusW = f
 }
 
 // SetBatSoCProvider wires the home-battery SoC reader used by the
@@ -1254,14 +1277,30 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 		// All allowed steps — driver picks the phase.
 		return lpCfg.AllowedStepsW
 	}
+	if minStep3 <= 0 {
+		return steps3
+	}
+
+	// Near-term gate: even if today's whole-day peak forecast will
+	// reach 3Φ minimum eventually, if the next 30 min won't, return
+	// 1Φ-allowed steps NOW so the LP captures the surplus that's
+	// here today instead of waiting for a peak that's hours away.
+	// Day-lock NOT set here — this is a "transient cloud" not a
+	// "low-PV day" verdict, so a later 3Φ window during the same
+	// day can still trigger a contactor cycle into 3Φ (the
+	// surplusMinPauseHold ≥ 35 s hysteresis caps the cycle rate).
+	if c.nearTermPeakSurplusW != nil {
+		const nearTermWindow = 30 * time.Minute
+		if nearPeak, ok := c.nearTermPeakSurplusW(nearTermWindow); ok && nearPeak < minStep3 {
+			return lpCfg.AllowedStepsW
+		}
+	}
+
 	if c.peakRemainingSurplusW == nil {
 		return steps3
 	}
 	peak, ok := c.peakRemainingSurplusW()
 	if !ok {
-		return steps3
-	}
-	if minStep3 <= 0 {
 		return steps3
 	}
 	if peak >= minStep3 {

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -510,6 +510,70 @@ func (c *Controller) AnyLoadpointSurplusActive() bool {
 	return false
 }
 
+// RefreshVehicle sends a one-off wake command to the vehicle driver
+// bound to the given loadpoint, bypassing the auto-wake cooldown.
+// Used by the API when the operator edits the schedule — wakes Tesla
+// (or whichever vehicle driver is bound) so the next poll surfaces
+// any vehicle-side limit / SoC / connection changes immediately
+// rather than waiting up to the next natural wake window.
+//
+// The wake action is the same `charge_start` the auto-wake loop uses;
+// Tesla treats it as "wake + (idempotently) start charging if not
+// already at limit", and the driver's normal poll cycle picks up the
+// fresh state. Returns nil if no vehicle driver is bound or the
+// controller isn't fully wired (no-op). Errors from the send hop are
+// returned for the caller to surface to the operator.
+func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
+	if c == nil || c.vehicleStatus == nil || c.send == nil {
+		return nil
+	}
+	driver, _, ok := c.vehicleStatus(lpID)
+	if !ok || driver == "" {
+		return nil
+	}
+	payload, err := json.Marshal(map[string]any{"action": "charge_start"})
+	if err != nil {
+		return err
+	}
+	// Reset the auto-wake throttle so a manual refresh doesn't leave
+	// the LP in a long backoff afterwards — the operator just told us
+	// they want a fresh read, no reason to apply 90s cooldown to the
+	// next legitimate auto-wake.
+	c.wakeMu.Lock()
+	if c.wakeLast == nil {
+		c.wakeLast = map[string]time.Time{}
+		c.wakeKickUntil = map[string]time.Time{}
+		c.wakeAttempts = map[string]int{}
+	}
+	delete(c.wakeAttempts, lpID)
+	c.wakeLast[lpID] = time.Now()
+	c.wakeMu.Unlock()
+	slog.Info("loadpoint manual wake (schedule edit)", "lp", lpID, "vehicle_driver", driver)
+	return c.send(ctx, driver, payload)
+}
+
+// IsBatSoCArmed reports whether the bat-SoC surplus unlock is
+// currently armed for the given loadpoint. Surfaced so main.go can
+// thread this runtime state into the MPC LoadpointSpec.SurplusOnly
+// — without it, MPC plans battery→EV transfers freely while the
+// dispatch layer's bat-SoC arming refuses to execute them, producing
+// misleading "battery discharges to feed EV" entries in the plan UI
+// that never actually happen.
+//
+// Returns false if the controller is nil, no arm map yet exists, or
+// the LP id isn't tracked. Safe to call concurrently with Tick.
+func (c *Controller) IsBatSoCArmed(lpID string) bool {
+	if c == nil {
+		return false
+	}
+	c.batSoCArmedMu.Lock()
+	defer c.batSoCArmedMu.Unlock()
+	if c.batSoCArmed == nil {
+		return false
+	}
+	return c.batSoCArmed[lpID]
+}
+
 // SetSiteFuse installs the grid-boundary fuse so the controller can
 // pass voltage + per-phase amperage to drivers in every command.
 // Called once at startup from main.go after config load. A zero-value

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -507,6 +507,17 @@ func (m *Manager) SetSchedule(id string, s Schedule) bool {
 	// Force RollSchedules to re-evaluate on next call — operator just
 	// changed the contract so any previous idempotence cache is stale.
 	lp.lastRolledFor = time.Time{}
+	// Clear the one-shot targetTime too. RollSchedules deliberately
+	// preserves a future targetTime (so daily-rolled deadlines stay
+	// stable across ticks), but that same guard makes a freshly-saved
+	// schedule a no-op when a stale future targetTime is sitting in
+	// state.db — the operator presses Save and nothing changes. The
+	// contract for SetSchedule is "this replaces the user's intent",
+	// so we wipe the derived field and let the next RollSchedules
+	// seed it from the new schedule. Applies to both recurring and
+	// non-recurring saves.
+	lp.targetTime = time.Time{}
+	lp.targetSoCPct = 0
 	saver := m.scheduleSaver
 	m.mu.Unlock()
 	if saver != nil {

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -178,6 +178,14 @@ type Manager struct {
 	// schedule is set or cleared. Wired by main.go to persist via
 	// state.SaveConfig. Left nil in tests / sites without storage.
 	scheduleSaver func(id string, s Schedule)
+
+	// surplusOnlySaver, if non-nil, persists the runtime surplus_only
+	// flag whenever an operator toggles it. Without this the flag
+	// reverts to whatever's in YAML on every restart — operators were
+	// finding that frustrating since the toggle lives in the dashboard
+	// EV modal, not the YAML they'd think to edit. Same pattern as
+	// scheduleSaver.
+	surplusOnlySaver func(id string, v bool)
 }
 
 // loadpointRuntime is the in-memory representation. Its fields are the
@@ -396,14 +404,44 @@ func (m *Manager) SetTarget(id string, socPct float64, targetTime time.Time) boo
 // handler forces a tagged replan in that case.
 func (m *Manager) SetSurplusOnly(id string, v bool) (prev bool, ok bool) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	lp, ok := m.byID[id]
 	if !ok {
+		m.mu.Unlock()
 		return false, false
 	}
 	prev = lp.Config.SurplusOnly
 	lp.Config.SurplusOnly = v
+	saver := m.surplusOnlySaver
+	m.mu.Unlock()
+	if saver != nil && prev != v {
+		saver(id, v)
+	}
 	return prev, true
+}
+
+// SetSurplusOnlySaver wires the persistence callback. Pass nil to
+// disable. Mirrors SetScheduleSaver — the saver runs on every change
+// (after the mutex is released, so the storage I/O isn't on the hot
+// path).
+func (m *Manager) SetSurplusOnlySaver(saver func(id string, v bool)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.surplusOnlySaver = saver
+}
+
+// HydrateSurplusOnly seeds the in-memory surplus_only flag from a
+// per-LP loader at boot. Called once after Load; loader returns
+// (value, true) when a persisted override exists and should win over
+// the YAML default, (zero, false) otherwise. Matches the pattern used
+// by HydrateSchedules.
+func (m *Manager) HydrateSurplusOnly(load func(id string) (bool, bool)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, lp := range m.byID {
+		if v, ok := load(id); ok {
+			lp.Config.SurplusOnly = v
+		}
+	}
 }
 
 // SetCurrentSoC lets an operator correct the inferred vehicle SoC

--- a/go/internal/loadpoint/schedule_test.go
+++ b/go/internal/loadpoint/schedule_test.go
@@ -174,6 +174,49 @@ func TestManager_HydrateSchedules(t *testing.T) {
 	}
 }
 
+// Regression: a stale one-shot target_time (set earlier via SetTarget or
+// loaded from disk) used to silently shadow a freshly-saved schedule,
+// because RollSchedules preserves future target_time values across
+// ticks. SetSchedule must wipe the derived target so the next
+// RollSchedules seeds the new deadline. Otherwise pressing Save on the
+// schedule UI is a visible no-op — the MPC keeps planning against the
+// old (often wrong) deadline.
+func TestManager_SetScheduleOverridesStaleTargetTime_Recurring(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	now := time.Date(2026, 5, 12, 20, 0, 0, 0, time.UTC)
+	// Operator (or stale state.db) leaves a one-shot target at 07:00
+	// tomorrow morning.
+	staleTarget := time.Date(2026, 5, 13, 5, 0, 0, 0, time.UTC)
+	m.SetTarget("garage", 100, staleTarget)
+	// Operator now saves a recurring schedule for 17:00 local CEST
+	// (15:00 UTC = 900 min).
+	m.SetSchedule("garage", Schedule{SoCPct: 100, TimeOfDayMinUTC: 900, Recurring: true})
+	m.RollSchedules(now)
+	st, _ := m.State("garage")
+	want := time.Date(2026, 5, 13, 15, 0, 0, 0, time.UTC)
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("recurring SetSchedule must override stale target_time; got %v, want %v",
+			st.TargetTime, want)
+	}
+}
+
+func TestManager_SetScheduleOverridesStaleTargetTime_NonRecurring(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "garage", DriverName: "easee"}})
+	now := time.Date(2026, 5, 12, 20, 0, 0, 0, time.UTC)
+	staleTarget := time.Date(2026, 5, 13, 5, 0, 0, 0, time.UTC)
+	m.SetTarget("garage", 100, staleTarget)
+	m.SetSchedule("garage", Schedule{SoCPct: 100, TimeOfDayMinUTC: 900, Recurring: false})
+	m.RollSchedules(now)
+	st, _ := m.State("garage")
+	want := time.Date(2026, 5, 13, 15, 0, 0, 0, time.UTC)
+	if !st.TargetTime.Equal(want) {
+		t.Errorf("non-recurring SetSchedule must override stale target_time; got %v, want %v",
+			st.TargetTime, want)
+	}
+}
+
 func TestManager_LoadPreservesSchedule(t *testing.T) {
 	m := NewManager()
 	m.Load([]Config{{ID: "garage", DriverName: "easee"}})

--- a/go/internal/loadpoint/surplus_reserve.go
+++ b/go/internal/loadpoint/surplus_reserve.go
@@ -1,17 +1,29 @@
 package loadpoint
 
 // EVRampHeadroomW is the per-LP buffer added on top of the EV's
-// current draw when computing the surplus reserve. It must cover the
-// worst-case single-step ramp the EV controller will take in the next
-// ~30 s: jumping from 1Φ at minimum to 3Φ at minimum (~6 A × 3 phases
-// × 230 V ≈ 4140 W, minus the current 1Φ × 6 A ≈ 1380 W draw, ≈ 2 kW
-// net). 2000 W is the round-trip step bound, generous enough that a
-// flapping EV controller doesn't immediately lose its ramp window
-// while still releasing the unused portion of MaxChargeW to the home
-// battery — the prior `evReserveW += MaxChargeW` reserved the EV's
-// theoretical max (often 11 kW for a 3Φ × 16 A wallbox) even when it
-// was physically holding at 2-3 kW, starving battery charge on
-// surprise PV slots.
+// current draw when computing the surplus reserve. It needs to cover
+// one single-amp step on the EV's current phase mode so the
+// controller can ramp up between ticks without the battery hoarding
+// the surplus.
+//
+// 2000 W comfortably covers:
+//   - any single-amp 1Φ step (+230 W) and 3Φ step (+690 W)
+//   - climbing 1Φ × 6 A → 1Φ × 14 A in one tick (+1840 W)
+//   - 1Φ-max → 3Φ-min crossover (1Φ × 16 A 3680 W → 3Φ × 6 A 4140 W,
+//     +460 W) — the realistic phase-change step the EV takes after
+//     climbing the 1Φ ladder
+//
+// What 2 kW does NOT cover is the direct 1Φ × 6 A → 3Φ × 6 A
+// cold-start jump (+2760 W). In practice pickSurplusSteps walks the
+// 1Φ ladder first, so this transition takes ~2 dispatch ticks (≈ 10 s)
+// instead of 1. Acceptable trade vs. the alternative — sizing the
+// headroom to that worst-case (3 kW) recreates the operator-reported
+// bug where the user's "3 kW exporting" scenario lines up exactly
+// with the reserve and the battery gets nothing.
+//
+// Tracking the LP's actual next reachable step via AllowedStepsW
+// would tighten this further; deferred until 2 kW proves wrong on a
+// real site.
 const EVRampHeadroomW = 2000
 
 // SurplusReserveW returns the aggregate PV headroom that must be

--- a/go/internal/loadpoint/surplus_reserve.go
+++ b/go/internal/loadpoint/surplus_reserve.go
@@ -1,0 +1,41 @@
+package loadpoint
+
+// EVRampHeadroomW is the per-LP buffer added on top of the EV's
+// current draw when computing the surplus reserve. It must cover the
+// worst-case single-step ramp the EV controller will take in the next
+// ~30 s: jumping from 1Φ at minimum to 3Φ at minimum (~6 A × 3 phases
+// × 230 V ≈ 4140 W, minus the current 1Φ × 6 A ≈ 1380 W draw, ≈ 2 kW
+// net). 2000 W is the round-trip step bound, generous enough that a
+// flapping EV controller doesn't immediately lose its ramp window
+// while still releasing the unused portion of MaxChargeW to the home
+// battery — the prior `evReserveW += MaxChargeW` reserved the EV's
+// theoretical max (often 11 kW for a 3Φ × 16 A wallbox) even when it
+// was physically holding at 2-3 kW, starving battery charge on
+// surprise PV slots.
+const EVRampHeadroomW = 2000
+
+// SurplusReserveW returns the aggregate PV headroom that must be
+// preserved for surplus_only loadpoints. For each surplus_only +
+// plugged_in LP it reserves min(MaxChargeW, CurrentPowerW +
+// EVRampHeadroomW) so the reserve tracks the EV's actual draw rather
+// than its theoretical max.
+//
+// Dispatch consumes the result via control.State.EVSurplusOnlyReserveW
+// in both the energy and the legacy/reactive paths.
+func SurplusReserveW(states []State) float64 {
+	var sum float64
+	for _, st := range states {
+		if !st.SurplusOnly || !st.PluggedIn {
+			continue
+		}
+		ceiling := st.CurrentPowerW + EVRampHeadroomW
+		if ceiling > st.MaxChargeW {
+			ceiling = st.MaxChargeW
+		}
+		if ceiling < 0 {
+			ceiling = 0
+		}
+		sum += ceiling
+	}
+	return sum
+}

--- a/go/internal/loadpoint/surplus_reserve_test.go
+++ b/go/internal/loadpoint/surplus_reserve_test.go
@@ -22,28 +22,28 @@ func TestSurplusReserveW(t *testing.T) {
 			want: 0,
 		},
 		{
-			name: "EV at 2.5kW with 11kW max → 4.5kW reserve (current + 2kW)",
+			name: "EV at 2.5kW with 11kW max → current + headroom",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 2500, MaxChargeW: 11000},
 			},
-			want: 4500,
+			want: 2500 + EVRampHeadroomW,
 		},
 		{
-			name: "EV at 0W with 11kW max → 2kW reserve (just the headroom)",
+			name: "EV at 0W with 11kW max → just the headroom",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},
 			},
-			want: 2000,
+			want: EVRampHeadroomW,
 		},
 		{
-			name: "EV at 10kW with 11kW max → 11kW reserve (clamped to max, not 12kW)",
+			name: "EV close to max → clamped to MaxChargeW (no overshoot)",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 10000, MaxChargeW: 11000},
 			},
 			want: 11000,
 		},
 		{
-			name: "EV at 11kW with 11kW max → 11kW reserve (already at ceiling)",
+			name: "EV at max → reserve equals max",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 11000, MaxChargeW: 11000},
 			},
@@ -52,18 +52,10 @@ func TestSurplusReserveW(t *testing.T) {
 		{
 			name: "multiple LPs sum",
 			states: []State{
-				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1500, MaxChargeW: 3700}, // 1Φ → 3500 < cap 3700
-				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},   // 2000
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1500, MaxChargeW: 3700}, // 1500 + 2000 = 3500, under cap
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},   // 0 + 2000 = 2000
 			},
-			want: 5500,
-		},
-		{
-			name: "negative current power floors at 0 then adds headroom",
-			states: []State{
-				// Telemetry glitch shouldn't push reserve negative.
-				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: -300, MaxChargeW: 11000},
-			},
-			want: 1700, // -300 + 2000 = 1700; still positive, no floor needed
+			want: (1500 + EVRampHeadroomW) + (0 + EVRampHeadroomW),
 		},
 	}
 	for _, tt := range tests {
@@ -76,13 +68,14 @@ func TestSurplusReserveW(t *testing.T) {
 	}
 }
 
+// Concrete regression: user's reported bug. EV at 2.5 kW on an Easee
+// with 11 kW max, plan says charge battery, 3 kW of PV exporting.
+// Pre-fix the reserve was 11 kW so ceiling = pvSurplus − (reserve −
+// current) = 3000 − (11000 − 2500) = −5500 → 0; battery idled and
+// the 3 kW crossed the meter at low spot price. Post-fix the reserve
+// is `current + EVRampHeadroomW`, so a meaningful share of the
+// surprise surplus reaches the battery.
 func TestSurplusReserveWReleasesUnusedMaxToBattery(t *testing.T) {
-	// Concrete regression: user's reported bug. EV at 2.5 kW on an
-	// Easee with 11 kW max. Pre-fix reserve was 11 kW; post-fix is
-	// 4.5 kW. With 3 kW of PV exporting beyond the EV, dispatch
-	// should now leave ceiling = pvSurplus - (reserve - current) =
-	// 3000 - (4500 - 2500) = 1000 W available to the battery. Pre-fix
-	// reserve - current = 8500 W → ceiling = -5500 → 0.
 	states := []State{
 		{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 2500, MaxChargeW: 11000},
 	}
@@ -90,7 +83,30 @@ func TestSurplusReserveWReleasesUnusedMaxToBattery(t *testing.T) {
 	current := states[0].CurrentPowerW
 	pvSurplus := 3000.0
 	ceiling := pvSurplus - (reserve - current)
-	if ceiling < 800 {
-		t.Errorf("ceiling = %.0f W — battery should get ≥ ~1000 W of the 3 kW surplus (was 0 pre-fix)", ceiling)
+	if ceiling <= 0 {
+		t.Fatalf("ceiling = %.0f W — battery should get some of the 3 kW surplus, was 0 pre-fix", ceiling)
+	}
+}
+
+// 1Φ ladder climb: EV at 1Φ × 6 A (1380 W) should be able to step
+// up several amps in one tick without the battery hoarding the
+// surplus. The headroom needs to cover the largest practical
+// single-tick climb that pickSurplusSteps will take on the 1Φ ladder
+// — ~1Φ × 14 A (3220 W, +1840 W) sits inside 2 kW. After climbing
+// the 1Φ ladder, the phase change (1Φ × 16 A → 3Φ × 6 A, +460 W) is
+// trivial. The direct 1Φ × 6 A → 3Φ × 6 A jump (+2760 W) is NOT
+// covered — that takes 2 ticks instead of 1, accepted on purpose to
+// keep the headroom from re-imposing the user-reported bug on
+// 3 kW-surplus scenarios.
+func TestSurplusReserveWAllowsOnePhaseLadderClimb(t *testing.T) {
+	states := []State{
+		{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1380, MaxChargeW: 11000},
+	}
+	reserve := SurplusReserveW(states)
+	reserveRemaining := reserve - states[0].CurrentPowerW
+	const ladderClimbW = 3220 - 1380 // 1Φ × 6 A → 1Φ × 14 A ≈ 1840 W
+	if reserveRemaining < ladderClimbW {
+		t.Errorf("reserveRemaining = %.0f W — must be ≥ %.0f W so EV can climb 1Φ ladder in one tick",
+			reserveRemaining, float64(ladderClimbW))
 	}
 }

--- a/go/internal/loadpoint/surplus_reserve_test.go
+++ b/go/internal/loadpoint/surplus_reserve_test.go
@@ -1,0 +1,96 @@
+package loadpoint
+
+import "testing"
+
+func TestSurplusReserveW(t *testing.T) {
+	tests := []struct {
+		name   string
+		states []State
+		want   float64
+	}{
+		{
+			name:   "empty",
+			states: nil,
+			want:   0,
+		},
+		{
+			name: "ignores not-surplus and not-plugged",
+			states: []State{
+				{SurplusOnly: false, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},
+				{SurplusOnly: true, PluggedIn: false, CurrentPowerW: 0, MaxChargeW: 11000},
+			},
+			want: 0,
+		},
+		{
+			name: "EV at 2.5kW with 11kW max → 4.5kW reserve (current + 2kW)",
+			states: []State{
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 2500, MaxChargeW: 11000},
+			},
+			want: 4500,
+		},
+		{
+			name: "EV at 0W with 11kW max → 2kW reserve (just the headroom)",
+			states: []State{
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},
+			},
+			want: 2000,
+		},
+		{
+			name: "EV at 10kW with 11kW max → 11kW reserve (clamped to max, not 12kW)",
+			states: []State{
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 10000, MaxChargeW: 11000},
+			},
+			want: 11000,
+		},
+		{
+			name: "EV at 11kW with 11kW max → 11kW reserve (already at ceiling)",
+			states: []State{
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 11000, MaxChargeW: 11000},
+			},
+			want: 11000,
+		},
+		{
+			name: "multiple LPs sum",
+			states: []State{
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1500, MaxChargeW: 3700}, // 1Φ → 3500 < cap 3700
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},   // 2000
+			},
+			want: 5500,
+		},
+		{
+			name: "negative current power floors at 0 then adds headroom",
+			states: []State{
+				// Telemetry glitch shouldn't push reserve negative.
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: -300, MaxChargeW: 11000},
+			},
+			want: 1700, // -300 + 2000 = 1700; still positive, no floor needed
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SurplusReserveW(tt.states)
+			if got != tt.want {
+				t.Errorf("SurplusReserveW = %.0f, want %.0f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSurplusReserveWReleasesUnusedMaxToBattery(t *testing.T) {
+	// Concrete regression: user's reported bug. EV at 2.5 kW on an
+	// Easee with 11 kW max. Pre-fix reserve was 11 kW; post-fix is
+	// 4.5 kW. With 3 kW of PV exporting beyond the EV, dispatch
+	// should now leave ceiling = pvSurplus - (reserve - current) =
+	// 3000 - (4500 - 2500) = 1000 W available to the battery. Pre-fix
+	// reserve - current = 8500 W → ceiling = -5500 → 0.
+	states := []State{
+		{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 2500, MaxChargeW: 11000},
+	}
+	reserve := SurplusReserveW(states)
+	current := states[0].CurrentPowerW
+	pvSurplus := 3000.0
+	ceiling := pvSurplus - (reserve - current)
+	if ceiling < 800 {
+		t.Errorf("ceiling = %.0f W — battery should get ≥ ~1000 W of the 3 kW surplus (was 0 pre-fix)", ceiling)
+	}
+}

--- a/go/internal/mpc/loadpoint_service_test.go
+++ b/go/internal/mpc/loadpoint_service_test.go
@@ -121,3 +121,93 @@ func TestSlotDirectiveEmptyWhenNoLoadpoint(t *testing.T) {
 		t.Errorf("expected nil LoadpointEnergyWh, got %+v", d.LoadpointEnergyWh)
 	}
 }
+
+// TestNoBatteryToEVForbidsBatteryFeedingEV asserts the DP refuses to
+// schedule battery discharge that would, by energy conservation, flow
+// into the EV when LoadpointSpec.NoBatteryToEV is true. The scenario
+// is constructed so the cost-optimal allocation WITHOUT the constraint
+// is "battery discharges to cover EV" (expensive grid + free battery
+// energy + EV demand). With the constraint, the DP must keep the
+// battery at most at house-residual-after-PV.
+func TestNoBatteryToEVForbidsBatteryFeedingEV(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	start := now.Truncate(15 * time.Minute)
+	// Two slots. First slot: very expensive grid, low PV (1 kW), modest
+	// house (1 kW), high battery SoC. Without the constraint the DP
+	// would happily discharge battery 5+ kW to cover house + EV; with
+	// it, battery must stay ≤ house_residual = max(0, 1000 - 1000) = 0.
+	slots := []Slot{
+		{
+			StartMs:    start.UnixMilli(),
+			LenMin:     60,
+			PriceOre:   500,
+			SpotOre:    500,
+			LoadW:      1000,
+			PVW:        -1000,
+			Confidence: 1.0,
+		},
+		{
+			StartMs:    start.Add(time.Hour).UnixMilli(),
+			LenMin:     60,
+			PriceOre:   500,
+			SpotOre:    500,
+			LoadW:      1000,
+			PVW:        -1000,
+			Confidence: 1.0,
+		},
+	}
+	mkParams := func(noBatToEV bool) Params {
+		return Params{
+			Mode:                ModeArbitrage,
+			SoCLevels:           11,
+			CapacityWh:          20000,
+			SoCMinPct:           10,
+			SoCMaxPct:           95,
+			InitialSoCPct:       90,
+			ActionLevels:        11,
+			MaxChargeW:          5000,
+			MaxDischargeW:       5000,
+			ChargeEfficiency:    0.95,
+			DischargeEfficiency: 0.95,
+			TerminalSoCPrice:    400,
+			Loadpoint: &LoadpointSpec{
+				ID:               "garage",
+				CapacityWh:       60000,
+				Levels:           11,
+				InitialSoCPct:    20,
+				PluggedIn:        true,
+				TargetSoCPct:     30,
+				TargetSlotIdx:    1,
+				MaxChargeW:       11000,
+				AllowedStepsW:    []float64{0, 11000},
+				ChargeEfficiency: 0.9,
+				NoBatteryToEV:    noBatToEV,
+			},
+		}
+	}
+
+	// Baseline (constraint off): DP is allowed to over-discharge.
+	planOff := Optimize(slots, mkParams(false))
+	// Find a slot where both EV charges AND battery discharges past
+	// house-residual. With house=1000, PV=-1000, residual is 0, so
+	// any battW < -50 simultaneous with evW > 0 is "feeding EV".
+	violationOff := false
+	for _, a := range planOff.Actions {
+		if a.LoadpointW > 100 && a.BatteryW < -50 {
+			violationOff = true
+			break
+		}
+	}
+	if !violationOff {
+		t.Skip("baseline never picked battery-to-EV — scenario didn't exercise the rule (price model / SoC grid changed?)")
+	}
+
+	// Constraint on: same scenario, DP must NOT pick that allocation.
+	planOn := Optimize(slots, mkParams(true))
+	for i, a := range planOn.Actions {
+		if a.LoadpointW > 100 && a.BatteryW < -50 {
+			t.Errorf("slot %d: NoBatteryToEV violated — battW=%.0f loadpointW=%.0f (PV=%.0f load=%.0f)",
+				i, a.BatteryW, a.LoadpointW, slots[i].PVW, slots[i].LoadW)
+		}
+	}
+}

--- a/go/internal/mpc/loadpoint_spec.go
+++ b/go/internal/mpc/loadpoint_spec.go
@@ -73,11 +73,15 @@ type LoadpointSpec struct {
 	// exceeds the PV-residual house demand — i.e. where some of the
 	// battery's energy must, by conservation, have flowed into the EV
 	// or out to grid (and the existing battery-export-vs-EV rule
-	// already covers the export case). The runtime dispatch has an
-	// equivalent clamp at dispatch.go:787 as a safety net; this DP
-	// rule stops the planner from emitting infeasible allocations
-	// that dispatch then has to censor, removing the plan↔reality
-	// divergence operators were seeing on planner_arbitrage slots.
+	// already covers the export case). The runtime dispatch in
+	// control/dispatch.go has the canonical clamp using identical
+	// accounting (search "CANONICAL \"battery may not feed EV\""); the
+	// DP rule here stops the planner from emitting infeasible
+	// allocations that dispatch then has to censor, removing the
+	// plan↔reality divergence operators were seeing on
+	// planner_arbitrage slots. A future refactor should extract the
+	// shared houseResidualW + feasibility predicate into a helper so
+	// the two sites can't drift.
 	NoBatteryToEV bool
 }
 

--- a/go/internal/mpc/loadpoint_spec.go
+++ b/go/internal/mpc/loadpoint_spec.go
@@ -65,6 +65,20 @@ type LoadpointSpec struct {
 	// lexicographic "miss target rather than break constraint"
 	// preference.
 	SurplusOnly bool
+
+	// NoBatteryToEV mirrors ctrl.State.BatteryCoversEV inverted: when
+	// true (operator's default), the home battery's discharge MUST NOT
+	// end up at the EV. The DP feasibility check enforces this by
+	// rejecting any (battW, evW) combination where battery discharge
+	// exceeds the PV-residual house demand — i.e. where some of the
+	// battery's energy must, by conservation, have flowed into the EV
+	// or out to grid (and the existing battery-export-vs-EV rule
+	// already covers the export case). The runtime dispatch has an
+	// equivalent clamp at dispatch.go:787 as a safety net; this DP
+	// rule stops the planner from emitting infeasible allocations
+	// that dispatch then has to censor, removing the plan↔reality
+	// divergence operators were seeing on planner_arbitrage slots.
+	NoBatteryToEV bool
 }
 
 // normalizedSteps returns a non-nil, 0-included, dedup'd + sorted

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -529,9 +529,13 @@ func Optimize(slots []Slot, p Params) Plan {
 						// much and still be claimed as "house only".
 						// Anything beyond it must go to EV (illegal here)
 						// or grid (covered by the rule above).
-						// Matches the runtime safety clamp at
-						// dispatch.go:787 — keep them aligned. 50 W
-						// epsilon mirrors the surrounding constraints.
+						// Matches the canonical runtime safety clamp in
+						// control/dispatch.go (search "CANONICAL
+						// \"battery may not feed EV\"") — keep them
+						// aligned. 50 W epsilon mirrors the surrounding
+						// constraints. TODO(refactor): the
+						// houseResidualW math + feasibility predicate
+						// is duplicated; extract a shared helper.
 						if evActive && lp.NoBatteryToEV && evW > 0 && battW < 0 {
 							houseResidualW := slot.LoadW + slot.PVW // PVW is negative
 							if houseResidualW < 0 {

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -516,6 +516,32 @@ func Optimize(slots []Slot, p Params) Plan {
 							continue
 						}
 
+						// NoBatteryToEV: operator has BatteryCoversEV=false
+						// (the default), meaning the home battery's energy
+						// is allowed to cover house load but never the EV.
+						// Reject any allocation where the battery's
+						// discharge exceeds the PV-residual house demand
+						// — i.e. where, by conservation, some of the
+						// battery's energy must have flowed into the EV.
+						// houseResidualW = max(0, load - pv_gen) is how
+						// much house demand is left after PV has covered
+						// what it can; the battery can supply up to that
+						// much and still be claimed as "house only".
+						// Anything beyond it must go to EV (illegal here)
+						// or grid (covered by the rule above).
+						// Matches the runtime safety clamp at
+						// dispatch.go:787 — keep them aligned. 50 W
+						// epsilon mirrors the surrounding constraints.
+						if evActive && lp.NoBatteryToEV && evW > 0 && battW < 0 {
+							houseResidualW := slot.LoadW + slot.PVW // PVW is negative
+							if houseResidualW < 0 {
+								houseResidualW = 0
+							}
+							if (-battW) > houseResidualW+50 {
+								continue
+							}
+						}
+
 						// Mode-based feasibility. Baseline includes
 						// EV so the mode check asks "is the extra
 						// battery action pulling the grid further

--- a/go/internal/mpc/power_limits_test.go
+++ b/go/internal/mpc/power_limits_test.go
@@ -189,3 +189,76 @@ func TestOptimizeRespectsExportCap(t *testing.T) {
 		t.Errorf("capped slot GridW = %.1f, below export cap -500 W", g)
 	}
 }
+
+// Live regression (Sat 14:45 plan): PV -6 kW + battery -9 kW + load
+// 0.7 kW = grid -14.2 kW exporting past the 11 kW fuse. Pre-fix, the
+// service-level fuse plumbing only set MaxImportW, so this slot was
+// feasible to the DP. With both directions plumbed (service.go:560),
+// the DP must pick a less-aggressive discharge that keeps |grid| ≤
+// fuse.
+func TestOptimizeRespectsFuseExportCap(t *testing.T) {
+	// One slot: 6 kW PV, 0.7 kW load, fuse 11 kW both ways. Price is
+	// peak (encourages aggressive discharge). The DP should pick a
+	// discharge that brings grid down to ≈ -11 kW, not -14 kW.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 345, SpotOre: 156,
+			PVW: -6000, LoadW: 700, Confidence: 1.0,
+			Limits: PowerLimits{MaxImportW: 11000, MaxExportW: 11000}},
+	}
+	p := Params{
+		Mode:                ModeArbitrage,
+		SoCLevels:           41,
+		CapacityWh:          20000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       85,
+		ActionLevels:        21,
+		MaxChargeW:          9000,
+		MaxDischargeW:       9000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    250,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(plan.Actions))
+	}
+	g := plan.Actions[0].GridW
+	if g < -11000-1 {
+		t.Errorf("plan grid %.0f W exceeds export fuse −11000 W — DP didn't apply MaxExportW. battery_w=%.0f, pv_w=%.0f",
+			g, plan.Actions[0].BatteryW, plan.Actions[0].PVW)
+	}
+}
+
+// Service-level: when FuseMaxW > 0, both MaxImportW and MaxExportW on
+// every slot must end up populated (and capped at FuseMaxW). This is
+// the plumbing layer between cfg.Fuse and the DP. Pre-fix the export
+// side was silently uncapped.
+func TestFuseMaxWPopulatesBothDirections(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 100, SpotOre: 50, Confidence: 1.0},
+		{StartMs: 3600_000, LenMin: 60, PriceOre: 100, SpotOre: 50, Confidence: 1.0,
+			Limits: PowerLimits{MaxImportW: 5000, MaxExportW: 7000}},
+	}
+	const fuseW = 11000
+	// Inline the plumbing under test (mirrors service.go:560-573).
+	for i := range slots {
+		if slots[i].Limits.MaxImportW <= 0 || slots[i].Limits.MaxImportW > fuseW {
+			slots[i].Limits.MaxImportW = fuseW
+		}
+		if slots[i].Limits.MaxExportW <= 0 || slots[i].Limits.MaxExportW > fuseW {
+			slots[i].Limits.MaxExportW = fuseW
+		}
+	}
+	// Slot 0: both were zero → both fill to fuse.
+	if slots[0].Limits.MaxImportW != fuseW || slots[0].Limits.MaxExportW != fuseW {
+		t.Errorf("slot 0 limits = (imp %.0f, exp %.0f), want both %.0f",
+			slots[0].Limits.MaxImportW, slots[0].Limits.MaxExportW, float64(fuseW))
+	}
+	// Slot 1: import 5000 < fuse → keep. Export 7000 < fuse → keep.
+	// (Tighter pre-existing caps win.)
+	if slots[1].Limits.MaxImportW != 5000 || slots[1].Limits.MaxExportW != 7000 {
+		t.Errorf("slot 1 limits = (imp %.0f, exp %.0f), want (5000, 7000)",
+			slots[1].Limits.MaxImportW, slots[1].Limits.MaxExportW)
+	}
+}

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -560,11 +561,20 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// Plumb the site fuse into per-slot limits so the DP joint-plans
 	// battery + EV under the fuse constraint instead of producing plans
 	// that dispatch then has to scale at execution time. The DP already
-	// honours Slot.Limits.MaxImportW (mpc.go:450); we just feed it.
+	// honours Slot.Limits.MaxImportW + MaxExportW (mpc.go:450); we just
+	// feed both directions — the fuse trips on |I| regardless of sign,
+	// and exporting 14 kW through an 11 kW breaker is just as bad as
+	// importing it (probably worse — the inverter's local current
+	// limiter trips first and the operator sees a sudden zero-output
+	// flap as PV+battery collapses). Pre-fix this only set MaxImportW,
+	// producing plans like 14:45 slot grid=-14.2 kW past an 11 kW fuse.
 	if s.FuseMaxW > 0 {
 		for i := range slots {
 			if slots[i].Limits.MaxImportW <= 0 || slots[i].Limits.MaxImportW > s.FuseMaxW {
 				slots[i].Limits.MaxImportW = s.FuseMaxW
+			}
+			if slots[i].Limits.MaxExportW <= 0 || slots[i].Limits.MaxExportW > s.FuseMaxW {
+				slots[i].Limits.MaxExportW = s.FuseMaxW
 			}
 		}
 	}
@@ -600,13 +610,22 @@ func (s *Service) replan(_ context.Context) *Plan {
 			p.TerminalSoCPrice = selfConsumptionTerminalPrice(prices,
 				s.ExportBonusOreKwh, s.ExportFeeOreKwh)
 		default:
-			// Arbitrage: battery can export, so full import price is the
-			// right upper bound on SoC value.
-			var sum float64
-			for _, pr := range prices {
-				sum += pr.TotalOreKwh
-			}
-			p.TerminalSoCPrice = sum / float64(len(prices))
+			// Arbitrage: stored SoC at horizon end will be discharged at
+			// the more expensive hours, not at a typical hour. Mean of
+			// all prices systematically undervalues this — on a site
+			// with a strong evening peak (e.g. 170 öre midday vs 345 öre
+			// peak, mean 262), it credits each kWh at 262 öre while the
+			// planner could discharge it at 345. The under-credit makes
+			// the DP too willing to dump SoC at mediocre prices because
+			// holding it "isn't worth much".
+			//
+			// Use the mean of the upper half of prices instead — a
+			// principled proxy for "discharge happens when prices are at
+			// or above median". For the 170/345 example this lifts the
+			// terminal value from ~262 to ~310, much closer to the
+			// realisable discharge value, without being naive about
+			// always discharging at the peak.
+			p.TerminalSoCPrice = upperHalfMeanPrice(prices)
 		}
 	}
 
@@ -895,6 +914,40 @@ func selfConsumptionTerminalPrice(prices []state.PricePoint, bonus, fee float64)
 		spread = 0
 	}
 	return spread
+}
+
+// upperHalfMeanPrice returns the arithmetic mean of the upper half of
+// retail prices over the horizon — proxy for "this kWh of stored SoC
+// will be discharged when prices are at or above median". Used as the
+// arbitrage-mode terminal credit; biases the DP toward retaining SoC
+// for the more expensive hours instead of dumping it at the mean.
+//
+// Falls back to the plain mean for tiny horizons (≤ 4 slots) where
+// "upper half" loses statistical meaning. Returns 0 on empty input.
+func upperHalfMeanPrice(prices []state.PricePoint) float64 {
+	if len(prices) == 0 {
+		return 0
+	}
+	if len(prices) <= 4 {
+		var sum float64
+		for _, pr := range prices {
+			sum += pr.TotalOreKwh
+		}
+		return sum / float64(len(prices))
+	}
+	// Sort a copy ascending — caller's slice is shared with other
+	// price-using paths (cost calc, export math) and must not mutate.
+	vals := make([]float64, len(prices))
+	for i, pr := range prices {
+		vals[i] = pr.TotalOreKwh
+	}
+	sort.Float64s(vals)
+	half := vals[len(vals)/2:]
+	var sum float64
+	for _, v := range half {
+		sum += v
+	}
+	return sum / float64(len(half))
 }
 
 // PlannerRadiationWeight is how much the RLS twin's prediction

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -69,6 +69,56 @@ func TestBuildSlotsKeepsTwinWhenPredictionIsSane(t *testing.T) {
 	}
 }
 
+// ---- upperHalfMeanPrice (arbitrage terminal valuation) ----
+
+func TestUpperHalfMeanLiftsTerminalCreditAboveOverallMean(t *testing.T) {
+	// Live-shaped horizon: midday cheap valley + evening peak. Mean is
+	// pulled down by the cheap hours; upper-half mean reflects the
+	// hours when stored SoC would actually be sold.
+	prices := []state.PricePoint{
+		{TotalOreKwh: 170}, // cheap midday
+		{TotalOreKwh: 175},
+		{TotalOreKwh: 180},
+		{TotalOreKwh: 200},
+		{TotalOreKwh: 250},
+		{TotalOreKwh: 300},
+		{TotalOreKwh: 320}, // evening peak
+		{TotalOreKwh: 345},
+	}
+	overall := 0.0
+	for _, p := range prices {
+		overall += p.TotalOreKwh
+	}
+	overall /= float64(len(prices))
+	got := upperHalfMeanPrice(prices)
+	// Upper half = {250, 300, 320, 345} mean = 303.75.
+	if math.Abs(got-303.75) > 0.01 {
+		t.Errorf("upperHalfMeanPrice = %.2f, want 303.75", got)
+	}
+	if got <= overall {
+		t.Errorf("upper-half mean (%.2f) must exceed overall mean (%.2f) on a non-flat horizon", got, overall)
+	}
+}
+
+func TestUpperHalfMeanFallsBackForTinyHorizon(t *testing.T) {
+	// With 4 or fewer slots, taking the "upper half" loses meaning —
+	// fall back to plain mean.
+	prices := []state.PricePoint{
+		{TotalOreKwh: 100},
+		{TotalOreKwh: 300},
+	}
+	got := upperHalfMeanPrice(prices)
+	if math.Abs(got-200) > 0.01 {
+		t.Errorf("upperHalfMeanPrice (tiny horizon) = %.2f, want 200 (plain mean)", got)
+	}
+}
+
+func TestUpperHalfMeanEmptyReturnsZero(t *testing.T) {
+	if got := upperHalfMeanPrice(nil); got != 0 {
+		t.Errorf("upperHalfMeanPrice(nil) = %f, want 0", got)
+	}
+}
+
 // ---- Terminal SoC valuation ----
 
 func TestSelfConsumptionTerminalPriceIsImportMinusExport(t *testing.T) {

--- a/web/app.js
+++ b/web/app.js
@@ -1514,19 +1514,21 @@
   }
 
   // buildSurplusOnlyRow renders a single checkbox: when ticked, the
-  // loadpoint is auto-configured for "charge only from PV surplus"
-  // with a 100 % target by 16 UTC (today, advancing to tomorrow if
-  // 16 UTC has already passed). The MPC will not plan any grid-funded
-  // EV charging — surplus_only is a hard DP constraint, the dispatch
-  // controller also clamps live setpoint to PV export, and the EV is
-  // held at 3Φ-eligible steps to avoid contactor-wearing phase swaps.
-  // Unticking restores manual target control without touching the
-  // existing SoC/deadline values.
+  // loadpoint is configured for "charge only from PV surplus". The
+  // toggle is independent of any schedule — the controller's surplus
+  // clamp harvests live export opportunistically with or without a
+  // target+deadline. Adding a schedule on top is optional: it tells
+  // the MPC the operator wants the car to reach X% by Y, which may
+  // grid-import during cheap slots. Without a schedule the MPC simply
+  // sits this loadpoint out and the runtime dispatch chases surplus.
+  //
+  // Patch semantics: both directions send only `{ surplus_only: ... }`
+  // so the operator's existing target/deadline (if any) is preserved.
   function buildSurplusOnlyRow(lp) {
     var row = document.createElement("div");
     row.style.display = "flex";
-    row.style.alignItems = "center";
-    row.style.gap = "0.5rem";
+    row.style.flexDirection = "column";
+    row.style.gap = "0.25rem";
     row.style.marginBottom = "0.3rem";
     var label = document.createElement("label");
     label.style.display = "flex";
@@ -1537,28 +1539,17 @@
     var cb = document.createElement("input");
     cb.type = "checkbox";
     cb.checked = !!lp.surplus_only;
-    cb.title = "Charge only from PV surplus. Auto-targets 100 % by 16:00 UTC. The DP refuses any plan that would import grid for this loadpoint, and the live dispatch holds 3-phase to avoid contactor wear.";
+    cb.title = "Charge only when PV exports exceed local load. No deadline planning, no grid import. Add a schedule below to also catch up via grid when prices are cheap.";
     var text = document.createElement("span");
-    text.textContent = "Surplus-only (PV-only, 100 % by 16:00 UTC)";
+    text.textContent = "Surplus only (PV exports only — never imports grid)";
+    var hint = document.createElement("div");
+    hint.style.fontSize = "0.72rem";
+    hint.style.color = "var(--text-dim)";
+    hint.style.marginLeft = "1.4rem";
+    hint.textContent = "Charges only when PV exports exceed your load. No deadline planning — no grid import. Optional: add a schedule below to also catch up via grid when cheap.";
     cb.addEventListener("change", function () {
       cb.disabled = true;
-      var body;
-      if (cb.checked) {
-        var now = new Date();
-        var target = new Date(Date.UTC(
-          now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(),
-          16, 0, 0));
-        if (target.getTime() <= now.getTime()) {
-          target.setUTCDate(target.getUTCDate() + 1);
-        }
-        body = { soc_pct: 100, target_time_ms: target.getTime(), surplus_only: true };
-      } else {
-        // Pointer/patch semantics on the backend: omitting fields
-        // preserves their existing values. Sending only surplus_only
-        // avoids overwriting the user's target/deadline with whatever
-        // (possibly stale or missing) snapshot we last fetched.
-        body = { surplus_only: false };
-      }
+      var body = { surplus_only: cb.checked };
       fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/target", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1571,6 +1562,7 @@
     label.appendChild(cb);
     label.appendChild(text);
     row.appendChild(label);
+    row.appendChild(hint);
     return row;
   }
 

--- a/web/loadpoints.js
+++ b/web/loadpoints.js
@@ -83,9 +83,23 @@
     const vehicle = (lp.vehicle_driver)
       ? `${lp.vehicle_driver}${lp.vehicle_charging_state ? ' · ' + lp.vehicle_charging_state : ''}${lp.vehicle_stale ? ' · stale' : ''}`
       : '—';
-    const soc = (lp.current_soc_pct != null)
-      ? `${lp.current_soc_pct.toFixed(1)}%${lp.soc_source ? ' (' + lp.soc_source + ')' : ''}`
-      : '—';
+    // When soc_source is "vehicle", the BMS reading (vehicle_soc_pct)
+    // is ground truth and what the operator expects to see — render
+    // that. current_soc_pct stays as the controller's inference state
+    // (the planner's input for stability across ticks) and is shown
+    // in parens as "(inferred: 65.1%)" so the discrepancy is visible
+    // when it exists. When soc_source is "inferred" the inference
+    // value is the only one we have, so display it directly.
+    let soc = '—';
+    if (lp.soc_source === 'vehicle' && lp.vehicle_soc_pct != null) {
+      soc = `${lp.vehicle_soc_pct.toFixed(0)}% (vehicle)`;
+      if (lp.current_soc_pct != null &&
+          Math.abs(lp.vehicle_soc_pct - lp.current_soc_pct) >= 1) {
+        soc += ` · inferred ${lp.current_soc_pct.toFixed(1)}%`;
+      }
+    } else if (lp.current_soc_pct != null) {
+      soc = `${lp.current_soc_pct.toFixed(1)}%${lp.soc_source ? ' (' + lp.soc_source + ')' : ''}`;
+    }
     const rows = [
       ['Driver',       lp.driver_name || '—'],
       ['Plugged in',   badge(lp.plugged_in ? 'YES' : 'NO', lp.plugged_in)],

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2070,10 +2070,20 @@
             }
           }
         }
+        // Prefer a plugged-in loadpoint when no driver filter is active —
+        // that's the one the operator is most likely thinking about. Fall
+        // back to the first configured loadpoint so the schedule editor
+        // is still reachable when no car is currently connected (the
+        // schedule is persistent loadpoint state, not driver state, and
+        // operators routinely want to set tomorrow morning's target
+        // before plugging in tonight).
         if (!matched) {
           for (var j = 0; j < lps.loadpoints.length; j++) {
             if (lps.loadpoints[j].plugged_in) { matched = lps.loadpoints[j]; break; }
           }
+        }
+        if (!matched) {
+          matched = lps.loadpoints[0];
         }
       }
       if (matched) {
@@ -2144,6 +2154,20 @@
     eyebrow.style.color = "var(--text-dim)";
     eyebrow.style.marginBottom = "0.55rem";
     box.appendChild(eyebrow);
+
+    // Schedule is persistent loadpoint state — operators can configure
+    // tomorrow morning's target tonight before plugging in. Show a
+    // small hint when the loadpoint isn't currently connected so saved
+    // edits don't feel inert: they'll apply at the next plug-in.
+    if (lp && !lp.plugged_in) {
+      var unpluggedHint = document.createElement("div");
+      unpluggedHint.textContent = "Car not plugged in. Edits are saved and apply at next plug-in.";
+      unpluggedHint.style.fontSize = "0.72rem";
+      unpluggedHint.style.color = "var(--text-dim)";
+      unpluggedHint.style.marginBottom = "0.5rem";
+      unpluggedHint.style.fontStyle = "italic";
+      box.appendChild(unpluggedHint);
+    }
 
     function row(labelText, controlEl) {
       var r = document.createElement("div");

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1708,6 +1708,11 @@
   // entries mean "no loadpoint for this driver" and the planet
   // falls back to legacy kW-only rendering.
   var loadpointsByDriver = null;
+  // Last successful /api/status payload — surfaced so secondary
+  // consumers (e.g. the EV modal's 5 s refresh) can read derived
+  // facts like siteHasPV() without re-fetching. `null` until the
+  // first fetch lands; consumers MUST handle null.
+  var lastStatusPayload = null;
   function fetchStatus() {
     Promise.all([
       fetch("/api/status").then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }),
@@ -1716,6 +1721,7 @@
       .then(function (results) {
         var data = results[0];
         var lp = results[1];
+        lastStatusPayload = data;
         if (lp && Array.isArray(lp.loadpoints)) {
           var idx = {};
           lp.loadpoints.forEach(function (l) {
@@ -2028,14 +2034,17 @@
     // to the clicked planet (multi-EV setups). Falls back to whatever
     // the backend returns when no driver filter is honored.
     var url = "/api/ev/status" + (evModalDriver ? "?driver=" + encodeURIComponent(evModalDriver) : "");
+    // siteHasPV is a static-per-config check, so we read the most
+    // recent payload cached by fetchStatus() instead of issuing a
+    // duplicate /api/status fetch on every 5 s modal tick. Falls back
+    // to "no PV" until the dashboard's own fetchStatus lands once.
     Promise.all([
       fetch(url).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
       fetch("/api/loadpoints").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
-      fetch("/api/status").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
     ]).then(function (results) {
       var d = results[0];
       var lps = results[1];
-      var status = results[2];
+      var status = lastStatusPayload;
       if (!d || d.connected === false) {
         setEvModalMessage("No EV charger connected");
         statusTableEl = null;

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2410,7 +2410,7 @@
       return b;
     }
     var clearBtn = mkBtn("Clear", false);
-    var saveBtn = mkBtn(hasSched ? "Update" : "Save", true);
+    var saveBtn = mkBtn(hasSched ? "Update schedule" : "Set schedule", true);
     clearBtn.disabled = !hasSched;
     if (!hasSched) clearBtn.style.opacity = "0.4";
     btnRow.appendChild(clearBtn);

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2140,47 +2140,38 @@
     var initSurplus = savedUnlock > 0;
     var initUnlock = savedUnlock > 0 ? savedUnlock : 50;
 
-    var box = document.createElement("div");
-    box.style.marginTop = "0.75rem";
-    box.style.paddingTop = "0.6rem";
-    box.style.borderTop = "1px solid var(--line)";
+    // Outer wrapper holds two distinct sections:
+    //  1. PV mode (surplus-only toggle) — saves immediately on click
+    //  2. Schedule (target SoC + deadline + bat-SoC unlock) — Save button
+    // They're separated so it's obvious which controls the Save button
+    // owns. Earlier we kept the surplus toggle inside the Schedule
+    // section and operators couldn't tell whether Save covered it.
+    var wrap = document.createElement("div");
+    wrap.style.marginTop = "0.75rem";
+    wrap.style.paddingTop = "0.6rem";
+    wrap.style.borderTop = "1px solid var(--line)";
 
-    var eyebrow = document.createElement("div");
-    eyebrow.textContent = "Schedule";
-    eyebrow.style.fontFamily = "var(--mono)";
-    eyebrow.style.fontSize = "0.7rem";
-    eyebrow.style.letterSpacing = "0.18em";
-    eyebrow.style.textTransform = "uppercase";
-    eyebrow.style.color = "var(--text-dim)";
-    eyebrow.style.marginBottom = "0.55rem";
-    box.appendChild(eyebrow);
+    // ---- Section 1: PV mode (surplus-only) ----
+    // Per-loadpoint hard flag, *independent* of any schedule. When on,
+    // dispatch refuses to import grid for this loadpoint regardless of
+    // what the MPC plans. Operators can run with this alone (no target,
+    // no deadline — just "harvest PV when there's enough") or layer a
+    // schedule on top below.
+    var soBox = document.createElement("div");
+    soBox.style.marginBottom = "0.8rem";
+    soBox.style.paddingBottom = "0.7rem";
+    soBox.style.borderBottom = "1px solid var(--line)";
 
-    // Schedule is persistent loadpoint state — operators can configure
-    // tomorrow morning's target tonight before plugging in. Show a
-    // small hint when the loadpoint isn't currently connected so saved
-    // edits don't feel inert: they'll apply at the next plug-in.
-    if (lp && !lp.plugged_in) {
-      var unpluggedHint = document.createElement("div");
-      unpluggedHint.textContent = "Car not plugged in. Edits are saved and apply at next plug-in.";
-      unpluggedHint.style.fontSize = "0.72rem";
-      unpluggedHint.style.color = "var(--text-dim)";
-      unpluggedHint.style.marginBottom = "0.5rem";
-      unpluggedHint.style.fontStyle = "italic";
-      box.appendChild(unpluggedHint);
-    }
+    var soEyebrow = document.createElement("div");
+    soEyebrow.textContent = "PV Mode";
+    soEyebrow.style.fontFamily = "var(--mono)";
+    soEyebrow.style.fontSize = "0.7rem";
+    soEyebrow.style.letterSpacing = "0.18em";
+    soEyebrow.style.textTransform = "uppercase";
+    soEyebrow.style.color = "var(--text-dim)";
+    soEyebrow.style.marginBottom = "0.45rem";
+    soBox.appendChild(soEyebrow);
 
-    // Surplus-only is a per-loadpoint hard flag that's *independent* of
-    // any schedule — when on, the dispatch refuses to import grid for
-    // this loadpoint regardless of what the MPC plans. Operators can
-    // run with surplus-only alone (no target, no deadline — just
-    // "harvest PV when there's enough") or layer a schedule on top
-    // ("opportunistic surplus, but also catch up via grid if cheap").
-    // Saved + applied immediately on every click via a dedicated POST
-    // — does not require Save to be pressed.
-    var sepRow = document.createElement("div");
-    sepRow.style.marginBottom = "0.55rem";
-    sepRow.style.paddingBottom = "0.55rem";
-    sepRow.style.borderBottom = "1px solid var(--line)";
     var soWrap = document.createElement("label");
     soWrap.style.display = "flex";
     soWrap.style.alignItems = "center";
@@ -2195,28 +2186,71 @@
     soText.textContent = "Surplus only (PV exports only — never imports grid)";
     soWrap.appendChild(soCb);
     soWrap.appendChild(soText);
-    var soHint = document.createElement("div");
-    soHint.style.fontSize = "0.72rem";
-    soHint.style.color = "var(--text-dim)";
-    soHint.style.marginTop = "0.25rem";
-    soHint.style.marginLeft = "1.4rem";
-    soHint.textContent = "Independent of the schedule below. Charges only when PV exports exceed your load. No deadline planning — no grid import.";
-    sepRow.appendChild(soWrap);
-    sepRow.appendChild(soHint);
-    box.appendChild(sepRow);
+
+    var soStatus = document.createElement("small");
+    soStatus.style.display = "block";
+    soStatus.style.color = "var(--text-dim)";
+    soStatus.style.marginTop = "0.25rem";
+    soStatus.style.marginLeft = "1.4rem";
+    soStatus.style.minHeight = "1em";
+    soStatus.textContent = "Saves automatically on click. Independent of the schedule below.";
+
+    soBox.appendChild(soWrap);
+    soBox.appendChild(soStatus);
+    wrap.appendChild(soBox);
+
     soCb.addEventListener("change", function () {
       soCb.disabled = true;
+      soStatus.textContent = "Saving…";
       fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/target", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ surplus_only: soCb.checked }),
       }).then(function () {
         soCb.disabled = false;
+        soStatus.textContent = "Saved. Independent of the schedule below.";
         // Rebuild on next poll so the schedule section reflects any
         // server-side side effects (e.g. soc_source recompute).
         schedNeedsRebuild = true;
-      }).catch(function () { soCb.disabled = false; });
+      }).catch(function () {
+        soCb.disabled = false;
+        soStatus.textContent = "Save failed — try again.";
+      });
     });
+
+    // ---- Section 2: Schedule ----
+    var box = document.createElement("div");
+
+    var eyebrow = document.createElement("div");
+    eyebrow.textContent = "Schedule (grid charging)";
+    eyebrow.style.fontFamily = "var(--mono)";
+    eyebrow.style.fontSize = "0.7rem";
+    eyebrow.style.letterSpacing = "0.18em";
+    eyebrow.style.textTransform = "uppercase";
+    eyebrow.style.color = "var(--text-dim)";
+    eyebrow.style.marginBottom = "0.55rem";
+    box.appendChild(eyebrow);
+
+    var schedExplainer = document.createElement("div");
+    schedExplainer.textContent = "Target SoC by a deadline. The planner uses cheap grid hours to fill the gap PV can't cover.";
+    schedExplainer.style.fontSize = "0.72rem";
+    schedExplainer.style.color = "var(--text-dim)";
+    schedExplainer.style.marginBottom = "0.5rem";
+    box.appendChild(schedExplainer);
+
+    // Schedule is persistent loadpoint state — operators can configure
+    // tomorrow morning's target tonight before plugging in. Show a
+    // small hint when the loadpoint isn't currently connected so saved
+    // edits don't feel inert: they'll apply at the next plug-in.
+    if (lp && !lp.plugged_in) {
+      var unpluggedHint = document.createElement("div");
+      unpluggedHint.textContent = "Car not plugged in. Edits are saved and apply at next plug-in.";
+      unpluggedHint.style.fontSize = "0.72rem";
+      unpluggedHint.style.color = "var(--text-dim)";
+      unpluggedHint.style.marginBottom = "0.5rem";
+      unpluggedHint.style.fontStyle = "italic";
+      box.appendChild(unpluggedHint);
+    }
 
     function row(labelText, controlEl) {
       var r = document.createElement("div");
@@ -2448,7 +2482,8 @@
       });
     });
 
-    return box;
+    wrap.appendChild(box);
+    return wrap;
   }
 
   function utcMinsToLocalHHMM(min) {

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1997,15 +1997,31 @@
     evModalBody.appendChild(p);
   }
 
-  // Schedule-control persistence across the modal's auto-refresh tick.
-  // refreshEvModal wipes evModalBody every poll; without these the
-  // user's in-progress edits to the schedule inputs would be reset
-  // every few seconds. The cached element is re-attached as long as
-  // the user has touched any field and hasn't yet hit Save / Clear,
-  // and the LP id hasn't changed (different planet clicked).
-  var schedCacheEl = null;
-  var schedCacheLpId = null;
-  var schedDirty = false;
+  // EV modal sub-elements held across refreshes. The status table is
+  // updated in place on every poll. The schedule section is mounted
+  // exactly once per (modal-open × LP) and is NEVER detached on a poll
+  // — detaching+reattaching a focused <input> blurs it mid-keystroke
+  // and resets caret position. After Save/Clear we set
+  // schedNeedsRebuild=true so the next poll picks up the new
+  // authoritative server state.
+  var statusTableEl = null;
+  var schedSectionEl = null;
+  var schedLpId = null;
+  var schedNeedsRebuild = false;
+
+  // Detect whether the site has any PV driver configured. Used to hide
+  // the "surplus charge from PV" option on PV-less sites where the
+  // bat-SoC unlock wouldn't have anything to grab anyway.
+  function siteHasPV(status) {
+    if (!status || !status.drivers) return false;
+    for (var k in status.drivers) {
+      if (Object.prototype.hasOwnProperty.call(status.drivers, k)) {
+        var dr = status.drivers[k];
+        if (dr && typeof dr.pv_w === "number") return true;
+      }
+    }
+    return false;
+  }
 
   function refreshEvModal() {
     // Pass driver query if known so the backend can scope the response
@@ -2015,15 +2031,31 @@
     Promise.all([
       fetch(url).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
       fetch("/api/loadpoints").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
+      fetch("/api/status").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
     ]).then(function (results) {
       var d = results[0];
       var lps = results[1];
+      var status = results[2];
       if (!d || d.connected === false) {
         setEvModalMessage("No EV charger connected");
+        statusTableEl = null;
+        schedSectionEl = null;
+        schedLpId = null;
         return;
       }
-      evModalBody.textContent = "";
-      evModalBody.appendChild(renderEvStatusTable(d));
+      // Status table: replace in place so the rest of the modal body
+      // (including any mounted schedule section) is untouched. On the
+      // very first call evModalBody may still contain the placeholder
+      // from setEvModalMessage; wipe only when we have no anchor yet.
+      var freshStatus = renderEvStatusTable(d);
+      if (statusTableEl && statusTableEl.parentNode === evModalBody) {
+        evModalBody.replaceChild(freshStatus, statusTableEl);
+      } else {
+        evModalBody.textContent = "";
+        evModalBody.appendChild(freshStatus);
+      }
+      statusTableEl = freshStatus;
+
       // Match the modal's driver to a configured loadpoint; the
       // surplus-only control only makes sense when the driver is
       // wired to one. With no driver filter we pick the first
@@ -2045,13 +2077,30 @@
         }
       }
       if (matched) {
-        if (schedDirty && schedCacheEl && schedCacheLpId === matched.id) {
-          // User is mid-edit: re-attach their dirty form instead of
-          // rebuilding it from server state and trampling input.
-          evModalBody.appendChild(schedCacheEl);
-        } else {
-          evModalBody.appendChild(buildScheduleControl(matched));
+        // Build schedule exactly once per LP. Polling never rebuilds
+        // it — inputs keep their focus, value and caret position. Only
+        // a Save / Clear (which sets schedNeedsRebuild) or switching
+        // to a different LP (planet) triggers a fresh build.
+        var lpChanged = schedSectionEl == null || schedLpId !== matched.id;
+        if (lpChanged || schedNeedsRebuild) {
+          if (schedSectionEl && schedSectionEl.parentNode === evModalBody) {
+            evModalBody.removeChild(schedSectionEl);
+          }
+          schedSectionEl = buildScheduleControl(matched, siteHasPV(status));
+          schedLpId = matched.id;
+          schedNeedsRebuild = false;
+          evModalBody.appendChild(schedSectionEl);
+        } else if (schedSectionEl.parentNode !== evModalBody) {
+          // Modal was previously closed: body got wiped but our
+          // cached section is still valid — re-attach.
+          evModalBody.appendChild(schedSectionEl);
         }
+      } else {
+        if (schedSectionEl && schedSectionEl.parentNode === evModalBody) {
+          evModalBody.removeChild(schedSectionEl);
+        }
+        schedSectionEl = null;
+        schedLpId = null;
       }
     }).catch(function () {
       setEvModalMessage("Failed to load EV status");
@@ -2065,7 +2114,7 @@
   // deadline forward each day when Recurring is set, and arms the
   // surplus-grab whenever the home battery sits at or above the
   // threshold (with 5 pp release hysteresis).
-  function buildScheduleControl(lp) {
+  function buildScheduleControl(lp, hasPV) {
     var sched = (lp && lp.schedule) || {};
     // Convert "minutes-of-day-UTC" to a "HH:MM" string in the
     // browser's local zone. The UI shows local time everywhere;
@@ -2178,7 +2227,7 @@
     }
 
     var recWrap = checkbox(initRec, "Recurring (every day)");
-    var surWrap = checkbox(initSurplus, "Surplus charge from home battery");
+    var surWrap = checkbox(initSurplus && !!hasPV, "Surplus charge from PV");
     var recCb = recWrap.input;
     var surCb = surWrap.input;
 
@@ -2191,7 +2240,12 @@
     checkRow.style.gap = "0.35rem";
     checkRow.style.marginBottom = "0.55rem";
     checkRow.appendChild(recWrap);
-    checkRow.appendChild(surWrap);
+    // Surplus-from-PV only makes sense on sites with a PV driver — the
+    // bat-SoC unlock would have no surplus to grab otherwise. Omit the
+    // checkbox + threshold entirely on PV-less sites.
+    if (hasPV) {
+      checkRow.appendChild(surWrap);
+    }
     box.appendChild(checkRow);
 
     var unlockHint = document.createElement("small");
@@ -2200,10 +2254,13 @@
     unlockHint.style.marginTop = "0.2rem";
     unlockHint.style.marginBottom = "0.3rem";
     unlockHint.textContent = "Always grab PV surplus when home battery ≥ threshold.";
-    box.appendChild(unlockHint);
 
     var thresholdRow = row("Threshold", unlockWrap);
-    box.appendChild(thresholdRow);
+
+    if (hasPV) {
+      box.appendChild(unlockHint);
+      box.appendChild(thresholdRow);
+    }
 
     function applySurplusGate() {
       var on = surCb.checked;
@@ -2212,8 +2269,10 @@
       thresholdRow.style.pointerEvents = on ? "auto" : "none";
       unlockHint.style.opacity = on ? "1" : "0.55";
     }
-    applySurplusGate();
-    surCb.addEventListener("change", applySurplusGate);
+    if (hasPV) {
+      applySurplusGate();
+      surCb.addEventListener("change", applySurplusGate);
+    }
 
     // Actions
     var btnRow = document.createElement("div");
@@ -2258,28 +2317,21 @@
     status.style.minHeight = "1em";
     box.appendChild(status);
 
-    // Cache + dirty wiring: each user edit flips schedDirty=true so
-    // the auto-refresh keeps THIS element on screen instead of
-    // rebuilding it from stale server state.
-    schedCacheEl = box;
-    schedCacheLpId = lp.id;
-    schedDirty = false;
-    function markDirty() { schedDirty = true; }
-    [socWrap.input, timeInp, unlockWrap.input].forEach(function (el) {
-      el.addEventListener("input", markDirty);
-      el.addEventListener("change", markDirty);
-    });
-    recCb.addEventListener("change", markDirty);
-
+    // Save and Clear both flag schedNeedsRebuild so the next poll
+    // rebuilds the section from the new authoritative server state
+    // (e.g. so the button label flips from "Save" → "Update" once a
+    // schedule exists). Polling never rebuilds otherwise — the cached
+    // schedSectionEl stays mounted and inputs keep focus.
     saveBtn.addEventListener("click", function () {
       saveBtn.disabled = true;
       clearBtn.disabled = true;
       status.textContent = "Saving…";
       var localHHMM = timeInp.value || initLocalHHMM;
       var minUTC = localHHMMToUtcMins(localHHMM);
-      // Surplus checkbox gates the threshold: when off, the threshold
-      // is sent as 0 (the backend interprets 0 as "feature disabled").
-      var unlockVal = surCb.checked ? Number(unlockWrap.input.value) : 0;
+      // Surplus checkbox gates the threshold: when off (or hidden on
+      // PV-less sites), the threshold is sent as 0 — the backend
+      // interprets 0 as "feature disabled".
+      var unlockVal = (hasPV && surCb.checked) ? Number(unlockWrap.input.value) : 0;
       var body = {
         schedule: {
           soc_pct: Number(socWrap.input.value),
@@ -2295,8 +2347,7 @@
       }).then(function (r) {
         if (!r.ok) throw new Error("HTTP " + r.status);
         status.textContent = "Saved.";
-        schedDirty = false;
-        schedCacheEl = null;
+        schedNeedsRebuild = true;
         refreshEvModal();
       }).catch(function (e) {
         status.textContent = "Save failed: " + e.message;
@@ -2316,8 +2367,7 @@
       }).then(function (r) {
         if (!r.ok) throw new Error("HTTP " + r.status);
         status.textContent = "Cleared.";
-        schedDirty = false;
-        schedCacheEl = null;
+        schedNeedsRebuild = true;
         refreshEvModal();
       }).catch(function (e) {
         status.textContent = "Clear failed: " + e.message;

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2045,7 +2045,15 @@
       var d = results[0];
       var lps = results[1];
       var status = lastStatusPayload;
-      if (!d || d.connected === false) {
+      var hasLoadpoints = lps && Array.isArray(lps.loadpoints) && lps.loadpoints.length > 0;
+      var carConnected = d && d.connected !== false;
+      // Hard short-circuit only when there's NOTHING to show: no
+      // active EV AND no configured loadpoint. Otherwise we fall
+      // through so the schedule editor stays reachable — operators
+      // routinely want to set tomorrow morning's target before
+      // plugging in tonight, and the schedule is LP state (persisted
+      // across restarts), not driver state.
+      if (!carConnected && !hasLoadpoints) {
         setEvModalMessage("No EV charger connected");
         statusTableEl = null;
         schedSectionEl = null;
@@ -2056,7 +2064,19 @@
       // (including any mounted schedule section) is untouched. On the
       // very first call evModalBody may still contain the placeholder
       // from setEvModalMessage; wipe only when we have no anchor yet.
-      var freshStatus = renderEvStatusTable(d);
+      // When no car is connected but loadpoints exist, render a
+      // dim placeholder note in place of the live status table so
+      // the modal still has a header before the schedule editor.
+      var freshStatus;
+      if (carConnected) {
+        freshStatus = renderEvStatusTable(d);
+      } else {
+        freshStatus = document.createElement("p");
+        freshStatus.style.color = "var(--text-dim)";
+        freshStatus.style.fontStyle = "italic";
+        freshStatus.style.margin = "0 0 0.6rem 0";
+        freshStatus.textContent = "No car connected — schedule below is saved to the loadpoint and applies on next plug-in.";
+      }
       if (statusTableEl && statusTableEl.parentNode === evModalBody) {
         evModalBody.replaceChild(freshStatus, statusTableEl);
       } else {

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2169,6 +2169,55 @@
       box.appendChild(unpluggedHint);
     }
 
+    // Surplus-only is a per-loadpoint hard flag that's *independent* of
+    // any schedule — when on, the dispatch refuses to import grid for
+    // this loadpoint regardless of what the MPC plans. Operators can
+    // run with surplus-only alone (no target, no deadline — just
+    // "harvest PV when there's enough") or layer a schedule on top
+    // ("opportunistic surplus, but also catch up via grid if cheap").
+    // Saved + applied immediately on every click via a dedicated POST
+    // — does not require Save to be pressed.
+    var sepRow = document.createElement("div");
+    sepRow.style.marginBottom = "0.55rem";
+    sepRow.style.paddingBottom = "0.55rem";
+    sepRow.style.borderBottom = "1px solid var(--line)";
+    var soWrap = document.createElement("label");
+    soWrap.style.display = "flex";
+    soWrap.style.alignItems = "center";
+    soWrap.style.gap = "0.4rem";
+    soWrap.style.fontSize = "0.85rem";
+    soWrap.style.cursor = "pointer";
+    var soCb = document.createElement("input");
+    soCb.type = "checkbox";
+    soCb.checked = !!(lp && lp.surplus_only);
+    soCb.style.accentColor = "var(--accent-e)";
+    var soText = document.createElement("span");
+    soText.textContent = "Surplus only (PV exports only — never imports grid)";
+    soWrap.appendChild(soCb);
+    soWrap.appendChild(soText);
+    var soHint = document.createElement("div");
+    soHint.style.fontSize = "0.72rem";
+    soHint.style.color = "var(--text-dim)";
+    soHint.style.marginTop = "0.25rem";
+    soHint.style.marginLeft = "1.4rem";
+    soHint.textContent = "Independent of the schedule below. Charges only when PV exports exceed your load. No deadline planning — no grid import.";
+    sepRow.appendChild(soWrap);
+    sepRow.appendChild(soHint);
+    box.appendChild(sepRow);
+    soCb.addEventListener("change", function () {
+      soCb.disabled = true;
+      fetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/target", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ surplus_only: soCb.checked }),
+      }).then(function () {
+        soCb.disabled = false;
+        // Rebuild on next poll so the schedule section reflects any
+        // server-side side effects (e.g. soc_source recompute).
+        schedNeedsRebuild = true;
+      }).catch(function () { soCb.disabled = false; });
+    });
+
     function row(labelText, controlEl) {
       var r = document.createElement("div");
       r.style.display = "flex";

--- a/web/plan.js
+++ b/web/plan.js
@@ -366,6 +366,37 @@
       ctx.setLineDash([]);
     }
 
+    // Planned EV charging — site-signed load (always ≥ 0, plotted above
+    // zero). Solid cyan so it's distinguishable from the dashed amber
+    // load forecast and the green PV trace. Only drawn when the plan
+    // carries a loadpoint dimension (loadpoint_w field present).
+    if (plan && plan.actions && plan.actions.some(a => a.loadpoint_w != null)) {
+      ctx.strokeStyle = 'rgba(34,211,238,0.95)';
+      ctx.lineWidth = 1.8;
+      ctx.beginPath();
+      let fEv = true;
+      for (const a of plan.actions) {
+        if (a.slot_start_ms > tMax) break;
+        if (a.loadpoint_w == null) continue;
+        const x = xScale(a.slot_start_ms);
+        const y = powerY(a.loadpoint_w);
+        if (fEv) { ctx.moveTo(x, y); fEv = false; }
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+      // EV step-fill at low opacity makes the on/off slots readable at a
+      // glance — the line alone hides the "off between two on" slots.
+      ctx.fillStyle = 'rgba(34,211,238,0.12)';
+      for (const a of plan.actions) {
+        if (a.slot_start_ms > tMax) break;
+        if (!a.loadpoint_w || a.loadpoint_w <= 0) continue;
+        const x0 = xScale(a.slot_start_ms);
+        const x1 = xScale(a.slot_start_ms + a.slot_len_min * 60 * 1000);
+        const yTop = powerY(a.loadpoint_w);
+        ctx.fillRect(x0, yTop, Math.max(1, x1 - x0 - 1), powerYCenter - yTop);
+      }
+    }
+
     // Power zero-line
     ctx.strokeStyle = 'rgba(255,255,255,0.25)';
     ctx.lineWidth = 1;
@@ -657,6 +688,10 @@
         lines.push(`<div class="tip-row"><span title="Solar generation the plan assumes for this slot">PV forecast</span><b>${pvGen.toFixed(1)} kW</b></div>`);
       }
       if (a.load_w != null) lines.push(`<div class="tip-row"><span title="Household consumption the plan assumes for this slot">Load forecast</span><b>${(a.load_w / 1000).toFixed(1)} kW</b></div>`);
+      if (a.loadpoint_w != null && a.loadpoint_w > 0) {
+        const evSoc = a.loadpoint_soc_pct != null ? ` → ${a.loadpoint_soc_pct.toFixed(0)}%` : '';
+        lines.push(`<div class="tip-row"><span title="Planned EV charging power for this slot">EV charging</span><b>${(a.loadpoint_w / 1000).toFixed(1)} kW${evSoc}</b></div>`);
+      }
       if (a.battery_w != null) {
         const dir = a.battery_w > 100 ? 'charge' : a.battery_w < -100 ? 'discharge' : 'idle';
         lines.push(`<div class="tip-row"><span title="Planned battery power. + = charging, − = discharging">Battery</span><b>${(a.battery_w / 1000).toFixed(1)} kW (${dir})</b></div>`);

--- a/web/settings/tabs/control.js
+++ b/web/settings/tabs/control.js
@@ -40,6 +40,22 @@
         field("Watchdog timeout (s)", "site.watchdog_timeout_s", "number", 60) +
         '</div></div>' +
         '</fieldset>' +
+        '<fieldset><legend>PV surplus absorber</legend>' +
+        '<p style="color:var(--ink-dim);font-size:0.85rem;margin:0 0 8px">' +
+        'Opt-in underlay for planner_cheap / planner_arbitrage. ' +
+        'When the plan would still leave the grid exporting beyond the threshold AND ' +
+        'average battery SoC is below the cap, the leftover export is redirected into the battery ' +
+        'instead of crossing the meter. Never reverses a discharge plan. ' +
+        'Set SoC cap to 0 to disable (default).' +
+        '</p>' +
+        '<div class="field-row"><div>' +
+        field("SoC cap (%)", "site.pv_surplus_absorb_soc_cap_pct", "number", 0,
+          "Stop absorbing once average battery SoC reaches this percentage. 0 disables the absorber entirely. Suggested 88 — leaves 2 pp below a typical planner soc_max_pct of 90 so the absorber doesn't slam into the wall.") +
+        '</div><div>' +
+        field("Export threshold (W)", "site.pv_surplus_absorb_threshold_w", "number", 100,
+          "Trigger when projected grid export exceeds this many watts after the plan's target. Defaults to 100 W when the cap is set but this isn't.") +
+        '</div></div>' +
+        '</fieldset>' +
         '<fieldset><legend>Fuse</legend>' +
         '<div class="field-row"><div>' +
         field("Max amps (A)", "fuse.max_amps", "number", 16) +


### PR DESCRIPTION
## Summary

Series of fixes shaking out from a single-session investigation into "why isn't my battery absorbing PV / why is the plan lying about EV charging / why does the planner export beyond my fuse / why doesn't my EV start". Each commit is one root cause, single-scope header so the release pipeline picks them all up.

Live-verified on a production Pi (now `v0.74.0-23-g5e4a3be`) before push. Worktree path: `.claude/worktrees/pv-surplus-absorber`.

## Commits (oldest first)

1. **`feat(control)`: PV surplus absorber underlay** — Opt-in dispatch-layer policy that catches the gap between the MPC's 15-min slot allocation and live PV/load drift in `planner_cheap` / `planner_arbitrage`. When the plan's target would still leave grid exporting beyond `pv_surplus_absorb_threshold_w` AND average SoC is below `pv_surplus_absorb_soc_cap_pct`, the leftover export is redirected into the battery. Never reverses a discharge plan. Disabled by default (cap = 0); operator opts in via the two new `Site` config fields.
2. **`feat(configreload)`: hot-apply pv_surplus_absorb_* fields** — Plumb the new absorber knobs through the YAML hot-reload path so toggling doesn't need a restart.
3. **`fix(web)`: stable schedule editor + PV-only surplus row** — Three issues in one: (a) schedule inputs stay focused across the 5 s modal poll (the section is mounted once per LP, not rebuilt every tick); (b) renamed "Surplus charge from home battery" → "from PV"; (c) hide the surplus row entirely on sites with no PV driver.
4. **`feat(mpc)`: bat-SoC arm → MPC SurplusOnly + force-wake on schedule edit** — (B) thread the runtime bat-SoC unlock arming into MPC's `LoadpointSpec.SurplusOnly` via a new `Controller.IsBatSoCArmed` accessor, so the plan stops prescribing battery→EV transfers that dispatch then has to censor. (C) `Controller.RefreshVehicle` wakes the bound vehicle when the operator edits a schedule, so the next MPC tick reads fresh SoC / charge_limit / connection state instead of stale data.
5. **`fix(control)`: ignore EV-charging-W noise in BatteryCoversEV safety net** — Easee reports ~1 W of last-known smoothed power when the contactor opens. The safety net used `EVChargingW > 0` as its gate, so that 1 W of noise clamped every evening-peak discharge to "just enough to zero the house" (~-1.4 kW instead of -9 kW). Replaced with a 100 W threshold. Real EV draws still trigger the cap.
6. **`fix(mpc)`: per-slot fuse export cap + arbitrage upper-half terminal price** — (1) service-level fuse plumbing only set `Limits.MaxImportW` — `MaxExportW` was left unlimited, so the DP planned `grid=-14.2 kW` past an 11 kW fuse. Fuses trip on \|I\| regardless of sign; export 14 kW through an 11 kW breaker is just as bad as import. Plumb both directions. (2) arbitrage terminal credit defaulted to mean-of-horizon, systematically undervaluing SoC on sites with strong evening peaks (mean 262 vs realisable discharge at 345). Switched to mean of the upper half of horizon prices — principled proxy for "discharge happens at or above median". Live diagnose shows terminal_soc_price lifted from 268 → 321.4 öre/kWh.
7. **`feat(web,api)`: Settings UI + snappy in-process apply for PV surplus absorber** — The absorber from (1) was config-only; operators had to edit YAML. Adds a dedicated fieldset on Settings → Control with both knobs (SoC cap %, export threshold W) and the help text explaining the planner_cheap / planner_arbitrage gating and the `cap = 0` disable. `handlePostConfig` mirrors the two fields into live `ctrl.State` under `CtrlMu` so save takes effect immediately, matching the existing pattern for `grid_target_w` / `slew_rate_w` / etc.
8. **`fix(web)`: surplus_only no longer auto-creates schedule; schedule editor visible offline** — Two UX gates: (a) the surplus-only toggle was sending a placeholder schedule (`{soc_pct:100, target_time: today 16:00 UTC}`) alongside the flag, creating the impression that surplus_only required a schedule. Backend has always been schedule-agnostic; the controller's surplus clamp harvests live PV regardless. Decouple so the toggle sends only `{ surplus_only: bool }`. (b) the schedule editor was hidden when no car was plugged in — but the schedule is persistent loadpoint state, not driver state. Fall through to the first configured loadpoint when none are plugged in; show a small italic hint inside the editor so the saved-but-not-active state is visible.
9. **`fix(driver)`: tesla — wake-retry on poll failure + 15-min cadence while charging** — (a) Wake-retry: when a non-wake poll fails with a network-level error (the host's 15 s HTTP timeout when the proxy is waiting on a sleeping car), arm `pending_wake_retry` and schedule the next poll in 5 s with `wakeup=true`. Previously we waited up to 30 min for the periodic cadence to force a wake, so a car that fell asleep between polls stayed offline for that whole window. Guarded by `WAKE_RETRY_MIN_GAP_MS` (10 s) to prevent wake storms. (b) While `last.charging_state == "Charging"`, drop the periodic wake cadence from 30 min to 15 min — the 12 V-battery rationale doesn't apply on the wall, and operator in-app changes (`charge_limit_soc`, max amps) propagate within 15 min instead of half an hour.
10. **`feat(loadpoint,driver)`: wake bound vehicle on wallbox-delivering edge** — (a) Generic `wake_up` vehicle action (cross-driver protocol; Tesla driver implements via the proxy's dedicated `/command/wake_up`, no side effects). (b) `RefreshVehicle` now sends `wake_up` instead of overloaded `charge_start` (`charge_start` stays in the auto-wake loop which actually wants to start a session). (c) Wallbox-delivering rising edge in `tickOne` fires `wakeVehicleAuto` (gated by 5 min `vehicleWakeCooldown` so pause/resume flap can't storm BLE). Result: planner gets real `charging_state` / `charge_limit_pct` / SoC within ~15 s of session start instead of waiting up to the next periodic poll for the proxy's cache to refresh.
11. **`feat(web)`: surplus_only toggle in the EV modal schedule editor** — The loadpoint-level surplus_only flag had no checkbox in the current EV modal (`web/next-app.js`) — only the legacy `web/app.js` had one and it's not wired in. Operators had to PATCH over the API. Add a dedicated row at the top of the schedule section, "Surplus only (PV exports only — never imports grid)", with an inline hint explaining it's independent of the schedule. Click sends `{surplus_only: bool}` immediately (no Save required) and flags `schedNeedsRebuild` so the rest of the section refreshes from the authoritative server state.
12. **`fix(web)`: show vehicle_soc_pct when soc_source is vehicle (loadpoints panel)** — The `/admin/loadpoints` debug panel rendered `current_soc_pct` (controller's inference state) even when `soc_source == "vehicle"` and the BMS truth was sitting in `vehicle_soc_pct`. Concrete example: panel reported "65.1% (vehicle)" while the actual Tesla reported 55%. The discrepancy is just the controller's session-Wh inference drift — important to keep stable for the DP's input but misleading to a human. Prefer `vehicle_soc_pct` when source is vehicle; show the inferred value in parens when it differs by ≥1 pp ("55% (vehicle) · inferred 65.1%").
13. **`fix(web)`: split EV modal into PV Mode + Schedule sections to clarify save semantics** — The surplus_only toggle from (11) was rendered inside the "Schedule" section directly above the Save button, making it look like Save was what persisted it. Save actually only covers the schedule fields (target SoC, time, recurring, surplus_unlock threshold). Split the editor into two clearly-labelled fieldsets: **PV MODE** (surplus toggle, saves on click with "Saving…/Saved." status) and **SCHEDULE (GRID CHARGING)** (target + deadline + Save button). Each section has its own explainer so operators can't confuse what owns what.
14. **`fix(web)`: label Save button "Set schedule" / "Update schedule"** — Companion to (13). "Save" alone was ambiguous; the button now names what it does and which mode it's in. "Set schedule" when none exists, "Update schedule" when one does.
15. **`fix(mpc)`: wire BatteryCoversEV into DP via NoBatteryToEV constraint** — `dispatch.go:778-779` had a comment promising the MPC also gets a NoBatteryToEV constraint so the plan stops prescribing what dispatch then has to censor. The constraint was never implemented: `LoadpointSpec` had no field, `main.go` never assigned anything derived from `ctrl.BatteryCoversEV`, and `mpc.Optimize` had no rule consulting it. Result: the DP happily picked battery discharge to feed the EV when grid was expensive, then the runtime safety clamp at `dispatch.go:787` censored battery down to house-only — producing a persistent plan↔reality divergence ("plan: 7.2 kW battery discharge + 11 kW EV at 10:30, reality: battery clamped"). Three-step fix: add the field, set it under `ctrlMu`, add the feasibility rule that rejects `(battW<0, evW>0)` when |battW| exceeds the PV-residual house demand (the same accounting the dispatch clamp uses). Regression test included; live plan verified zero violations across next 30 slots.
16. **`fix(api)`: manual EV Start / Resume install sticky hold; Pause clears it** — `/api/ev/command` forwarded `ev_start` to the Easee driver, which faithfully told the wallbox to start. But the next 5 s dispatch tick ran `computeCommand` → no MPC budget for this LP (no schedule, no vehicle SoC, or surplus_only with no live PV) → `cmdW = 0` → controller sent `ev_set_current power_w=0` → wallbox paused again. Net result: the operator's click looked like a no-op. Install a no-expiry `ManualHold` on the loadpoint's `MaxChargeW` on Start/Resume so the dispatch loop's manual-hold short-circuit at `controller.go:770` pins the wallbox to that wattage regardless of plan / surplus state. Pause clears the hold so the LP immediately reverts to plan / surplus rules — matches the operator's mental model: "Start = override the plan; Pause = let the plan take back over."
17. **`fix(loadpoint)`: allow 1Φ surplus start when 3Φ window isn't imminent** — `pickSurplusSteps` gated 1Φ on today's WHOLE-DAY peak forecast: if any future slot would hit 4140 W (3Φ × 6 A min), it locked the LP to 3Φ and made it wait, even when live surplus was at 3 kW RIGHT NOW. Operators reported "EV doesn't start reactively when there's PV surplus" — a sunny morning with the noon peak hours away left the wallbox idle. Add `SetNearTermPeakSurplusW` (same data, 30 min window). `pickSurplusSteps` consults near-term BEFORE day-peak: if 3Φ isn't reachable within the next 30 min, return 1Φ-allowed steps NOW. Day-lock NOT set on near-term-driven 1Φ — a passing cloud shouldn't commit the LP to 1Φ for the rest of the day; existing 35 s pause hysteresis caps the contactor cycle rate if surplus later grows past 3Φ minimum.
18. **`chore(loadpoint)`: log when 1Φ near-term fallback fires (throttled 10m)** — Visibility companion to (17). One INFO line per LP per 10 min when the near-term path returns 1Φ-allowed steps so operators staring at `current_power_w=0` can confirm the new branch is active and the wait is "1Φ allowed but live surplus hasn't reached 1380 W either", not "the path didn't even fire".
19. **`fix(loadpoint)`: default phase_mode to "auto" when surplus is active** — The Easee driver (`drivers/easee_cloud.lua:105`) interprets an UNSET `phase_mode` as `"3p"` — silently locking the wallbox to 3-phase. The near-term 1Φ branch from (17) was passing 1Φ-eligible steps to the dispatcher, but with `phase_mode` left empty the wallbox stayed on 3Φ and rejected the low-power offer (2 A per phase, below the 6 A minimum). Default `phase_mode` to `"auto"` in both branches (manual hold + normal dispatch) when surplus is active and the operator didn't pick a phase. Operators who picked "3p" or "1p" explicitly still get their choice; the 1Φ day-lock still forces "1p". Live-verified: EV picked up surplus and started 1Φ × 8 A charging at 1840 W within ~90 s (the Easee `MinPhaseHoldS` hysteresis).
20. **`fix(loadpoint)`: persist surplus_only toggle across restarts** — `Manager.SetSurplusOnly` mutated `lp.Config.SurplusOnly` in memory but never wrote to disk, so every container restart reverted the flag to whatever was in YAML. Operators toggle this from the dashboard EV modal — they don't expect to also have to edit YAML, and the silent revert had bit me twice during today's ship sequence. Add `surplusOnlySaver` + `SetSurplusOnlySaver` mirroring the existing `scheduleSaver` pattern. `main.go` wires it to `state.config` key `loadpoint_surplus_only:<id>`. `HydrateSurplusOnly` is called once after `Manager.Load` so persisted overrides win over the YAML default at boot. Verified end-to-end: set → restart → still on.

## Test plan

- [x] `make test` green (incl. e2e)
- [x] Live deploy on production Pi (now `v0.74.0-23-g5e4a3be`)
- [x] Verified terminal_soc_price 268 → 321 in `/api/mpc/diagnose`
- [x] Verified new plan has no slot with `|grid_w| > fuse` over next 14 slots
- [x] Verified absorber lifts SoC from 25.5% → 88.2% over one day (hits the cap, then export resumes)
- [x] Verified `loadpoint_active=true` log line after bat-SoC arm flips, terminal_ore drops to surplus-only formula
- [x] Verified evening-peak discharge ramps up correctly after EV-noise threshold fix (live -1.5 kW → -5.7 kW over slew time)
- [x] Verified Tesla wake-retry fires within ~15 s on a sleeping car (was 30 min)
- [x] Verified vehicle wake_up endpoint hit on wallbox-delivering edge (5 min cooldown holds)
- [x] Verified Settings → PV surplus absorber fieldset writes both fields + applies live
- [x] Verified Surplus only checkbox in EV modal toggles without creating a placeholder schedule
- [x] Verified loadpoints panel now shows vehicle BMS truth alongside inferred discrepancy
- [x] Verified NoBatteryToEV constraint: live plan has zero (battery_discharge, EV_charge) violations in next 30 slots
- [x] Verified manual EV Start installs sticky hold; Pause clears it and reverts to plan
- [x] Verified 1Φ surplus start fires on a sunny morning when day-peak forecast says 3Φ comes later
- [x] Verified `surplus_only` persists across `docker compose restart` (was lost before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)