### PR TITLE
feat(api): historical vs flat-rate savings — /api/savings/daily

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -157,6 +157,13 @@ type Server struct {
 	// ~30 SQL round-trips with ~500k rows shipped to Go to at most one.
 	dailyCacheMu sync.Mutex
 	dailyCache   map[string]state.DayEnergy
+
+	// savingsCache mirrors dailyCache for /api/savings/daily. Same
+	// immutable-past-day rationale. Lazily allocated on first request
+	// because the savings endpoint is opt-in (no-op without a configured
+	// price zone), so most boots never need the map.
+	savingsCacheMu sync.Mutex
+	savingsCache   map[string]daySavings
 }
 
 // New creates a new API server.
@@ -216,6 +223,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/self_tune/cancel", s.handleSelfTuneCancel)
 	s.handle("GET  /api/history", s.handleHistory)
 	s.handle("GET  /api/energy/daily", s.handleEnergyDaily)
+	s.handle("GET  /api/savings/daily", s.handleSavingsDaily)
 	s.handle("GET  /api/prices", s.handlePrices)
 	s.handle("GET  /api/forecast", s.handleForecast)
 	s.handle("GET  /api/mpc/plan", s.handleMPCPlan)

--- a/go/internal/api/api_savings.go
+++ b/go/internal/api/api_savings.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/state"
+)
+
+// daySavings is the cached per-local-day cost breakdown that powers
+// /api/savings/daily. Mirrors the immutable-day pattern dailyCache uses.
+// Past days never re-render; only today is recomputed each request.
+type daySavings struct {
+	ImportWh         float64
+	ExportWh         float64
+	ImportCostOre    float64
+	ExportRevenueOre float64
+	AvgImportOreKwh  float64
+	AvgExportOreKwh  float64
+	ActualCostOre    float64
+	FlatCostOre      float64
+	SavedOre         float64
+	Resolution       string // "slot" or "no_prices"
+}
+
+func fromBreakdown(b state.DayCostBreakdown, resolution string) daySavings {
+	return daySavings{
+		ImportWh:         b.ImportWh,
+		ExportWh:         b.ExportWh,
+		ImportCostOre:    b.ImportCostOre,
+		ExportRevenueOre: b.ExportRevenueOre,
+		AvgImportOreKwh:  b.AvgImportOreKwh,
+		AvgExportOreKwh:  b.AvgExportOreKwh,
+		ActualCostOre:    b.ActualCostOre(),
+		FlatCostOre:      b.FlatCostOre(),
+		SavedOre:         b.SavedOre(),
+		Resolution:       resolution,
+	}
+}
+
+// savingsCache is created lazily on first request. Process-lifetime.
+// Keyed on YYYY-MM-DD; immutable days are cached forever. Cleared on
+// process restart, which is the only practical way config-driven
+// export-pricing changes invalidate it — operators changing
+// cfg.Price.ExportBonusOreKwh mid-run will see stale historical answers
+// until a restart. Acceptable for an MVP — those fields rarely change.
+type savingsCacheT struct {
+	mu sync.Mutex
+	m  map[string]daySavings
+}
+
+// handleSavingsDaily returns per-local-day savings vs flat-rate.
+//
+// GET /api/savings/daily?days=N
+//
+// Response:
+//
+//	{
+//	  "days": [
+//	    {
+//	      "day": "YYYY-MM-DD",
+//	      "import_wh": ..., "export_wh": ...,
+//	      "import_cost_ore": ..., "export_revenue_ore": ...,
+//	      "actual_cost_ore": ..., "flat_cost_ore": ..., "saved_ore": ...,
+//	      "avg_import_ore_kwh": ..., "avg_export_ore_kwh": ...,
+//	      "resolution": "slot" | "no_prices"
+//	    },
+//	    ...
+//	  ],
+//	  "totals": { "import_wh": ..., "export_wh": ...,
+//	              "actual_cost_ore": ..., "flat_cost_ore": ..., "saved_ore": ... },
+//	  "tz": "Local"
+//	}
+//
+// Days where the prices table has no slot for the zone come back with
+// resolution="no_prices" and zeroed costs. Volume columns are still
+// populated for those days so the UI can distinguish "no data" from
+// "data but no prices yet".
+func (s *Server) handleSavingsDaily(w http.ResponseWriter, r *http.Request) {
+	if s.deps.State == nil {
+		writeJSON(w, 200, map[string]any{"days": []any{}})
+		return
+	}
+
+	days := 7
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+	if days > 90 {
+		days = 90
+	}
+
+	// Pull export pricing + zone from current config. Take the config
+	// mutex briefly to copy the small set of scalars we need so handler
+	// work doesn't block hot-path readers.
+	zone := ""
+	ep := state.ExportPricing{}
+	if s.deps.CfgMu != nil && s.deps.Cfg != nil {
+		s.deps.CfgMu.RLock()
+		if s.deps.Cfg.Price != nil {
+			zone = s.deps.Cfg.Price.Zone
+			ep.BonusOreKwh = s.deps.Cfg.Price.ExportBonusOreKwh
+			ep.FeeOreKwh = s.deps.Cfg.Price.ExportFeeOreKwh
+		}
+		if s.deps.Cfg.Planner != nil {
+			ep.FlatOreKwh = s.deps.Cfg.Planner.ExportOrePerKWh
+		}
+		s.deps.CfgMu.RUnlock()
+	}
+	if zone == "" {
+		// No price provider configured → nothing to compare against.
+		writeJSON(w, 200, map[string]any{"days": []any{}, "tz": time.Now().Location().String()})
+		return
+	}
+
+	now := time.Now()
+	loc := now.Location()
+	todayMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+
+	s.ensureSavingsCache()
+
+	out := make([]map[string]any, 0, days)
+	var tImpWh, tExpWh, tActual, tFlat, tSaved float64
+
+	for i := days - 1; i >= 0; i-- {
+		dayStart := todayMidnight.AddDate(0, 0, -i)
+		dayKey := dayStart.Format("2006-01-02")
+		isToday := i == 0
+
+		var ds daySavings
+		if isToday {
+			b, err := s.deps.State.DailyCostBreakdown(dayStart.UnixMilli(), now.UnixMilli(), zone, ep)
+			if err != nil {
+				slog.Error("handleSavingsDaily: DailyCostBreakdown failed", "err", err, "day", dayKey)
+				http.Error(w, "savings load failed", http.StatusInternalServerError)
+				return
+			}
+			ds = fromBreakdown(b, resolutionFor(b))
+		} else {
+			s.savingsCacheMu.Lock()
+			cached, ok := s.savingsCache[dayKey]
+			s.savingsCacheMu.Unlock()
+			if ok {
+				ds = cached
+			} else {
+				dayEnd := dayStart.AddDate(0, 0, 1)
+				b, err := s.deps.State.DailyCostBreakdown(dayStart.UnixMilli(), dayEnd.UnixMilli(), zone, ep)
+				if err != nil {
+					slog.Error("handleSavingsDaily: DailyCostBreakdown failed", "err", err, "day", dayKey)
+					http.Error(w, "savings load failed", http.StatusInternalServerError)
+					return
+				}
+				ds = fromBreakdown(b, resolutionFor(b))
+				s.savingsCacheMu.Lock()
+				s.savingsCache[dayKey] = ds
+				s.savingsCacheMu.Unlock()
+			}
+		}
+
+		tImpWh += ds.ImportWh
+		tExpWh += ds.ExportWh
+		tActual += ds.ActualCostOre
+		tFlat += ds.FlatCostOre
+		tSaved += ds.SavedOre
+
+		out = append(out, map[string]any{
+			"day":                dayKey,
+			"import_wh":          ds.ImportWh,
+			"export_wh":          ds.ExportWh,
+			"import_cost_ore":    ds.ImportCostOre,
+			"export_revenue_ore": ds.ExportRevenueOre,
+			"actual_cost_ore":    ds.ActualCostOre,
+			"flat_cost_ore":      ds.FlatCostOre,
+			"saved_ore":          ds.SavedOre,
+			"avg_import_ore_kwh": ds.AvgImportOreKwh,
+			"avg_export_ore_kwh": ds.AvgExportOreKwh,
+			"resolution":         ds.Resolution,
+		})
+	}
+
+	writeJSON(w, 200, map[string]any{
+		"days": out,
+		"totals": map[string]any{
+			"import_wh":       tImpWh,
+			"export_wh":       tExpWh,
+			"actual_cost_ore": tActual,
+			"flat_cost_ore":   tFlat,
+			"saved_ore":       tSaved,
+		},
+		"tz": loc.String(),
+	})
+}
+
+// resolutionFor reports whether the breakdown saw any price data. A day
+// with energy traffic but zero average prices means the prices table had
+// no slot covering the range, which the UI may want to render
+// differently ("no_prices") from a true zero-cost day.
+func resolutionFor(b state.DayCostBreakdown) string {
+	if b.AvgImportOreKwh == 0 && b.AvgExportOreKwh == 0 {
+		return "no_prices"
+	}
+	return "slot"
+}
+
+func (s *Server) ensureSavingsCache() {
+	s.savingsCacheMu.Lock()
+	defer s.savingsCacheMu.Unlock()
+	if s.savingsCache == nil {
+		s.savingsCache = make(map[string]daySavings)
+	}
+}

--- a/go/internal/api/api_savings_test.go
+++ b/go/internal/api/api_savings_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+	"github.com/frahlg/forty-two-watts/go/internal/state"
+)
+
+// No state and no config → empty days, 200. Matches /api/energy/daily's
+// "history is optional" contract so dev / test harnesses without a DB
+// don't 500.
+func TestHandleSavingsDailyNoState(t *testing.T) {
+	srv := New(&Deps{})
+	req := httptest.NewRequest(http.MethodGet, "/api/savings/daily?days=7", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if days, _ := body["days"].([]any); len(days) != 0 {
+		t.Fatalf("expected empty days, got %d", len(days))
+	}
+}
+
+// State present but cfg.Price.Zone empty → endpoint short-circuits with
+// empty days. There's nothing to flat-baseline against without prices.
+func TestHandleSavingsDailyNoZone(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	srv := New(&Deps{
+		State:  st,
+		Cfg:    &config.Config{Price: &config.Price{Zone: ""}},
+		CfgMu:  &sync.RWMutex{},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/savings/daily?days=3", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if days, _ := body["days"].([]any); len(days) != 0 {
+		t.Fatalf("expected empty days for unconfigured zone, got %d", len(days))
+	}
+}
+
+// End-to-end with real history + prices: seed a known cheap/expensive
+// slot pair within today, confirm the handler returns the slot-weighted
+// vs flat-rate savings the underlying state.DailyCostBreakdown produced.
+// This is the cross-layer integration check — if either the SQL changes
+// or the handler stops applying export pricing, the math comes out
+// wrong and this fails.
+func TestHandleSavingsDailyEndToEnd(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	now := time.Now()
+	loc := now.Location()
+	todayMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	elapsed := now.Sub(todayMidnight)
+	if elapsed < 30*time.Minute {
+		t.Skip("too close to local midnight; need a wider in-day window")
+	}
+
+	// Two 5-min hot-tier slots inside today: import in a cheap slot, then
+	// the closing sample (the export half) is integrated against the
+	// next-slot price. Same shape as the state-level test but anchored
+	// to wall-clock so we land inside the handler's "today" range.
+	t0 := todayMidnight.Add(elapsed / 3)
+	t1 := t0.Add(5 * time.Minute)
+	t2 := t1.Add(5 * time.Minute)
+	t3 := t2.Add(5 * time.Minute)
+
+	// Slot 0 cheap (100 öre total / 80 öre spot), slot 1 expensive
+	// (200 öre total / 150 öre spot). 1h slots so all four sample mid-
+	// points land in the same slot in pairs.
+	slot0 := todayMidnight.Add(elapsed/3 - time.Hour).UnixMilli()
+	slot1 := slot0 + 3_600_000
+	if err := st.SavePrices([]state.PricePoint{
+		{Zone: "SE3", SlotTsMs: slot0, SlotLenMin: 60, SpotOreKwh: 80, TotalOreKwh: 100, Source: "test"},
+		{Zone: "SE3", SlotTsMs: slot1, SlotLenMin: 60, SpotOreKwh: 150, TotalOreKwh: 200, Source: "test"},
+	}); err != nil {
+		t.Fatalf("SavePrices: %v", err)
+	}
+
+	for _, p := range []state.HistoryPoint{
+		{TsMs: t0.UnixMilli(), GridW: 1000},
+		{TsMs: t1.UnixMilli(), GridW: 1000},
+		{TsMs: t2.UnixMilli(), GridW: -2000},
+		{TsMs: t3.UnixMilli(), GridW: -2000},
+	} {
+		if err := st.RecordHistory(p); err != nil {
+			t.Fatalf("RecordHistory: %v", err)
+		}
+	}
+
+	srv := New(&Deps{
+		State: st,
+		Cfg:   &config.Config{Price: &config.Price{Zone: "SE3"}},
+		CfgMu: &sync.RWMutex{},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/savings/daily?days=2", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		Days   []map[string]any `json:"days"`
+		Totals map[string]any   `json:"totals"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v (body: %s)", err, rr.Body.String())
+	}
+	if len(body.Days) != 2 {
+		t.Fatalf("want 2 days, got %d", len(body.Days))
+	}
+	// Today is the last entry; the prior day should be all-zero.
+	yesterday := body.Days[0]
+	for _, k := range []string{"import_wh", "export_wh", "actual_cost_ore", "flat_cost_ore", "saved_ore"} {
+		if v, _ := yesterday[k].(float64); v != 0 {
+			t.Errorf("yesterday.%s = %v, want 0", k, v)
+		}
+	}
+	today := body.Days[1]
+	if v, _ := today["import_wh"].(float64); v <= 0 {
+		t.Errorf("today.import_wh = %v, want > 0", v)
+	}
+	if v, _ := today["export_wh"].(float64); v <= 0 {
+		t.Errorf("today.export_wh = %v, want > 0", v)
+	}
+	if v, _ := today["saved_ore"].(float64); v == 0 {
+		t.Errorf("today.saved_ore = 0 — expected non-zero timing benefit, body: %s", rr.Body.String())
+	}
+	if r, _ := today["resolution"].(string); r != "slot" {
+		t.Errorf("today.resolution = %q, want \"slot\"", r)
+	}
+	// Totals must aggregate the per-day values (yesterday is 0).
+	totalSaved, _ := body.Totals["saved_ore"].(float64)
+	todaySaved, _ := today["saved_ore"].(float64)
+	if !approxEqAPI(totalSaved, todaySaved, 0.01) {
+		t.Errorf("totals.saved_ore = %v, want ~%v (only today should have data)", totalSaved, todaySaved)
+	}
+}
+
+// Same days-param clamping convention as /api/energy/daily: garbage/0/
+// negative → default 7, >90 → 90. Keep behavior identical so callers
+// have one mental model across daily endpoints.
+func TestHandleSavingsDailyDaysClamping(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	srv := New(&Deps{
+		State: st,
+		Cfg:   &config.Config{Price: &config.Price{Zone: "SE3"}},
+		CfgMu: &sync.RWMutex{},
+	})
+
+	cases := []struct {
+		q    string
+		want int
+	}{
+		{"", 7},
+		{"abc", 7},
+		{"-5", 7},
+		{"0", 7},
+		{"14", 14},
+		{"150", 90},
+	}
+	for _, tc := range cases {
+		t.Run(tc.q, func(t *testing.T) {
+			url := "/api/savings/daily"
+			if tc.q != "" {
+				url += "?days=" + tc.q
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rr := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("got %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+			}
+			var body struct {
+				Days []map[string]any `json:"days"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("json: %v", err)
+			}
+			if len(body.Days) != tc.want {
+				t.Errorf("days=%q → %d days, want %d", tc.q, len(body.Days), tc.want)
+			}
+		})
+	}
+}
+
+func approxEqAPI(a, b, tol float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= tol
+}

--- a/go/internal/state/cost.go
+++ b/go/internal/state/cost.go
@@ -1,0 +1,151 @@
+package state
+
+
+// DayCostBreakdown decomposes grid traffic over a time range into actual cost
+// (slot-weighted against the prices table) and the data needed to compute a
+// flat-rate baseline (unweighted mean prices). All monetary values are in öre.
+//
+// The shape mirrors how mpc.ComputeBaselines computes "vs flat avg price" for
+// the planner horizon: separate import / export means, applied to import /
+// export volumes. Keeping the math identical means the historical answer for
+// a finished day matches what the live badge said when that day was the plan.
+type DayCostBreakdown struct {
+	ImportWh         float64
+	ExportWh         float64
+	ImportCostOre    float64 // Σ slot ( import_wh × total_ore_kwh ) / 1000
+	ExportRevenueOre float64 // Σ slot ( export_wh × export_price_ore ) / 1000
+	AvgImportOreKwh  float64 // unweighted mean of total_ore_kwh over slots in range
+	AvgExportOreKwh  float64 // unweighted mean of clamped export price over slots in range
+}
+
+// ActualCostOre is the net cost the household actually paid: import cost minus
+// export revenue. Positive = paid out, negative = net earned.
+func (b DayCostBreakdown) ActualCostOre() float64 {
+	return b.ImportCostOre - b.ExportRevenueOre
+}
+
+// FlatCostOre is the no-timing baseline — same kWh volumes priced at the
+// range's mean import / export prices. Matches mpc.ComputeBaselines'
+// FlatAvgOre formula.
+func (b DayCostBreakdown) FlatCostOre() float64 {
+	return (b.ImportWh*b.AvgImportOreKwh - b.ExportWh*b.AvgExportOreKwh) / 1000.0
+}
+
+// SavedOre is FlatCostOre − ActualCostOre. Positive means the system spent
+// less than flat-rate would have; negative means timing lost money relative
+// to flat-rate.
+func (b DayCostBreakdown) SavedOre() float64 {
+	return b.FlatCostOre() - b.ActualCostOre()
+}
+
+// ExportPricing captures the runtime knobs that turn a slot's raw spot price
+// into the öre/kWh the household actually earns when exporting. Mirrors the
+// three relevant fields on mpc.Params so a single source of truth for the
+// export model is used across plan-vs-actual and historical reporting.
+type ExportPricing struct {
+	BonusOreKwh float64 // added to spot before clamp
+	FeeOreKwh   float64 // subtracted from spot before clamp
+	FlatOreKwh  float64 // if > 0, overrides spot+bonus−fee entirely
+}
+
+// DailyCostBreakdown integrates grid flow across [sinceMs, untilMs] using all
+// three history tiers and prices it slot-by-slot against the prices table for
+// zone. The price for each integration step is the slot whose [slot_ts_ms,
+// slot_ts_ms+slot_len_min*60000) window contains the midpoint of (prev_ts,
+// ts_ms] — using the midpoint instead of either edge keeps the result stable
+// across slot boundaries (no off-by-one based on which side of the boundary a
+// sample landed on).
+//
+// Two SQL round-trips: one for slot-weighted actuals, one for unweighted
+// averages over slots in the range. SetMaxOpenConns(1) makes interleaved
+// queries deadlock, so they're sequential by design.
+//
+// Returns zeroes (not an error) when the history is empty over the range —
+// callers can render that as "no data" without special-casing nil.
+func (s *Store) DailyCostBreakdown(sinceMs, untilMs int64, zone string, ep ExportPricing) (DayCostBreakdown, error) {
+	// Positional `?` params (named params with numeric or leading-digit
+	// names are rejected by the SQLite driver). Args repeat where the SQL
+	// uses the same logical value more than once — keep the order in lock
+	// step with the `?`s below.
+	const integrate = `
+WITH all_rows AS (
+	SELECT ts_ms, COALESCE(grid_w, 0) AS grid_w FROM history_hot  WHERE ts_ms BETWEEN ? AND ?
+	UNION ALL
+	SELECT ts_ms, COALESCE(grid_w, 0)            FROM history_warm WHERE ts_ms BETWEEN ? AND ?
+	UNION ALL
+	SELECT ts_ms, COALESCE(grid_w, 0)            FROM history_cold WHERE ts_ms BETWEEN ? AND ?
+),
+lagged AS (
+	SELECT ts_ms, grid_w, LAG(ts_ms) OVER (ORDER BY ts_ms) AS prev_ts FROM all_rows
+),
+priced AS (
+	SELECT
+		l.grid_w,
+		(l.ts_ms - l.prev_ts)              AS dt_ms,
+		(l.ts_ms + l.prev_ts) / 2          AS mid_ts,
+		(SELECT p.total_ore_kwh FROM prices p
+		 WHERE p.zone = ?
+		   AND p.slot_ts_ms <= (l.ts_ms + l.prev_ts) / 2
+		   AND p.slot_ts_ms + p.slot_len_min * 60000 > (l.ts_ms + l.prev_ts) / 2
+		 LIMIT 1)                         AS total_ore,
+		(SELECT p.spot_ore_kwh FROM prices p
+		 WHERE p.zone = ?
+		   AND p.slot_ts_ms <= (l.ts_ms + l.prev_ts) / 2
+		   AND p.slot_ts_ms + p.slot_len_min * 60000 > (l.ts_ms + l.prev_ts) / 2
+		 LIMIT 1)                         AS spot_ore
+	FROM lagged l
+	WHERE l.prev_ts IS NOT NULL
+)
+SELECT
+	COALESCE(SUM(CASE WHEN grid_w > 0 THEN  grid_w * dt_ms / 3600000.0 ELSE 0 END), 0),
+	COALESCE(SUM(CASE WHEN grid_w < 0 THEN -grid_w * dt_ms / 3600000.0 ELSE 0 END), 0),
+	COALESCE(SUM(CASE WHEN grid_w > 0 AND total_ore IS NOT NULL
+	             THEN  grid_w * dt_ms / 3600000.0 * total_ore / 1000.0 ELSE 0 END), 0),
+	COALESCE(SUM(CASE WHEN grid_w < 0 AND spot_ore IS NOT NULL THEN
+		-grid_w * dt_ms / 3600000.0 *
+		(CASE WHEN ? > 0 THEN ?
+		      WHEN (spot_ore + ? - ?) > 0 THEN (spot_ore + ? - ?)
+		      ELSE 0
+		 END) / 1000.0
+	ELSE 0 END), 0)
+FROM priced
+`
+
+	var out DayCostBreakdown
+	if err := s.db.QueryRow(integrate,
+		sinceMs, untilMs, // history_hot
+		sinceMs, untilMs, // history_warm
+		sinceMs, untilMs, // history_cold
+		zone, // import-price lookup
+		zone, // spot-price lookup
+		ep.FlatOreKwh, ep.FlatOreKwh, // CASE WHEN flat > 0 THEN flat
+		ep.BonusOreKwh, ep.FeeOreKwh, // CASE WHEN (spot + bonus - fee) > 0
+		ep.BonusOreKwh, ep.FeeOreKwh, // THEN (spot + bonus - fee)
+	).Scan(&out.ImportWh, &out.ExportWh, &out.ImportCostOre, &out.ExportRevenueOre); err != nil {
+		return DayCostBreakdown{}, err
+	}
+
+	// Unweighted averages over slots in range — the flat-rate baseline.
+	const avgQ = `
+SELECT
+	COALESCE(AVG(total_ore_kwh), 0),
+	COALESCE(AVG(
+		CASE WHEN ? > 0 THEN ?
+		     WHEN (spot_ore_kwh + ? - ?) > 0 THEN (spot_ore_kwh + ? - ?)
+		     ELSE 0
+		END
+	), 0)
+FROM prices
+WHERE zone = ? AND slot_ts_ms BETWEEN ? AND ?
+`
+	if err := s.db.QueryRow(avgQ,
+		ep.FlatOreKwh, ep.FlatOreKwh,
+		ep.BonusOreKwh, ep.FeeOreKwh,
+		ep.BonusOreKwh, ep.FeeOreKwh,
+		zone, sinceMs, untilMs,
+	).Scan(&out.AvgImportOreKwh, &out.AvgExportOreKwh); err != nil {
+		return DayCostBreakdown{}, err
+	}
+
+	return out, nil
+}

--- a/go/internal/state/cost_test.go
+++ b/go/internal/state/cost_test.go
@@ -1,0 +1,195 @@
+package state
+
+import (
+	"math"
+	"testing"
+)
+
+// approxEq compares two float64 values within tol absolute error.
+func approxEq(a, b, tol float64) bool {
+	return math.Abs(a-b) <= tol
+}
+
+func TestDailyCostBreakdown_SlotWeightedAgainstFlat(t *testing.T) {
+	s := freshStore(t)
+
+	// Two 1-hour price slots covering [0, 7200000) ms.
+	// Slot 0 is cheap, slot 1 is expensive — so importing in slot 0 and
+	// exporting in slot 1 is the *timing-winning* scenario; the planner
+	// should look better than flat-rate.
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 80, TotalOreKwh: 100, Source: "test", FetchedAtMs: 0},
+		{Zone: "SE3", SlotTsMs: 3600000, SlotLenMin: 60, SpotOreKwh: 150, TotalOreKwh: 200, Source: "test", FetchedAtMs: 0},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+
+	// History samples every 10 min = 600_000 ms.
+	// Slot 0 (mid-times 300k..3300k all inside [0, 3600000)):
+	//   ts 600k, 1200k, 1800k, 2400k, 3000k, 3600k — grid_w = +1000 W (import 1 kW)
+	// Slot 1 (mid-times 3900k..6900k all inside [3600000, 7200000)):
+	//   ts 4200k, 4800k, 5400k, 6000k, 6600k, 7200k — grid_w = -2000 W (export 2 kW)
+	//
+	// Each integration step covers dt = 600_000 ms = 1/6 h.
+	// Slot 0: 6 steps × 1000 W × 1/6 h = 1000 Wh import.
+	// Slot 1: 6 steps × 2000 W × 1/6 h = 2000 Wh export.
+	pts := []HistoryPoint{}
+	for i := 1; i <= 6; i++ {
+		pts = append(pts, HistoryPoint{TsMs: int64(i) * 600_000, GridW: 1000})
+	}
+	for i := 7; i <= 12; i++ {
+		pts = append(pts, HistoryPoint{TsMs: int64(i) * 600_000, GridW: -2000})
+	}
+	if err := s.BulkRecordHistory(pts); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	ep := ExportPricing{} // no bonus/fee/flat → export = spot, clamped at 0
+
+	b, err := s.DailyCostBreakdown(0, 7_200_000, "SE3", ep)
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+
+	// Volumes: the first sample (ts=600k) has prev_ts=NULL after LAG and
+	// is dropped; integration starts at the second sample. So we lose one
+	// 10-min step of slot-0 import → 5 steps × 1 kW × 1/6 h = 833.33 Wh.
+	// All 6 export samples have a previous sample (the last import sample
+	// at ts=3600k is their predecessor) → 6 steps × 2 kW × 1/6 h = 2000 Wh.
+	wantImpWh := 5.0 * 1000.0 / 6.0
+	wantExpWh := 6.0 * 2000.0 / 6.0
+	if !approxEq(b.ImportWh, wantImpWh, 0.01) {
+		t.Errorf("ImportWh = %.4f, want %.4f", b.ImportWh, wantImpWh)
+	}
+	if !approxEq(b.ExportWh, wantExpWh, 0.01) {
+		t.Errorf("ExportWh = %.4f, want %.4f", b.ExportWh, wantExpWh)
+	}
+
+	// First export sample (ts=4200k, prev=3600k) midpoint = 3900k → slot 1.
+	// All export samples are priced at slot 1 (spot=150, no bonus/fee).
+	// First import-after-NULL sample drops out; remaining import samples are
+	// all priced at slot 0 (total=100). One step crosses the slot boundary:
+	// sample at ts=3600k, prev=3000k, mid=3300k → slot 0. Good.
+	//
+	// import_cost = 833.33 Wh × 100 öre/kWh / 1000 = 83.333 öre
+	// export_rev  = 2000 Wh × 150 öre/kWh / 1000   = 300 öre
+	wantImpCost := wantImpWh * 100.0 / 1000.0
+	wantExpRev := wantExpWh * 150.0 / 1000.0
+	if !approxEq(b.ImportCostOre, wantImpCost, 0.01) {
+		t.Errorf("ImportCostOre = %.4f, want %.4f", b.ImportCostOre, wantImpCost)
+	}
+	if !approxEq(b.ExportRevenueOre, wantExpRev, 0.01) {
+		t.Errorf("ExportRevenueOre = %.4f, want %.4f", b.ExportRevenueOre, wantExpRev)
+	}
+
+	// Avg prices are unweighted means over slots in range — mirrors
+	// mpc.ComputeBaselines' flat-avg pricing.
+	// avg_import = (100 + 200) / 2 = 150
+	// avg_export = (80 + 150) / 2 = 115
+	if !approxEq(b.AvgImportOreKwh, 150, 0.01) {
+		t.Errorf("AvgImportOreKwh = %.4f, want 150", b.AvgImportOreKwh)
+	}
+	if !approxEq(b.AvgExportOreKwh, 115, 0.01) {
+		t.Errorf("AvgExportOreKwh = %.4f, want 115", b.AvgExportOreKwh)
+	}
+
+	// Derived ergonomics:
+	//   actual = 83.333 - 300 = -216.667 (net earned 216.667 öre)
+	//   flat   = (833.33 * 150 - 2000 * 115) / 1000 = (125000 - 230000) / 1000 = -105 öre
+	//   saved  = flat - actual = -105 - (-216.667) = 111.667 öre  (timing won)
+	wantActual := wantImpCost - wantExpRev
+	wantFlat := (wantImpWh*150.0 - wantExpWh*115.0) / 1000.0
+	wantSaved := wantFlat - wantActual
+	if !approxEq(b.ActualCostOre(), wantActual, 0.01) {
+		t.Errorf("ActualCostOre = %.4f, want %.4f", b.ActualCostOre(), wantActual)
+	}
+	if !approxEq(b.FlatCostOre(), wantFlat, 0.01) {
+		t.Errorf("FlatCostOre = %.4f, want %.4f", b.FlatCostOre(), wantFlat)
+	}
+	if !approxEq(b.SavedOre(), wantSaved, 0.01) {
+		t.Errorf("SavedOre = %.4f, want %.4f", b.SavedOre(), wantSaved)
+	}
+	if wantSaved <= 0 {
+		t.Fatalf("test scenario malformed — flat should beat actual by a positive margin, got %.2f", wantSaved)
+	}
+}
+
+func TestDailyCostBreakdown_ExportClampedAtZero(t *testing.T) {
+	s := freshStore(t)
+
+	// Single slot with NEGATIVE spot price — export should earn 0 (clamped),
+	// not pay-to-export.
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: -50, TotalOreKwh: 30, Source: "test", FetchedAtMs: 0},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+
+	// Just export, no import.
+	pts := []HistoryPoint{}
+	for i := 1; i <= 6; i++ {
+		pts = append(pts, HistoryPoint{TsMs: int64(i) * 600_000, GridW: -1000})
+	}
+	if err := s.BulkRecordHistory(pts); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	ep := ExportPricing{BonusOreKwh: 5, FeeOreKwh: 10} // bonus 5 - fee 10 on top of -50 → still ≤ 0
+
+	b, err := s.DailyCostBreakdown(0, 3_600_000, "SE3", ep)
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+	if b.ExportRevenueOre != 0 {
+		t.Errorf("ExportRevenueOre = %.4f, want 0 (clamped on negative net export price)", b.ExportRevenueOre)
+	}
+	// AvgExportOreKwh should also be the clamped value (0) for the one slot.
+	if !approxEq(b.AvgExportOreKwh, 0, 0.001) {
+		t.Errorf("AvgExportOreKwh = %.4f, want 0", b.AvgExportOreKwh)
+	}
+}
+
+func TestDailyCostBreakdown_FlatExportOverride(t *testing.T) {
+	s := freshStore(t)
+
+	// When ExportPricing.FlatOreKwh > 0, it must override the spot model
+	// entirely (mirrors mpc.SlotExportPriceOre's ExportOrePerKWh branch).
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 200, TotalOreKwh: 250, Source: "test", FetchedAtMs: 0},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	pts := []HistoryPoint{
+		{TsMs: 600_000, GridW: -1000},
+		{TsMs: 1_200_000, GridW: -1000},
+	}
+	if err := s.BulkRecordHistory(pts); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	ep := ExportPricing{FlatOreKwh: 42}
+	b, err := s.DailyCostBreakdown(0, 3_600_000, "SE3", ep)
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+	// One step survives LAG (ts=1200k, prev=600k), 1 kW × 1/6 h = 166.67 Wh
+	// × 42 öre/kWh / 1000 = 7.0 öre.
+	wantRev := (1000.0 / 6.0) * 42.0 / 1000.0
+	if !approxEq(b.ExportRevenueOre, wantRev, 0.01) {
+		t.Errorf("ExportRevenueOre = %.4f, want %.4f", b.ExportRevenueOre, wantRev)
+	}
+	if !approxEq(b.AvgExportOreKwh, 42, 0.01) {
+		t.Errorf("AvgExportOreKwh = %.4f, want 42 (flat override)", b.AvgExportOreKwh)
+	}
+}
+
+func TestDailyCostBreakdown_EmptyRange(t *testing.T) {
+	s := freshStore(t)
+	b, err := s.DailyCostBreakdown(0, 1_000_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown empty: %v", err)
+	}
+	if b.ImportWh != 0 || b.ExportWh != 0 || b.ImportCostOre != 0 || b.ExportRevenueOre != 0 {
+		t.Errorf("empty range returned non-zero breakdown: %+v", b)
+	}
+}


### PR DESCRIPTION
## Summary

- New `state.DailyCostBreakdown(sinceMs, untilMs, zone, exportPricing)` integrates grid traffic across all three history tiers and joins it to the `prices` table for slot-weighted import cost + export revenue, plus the unweighted slot-mean prices the flat-rate baseline needs. Mirrors `mpc.ComputeBaselines` so a finished day's historical answer matches what the live plan badge said when that day was the plan.
- New `GET /api/savings/daily?days=N` returns per-day import/export Wh, actual cost, flat cost, saved öre, and a totals block. Same immutable-past-day cache pattern as `handleEnergyDaily`. Empty days when `cfg.Price.Zone` is unset.
- Slot lookup uses the midpoint of `(prev_ts, ts_ms]` so a sample on a slot boundary isn't off-by-one toward either side. Export pricing mirrors `mpc.SlotExportPriceOre` exactly: `FlatOreKwh > 0` overrides; otherwise `max(spot + bonus − fee, 0)`.

## Test plan

- [x] `go test ./internal/state/ -run TestDailyCostBreakdown` — 4 cases: slot-weighted vs flat with timing win, export clamped at zero on negative spot, flat-export override path, empty range.
- [x] `go test ./internal/api/ -run TestHandleSavings` — 4 cases: nil state, unconfigured zone, end-to-end with seeded prices+history, days clamping.
- [x] `make test` — all packages green.
- [x] `make e2e` — full-stack green.

Closes #278.