### PR TITLE
feat(control): plan-grid soft reactive cap on energy-dispatch path

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -433,7 +433,102 @@ enough samples tamed β. Returning the prior instead means the
 forecast degrades to "as good as before we had a twin" during the
 bad period, and recovers when β does.
 
-## 8. Default mode (`driver_default_mode`)
+## 8. Plan-grid soft reactive cap (energy-dispatch path)
+
+The `planner_cheap` / `planner_arbitrage` dispatch path (`useEnergyPath`
+in [`dispatch.go`](../go/internal/control/dispatch.go)) executes the
+plan's per-slot battery Wh budget as instantaneous power:
+
+```
+targetTotalW = remainingWh × 3600 / remainingS
+```
+
+This is the right behaviour when the forecast holds: the battery
+delivers exactly the energy the MPC scheduled, and grid is the
+residual. It is the wrong behaviour when the forecast breaks during
+the slot. Concretely: the MPC planned to charge 4.8 kW from
+forecast 5 kW PV (gridW ≈ 0). A cloud passes, live PV drops to
+1.8 kW. The formula still demands 4.8 kW of battery charge, and the
+3 kW gap is pulled from the grid — at whatever import price the slot
+has — until the reactive replan (`mpc/service.go:266-290`) catches up.
+That trigger is gated by a 500 Wh PV-error integral and a 60 s
+cooldown; in practice it can take 10+ minutes of unintended grid
+import before the next plan re-decides. Originating field report:
+2026-05-19, `planner_arbitrage`.
+
+### How the cap works
+
+`mpc.Action.GridW` is the plan's own forecast of slot-average grid
+power (site-signed: + = import). It is plumbed through
+`mpc.SlotDirective.GridW` → `control.SlotDirective.PlannedGridW` (a
+pointer, so nil opts out for tests / legacy callers).
+
+Every tick on the energy path, after the EV / PV-absorber clamps but
+before `totalCorrection` is set, the cap computes
+
+```
+gridErr := rawGridW − *PlannedGridW
+```
+
+and, **only when `targetTotalW > 0`** (charging slot) and
+`gridErr > 100 W`, backs the target off by the gap:
+
+```
+targetTotalW = max(0, targetTotalW − gridErr)
+```
+
+The 100 W deadband matches `IdleGateThresholdW` / `evActiveThresholdW`
+used elsewhere in the package — below it the divergence is meter
+noise. The floor at 0 prevents the cap from flipping dispatch
+direction.
+
+### Charge-only by design
+
+The mirror case (discharge slot, live gridW more negative than plan)
+is intentionally **not** clamped. Three reasons:
+
+1. **The Wh budget gets delivered either way.** Extra export during
+   a discharge slot comes from load undershooting forecast, not from
+   over-discharging the battery. Backing off would leave Wh sitting
+   in the battery for a future slot the DP already evaluated against
+   the current slot and chose to skip — undermining the plan.
+
+2. **Economics are asymmetric.** Extra import during a charge slot
+   costs the operator real money (paying for energy the plan assumed
+   PV would supply, often at peak prices the DP would never have
+   chosen for charging). Extra export during a discharge slot is
+   bonus revenue at the slot's chosen export price, which the DP
+   picked precisely because it's good.
+
+3. **The discharge-side divergence has other handlers.** Live import
+   > plan during a discharge slot means load surged; the reactive
+   replan picks it up, and the fuse guard / SoC floor / EV-discharge
+   cap protect against the dangerous edges.
+
+Regression guards against re-symmetrising the cap:
+`TestEnergyDispatchPlannedGridCapBacksOffChargeWhenPVDrops` (charge
+case fires correctly), `TestEnergyDispatchPlannedGridCapDoesNotFireOnDischarge`
+(discharge case must not fire). Allowed-import case:
+`TestEnergyDispatchPlannedGridCapAllowsPlannedImport` (cheap-grid
+charge slot follows plan when live gridW matches plan's import).
+
+### Interaction with the PV surplus absorber
+
+The PV surplus absorber (same code path, ~30 lines earlier) handles
+the opposite-direction case for charge slots: live gridW *more*
+negative than plan (PV came in higher than forecast). It
+opportunistically *adds* charge to soak up the extra surplus. The
+two clamps are direction-orthogonal and do not interact.
+
+### When to revisit
+
+If a future planner mode wants to honour planned discharge Wh more
+loosely (e.g. let discharge back off when grid is exporting beyond
+some operator-set ceiling), that's a separate clamp — do not
+re-enable the discharge branch here without a field-validated reason
+and a regression test that captures the specific motivating scenario.
+
+## 9. Default mode (`driver_default_mode`)
 
 Every Lua driver exposes a `driver_default_mode()` function invoked
 by `reg.SendDefault` ([`registry.go:255-267`](../go/internal/drivers/registry.go)).
@@ -489,7 +584,7 @@ Triggers for default-mode invocation:
 - Site-meter stale short-circuit (every driver, see section 2)
 - Driver shutdown / hot-reload
 
-## 9. Failure-mode catalog
+## 10. Failure-mode catalog
 
 | Failure | Detection | Response |
 |---|---|---|

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -921,6 +921,7 @@ func main() {
 			if !ok {
 				return control.SlotDirective{}, false
 			}
+			plannedGridW := d.GridW
 			return control.SlotDirective{
 				SlotStart:       d.SlotStart,
 				SlotEnd:         d.SlotEnd,
@@ -928,6 +929,7 @@ func main() {
 				SoCTargetPct:    d.SoCTargetPct,
 				Strategy:        string(d.Strategy),
 				PVLimitW:        d.PVLimitW,
+				PlannedGridW:    &plannedGridW,
 			}, true
 		}
 		// Default to the energy-allocation path. The plan is a

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -921,7 +921,6 @@ func main() {
 			if !ok {
 				return control.SlotDirective{}, false
 			}
-			plannedGridW := d.GridW
 			return control.SlotDirective{
 				SlotStart:       d.SlotStart,
 				SlotEnd:         d.SlotEnd,
@@ -929,7 +928,8 @@ func main() {
 				SoCTargetPct:    d.SoCTargetPct,
 				Strategy:        string(d.Strategy),
 				PVLimitW:        d.PVLimitW,
-				PlannedGridW:    &plannedGridW,
+				PlannedGridW:    d.GridW,
+				HasPlannedGridW: true,
 			}, true
 		}
 		// Default to the energy-allocation path. The plan is a

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1213,14 +1213,21 @@ func TestEnergyDispatchNilPlannedGridWBypassesCap(t *testing.T) {
 	}
 }
 
-// TestEnergyDispatchPlannedGridCapBacksOffDischargeOnOverExport —
-// symmetric to the charge case. Plan: discharge slot, PlannedGridW=−200
-// (expected to export 200 W after covering load). Load drops, live
-// gridW = −3000 (exporting 3 kW), so without the cap the battery
-// would keep discharging at planned power and the extra goes to grid
-// at whatever spot price the slot has. Cap should back off discharge
-// by the gap (≈2800 W).
-func TestEnergyDispatchPlannedGridCapBacksOffDischargeOnOverExport(t *testing.T) {
+// TestEnergyDispatchPlannedGridCapDoesNotFireOnDischarge — the cap
+// is deliberately ONE-WAY (charge direction only). Plan: discharge
+// slot, PlannedGridW=−200 (expected export 200 W after covering load).
+// Load drops, live gridW = −3000 (exporting 3 kW). The battery must
+// still deliver its planned discharge — the extra export is bonus
+// revenue at the slot's chosen price, not a problem.
+//
+// Rationale (see dispatch.go cap docstring): the battery delivers
+// planned Wh either way; the extra export comes from load undershoot,
+// not over-discharge. Backing off would leave Wh in the battery for a
+// later slot the DP already evaluated and rejected, undermining the
+// plan. Economics are asymmetric vs the charge case.
+//
+// Regression guard against re-symmetrising the cap.
+func TestEnergyDispatchPlannedGridCapDoesNotFireOnDischarge(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{
 		SlotStart:       now,
@@ -1245,12 +1252,12 @@ func TestEnergyDispatchPlannedGridCapBacksOffDischargeOnOverExport(t *testing.T)
 		t.Fatalf("want 1 target, got %d", len(targets))
 	}
 	got := targets[0].TargetW
-	// Raw plan: -4000 W. gridErr = -3000 - (-200) = -2800. Cap pulls
-	// target toward 0: -4000 - (-2800) = -1200 W. Tolerance ±300 W
-	// covers slew + slot-time drift.
-	if got < -1500 || got > -900 {
-		t.Errorf("TargetW = %f W — cap should pull discharge back to ~−1200 W "+
-			"(plan −4000 W minus 2800 W of unforecast extra export)", got)
+	// Battery must follow raw plan ~−4000 W (capped by per-cmd 5 kW).
+	// Anything above −3500 means the cap mistakenly fired on discharge.
+	if got > -3500 {
+		t.Errorf("TargetW = %f W — discharge cap fired (regression). "+
+			"The plan-grid cap must be charge-direction-only; extra "+
+			"export during a discharge slot is bonus revenue, not a problem.", got)
 	}
 }
 

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1053,6 +1053,207 @@ func TestEnergyDispatchHoldsPlanUnderArbitrage(t *testing.T) {
 	}
 }
 
+// ptr is a tiny helper for tests that need a *float64 on SlotDirective.
+func ptr[T any](v T) *T { return &v }
+
+// ---- planner_arbitrage PlannedGridW soft reactive cap ----
+//
+// Community report (2026-05-19, planner_arbitrage): "When the sun goes
+// behind clouds the system compensates with grid import to maintain the
+// planned battery_w. Didn't used to behave that way — battery used to
+// just absorb what surplus existed." Root cause: the energy-allocation
+// path executes BatteryEnergyWh as `remainingWh × 3600 / remainingS`
+// without consulting live gridW. When forecast PV doesn't materialise,
+// the formula still demands the planned charge power and grid fills the
+// gap until the reactive replan trigger (mpc/service.go, 500 Wh PV
+// integral + 60 s cooldown) catches up — typically 10+ minutes.
+//
+// The fix: SlotDirective.PlannedGridW (the plan's own gridW forecast)
+// gets used as a soft reactive cap. When live gridW exceeds plan in
+// the dispatch direction, back off targetTotalW by the gap.
+
+// TestEnergyDispatchPlannedGridCapBacksOffChargeWhenPVDrops is the
+// motivating regression. Plan: arbitrage charge slot, 1200 Wh over 15
+// min ≈ 4800 W, with PV forecast 5 kW so gridW forecast ≈ 0. Cloud
+// hits, live PV drops to 1.8 kW (load 0 W), so without the cap the
+// battery would charge 4800 W against 1800 W of available PV → 3000 W
+// of grid import. With the cap the battery target should back off to
+// ~1800 W and grid stays near zero.
+func TestEnergyDispatchPlannedGridCapBacksOffChargeWhenPVDrops(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1200, // ~4800 W average
+		Strategy:        "arbitrage",
+		PlannedGridW:    ptr(0.0), // plan expected near-zero grid (PV did the work)
+	}
+	// Live: gridW = +3000 (importing 3 kW because PV dropped to 1800 W
+	// vs 5 kW planned, no other load drift). Battery at 0.
+	store := seedStore(3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -1800, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Raw plan: 4800 W. After cap: 4800 - 3000 = 1800 W. Tolerance ±200 W
+	// covers slot-time drift (a few seconds shaves remainingS).
+	if got > 2000 || got < 1500 {
+		t.Errorf("TargetW = %f W — cap should pull battery back to ~1800 W "+
+			"(plan 4800 W minus 3000 W of unforecast grid import), not chase plan against missing PV", got)
+	}
+}
+
+// TestEnergyDispatchPlannedGridCapAllowsPlannedImport — the cap must
+// NOT fire when the plan committed to importing (cheap-grid charge
+// during a low-price slot). PlannedGridW = +2000 (plan expected to
+// import 2 kW to charge). Live gridW = +2000 matches plan. Battery
+// must follow plan; no cap-induced back-off.
+func TestEnergyDispatchPlannedGridCapAllowsPlannedImport(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 500, // 2000 W average over 15 min
+		Strategy:        "cheap_charge",
+		PlannedGridW:    ptr(2000.0), // plan: import 2 kW to charge
+	}
+	store := seedStore(2000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	if got < 1800 || got > 2200 {
+		t.Errorf("TargetW = %f W — live gridW matches plan, battery must follow plan (~2000 W) "+
+			"without any cap pull-back", got)
+	}
+}
+
+// TestEnergyDispatchPlannedGridCapNoFireInsideDeadband — small live
+// divergences (≤100 W) are meter noise / smoothing residue. The cap
+// must not fire there, otherwise it nibbles at every tick.
+func TestEnergyDispatchPlannedGridCapNoFireInsideDeadband(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1200, // 4800 W average
+		Strategy:        "arbitrage",
+		PlannedGridW:    ptr(0.0),
+	}
+	// Live grid +50 W — inside the 100 W deadband.
+	store := seedStore(50, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	if got < 4700 || got > 4900 {
+		t.Errorf("TargetW = %f W — inside the 100 W deadband the cap must stay off "+
+			"and battery follows raw plan (~4800 W)", got)
+	}
+}
+
+// TestEnergyDispatchNilPlannedGridWBypassesCap — legacy callers /
+// tests construct SlotDirective without setting PlannedGridW. The
+// nil pointer is the opt-out signal; behaviour must be unchanged from
+// before the cap landed (battery chases the plan, just like the
+// pre-fix behaviour the community report identified).
+func TestEnergyDispatchNilPlannedGridWBypassesCap(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1200, // 4800 W average
+		Strategy:        "arbitrage",
+		// PlannedGridW intentionally nil
+	}
+	store := seedStore(3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// No cap → battery follows plan ~4800 W (pre-fix behaviour).
+	if got < 4700 || got > 4900 {
+		t.Errorf("TargetW = %f W — with PlannedGridW=nil the cap must not fire; "+
+			"behaviour should be identical to pre-fix arbitrage (~4800 W)", got)
+	}
+}
+
+// TestEnergyDispatchPlannedGridCapBacksOffDischargeOnOverExport —
+// symmetric to the charge case. Plan: discharge slot, PlannedGridW=−200
+// (expected to export 200 W after covering load). Load drops, live
+// gridW = −3000 (exporting 3 kW), so without the cap the battery
+// would keep discharging at planned power and the extra goes to grid
+// at whatever spot price the slot has. Cap should back off discharge
+// by the gap (≈2800 W).
+func TestEnergyDispatchPlannedGridCapBacksOffDischargeOnOverExport(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -1000, // -4000 W average discharge
+		Strategy:        "arbitrage",
+		PlannedGridW:    ptr(-200.0),
+	}
+	store := seedStore(-3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -3500, 0.5},
+	})
+	store.Update("pv-1", telemetry.DerPV, -100, nil, nil)
+	store.DriverHealthMut("pv-1").RecordSuccess()
+
+	st := newStateWithEnergyDispatch(dir, "ferroamp")
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Raw plan: -4000 W. gridErr = -3000 - (-200) = -2800. Cap pulls
+	// target toward 0: -4000 - (-2800) = -1200 W. Tolerance ±300 W
+	// covers slew + slot-time drift.
+	if got < -1500 || got > -900 {
+		t.Errorf("TargetW = %f W — cap should pull discharge back to ~−1200 W "+
+			"(plan −4000 W minus 2800 W of unforecast extra export)", got)
+	}
+}
+
 // ---- planner_self reactive execution (issue #130) ----
 //
 // planner_self promises "never imports to charge, never exports via the

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1083,7 +1083,8 @@ func TestEnergyDispatchPlannedGridCapBacksOffChargeWhenPVDrops(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 1200, // ~4800 W average
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptrF64(0), // plan expected near-zero grid (PV did the work)
+		PlannedGridW:    0, // plan expected near-zero grid (PV did the work)
+		HasPlannedGridW: true,
 	}
 	// Live: gridW = +3000 (importing 3 kW because PV dropped to 1800 W
 	// vs 5 kW planned, no other load drift). Battery at 0.
@@ -1123,7 +1124,8 @@ func TestEnergyDispatchPlannedGridCapAllowsPlannedImport(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 500, // 2000 W average over 15 min
 		Strategy:        "cheap_charge",
-		PlannedGridW:    ptrF64(2000), // plan: import 2 kW to charge
+		PlannedGridW:    2000, // plan: import 2 kW to charge
+		HasPlannedGridW: true,
 	}
 	store := seedStore(2000, []struct {
 		name          string
@@ -1154,7 +1156,8 @@ func TestEnergyDispatchPlannedGridCapNoFireInsideDeadband(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 1200, // 4800 W average
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptrF64(0),
+		PlannedGridW:    0,
+		HasPlannedGridW: true,
 	}
 	// Live grid +50 W — inside the 100 W deadband.
 	store := seedStore(50, []struct {
@@ -1176,19 +1179,20 @@ func TestEnergyDispatchPlannedGridCapNoFireInsideDeadband(t *testing.T) {
 	}
 }
 
-// TestEnergyDispatchNilPlannedGridWBypassesCap — legacy callers /
-// tests construct SlotDirective without setting PlannedGridW. The
-// nil pointer is the opt-out signal; behaviour must be unchanged from
-// before the cap landed (battery chases the plan, just like the
-// pre-fix behaviour the community report identified).
-func TestEnergyDispatchNilPlannedGridWBypassesCap(t *testing.T) {
+// TestEnergyDispatchUnsetPlannedGridWBypassesCap — legacy callers /
+// tests construct SlotDirective without setting PlannedGridW (and
+// without flipping HasPlannedGridW). HasPlannedGridW=false is the
+// opt-out signal; behaviour must be unchanged from before the cap
+// landed (battery chases the plan, just like the pre-fix behaviour
+// the community report identified).
+func TestEnergyDispatchUnsetPlannedGridWBypassesCap(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{
 		SlotStart:       now,
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 1200, // 4800 W average
 		Strategy:        "arbitrage",
-		// PlannedGridW intentionally nil
+		// PlannedGridW + HasPlannedGridW intentionally zero-valued
 	}
 	store := seedStore(3000, []struct {
 		name          string
@@ -1205,7 +1209,7 @@ func TestEnergyDispatchNilPlannedGridWBypassesCap(t *testing.T) {
 	got := targets[0].TargetW
 	// No cap → battery follows plan ~4800 W (pre-fix behaviour).
 	if got < 4700 || got > 4900 {
-		t.Errorf("TargetW = %f W — with PlannedGridW=nil the cap must not fire; "+
+		t.Errorf("TargetW = %f W — with HasPlannedGridW=false the cap must not fire; "+
 			"behaviour should be identical to pre-fix arbitrage (~4800 W)", got)
 	}
 }
@@ -1231,7 +1235,8 @@ func TestEnergyDispatchPlannedGridCapDoesNotFireOnDischarge(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: -1000, // -4000 W average discharge
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptrF64(-200),
+		PlannedGridW:    -200,
+		HasPlannedGridW: true,
 	}
 	store := seedStore(-3000, []struct {
 		name          string

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1053,9 +1053,6 @@ func TestEnergyDispatchHoldsPlanUnderArbitrage(t *testing.T) {
 	}
 }
 
-// ptr is a tiny helper for tests that need a *float64 on SlotDirective.
-func ptr[T any](v T) *T { return &v }
-
 // ---- planner_arbitrage PlannedGridW soft reactive cap ----
 //
 // Community report (2026-05-19, planner_arbitrage): "When the sun goes
@@ -1086,7 +1083,7 @@ func TestEnergyDispatchPlannedGridCapBacksOffChargeWhenPVDrops(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 1200, // ~4800 W average
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptr(0.0), // plan expected near-zero grid (PV did the work)
+		PlannedGridW:    ptrF64(0), // plan expected near-zero grid (PV did the work)
 	}
 	// Live: gridW = +3000 (importing 3 kW because PV dropped to 1800 W
 	// vs 5 kW planned, no other load drift). Battery at 0.
@@ -1126,7 +1123,7 @@ func TestEnergyDispatchPlannedGridCapAllowsPlannedImport(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 500, // 2000 W average over 15 min
 		Strategy:        "cheap_charge",
-		PlannedGridW:    ptr(2000.0), // plan: import 2 kW to charge
+		PlannedGridW:    ptrF64(2000), // plan: import 2 kW to charge
 	}
 	store := seedStore(2000, []struct {
 		name          string
@@ -1157,7 +1154,7 @@ func TestEnergyDispatchPlannedGridCapNoFireInsideDeadband(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: 1200, // 4800 W average
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptr(0.0),
+		PlannedGridW:    ptrF64(0),
 	}
 	// Live grid +50 W — inside the 100 W deadband.
 	store := seedStore(50, []struct {
@@ -1234,7 +1231,7 @@ func TestEnergyDispatchPlannedGridCapDoesNotFireOnDischarge(t *testing.T) {
 		SlotEnd:         now.Add(15 * time.Minute),
 		BatteryEnergyWh: -1000, // -4000 W average discharge
 		Strategy:        "arbitrage",
-		PlannedGridW:    ptr(-200.0),
+		PlannedGridW:    ptrF64(-200),
 	}
 	store := seedStore(-3000, []struct {
 		name          string

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -62,6 +62,22 @@ type SlotDirective struct {
 	SoCTargetPct    float64
 	Strategy        string  // echoed for logging / API; mirrors mpc.Mode
 	PVLimitW        float64 // 0 = no curtail; > 0 = cap aggregate PV output
+
+	// PlannedGridW is the plan's forecast of slot-average gridW given the
+	// planned battery / load / PV mix (site-signed: + = import). The
+	// energy-dispatch path uses it as a soft reactive cap: don't push
+	// live gridW past plan in the dispatch direction. When live PV / load
+	// drifts away from the plan's forecast — e.g. a cloud cuts PV mid-
+	// slot during a planner_arbitrage charge slot that expected to charge
+	// off solar — the cap pulls the battery toward "what would make
+	// live gridW match plan", preventing the energy budget from blindly
+	// driving extra grid import (or, on a discharge slot, extra export).
+	//
+	// Pointer so the zero-value SlotDirective used by existing tests
+	// (and any caller that doesn't know the plan's grid forecast) opts
+	// out of the cap by default. main.go populates it when running
+	// against a real MPC plan.
+	PlannedGridW *float64
 }
 
 // SlotDirectiveFunc returns the plan's energy-allocation directive for
@@ -920,6 +936,55 @@ func ComputeDispatch(
 			}
 			if targetTotalW > ceiling {
 				targetTotalW = ceiling
+			}
+		}
+
+		// Plan-grid soft reactive cap. When the plan committed to a
+		// gridW forecast for this slot, don't let the energy-path
+		// target push live gridW past plan in the dispatch direction.
+		//
+		// Catches the "cloud cuts PV mid-charge-slot, energy budget
+		// chases plan via grid import" failure mode: plan thought
+		// gridW ≈ 0 with PV doing the work, PV drops 3 kW, live gridW
+		// imports — without this cap, `remainingWh × 3600 / remainingS`
+		// holds the planned charge power against real (now-grid-fed)
+		// PV deficit until the reactive replan in mpc/service.go:266–290
+		// fires (≥10 min later, gated by the 500 Wh PV-error integral
+		// and the 60 s cooldown). The cap pulls the battery target
+		// toward "what would make live gridW match plan", reducing the
+		// damage in the gap.
+		//
+		// Direction-asymmetric on purpose: only fires when the live
+		// divergence is in the SAME direction as the dispatch. Charging
+		// slot importing more than plan → back off charge. Discharging
+		// slot exporting more than plan → back off discharge. The
+		// opposite directions are handled above:
+		//   - charging slot exporting more than plan → PV surplus
+		//     absorber (line 866) opportunistically adds charge
+		//   - discharging slot importing more than plan → next replan
+		//     handles it (no clamp; the plan still wants the discharge,
+		//     it just turned out to be insufficient)
+		//
+		// 100 W deadband matches IdleGateThresholdW / evActiveThresholdW
+		// elsewhere in this package — below it, the live divergence
+		// is meter noise / smoothing residue and the energy path keeps
+		// following plan.
+		if currentDirective.PlannedGridW != nil {
+			const planGridDeadband = 100.0
+			gridErr := rawGridW - *currentDirective.PlannedGridW
+			switch {
+			case targetTotalW > 0 && gridErr > planGridDeadband:
+				adjusted := targetTotalW - gridErr
+				if adjusted < 0 {
+					adjusted = 0
+				}
+				targetTotalW = adjusted
+			case targetTotalW < 0 && gridErr < -planGridDeadband:
+				adjusted := targetTotalW - gridErr
+				if adjusted > 0 {
+					adjusted = 0
+				}
+				targetTotalW = adjusted
 			}
 		}
 

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -939,49 +939,54 @@ func ComputeDispatch(
 			}
 		}
 
-		// Plan-grid soft reactive cap. When the plan committed to a
-		// gridW forecast for this slot, don't let the energy-path
-		// target push live gridW past plan in the dispatch direction.
+		// Plan-grid soft reactive cap (charge-direction only).
 		//
 		// Catches the "cloud cuts PV mid-charge-slot, energy budget
 		// chases plan via grid import" failure mode: plan thought
-		// gridW ≈ 0 with PV doing the work, PV drops 3 kW, live gridW
-		// imports — without this cap, `remainingWh × 3600 / remainingS`
-		// holds the planned charge power against real (now-grid-fed)
-		// PV deficit until the reactive replan in mpc/service.go:266–290
-		// fires (≥10 min later, gated by the 500 Wh PV-error integral
-		// and the 60 s cooldown). The cap pulls the battery target
-		// toward "what would make live gridW match plan", reducing the
-		// damage in the gap.
+		// gridW ≈ 0 with PV doing the charging work, PV drops 3 kW,
+		// live gridW imports — without this cap, `remainingWh × 3600
+		// / remainingS` holds the planned charge power against the
+		// real (now-grid-fed) PV deficit until the reactive replan in
+		// mpc/service.go:266–290 fires (≥10 min later, gated by the
+		// 500 Wh PV-error integral and the 60 s cooldown). The cap
+		// pulls the battery target toward "what would make live gridW
+		// match plan", reducing the damage in the gap. Floored at 0
+		// so the cap can never flip dispatch direction.
 		//
-		// Direction-asymmetric on purpose: only fires when the live
-		// divergence is in the SAME direction as the dispatch. Charging
-		// slot importing more than plan → back off charge. Discharging
-		// slot exporting more than plan → back off discharge. The
-		// opposite directions are handled above:
-		//   - charging slot exporting more than plan → PV surplus
-		//     absorber (line 866) opportunistically adds charge
-		//   - discharging slot importing more than plan → next replan
-		//     handles it (no clamp; the plan still wants the discharge,
-		//     it just turned out to be insufficient)
+		// CHARGE-ONLY by design. The mirror case (discharge slot,
+		// live gridW more negative than plan) is intentionally NOT
+		// clamped:
+		//
+		//   - Battery delivers the planned discharge Wh either way;
+		//     the "extra" export to grid comes from load undershooting
+		//     forecast, not from over-discharging. Backing off would
+		//     leave Wh in the battery for a later slot the DP already
+		//     evaluated and rejected — undermining the DP's choice.
+		//   - The economics are asymmetric: extra import during a
+		//     charge slot costs the operator (paying for energy the
+		//     plan assumed PV would supply); extra export during a
+		//     discharge slot is bonus revenue at the slot's chosen
+		//     export price.
+		//   - Discharge-direction divergence (live import > plan,
+		//     e.g. load surged) is left to the reactive replan +
+		//     downstream clamps (fuse, SoC floor, EV-discharge cap).
+		//
+		// The charging slot's opposite-direction case (live gridW
+		// more negative than plan because PV came in higher than
+		// forecast) is handled above by the PV surplus absorber
+		// (dispatch.go ~line 866), which opportunistically *adds*
+		// charge.
 		//
 		// 100 W deadband matches IdleGateThresholdW / evActiveThresholdW
 		// elsewhere in this package — below it, the live divergence
 		// is meter noise / smoothing residue and the energy path keeps
 		// following plan.
-		if currentDirective.PlannedGridW != nil {
+		if currentDirective.PlannedGridW != nil && targetTotalW > 0 {
 			const planGridDeadband = 100.0
 			gridErr := rawGridW - *currentDirective.PlannedGridW
-			switch {
-			case targetTotalW > 0 && gridErr > planGridDeadband:
+			if gridErr > planGridDeadband {
 				adjusted := targetTotalW - gridErr
 				if adjusted < 0 {
-					adjusted = 0
-				}
-				targetTotalW = adjusted
-			case targetTotalW < 0 && gridErr < -planGridDeadband:
-				adjusted := targetTotalW - gridErr
-				if adjusted > 0 {
 					adjusted = 0
 				}
 				targetTotalW = adjusted

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -65,13 +65,20 @@ type SlotDirective struct {
 
 	// PlannedGridW is the plan's forecast of slot-average gridW given the
 	// planned battery / load / PV mix (site-signed: + = import). The
-	// energy-dispatch path uses it as a soft reactive cap: don't push
-	// live gridW past plan in the dispatch direction. When live PV / load
-	// drifts away from the plan's forecast — e.g. a cloud cuts PV mid-
-	// slot during a planner_arbitrage charge slot that expected to charge
-	// off solar — the cap pulls the battery toward "what would make
+	// energy-dispatch path uses it as a CHARGE-ONLY soft reactive cap:
+	// on a charge slot (targetTotalW > 0), don't push live gridW past
+	// plan in the import direction. When live PV / load drifts away
+	// from the plan's forecast — e.g. a cloud cuts PV mid-slot during
+	// a planner_arbitrage charge slot that expected to charge off
+	// solar — the cap pulls the battery target toward "what would make
 	// live gridW match plan", preventing the energy budget from blindly
-	// driving extra grid import (or, on a discharge slot, extra export).
+	// driving extra grid import.
+	//
+	// Discharge slots are intentionally NOT clamped: extra export during
+	// a discharge slot is bonus revenue (the Wh budget is still delivered
+	// — the extra comes from load undershooting forecast), and backing
+	// off would undermine a DP choice the planner already evaluated. See
+	// docs/safety.md §8 for the full rationale.
 	//
 	// Pointer so the zero-value SlotDirective used by existing tests
 	// (and any caller that doesn't know the plan's grid forecast) opts

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -80,11 +80,13 @@ type SlotDirective struct {
 	// off would undermine a DP choice the planner already evaluated. See
 	// docs/safety.md §8 for the full rationale.
 	//
-	// Pointer so the zero-value SlotDirective used by existing tests
-	// (and any caller that doesn't know the plan's grid forecast) opts
-	// out of the cap by default. main.go populates it when running
-	// against a real MPC plan.
-	PlannedGridW *float64
+	// HasPlannedGridW gates whether the cap should consult PlannedGridW
+	// at all. Stored as a separate bool (rather than a *float64) so the
+	// per-tick directive bridge in main.go doesn't escape-allocate. The
+	// zero-value SlotDirective used by existing tests / legacy callers
+	// has HasPlannedGridW=false → cap opts out by default.
+	PlannedGridW    float64
+	HasPlannedGridW bool
 }
 
 // SlotDirectiveFunc returns the plan's energy-allocation directive for
@@ -988,9 +990,9 @@ func ComputeDispatch(
 		// elsewhere in this package — below it, the live divergence
 		// is meter noise / smoothing residue and the energy path keeps
 		// following plan.
-		if currentDirective.PlannedGridW != nil && targetTotalW > 0 {
+		if currentDirective.HasPlannedGridW && targetTotalW > 0 {
 			const planGridDeadband = 100.0
-			gridErr := rawGridW - *currentDirective.PlannedGridW
+			gridErr := rawGridW - currentDirective.PlannedGridW
 			if gridErr > planGridDeadband {
 				adjusted := targetTotalW - gridErr
 				if adjusted < 0 {

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -210,6 +210,14 @@ type SlotDirective struct {
 	// site's PV-supporting drivers and sends `curtail` commands.
 	PVLimitW float64
 
+	// GridW is the plan's forecast of slot-average grid power given the
+	// planned battery / load / PV mix (site-signed: + = import). The
+	// dispatch layer treats it as a soft reactive cap on the energy
+	// path — battery isn't allowed to push live gridW past plan in the
+	// dispatch direction. See control.SlotDirective.PlannedGridW for
+	// the full rationale.
+	GridW float64
+
 	// LoadpointEnergyWh carries per-loadpoint EV energy budgets for
 	// this slot. Keyed by Loadpoint.ID. Positive = charging energy
 	// the plan allocated. Empty map when no loadpoints are
@@ -260,6 +268,7 @@ func (s *Service) SlotDirectiveAt(now time.Time) (SlotDirective, bool) {
 			SoCTargetPct:    a.SoCPct,
 			Strategy:        s.Defaults.Mode,
 			PVLimitW:        a.PVLimitW,
+			GridW:           a.GridW,
 		}
 		// EV energy budget for the slot (single-loadpoint for now —
 		// keyed under lpID snapshot so the dispatch layer routes

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -212,10 +212,12 @@ type SlotDirective struct {
 
 	// GridW is the plan's forecast of slot-average grid power given the
 	// planned battery / load / PV mix (site-signed: + = import). The
-	// dispatch layer treats it as a soft reactive cap on the energy
-	// path — battery isn't allowed to push live gridW past plan in the
-	// dispatch direction. See control.SlotDirective.PlannedGridW for
-	// the full rationale.
+	// dispatch layer treats it as a CHARGE-ONLY soft reactive cap on
+	// the energy path — on a charging slot, the battery target is
+	// pulled back when live gridW imports more than plan. Discharge
+	// slots are intentionally not clamped (extra export = bonus revenue
+	// at the slot's chosen price). See control.SlotDirective.PlannedGridW
+	// and docs/safety.md §8 for the asymmetry rationale.
 	GridW float64
 
 	// LoadpointEnergyWh carries per-loadpoint EV energy budgets for

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -321,6 +321,7 @@ func TestSlotDirectiveAt(t *testing.T) {
 				SlotLenMin:  slotLenMin,
 				BatteryW:    800, // 800 W × 15/60 h = 200 Wh for the slot
 				SoCPct:      45.5,
+				GridW:       -150, // plan expects 150 W export
 			}},
 		},
 	}
@@ -343,6 +344,12 @@ func TestSlotDirectiveAt(t *testing.T) {
 	}
 	if d.Strategy != ModeArbitrage {
 		t.Errorf("Strategy = %v, want arbitrage", d.Strategy)
+	}
+	// GridW must surface unchanged from the plan action — this is the
+	// wiring the control-layer PlannedGridW cap depends on. If it
+	// silently breaks, the cap silently never fires.
+	if d.GridW != -150 {
+		t.Errorf("GridW = %f, want −150 (must propagate from Action.GridW)", d.GridW)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes a regression reported on `planner_arbitrage`: when a cloud cuts PV mid-charge-slot, the EMS imports from grid to maintain the plan's charge power instead of letting the battery absorb only what PV is actually delivering. Pre-energy-path behaviour was the opposite — battery soaked up only the available surplus, grid stayed near the plan.

**Root cause.** `useEnergyPath` executes `BatteryEnergyWh` as `remainingWh × 3600 / remainingS` without consulting live `gridW`. When forecast PV doesn't materialise, the formula still demands the planned charge power and grid fills the gap. The reactive replan in `mpc/service.go:266-290` would eventually catch up, but it's gated by a 500 Wh PV-error integral and a 60 s cooldown — typically ≥10 min of grid import before a fresh plan re-decides.

**Fix.** Use the plan's own `gridW` forecast (already computed by the DP as `mpc.Action.GridW`) as a **charge-direction-only** soft reactive cap on `targetTotalW`. When `targetTotalW > 0` (charge slot) AND live `gridW − plannedGridW > 100 W` (importing more than plan, outside deadband), back off the target by the gap, floored at zero so the cap can never flip dispatch direction.

**Why charge-only.** The mirror case (discharge slot, live `gridW` more negative than plan) is intentionally NOT clamped:

- The battery still delivers its planned discharge Wh — the "extra" export comes from load undershooting forecast, not over-discharging. Backing off would leave Wh in the battery for a future slot the DP already evaluated and rejected against this one.
- Economics are asymmetric: extra import during a charge slot costs real money (paying for energy the plan assumed PV would supply, often at peak prices the DP would never have chosen for charging); extra export during a discharge slot is bonus revenue at the slot's chosen export price.
- The discharge-direction divergence (live import > plan during a discharge slot, e.g. load surged) is left to the reactive replan + downstream clamps (fuse, SoC floor, EV-discharge cap).

The opposite-direction case for charge slots (live `gridW` more negative than plan, PV came in higher than forecast) is handled by the existing PV surplus absorber that opportunistically *adds* charge.

`PlannedGridW` is a pointer on `control.SlotDirective` so existing tests and legacy callers opt out via nil. Wired through main.go's `SlotDirectiveFunc` adapter.

## Files

- `internal/control/dispatch.go` — `PlannedGridW *float64` field + charge-only cap logic in `useEnergyPath`
- `internal/mpc/service.go` — `SlotDirective.GridW` populated from `a.GridW`
- `internal/mpc/service_test.go` — assertion that `SlotDirectiveAt` propagates `GridW` (silent-regression guard)
- `cmd/forty-two-watts/main.go` — bridges `mpc.SlotDirective.GridW` → `control.SlotDirective.PlannedGridW`
- `internal/control/control_test.go` — regression tests
- `docs/safety.md` — new §8 "Plan-grid soft reactive cap" documenting mechanics + asymmetry rationale

## Test plan

- [x] `go test ./internal/control/...` — green
- [x] `go test ./...` — green including e2e
- [x] Regression: cap fires when PV drops mid-charge-slot
- [x] Regression: cap does NOT fire on discharge slot with extra export (guards against re-symmetrising)
- [x] Regression: deadband (≤100 W divergence) keeps cap silent
- [x] Regression: nil `PlannedGridW` (legacy callers) bypasses cap
- [x] Wiring test: `SlotDirectiveAt` propagates `GridW` from `Action.GridW`
- [x] Field-deployed to dev Pi running `planner_arbitrage` (v0.78.1-2-g64d07dc, container healthy)
- [ ] Field validation during a cloud-pass charge slot — confirm battery target backs off and grid stays near plan

## Review history

- `0219cae` — original feature (charge + discharge cap)
- `64d07dc` — self-review caught the discharge branch was semantically wrong; removed it, flipped test to regression guard, added `docs/safety.md` §8
- `228b99c` — Copilot review pass: docstring drift fixes, dropped duplicate `ptr` helper, added `SlotDirectiveAt.GridW` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)