### PR TITLE
feat: phase-stable EV + MPC absorbs PV for nightly cover

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1138,6 +1138,15 @@ func main() {
 		// imminent enough to be worth waiting for. When near-term <
 		// 3Φ minimum but day-peak is, we'd rather charge 1Φ now and
 		// switch to 3Φ later than sit idle waiting.
+		//
+		// "Surplus" here is what the EV can claim, not the raw PV
+		// excess. The MPC has already allocated battery_w out of PV;
+		// the EV gets only what's left after PV - Load - Battery. A
+		// borderline-PV day where MPC reserves 4.5 kW for battery
+		// charging while raw -PV - Load = 5 kW would otherwise pin
+		// the gate to 3Φ-only based on a peak the battery is going
+		// to consume — leaving the EV stuck at 0 W in 3Φ-only step
+		// land because real-time room is below 4140 W.
 		lpController.SetNearTermPeakSurplusW(func(window time.Duration) (float64, bool) {
 			if mpcSvc == nil {
 				return 0, false
@@ -1159,7 +1168,15 @@ func main() {
 				if time.UnixMilli(a.SlotStartMs).After(horizon) {
 					break
 				}
-				surplus := -a.PVW - a.LoadW
+				// Net PV headroom for non-battery loads: positive when
+				// PV export exceeds load + planned battery charge.
+				// BatteryW is site-signed: positive = charge (import),
+				// negative = discharge (export). When discharging,
+				// subtracting a negative grows the surplus available
+				// to the EV — exactly right, because a discharging
+				// battery is contributing PV-deferred energy to the
+				// site.
+				surplus := -a.PVW - a.LoadW - a.BatteryW
 				if !any || surplus > peak {
 					peak = surplus
 					any = true

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1171,12 +1171,19 @@ func main() {
 				// Net PV headroom for non-battery loads: positive when
 				// PV export exceeds load + planned battery charge.
 				// BatteryW is site-signed: positive = charge (import),
-				// negative = discharge (export). When discharging,
-				// subtracting a negative grows the surplus available
-				// to the EV — exactly right, because a discharging
-				// battery is contributing PV-deferred energy to the
-				// site.
-				surplus := -a.PVW - a.LoadW - a.BatteryW
+				// negative = discharge (export). Only subtract planned
+				// CHARGE — planned discharge is already earmarked to
+				// cover house load (or grid export in arbitrage), not
+				// available room for the EV to claim. Counting it would
+				// route plan-discharge → EV → re-charge cycles: the EV
+				// takes power the plan reserved for load coverage, then
+				// the dispatch has to re-import or further discharge to
+				// keep the original balance.
+				plannedChargeW := a.BatteryW
+				if plannedChargeW < 0 {
+					plannedChargeW = 0
+				}
+				surplus := -a.PVW - a.LoadW - plannedChargeW
 				if !any || surplus > peak {
 					peak = surplus
 					any = true
@@ -1767,7 +1774,28 @@ func main() {
 			// legacy/reactive paths. Computed every tick so toggling
 			// surplus_only, plugging/unplugging, or an EV ramp picks
 			// up immediately.
-			evReserveW := loadpoint.SurplusReserveW(lpMgr.States())
+			// Build the wake-kick-active set so the reserve calc can
+			// hold the floor for an LP whose wallbox is actively
+			// offering current to a still-ramping EV. Without this,
+			// the home battery would snatch the freed surplus during
+			// the brief gap before the EV's contactor settles.
+			lpStatesSnapshot := lpMgr.States()
+			var wakeKickActiveIDs map[string]bool
+			if lpController != nil {
+				now := time.Now()
+				for _, st := range lpStatesSnapshot {
+					if !st.PluggedIn || !st.SurplusOnly {
+						continue
+					}
+					if lpController.IsWakeKickActive(st.ID, now) {
+						if wakeKickActiveIDs == nil {
+							wakeKickActiveIDs = map[string]bool{}
+						}
+						wakeKickActiveIDs[st.ID] = true
+					}
+				}
+			}
+			evReserveW := loadpoint.SurplusReserveW(lpStatesSnapshot, wakeKickActiveIDs)
 
 			ctrlMu.Lock()
 			ctrl.EVSurplusOnlyReserveW = evReserveW

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1767,7 +1767,27 @@ func main() {
 			// legacy/reactive paths. Computed every tick so toggling
 			// surplus_only, plugging/unplugging, or an EV ramp picks
 			// up immediately.
-			evReserveW := loadpoint.SurplusReserveW(lpMgr.States())
+			// Decorate states with VehicleChargingState before computing
+			// the reserve. lpMgr only tracks plug + power; the vehicle's
+			// charging state lives in telemetry.DerVehicle. Without this
+			// decoration, SurplusReserveW can't tell a Complete vehicle
+			// from one that's actively charging — and the dispatch
+			// continues to reserve 2 kW for a car that finished hours
+			// ago, blocking the home battery from absorbing PV that
+			// would otherwise go to grid.
+			lpStates := lpMgr.States()
+			lpNow := time.Now()
+			for i := range lpStates {
+				if !lpStates[i].PluggedIn {
+					continue
+				}
+				delivering := lpStates[i].CurrentPowerW > loadpoint.DeliveringW
+				pick := telemetry.PickBestVehicleForLoadpoint(tel, delivering, lpNow)
+				if pick.Driver != "" {
+					lpStates[i].VehicleChargingState = pick.ChargingState
+				}
+			}
+			evReserveW := loadpoint.SurplusReserveW(lpStates)
 
 			ctrlMu.Lock()
 			ctrl.EVSurplusOnlyReserveW = evReserveW

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1602,6 +1602,18 @@ func main() {
 	// the Tesla / vehicle driver gets ground truth from the car, the
 	// plan should incorporate it (especially for EV target deadlines).
 	var vehicleReplanFired bool
+	// Per-loadpoint last observed draw for the EV-stop edge replan.
+	// A falling edge (was >100 W, now <50 W while still plugged in)
+	// signals the EV finished or paused itself — the slot's plan no
+	// longer reflects reality (battery may have been held at 0 to leave
+	// room for the EV; with EV gone the freed PV should be re-allocated).
+	// Cooldown shares the fuse-replan cooldown to keep per-second flap
+	// from spamming the optimizer.
+	evDrawPrev := map[string]float64{}
+	var lastEVStopReplan time.Time
+	const evStopReplanCooldown = 60 * time.Second
+	const evStopHigh = 100.0 // W — "was actually drawing"
+	const evStopLow = 50.0   // W — "now essentially zero"
 	for {
 		select {
 		case <-sigc:
@@ -1830,6 +1842,33 @@ func main() {
 				slog.Info("fuse-saturated → MPC replan triggered")
 			}
 			prevFuseSaturated = fuseSatNow
+
+			// EV-stop edge replan trigger: when an LP's draw drops
+			// from a clearly-charging value to ~0 while still plugged,
+			// the current plan slot's allocation (e.g. "idle, the EV
+			// takes the surplus") is stale — fire a replan so the DP
+			// re-routes the freed PV. Unplug edges are NOT a trigger:
+			// the plug-out itself toggles plugged_in→false which the
+			// scheduled replan path picks up, and chaining a replan
+			// there would race with the LP manager. Cooldown bounded
+			// to one replan per evStopReplanCooldown so a hardware
+			// flap doesn't storm the optimizer.
+			if mpcSvc != nil {
+				fired := false
+				for _, lp := range lpMgr.States() {
+					prev := evDrawPrev[lp.ID]
+					curr := lp.CurrentPowerW
+					if lp.PluggedIn && prev >= evStopHigh && curr < evStopLow &&
+						time.Since(lastEVStopReplan) > evStopReplanCooldown && !fired {
+						lastEVStopReplan = time.Now()
+						fired = true
+						go mpcSvc.ReplanWithReason(ctx, "loadpoint_ev_stopped")
+						slog.Info("loadpoint EV stopped → MPC replan triggered",
+							"lp", lp.ID, "prev_w", prev, "curr_w", curr)
+					}
+					evDrawPrev[lp.ID] = curr
+				}
+			}
 
 			// First-vehicle-SoC replan trigger: as soon as any
 			// DerVehicle driver is online and reporting SoC, redo the

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -2314,7 +2314,22 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		SoCMinPct:           socMin,
 		SoCMaxPct:           socMax,
 		InitialSoCPct:       50,
-		ActionLevels:        21,
+		// ActionLevels = 41 → 450 W discretization step on a ±9 kW
+		// action range. ActionLevels=21 (900 W step) was too coarse:
+		// on borderline days where the planner needed to absorb a
+		// 1700 W net PV surplus into the battery, the closest legal
+		// charge action was +900 W (next step +1800 W pushed grid
+		// past zero and got blocked by ModeSelfConsumption's no-
+		// battery-export rule). The marginal benefit of +900 over 0
+		// then sometimes wasn't enough to overcome action-grid noise
+		// over a 48 h horizon, so the DP picked idle/export — leaking
+		// 1.7 kW of cheap midday PV to grid while SoC sat well below
+		// SoCMaxPct. 41 levels closes the gap to 450 W steps so the
+		// DP can land on a charge target within ~225 W of the
+		// optimum. DP complexity is O(N×S×A×EL×EA) — at the production
+		// 192-slot × 41-SoC × 1-EV grid, doubling A goes from 165k
+		// to 330k evaluations, still well under 10 ms.
+		ActionLevels:        41,
 		MaxChargeW:          maxChg,
 		MaxDischargeW:       maxDis,
 		ChargeEfficiency:    chgEff,

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -2314,22 +2314,17 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		SoCMinPct:           socMin,
 		SoCMaxPct:           socMax,
 		InitialSoCPct:       50,
-		// ActionLevels = 41 → 450 W discretization step on a ±9 kW
-		// action range. ActionLevels=21 (900 W step) was too coarse:
-		// on borderline days where the planner needed to absorb a
-		// 1700 W net PV surplus into the battery, the closest legal
-		// charge action was +900 W (next step +1800 W pushed grid
-		// past zero and got blocked by ModeSelfConsumption's no-
-		// battery-export rule). The marginal benefit of +900 over 0
-		// then sometimes wasn't enough to overcome action-grid noise
-		// over a 48 h horizon, so the DP picked idle/export — leaking
-		// 1.7 kW of cheap midday PV to grid while SoC sat well below
-		// SoCMaxPct. 41 levels closes the gap to 450 W steps so the
-		// DP can land on a charge target within ~225 W of the
-		// optimum. DP complexity is O(N×S×A×EL×EA) — at the production
-		// 192-slot × 41-SoC × 1-EV grid, doubling A goes from 165k
-		// to 330k evaluations, still well under 10 ms.
-		ActionLevels:        41,
+		// ActionLevels = 81 → 225 W discretization step on a ±9 kW
+		// action range. Coarser values (21=900 W, 41=450 W) lose
+		// borderline-PV slots: on a 273 W net surplus the 450 W min
+		// charge action overshoots ModeSelfConsumption's no-battery-
+		// export rule (gridW ends up positive past tolerance) and the
+		// DP falls back to idle/export the surplus. 81 levels lets the
+		// DP land on +225 W and absorb the surplus into the battery.
+		// DP complexity is O(N×S×A×EL×EA) — at the production 192-slot
+		// × 41-SoC × 1-EV grid, 81 actions is ~636k evaluations,
+		// still ~5 ms per replan on the Pi.
+		ActionLevels:        81,
 		MaxChargeW:          maxChg,
 		MaxDischargeW:       maxDis,
 		ChargeEfficiency:    chgEff,

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1767,27 +1767,7 @@ func main() {
 			// legacy/reactive paths. Computed every tick so toggling
 			// surplus_only, plugging/unplugging, or an EV ramp picks
 			// up immediately.
-			// Decorate states with VehicleChargingState before computing
-			// the reserve. lpMgr only tracks plug + power; the vehicle's
-			// charging state lives in telemetry.DerVehicle. Without this
-			// decoration, SurplusReserveW can't tell a Complete vehicle
-			// from one that's actively charging — and the dispatch
-			// continues to reserve 2 kW for a car that finished hours
-			// ago, blocking the home battery from absorbing PV that
-			// would otherwise go to grid.
-			lpStates := lpMgr.States()
-			lpNow := time.Now()
-			for i := range lpStates {
-				if !lpStates[i].PluggedIn {
-					continue
-				}
-				delivering := lpStates[i].CurrentPowerW > loadpoint.DeliveringW
-				pick := telemetry.PickBestVehicleForLoadpoint(tel, delivering, lpNow)
-				if pick.Driver != "" {
-					lpStates[i].VehicleChargingState = pick.ChargingState
-				}
-			}
-			evReserveW := loadpoint.SurplusReserveW(lpStates)
+			evReserveW := loadpoint.SurplusReserveW(lpMgr.States())
 
 			ctrlMu.Lock()
 			ctrl.EVSurplusOnlyReserveW = evReserveW

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -247,6 +247,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/loadpoints", s.handleLoadpoints)
 	s.handle("POST /api/loadpoints/{id}/target", s.handleLoadpointTarget)
 	s.handle("POST /api/loadpoints/{id}/soc", s.handleLoadpointSoC)
+	s.handle("POST /api/loadpoints/{id}/force_start", s.handleLoadpointForceStart)
 	s.handle("POST /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHold)
 	s.handle("DELETE /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHoldClear)
 	s.handle("GET  /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHoldGet)

--- a/go/internal/api/api_loadpoint_vehicle.go
+++ b/go/internal/api/api_loadpoint_vehicle.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/loadpoint"
 )
 
 // POST /api/loadpoints/{id}/force_start fires the generic
@@ -15,8 +18,9 @@ import (
 // they just woke it from the Tesla app or plug-cycled — and want
 // charging to resume immediately rather than waiting for the next
 // auto-wake window. Bound timeout (15 s) is enough for a Tesla BLE
-// proxy hop including a one-shot wake; longer roundtrips return the
-// proxy's error to the caller.
+// proxy hop including a one-shot wake; longer roundtrips return a
+// 502 to the caller (driver-internal error strings are intentionally
+// not surfaced — they may include endpoint URLs / IPs).
 //
 // Generic across vehicle drivers: any driver that implements the
 // cross-driver `charge_start` (or its `ev_start` alias) action picks
@@ -24,6 +28,15 @@ import (
 // loadpoint.Controller.ForceStartVehicle, which owns the throttle
 // reset + wake-kick arming so behaviour is identical to the auto-wake
 // path minus the cooldown gate.
+//
+// Status codes:
+//
+//	400 — missing/empty loadpoint id in path
+//	404 — loadpoint id not configured
+//	422 — loadpoint exists but no vehicle driver bound
+//	502 — driver send hop returned an error (timeout, refused, etc.)
+//	503 — loadpoint controller not wired in this build
+//	200 — sent
 func (s *Server) handleLoadpointForceStart(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -37,15 +50,24 @@ func (s *Server) handleLoadpointForceStart(w http.ResponseWriter, r *http.Reques
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 	driver, err := s.deps.LoadpointCtrl.ForceStartVehicle(ctx, id)
-	if driver == "" && err == nil {
-		writeJSON(w, 404, map[string]string{"error": "no vehicle driver bound to loadpoint"})
+	switch {
+	case errors.Is(err, loadpoint.ErrForceStartNotReady):
+		writeJSON(w, 503, map[string]string{"error": "loadpoint controller not ready"})
 		return
-	}
-	if err != nil {
+	case errors.Is(err, loadpoint.ErrForceStartLoadpointGone):
+		writeJSON(w, 404, map[string]string{"error": "loadpoint not found", "loadpoint_id": id})
+		return
+	case errors.Is(err, loadpoint.ErrForceStartNoVehicleBound):
+		writeJSON(w, 422, map[string]string{"error": "no vehicle driver bound to loadpoint", "loadpoint_id": id})
+		return
+	case err != nil:
+		// Generic 502 — do NOT surface the underlying driver error
+		// string (may contain endpoint URLs, internal IPs, proxy
+		// auth context). The log line on the controller side
+		// carries the detail for the operator to inspect.
 		writeJSON(w, 502, map[string]string{
 			"error":  "vehicle driver send failed",
 			"driver": driver,
-			"detail": err.Error(),
 		})
 		return
 	}

--- a/go/internal/api/api_loadpoint_vehicle.go
+++ b/go/internal/api/api_loadpoint_vehicle.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// POST /api/loadpoints/{id}/force_start fires the generic
+// `charge_start` action on the loadpoint's bound vehicle driver,
+// bypassing the auto-wake's cooldown + stretched-backoff throttle.
+//
+// Used when the auto-wake has given up (5+ failed attempts → 10 min
+// cooldown) and the operator knows the car is now reachable — e.g.
+// they just woke it from the Tesla app or plug-cycled — and want
+// charging to resume immediately rather than waiting for the next
+// auto-wake window. Bound timeout (15 s) is enough for a Tesla BLE
+// proxy hop including a one-shot wake; longer roundtrips return the
+// proxy's error to the caller.
+//
+// Generic across vehicle drivers: any driver that implements the
+// cross-driver `charge_start` (or its `ev_start` alias) action picks
+// this up unchanged. The handler delegates to
+// loadpoint.Controller.ForceStartVehicle, which owns the throttle
+// reset + wake-kick arming so behaviour is identical to the auto-wake
+// path minus the cooldown gate.
+func (s *Server) handleLoadpointForceStart(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, 400, map[string]string{"error": "loadpoint id required"})
+		return
+	}
+	if s.deps.LoadpointCtrl == nil {
+		writeJSON(w, 503, map[string]string{"error": "loadpoint controller not configured"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	driver, err := s.deps.LoadpointCtrl.ForceStartVehicle(ctx, id)
+	if driver == "" && err == nil {
+		writeJSON(w, 404, map[string]string{"error": "no vehicle driver bound to loadpoint"})
+		return
+	}
+	if err != nil {
+		writeJSON(w, 502, map[string]string{
+			"error":  "vehicle driver send failed",
+			"driver": driver,
+			"detail": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, 200, map[string]any{
+		"ok":             true,
+		"loadpoint_id":   id,
+		"vehicle_driver": driver,
+		"action":         "charge_start",
+	})
+}

--- a/go/internal/api/api_loadpoint_vehicle_test.go
+++ b/go/internal/api/api_loadpoint_vehicle_test.go
@@ -1,0 +1,168 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/loadpoint"
+)
+
+// POST /api/loadpoints/{id}/force_start — handler coverage.
+
+// newForceStartServer builds a Server with a Manager + Controller
+// and pre-installs a stub vehicleStatus + sender. Pass overrides to
+// switch the stubs per-test (e.g. for the "send fails" case).
+func newForceStartServer(
+	t *testing.T,
+	vehicleStatus func(string) (string, string, bool),
+	send loadpoint.SenderFunc,
+) *Server {
+	t.Helper()
+	mgr := loadpoint.NewManager()
+	mgr.Load([]loadpoint.Config{{
+		ID:         "garage",
+		DriverName: "easee",
+		MinChargeW: 1380,
+		MaxChargeW: 11000,
+	}})
+	ctrl := loadpoint.NewController(mgr, nil, nil, send)
+	if vehicleStatus != nil {
+		ctrl.SetVehicleStatus(vehicleStatus)
+	}
+	return New(&Deps{Loadpoints: mgr, LoadpointCtrl: ctrl})
+}
+
+func TestForceStart_503WhenControllerMissing(t *testing.T) {
+	s := New(&Deps{})
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/garage/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestForceStart_503WhenControllerNotReady(t *testing.T) {
+	// Controller exists but vehicleStatus / send wiring is missing.
+	s := newForceStartServer(t, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/garage/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503 (controller not ready), body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestForceStart_404WhenLoadpointMissing(t *testing.T) {
+	s := newForceStartServer(t,
+		func(string) (string, string, bool) { return "tesla-vehicle", "Stopped", true },
+		func(context.Context, string, []byte) error { return nil },
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/no-such-lp/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 404 {
+		t.Fatalf("status = %d, want 404, body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]string
+	_ = json.NewDecoder(rec.Body).Decode(&body)
+	if body["loadpoint_id"] != "no-such-lp" {
+		t.Errorf("response should echo the requested loadpoint_id, got %q", body["loadpoint_id"])
+	}
+}
+
+func TestForceStart_422WhenNoVehicleBound(t *testing.T) {
+	s := newForceStartServer(t,
+		func(string) (string, string, bool) { return "", "", false }, // LP exists, no vehicle bound
+		func(context.Context, string, []byte) error { return nil },
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/garage/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 422 {
+		t.Fatalf("status = %d, want 422 (no vehicle bound), body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestForceStart_502OnDriverSendError(t *testing.T) {
+	s := newForceStartServer(t,
+		func(string) (string, string, bool) { return "tesla-vehicle", "Stopped", true },
+		func(context.Context, string, []byte) error {
+			// Driver-internal error strings (URLs, IPs) must NOT leak
+			// through to the HTTP response body — asserted below.
+			return errors.New("http://192.168.1.223:8080/api/1/vehicles/SECRET/wake: connection refused")
+		},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/garage/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 502 {
+		t.Fatalf("status = %d, want 502, body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); containsAny(got, "192.168.1.223", "SECRET", "connection refused") {
+		t.Errorf("502 body leaked driver-internal error string: %s", got)
+	}
+}
+
+func TestForceStart_200OnSuccess(t *testing.T) {
+	var sentDriver string
+	var sentPayload []byte
+	s := newForceStartServer(t,
+		func(string) (string, string, bool) { return "tesla-vehicle", "Stopped", true },
+		func(_ context.Context, driver string, payload []byte) error {
+			sentDriver = driver
+			sentPayload = payload
+			return nil
+		},
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/loadpoints/garage/force_start", nil)
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	if sentDriver != "tesla-vehicle" {
+		t.Errorf("sent to driver %q, want tesla-vehicle", sentDriver)
+	}
+	if !containsAny(string(sentPayload), `"action":"charge_start"`) {
+		t.Errorf("payload did not include the charge_start action: %s", sentPayload)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(rec.Body).Decode(&body)
+	if body["ok"] != true {
+		t.Errorf("response ok=%v, want true", body["ok"])
+	}
+	if body["vehicle_driver"] != "tesla-vehicle" {
+		t.Errorf("response vehicle_driver=%v, want tesla-vehicle", body["vehicle_driver"])
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if n == "" {
+			continue
+		}
+		if idx := indexOf(haystack, n); idx >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// indexOf is a local strings.Contains-ish helper to keep this file
+// from importing strings just for one call.
+func indexOf(s, sub string) int {
+	if len(sub) == 0 {
+		return 0
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1623,10 +1623,17 @@ func TestPlannerSelfParticipatesReactivelyDischargesOnImport(t *testing.T) {
 	}
 }
 
-// A charge/idle planner_self slot must not discharge just because the live
-// meter is importing. It waits for the next replan rather than spending SoC
-// against a slot the DP selected for saving or charging.
-func TestPlannerSelfPlanChargeDoesNotDischargeOnLiveImport(t *testing.T) {
+// planner_self in a charge-intent slot must STILL discharge when the
+// live meter shows import — the operator's directive for SC mode is
+// "always chase grid=0", which is symmetric: charge on live export,
+// discharge on live import, regardless of which direction the plan's
+// per-slot battery_w hint pointed. The plan's charge target is a
+// forecast-based budget that gets revised by the reactive replan; the
+// live PI must not refuse to cover import while waiting for replan,
+// because the operator's stored SoC is exactly there to cover the
+// load. Inverted from v0.79.5's "plan charge wins" rule after operator
+// feedback.
+func TestPlannerSelfPlanChargeStillDischargesOnLiveImport(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{
 		SlotStart:       now,
@@ -1651,8 +1658,8 @@ func TestPlannerSelfPlanChargeDoesNotDischargeOnLiveImport(t *testing.T) {
 	if len(targets) != 1 {
 		t.Fatalf("want 1 target, got %d", len(targets))
 	}
-	if targets[0].TargetW < 0 {
-		t.Errorf("TargetW = %f W — planner_self must not discharge on live import even when the plan slot was charge", targets[0].TargetW)
+	if targets[0].TargetW >= 0 {
+		t.Errorf("TargetW = %f W — planner_self must discharge to cover live import even when the plan slot was charge", targets[0].TargetW)
 	}
 }
 

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -568,9 +568,11 @@ func ComputeDispatch(
 				planFresh = true
 				state.PlanStale = false
 				slotH := dir.SlotEnd.Sub(dir.SlotStart).Hours()
-				// Idle decision is derived from forecast PV+load
-				// baseline (what the grid would be with battery=0),
-				// NOT from the DP's quantized battery action. The DP's
+				// Idle decision is derived from the plan's forecast
+				// baseline grid (what the grid would be with the
+				// battery doing nothing — includes house load, PV,
+				// and any planned EV draw), NOT from the DP's
+				// quantized battery action. The DP's
 				// action grid (currently 225 W step) rounds small
 				// baseline values to 0 — on a 200 W net surplus the
 				// plan picks battery_w=0 because no charge step fits

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -568,8 +568,33 @@ func ComputeDispatch(
 				planFresh = true
 				state.PlanStale = false
 				slotH := dir.SlotEnd.Sub(dir.SlotStart).Hours()
-				if slotH > 0 && math.Abs(dir.BatteryEnergyWh)/slotH < mpc.IdleGateThresholdW {
-					plannerSelfIdleGate = true
+				// Idle decision is derived from forecast PV+load
+				// baseline (what the grid would be with battery=0),
+				// NOT from the DP's quantized battery action. The DP's
+				// action grid (currently 225 W step) rounds small
+				// baseline values to 0 — on a 200 W net surplus the
+				// plan picks battery_w=0 because no charge step fits
+				// under ModeSelfConsumption's no-export rule. Reading
+				// the plan's BatteryEnergyWh treats that quantization
+				// artefact as an idle decision, holding the battery at
+				// 0 while the same 200 W exports to grid. By looking at
+				// PlannedGridW − BatteryEnergyWh/slotH (i.e. the
+				// forecast baseline grid without battery action), we
+				// participate whenever there's meaningful surplus or
+				// deficit to absorb/cover, regardless of whether the
+				// DP's discrete action grid could express it. Falls
+				// back to the legacy BatteryEnergyWh check when
+				// PlannedGridW isn't set (older plan format, or the
+				// DP couldn't compute it for this slot).
+				if slotH > 0 {
+					if dir.HasPlannedGridW {
+						baselineW := dir.PlannedGridW - dir.BatteryEnergyWh/slotH
+						if math.Abs(baselineW) < mpc.IdleGateThresholdW {
+							plannerSelfIdleGate = true
+						}
+					} else if math.Abs(dir.BatteryEnergyWh)/slotH < mpc.IdleGateThresholdW {
+						plannerSelfIdleGate = true
+					}
 				}
 			}
 		}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1721,6 +1721,19 @@ func planHasNonDischargeIntent(state *State) bool {
 	if state == nil || !state.Mode.IsPlannerMode() {
 		return false
 	}
+	// planner_self is pure reactive PI on grid=0 in non-idle slots —
+	// the plannerSelfIdleGate ALONE decides whether to discharge. The
+	// plan's per-slot charge intent (BatteryEnergyWh > 0) must NOT
+	// gate discharge here: SC mode's contract is "always chase
+	// grid=0" so a forecast miss that leaves the meter importing has
+	// to be covered by the battery. Without this exemption, a slot
+	// the planner forecast as +675 W of PV absorption would refuse to
+	// discharge even when the cloud rolled in and the live meter is
+	// importing 500 W — the symptom the operator hit on v0.79.5
+	// before this carve-out.
+	if state.Mode == ModePlannerSelf {
+		return false
+	}
 	const idleWh = 50.0
 	const idleGridW = 100.0
 	if state.SlotDirective != nil {

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -1082,8 +1082,18 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		phaseMode := lpCfg.PhaseMode
 		if c.surplusLockedTo1P(lpCfg.ID) {
 			phaseMode = "1p"
-		} else if surplusOn && phaseMode == "" {
-			phaseMode = "auto"
+		} else if surplusOn {
+			// Honour the 30-min near-term dwell decision: pin the
+			// driver to that phase across the dwell window so a
+			// transient cmd_w=0 (pause) doesn't make the driver's
+			// "auto" snap to 1Φ and flip the contactor. Without this,
+			// pickSurplusSteps' step-list lock is silently bypassed
+			// every time the surplus clamp pauses.
+			if dwell := c.dwellSelectedPhaseMode(lpCfg.ID); dwell != "" {
+				phaseMode = dwell
+			} else if phaseMode == "" {
+				phaseMode = "auto"
+			}
 		}
 		if phaseMode != "" {
 			cmd["phase_mode"] = phaseMode
@@ -1569,6 +1579,29 @@ func (c *Controller) surplusLockedTo1P(id string) bool {
 	c.phaseLockMu.Lock()
 	defer c.phaseLockMu.Unlock()
 	return c.phaseLocked1P[id]
+}
+
+// dwellSelectedPhaseMode returns the phase_mode string ("1p"/"3p")
+// implied by the near-term dwell selection for this loadpoint, or the
+// empty string when no dwell decision is on file (first-tick, fresh
+// day, no near-term peak source). Used by the dispatch command builder
+// to override the operator's "auto" so the driver doesn't auto-flip
+// phase on a transient cmd_w=0 (pause), which would defeat the
+// 30-min minimum-dwell guarantee.
+func (c *Controller) dwellSelectedPhaseMode(id string) string {
+	if c == nil {
+		return ""
+	}
+	c.phaseLockMu.Lock()
+	defer c.phaseLockMu.Unlock()
+	sel, ok := c.phaseSelected3P[id]
+	if !ok {
+		return ""
+	}
+	if sel {
+		return "3p"
+	}
+	return "1p"
 }
 
 // sameLocalDay reports whether two time.Time values fall on the

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -3,6 +3,7 @@ package loadpoint
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"math"
 	"sync"
@@ -698,6 +699,18 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 	return c.send(ctx, driver, payload)
 }
 
+// ForceStart outcome sentinels. The API layer maps each to a distinct
+// HTTP status: NotReady → 503, LoadpointNotFound → 404 "lp", NoVehicle
+// → 422 "no vehicle bound", any other error → 502 "driver send".
+// Distinguishing these is what the previous (string, error) two-value
+// return tried to encode via empty strings — sentinels make it
+// type-checked.
+var (
+	ErrForceStartNotReady       = errors.New("loadpoint controller not ready (missing vehicleStatus/send wiring)")
+	ErrForceStartLoadpointGone  = errors.New("loadpoint not found")
+	ErrForceStartNoVehicleBound = errors.New("no vehicle driver bound to loadpoint")
+)
+
 // ForceStartVehicle sends a generic `charge_start` to the loadpoint's
 // bound vehicle driver immediately, bypassing the auto-wake's
 // `vehicleWakeCooldown` + `wakeBackoffCooldown` throttle. Used by the
@@ -707,7 +720,7 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 // stretched cooldown still has minutes to run, operator wants charging
 // to resume now).
 //
-// Side effects, in order:
+// Side effects on success (after the send returns nil), in order:
 //  1. Reset the wake-attempt counter so subsequent auto-wakes start
 //     from a fresh cooldown.
 //  2. Bump wakeLast so the auto-wake loop will not duplicate this
@@ -720,18 +733,29 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 //     Tesla, BMW, Audi drivers all implement it against their own
 //     back-ends).
 //
-// Returns the driver name actually targeted (empty string when no
-// driver is bound or the controller isn't wired) and any send error.
-// Empty driver + nil error means "no-op, nothing to send" — distinct
-// from a send error so the API layer can return 404 vs 502
-// appropriately.
+// If the send fails, the throttle resets and wake-kick arming still
+// stand — that's intentional: the operator's intent was to break the
+// backoff, and a failed send shouldn't punish a subsequent retry.
+//
+// Returns the driver name actually targeted plus the outcome:
+//
+//	("", ErrForceStartNotReady)        — controller missing wiring
+//	("", ErrForceStartLoadpointGone)   — no such loadpoint id
+//	("", ErrForceStartNoVehicleBound)  — loadpoint exists, no vehicle
+//	(driver, sendErr)                  — send hop returned an error
+//	(driver, nil)                      — sent
 func (c *Controller) ForceStartVehicle(ctx context.Context, lpID string) (string, error) {
 	if c == nil || c.vehicleStatus == nil || c.send == nil {
-		return "", nil
+		return "", ErrForceStartNotReady
+	}
+	if c.manager != nil {
+		if _, ok := c.manager.State(lpID); !ok {
+			return "", ErrForceStartLoadpointGone
+		}
 	}
 	driver, _, ok := c.vehicleStatus(lpID)
 	if !ok || driver == "" {
-		return "", nil
+		return "", ErrForceStartNoVehicleBound
 	}
 	now := time.Now()
 	c.wakeMu.Lock()
@@ -746,10 +770,18 @@ func (c *Controller) ForceStartVehicle(ctx context.Context, lpID string) (string
 	c.wakeMu.Unlock()
 	payload, err := json.Marshal(map[string]any{"action": "charge_start"})
 	if err != nil {
+		slog.Warn("loadpoint force-start: payload marshal", "lp", lpID, "err", err)
 		return driver, err
 	}
-	slog.Info("loadpoint force-start (operator)", "lp", lpID, "vehicle_driver", driver)
-	return driver, c.send(ctx, driver, payload)
+	sendErr := c.send(ctx, driver, payload)
+	if sendErr != nil {
+		slog.Warn("loadpoint force-start (operator) — send failed",
+			"lp", lpID, "vehicle_driver", driver, "err", sendErr)
+	} else {
+		slog.Info("loadpoint force-start (operator) — sent",
+			"lp", lpID, "vehicle_driver", driver)
+	}
+	return driver, sendErr
 }
 
 // wakeVehicleAuto sends a `wake_up` to the loadpoint's bound vehicle
@@ -1136,11 +1168,19 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		phaseMode := lpCfg.PhaseMode
 		if c.surplusLockedTo1P(lpCfg.ID) {
 			phaseMode = "1p"
-		} else if surplusOn {
-			// Honour the 30-min near-term dwell decision: pin the
-			// driver to that phase across the dwell window so a
-			// transient cmd_w=0 (pause) doesn't make the driver's
-			// "auto" snap to 1Φ and flip the contactor. Without this,
+		} else if surplusOn && (phaseMode == "" || phaseMode == "auto") {
+			// Honour the 30-min near-term dwell decision ONLY when the
+			// operator hasn't explicitly pinned a phase. Explicit "1p"
+			// or "3p" is a fixed-install contract: a 1Φ-only home or a
+			// 3Φ-only contactor preference. Overriding it via dwell
+			// would let a near-term forecast flip the install's
+			// physical configuration, exactly the wear case the dwell
+			// was meant to avoid.
+			//
+			// When phase_mode is unset or "auto", pin the driver to
+			// the dwell decision across the dwell window so a transient
+			// cmd_w=0 (pause) doesn't make the driver's "auto" snap to
+			// 1Φ and flip the contactor. Without this,
 			// pickSurplusSteps' step-list lock is silently bypassed
 			// every time the surplus clamp pauses.
 			if dwell := c.dwellSelectedPhaseMode(lpCfg.ID); dwell != "" {
@@ -1721,6 +1761,17 @@ func (c *Controller) wakeKickActive(id string, now time.Time) bool {
 	defer c.wakeMu.Unlock()
 	t, ok := c.wakeKickUntil[id]
 	return ok && now.Before(t)
+}
+
+// IsWakeKickActive is the public accessor mirroring wakeKickActive.
+// Main wires it into the per-tick reserve calc so the home battery
+// doesn't grab a freed PV surplus during the gap between the wake-kick
+// commanding the wallbox to offer current and the EV actually starting
+// to draw — the wake-kick window is the operator-correct "ramp" period
+// where the EV's share of surplus should be held even when its
+// instantaneous CurrentPowerW is still 0.
+func (c *Controller) IsWakeKickActive(id string, now time.Time) bool {
+	return c.wakeKickActive(id, now)
 }
 
 // resetSurplusSession drops the per-loadpoint rolling buffer + paused

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -126,16 +126,26 @@ type Controller struct {
 	fusePauseMu    sync.Mutex
 	fusePauseUntil map[string]time.Time
 
-	// phaseLockMu protects phaseLocked1P + phaseLockedAt. The 1Φ
-	// lock is sticky for the rest of the day so a slowly recovering
+	// phaseLockMu protects phaseLocked1P + phaseLockedAt + phaseSelected3P.
+	// The 1Φ lock is sticky for the rest of the day so a slowly recovering
 	// PV doesn't flip 1Φ ↔ 3Φ as clouds shift. It's automatically
 	// cleared at the start of the next local day if the forecast
 	// shows we'll see enough surplus to sustain 3Φ again — that's
 	// the natural reset point that matches the operator's "look at
 	// today vs tomorrow" mental model.
-	phaseLockMu   sync.Mutex
-	phaseLocked1P map[string]bool
-	phaseLockedAt map[string]time.Time
+	// phaseSelected3P + phaseSelectedAt enforce the minimum-dwell rule
+	// on the near-term gate: once a 3Φ-only ↔ 1Φ-allowed decision is
+	// taken, hold it for at least phaseSwitchMinHold before the next
+	// switch is allowed. Without this, a forecast peak hovering around
+	// the 4140 W threshold flaps the step set every tick, which
+	// cascades into Easee phaseMode flips + contactor cycles + battery
+	// PI windup. Operator rule: at most one 1Φ↔3Φ switch per 30 min.
+	// Cleared on day rollover via the same path as phaseLocked1P.
+	phaseLockMu      sync.Mutex
+	phaseLocked1P    map[string]bool
+	phaseLockedAt    map[string]time.Time
+	phaseSelected3P  map[string]bool
+	phaseSelectedAt  map[string]time.Time
 
 	// wakeMu protects the per-loadpoint last-wake timestamp used to
 	// throttle charge_start retries. Tesla rate-limits BLE commands;
@@ -245,6 +255,15 @@ const surplusMinPauseHold = 35 * time.Second
 // unreachable)" log line so a long morning with sustained low surplus
 // produces one line per 10 min per LP instead of one per 5 s tick.
 const nearTermLogCooldown = 10 * time.Minute
+
+// phaseSwitchMinHold is the minimum dwell between 1Φ↔3Φ switches on
+// the near-term gate. Operator rule: at most one switch per 30 min.
+// The Easee contactor is rated for limited switching cycles; on a
+// borderline-PV day a frequent 1Φ↔3Φ flip would burn through them
+// quickly and inject load-step transients into the battery PI loop
+// every couple of minutes. 30 min lets the forecast machinery commit
+// to a verdict before the next reconsider.
+const phaseSwitchMinHold = 30 * time.Minute
 
 // fusePauseCooldown is how long an LP stays at 0 W after a fuse-over-
 // limit force-pause. Long enough that whatever house load caused the
@@ -1404,6 +1423,8 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 		if peak, ok := c.peakRemainingSurplusW(); ok && peak >= minStep3 {
 			delete(c.phaseLocked1P, lpCfg.ID)
 			delete(c.phaseLockedAt, lpCfg.ID)
+			delete(c.phaseSelected3P, lpCfg.ID)
+			delete(c.phaseSelectedAt, lpCfg.ID)
 			locked = false
 			c.phaseLockMu.Unlock()
 			slog.Info("loadpoint surplus_only unlocked: new day with sufficient PV forecast",
@@ -1427,11 +1448,61 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 	// here today instead of waiting for a peak that's hours away.
 	// Day-lock NOT set here — this is a "transient cloud" not a
 	// "low-PV day" verdict, so a later 3Φ window during the same
-	// day can still trigger a contactor cycle into 3Φ (the
-	// surplusMinPauseHold ≥ 35 s hysteresis caps the cycle rate).
+	// day can still trigger a contactor cycle into 3Φ.
+	//
+	// Minimum-dwell guard: a forecast peak hovering around the 4140 W
+	// threshold would otherwise flap the step set every tick, which
+	// cascades into Easee phaseMode flips + contactor cycles + battery
+	// PI windup. Operator rule: at most one 1Φ↔3Φ switch per
+	// phaseSwitchMinHold. The prior decision is held until the dwell
+	// elapses; on day rollover the selection is cleared so a fresh
+	// morning gets a fresh forecast verdict.
 	if c.nearTermPeakSurplusW != nil {
 		const nearTermWindow = 30 * time.Minute
-		if nearPeak, ok := c.nearTermPeakSurplusW(nearTermWindow); ok && nearPeak < minStep3 {
+		nearPeak, peakOK := c.nearTermPeakSurplusW(nearTermWindow)
+
+		c.phaseLockMu.Lock()
+		prevSelected3P, hasPrev := c.phaseSelected3P[lpCfg.ID]
+		prevAt := c.phaseSelectedAt[lpCfg.ID]
+		if hasPrev && !sameLocalDay(prevAt, now) {
+			delete(c.phaseSelected3P, lpCfg.ID)
+			delete(c.phaseSelectedAt, lpCfg.ID)
+			hasPrev = false
+		}
+		var selected3P bool
+		var recordDecision bool
+		switch {
+		case !peakOK && !hasPrev:
+			// No forecast yet and no prior decision: conservative
+			// fall-through to the whole-day branch below.
+			c.phaseLockMu.Unlock()
+			goto afterNearTerm
+		case !peakOK:
+			// No forecast this tick — honour the prior decision.
+			selected3P = prevSelected3P
+		case !hasPrev:
+			// First decision today — go with the forecast verdict.
+			selected3P = nearPeak >= minStep3
+			recordDecision = true
+		case now.Sub(prevAt) < phaseSwitchMinHold:
+			// Dwell window not yet elapsed — hold the prior decision.
+			selected3P = prevSelected3P
+		default:
+			// Dwell elapsed — re-decide from the forecast.
+			selected3P = nearPeak >= minStep3
+			recordDecision = selected3P != prevSelected3P
+		}
+		if recordDecision {
+			if c.phaseSelected3P == nil {
+				c.phaseSelected3P = map[string]bool{}
+				c.phaseSelectedAt = map[string]time.Time{}
+			}
+			c.phaseSelected3P[lpCfg.ID] = selected3P
+			c.phaseSelectedAt[lpCfg.ID] = now
+		}
+		c.phaseLockMu.Unlock()
+
+		if !selected3P {
 			c.nearTermLogMu.Lock()
 			lastFor, has := c.nearTermLogLast[lpCfg.ID]
 			fireLog := !has || now.Sub(lastFor) > nearTermLogCooldown
@@ -1445,11 +1516,12 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 			if fireLog {
 				slog.Info("loadpoint surplus: 1Φ steps allowed (near-term 3Φ unreachable)",
 					"lp", lpCfg.ID, "near_term_peak_w", nearPeak, "min_3p_step_w", minStep3,
-					"window", nearTermWindow.String())
+					"window", nearTermWindow.String(), "dwell_hold", phaseSwitchMinHold.String())
 			}
 			return lpCfg.AllowedStepsW
 		}
 	}
+afterNearTerm:
 
 	if c.peakRemainingSurplusW == nil {
 		return steps3
@@ -1480,6 +1552,8 @@ func (c *Controller) pickSurplusSteps(now time.Time, lpCfg Config) []float64 {
 	}
 	c.phaseLocked1P[lpCfg.ID] = true
 	c.phaseLockedAt[lpCfg.ID] = now
+	delete(c.phaseSelected3P, lpCfg.ID)
+	delete(c.phaseSelectedAt, lpCfg.ID)
 	c.phaseLockMu.Unlock()
 	slog.Info("loadpoint surplus_only locked to 1Φ for the day",
 		"lp", lpCfg.ID, "peak_remaining_surplus_w", peak, "min_3p_step_w", minStep3)

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -698,6 +698,60 @@ func (c *Controller) RefreshVehicle(ctx context.Context, lpID string) error {
 	return c.send(ctx, driver, payload)
 }
 
+// ForceStartVehicle sends a generic `charge_start` to the loadpoint's
+// bound vehicle driver immediately, bypassing the auto-wake's
+// `vehicleWakeCooldown` + `wakeBackoffCooldown` throttle. Used by the
+// operator-driven "force start" API path when the auto-wake has
+// backed off and the operator wants to break the backoff (typical case:
+// car was unresponsive earlier, has since become reachable, the 10-min
+// stretched cooldown still has minutes to run, operator wants charging
+// to resume now).
+//
+// Side effects, in order:
+//  1. Reset the wake-attempt counter so subsequent auto-wakes start
+//     from a fresh cooldown.
+//  2. Bump wakeLast so the auto-wake loop will not duplicate this
+//     send on the same tick.
+//  3. Arm the wake-kick window so the next few dispatch ticks force
+//     the wallbox to signal at least min current — without it a
+//     successful charge_start lands on a 0 A wallbox and the car has
+//     nothing to negotiate with.
+//  4. Send the generic `charge_start` action (cross-driver protocol —
+//     Tesla, BMW, Audi drivers all implement it against their own
+//     back-ends).
+//
+// Returns the driver name actually targeted (empty string when no
+// driver is bound or the controller isn't wired) and any send error.
+// Empty driver + nil error means "no-op, nothing to send" — distinct
+// from a send error so the API layer can return 404 vs 502
+// appropriately.
+func (c *Controller) ForceStartVehicle(ctx context.Context, lpID string) (string, error) {
+	if c == nil || c.vehicleStatus == nil || c.send == nil {
+		return "", nil
+	}
+	driver, _, ok := c.vehicleStatus(lpID)
+	if !ok || driver == "" {
+		return "", nil
+	}
+	now := time.Now()
+	c.wakeMu.Lock()
+	if c.wakeLast == nil {
+		c.wakeLast = map[string]time.Time{}
+		c.wakeKickUntil = map[string]time.Time{}
+		c.wakeAttempts = map[string]int{}
+	}
+	delete(c.wakeAttempts, lpID)
+	c.wakeLast[lpID] = now
+	c.wakeKickUntil[lpID] = now.Add(wakeKickDuration)
+	c.wakeMu.Unlock()
+	payload, err := json.Marshal(map[string]any{"action": "charge_start"})
+	if err != nil {
+		return driver, err
+	}
+	slog.Info("loadpoint force-start (operator)", "lp", lpID, "vehicle_driver", driver)
+	return driver, c.send(ctx, driver, payload)
+}
+
 // wakeVehicleAuto sends a `wake_up` to the loadpoint's bound vehicle
 // driver, gated by the same `vehicleWakeCooldown` (5 min) the
 // charge_start auto-wake loop uses. Used for event-triggered wakes

--- a/go/internal/loadpoint/controller_surplus_test.go
+++ b/go/internal/loadpoint/controller_surplus_test.go
@@ -274,3 +274,71 @@ func (c *Controller) surplusPausedFor(id string) bool {
 	paused, _ := c.getSurplusPause(id)
 	return paused
 }
+
+// TestPickSurplusSteps_NearTermDwell verifies the 30-min minimum-dwell
+// on the near-term 1Φ↔3Φ gate. The fix is operator-stated: at most one
+// switch per phaseSwitchMinHold so a forecast peak hovering around the
+// 4140 W threshold doesn't flap the Easee contactor every couple of
+// minutes (the symptom from the May 2026 borderline-PV trace).
+func TestPickSurplusSteps_NearTermDwell(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	cfg := surplusTestConfig()
+
+	// Day peak always comfortable (above 3Φ min) so we exercise the
+	// near-term gate, not the day-long lock.
+	c.SetPeakRemainingSurplusW(func() (float64, bool) { return 9000, true })
+
+	var nearPeak float64
+	c.SetNearTermPeakSurplusW(func(window time.Duration) (float64, bool) {
+		return nearPeak, true
+	})
+
+	day1 := time.Date(2026, 5, 3, 9, 0, 0, 0, time.Local)
+	steps3 := surplus3PhaseSteps(cfg)
+	minStep3 := smallestNonZero(steps3)
+
+	// First call — near-term forecast comfortably above minStep3 → 3Φ-only.
+	nearPeak = minStep3 + 1000
+	if got := c.pickSurplusSteps(day1, cfg); len(got) != len(steps3) {
+		t.Fatalf("expected 3Φ-only on first call with sufficient near-term peak, got %d steps", len(got))
+	}
+
+	// Two seconds later, forecast dips below threshold. Dwell must
+	// hold the prior 3Φ decision — no flap-down.
+	nearPeak = minStep3 - 500
+	if got := c.pickSurplusSteps(day1.Add(2*time.Second), cfg); len(got) != len(steps3) {
+		t.Fatalf("dwell must hold 3Φ within phaseSwitchMinHold even when near-term peak dips, got %d steps", len(got))
+	}
+
+	// 29 min later — still inside dwell window — same 3Φ verdict held.
+	if got := c.pickSurplusSteps(day1.Add(29*time.Minute), cfg); len(got) != len(steps3) {
+		t.Fatalf("dwell must hold 3Φ until phaseSwitchMinHold elapses, got %d steps", len(got))
+	}
+
+	// Past the dwell with low forecast — switch DOWN to 1Φ-allowed.
+	afterDwell := day1.Add(phaseSwitchMinHold + time.Second)
+	if got := c.pickSurplusSteps(afterDwell, cfg); len(got) != len(cfg.AllowedStepsW) {
+		t.Fatalf("expected 1Φ-allowed after dwell elapses with low near-term peak, got %d steps", len(got))
+	}
+
+	// Two seconds later, forecast recovers ABOVE minStep3. Dwell now
+	// guards the 1Φ→3Φ direction too — must NOT flap back up.
+	nearPeak = minStep3 + 1000
+	if got := c.pickSurplusSteps(afterDwell.Add(2*time.Second), cfg); len(got) != len(cfg.AllowedStepsW) {
+		t.Fatalf("dwell must hold 1Φ-allowed within phaseSwitchMinHold even on forecast recovery, got %d steps", len(got))
+	}
+
+	// Past the second dwell window — switch UP allowed again.
+	afterSecondDwell := afterDwell.Add(phaseSwitchMinHold + time.Second)
+	if got := c.pickSurplusSteps(afterSecondDwell, cfg); len(got) != len(steps3) {
+		t.Fatalf("expected 3Φ-only after second dwell elapses with high near-term peak, got %d steps", len(got))
+	}
+
+	// Day rollover with high forecast clears the selection so a fresh
+	// morning gets a fresh verdict, not a stale-from-yesterday state.
+	day2 := day1.Add(24 * time.Hour)
+	nearPeak = minStep3 + 1000
+	if got := c.pickSurplusSteps(day2, cfg); len(got) != len(steps3) {
+		t.Fatalf("expected 3Φ-only on day 2 with sufficient forecast, got %d steps", len(got))
+	}
+}

--- a/go/internal/loadpoint/surplus_reserve.go
+++ b/go/internal/loadpoint/surplus_reserve.go
@@ -40,6 +40,19 @@ func SurplusReserveW(states []State) float64 {
 		if !st.SurplusOnly || !st.PluggedIn {
 			continue
 		}
+		// Skip the reserve when the vehicle is in a terminal non-drawing
+		// state. "Complete" means the car reached its SoC target and
+		// won't draw more without operator intervention (re-target via
+		// app, plug-cycle, force_start). Leaving 2 kW reserved for a car
+		// that's refusing the offer makes the home battery hold steady
+		// at the current SoC while the same 2 kW exports to grid — the
+		// "charging a bit but not full surplus" symptom from a session
+		// where the EV finished charging mid-afternoon. Other states
+		// ("Stopped", "Disconnected", empty) keep the reserve so the
+		// system can bootstrap a re-start.
+		if st.VehicleChargingState == "Complete" {
+			continue
+		}
 		ceiling := st.CurrentPowerW + EVRampHeadroomW
 		if ceiling > st.MaxChargeW {
 			ceiling = st.MaxChargeW

--- a/go/internal/loadpoint/surplus_reserve.go
+++ b/go/internal/loadpoint/surplus_reserve.go
@@ -34,7 +34,18 @@ const EVRampHeadroomW = 2000
 //
 // Dispatch consumes the result via control.State.EVSurplusOnlyReserveW
 // in both the energy and the legacy/reactive paths.
-func SurplusReserveW(states []State) float64 {
+// SurplusReserveW takes the loadpoint states plus the set of LP IDs
+// whose wake-kick window is currently active. Wake-kick LPs get the
+// reserve floor (CurrentPowerW probably still 0 W while the EV is
+// ramping) so the home battery doesn't grab the freed surplus during
+// the brief gap between the wallbox offering current and the EV
+// actually starting to draw. Non-wake LPs that aren't drawing
+// (CurrentPowerW < 50 W) contribute nothing — they're not actively
+// claiming the surplus.
+//
+// wakeKickActiveIDs may be nil; callers without a wake-state source
+// pass nil and the reserve degrades to the actual-draw rule only.
+func SurplusReserveW(states []State, wakeKickActiveIDs map[string]bool) float64 {
 	var sum float64
 	for _, st := range states {
 		if !st.SurplusOnly || !st.PluggedIn {
@@ -45,12 +56,30 @@ func SurplusReserveW(states []State) float64 {
 		// or whose vehicle driver has gone offline (Tesla proxy flake
 		// etc.) reports CurrentPowerW≈0 — leaving 2 kW reserved for it
 		// makes the home battery hold steady at SoC while the same
-		// 2 kW exports to grid. The wake-kick path (controller.tickOne)
-		// commands cmd_w = min-step (1380 W) during the kick window,
-		// which materialises as CurrentPowerW>50 W within one tick if
-		// the EV is actually going to start — at which point this
-		// reserve activates and the battery makes room.
+		// 2 kW exports to grid.
 		//
+		// Wake-kick override: during the kick window the wallbox is
+		// actively offering current to a not-yet-drawing EV. Holding
+		// the reserve at the LP's min charge level keeps the battery
+		// from snatching the freed surplus before the EV's contactor
+		// settles. Without this, a car slow to ramp (cold pack,
+		// settling time) would see the surplus disappear into the
+		// home battery within one tick and the wake-kick would abort.
+		if wakeKickActiveIDs[st.ID] {
+			floor := st.MinChargeW
+			if floor <= 0 {
+				floor = EVRampHeadroomW
+			}
+			if st.CurrentPowerW > floor {
+				floor = st.CurrentPowerW
+			}
+			ceiling := floor + EVRampHeadroomW
+			if ceiling > st.MaxChargeW {
+				ceiling = st.MaxChargeW
+			}
+			sum += ceiling
+			continue
+		}
 		// Threshold 50 W picks up any non-trivial draw while ignoring
 		// idle pilot / standby consumption that doesn't represent
 		// "EV is actively claiming surplus".

--- a/go/internal/loadpoint/surplus_reserve.go
+++ b/go/internal/loadpoint/surplus_reserve.go
@@ -40,17 +40,21 @@ func SurplusReserveW(states []State) float64 {
 		if !st.SurplusOnly || !st.PluggedIn {
 			continue
 		}
-		// Skip the reserve when the vehicle is in a terminal non-drawing
-		// state. "Complete" means the car reached its SoC target and
-		// won't draw more without operator intervention (re-target via
-		// app, plug-cycle, force_start). Leaving 2 kW reserved for a car
-		// that's refusing the offer makes the home battery hold steady
-		// at the current SoC while the same 2 kW exports to grid — the
-		// "charging a bit but not full surplus" symptom from a session
-		// where the EV finished charging mid-afternoon. Other states
-		// ("Stopped", "Disconnected", empty) keep the reserve so the
-		// system can bootstrap a re-start.
-		if st.VehicleChargingState == "Complete" {
+		// Tie the reserve to the EV's ACTUAL draw, not just "plugged in
+		// + surplus_only". A car that's Complete, refusing the offer,
+		// or whose vehicle driver has gone offline (Tesla proxy flake
+		// etc.) reports CurrentPowerW≈0 — leaving 2 kW reserved for it
+		// makes the home battery hold steady at SoC while the same
+		// 2 kW exports to grid. The wake-kick path (controller.tickOne)
+		// commands cmd_w = min-step (1380 W) during the kick window,
+		// which materialises as CurrentPowerW>50 W within one tick if
+		// the EV is actually going to start — at which point this
+		// reserve activates and the battery makes room.
+		//
+		// Threshold 50 W picks up any non-trivial draw while ignoring
+		// idle pilot / standby consumption that doesn't represent
+		// "EV is actively claiming surplus".
+		if st.CurrentPowerW < 50.0 {
 			continue
 		}
 		ceiling := st.CurrentPowerW + EVRampHeadroomW

--- a/go/internal/loadpoint/surplus_reserve_test.go
+++ b/go/internal/loadpoint/surplus_reserve_test.go
@@ -68,7 +68,7 @@ func TestSurplusReserveW(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SurplusReserveW(tt.states)
+			got := SurplusReserveW(tt.states, nil)
 			if got != tt.want {
 				t.Errorf("SurplusReserveW = %.0f, want %.0f", got, tt.want)
 			}
@@ -87,12 +87,49 @@ func TestSurplusReserveWReleasesUnusedMaxToBattery(t *testing.T) {
 	states := []State{
 		{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 2500, MaxChargeW: 11000},
 	}
-	reserve := SurplusReserveW(states)
+	reserve := SurplusReserveW(states, nil)
 	current := states[0].CurrentPowerW
 	pvSurplus := 3000.0
 	ceiling := pvSurplus - (reserve - current)
 	if ceiling <= 0 {
 		t.Fatalf("ceiling = %.0f W — battery should get some of the 3 kW surplus, was 0 pre-fix", ceiling)
+	}
+}
+
+// Wake-kick active: even though CurrentPowerW is still 0 W, the
+// wallbox is actively offering current and the EV is expected to ramp
+// within the next tick. The reserve must hold the floor so the home
+// battery doesn't snatch the freed surplus during the brief gap.
+func TestSurplusReserveWHonoursWakeKickFloor(t *testing.T) {
+	states := []State{
+		{ID: "lp1", SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000, MinChargeW: 1380},
+	}
+	wakeKick := map[string]bool{"lp1": true}
+	reserve := SurplusReserveW(states, wakeKick)
+	if reserve < 1380 {
+		t.Errorf("wake-kick active should reserve at least MinChargeW (1380 W), got %.0f", reserve)
+	}
+}
+
+// Boundary at the 50 W threshold: < 50 → no reserve, ≥ 50 → reserved.
+// Locks the numeric contract so a future change to the threshold
+// can't silently desync from callers reading it as documentation.
+func TestSurplusReserveWThresholdBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		power float64
+		want  float64
+	}{
+		{0, 0},
+		{49.9, 0},
+		{50.0, 50.0 + EVRampHeadroomW},   // strict-less-than gate: exactly 50 W is on the "drawing" side
+		{50.001, 50.001 + EVRampHeadroomW},
+		{1380, 1380 + EVRampHeadroomW},
+	} {
+		states := []State{{SurplusOnly: true, PluggedIn: true, CurrentPowerW: tc.power, MaxChargeW: 11000}}
+		got := SurplusReserveW(states, nil)
+		if got != tc.want {
+			t.Errorf("CurrentPowerW=%.3f: reserve=%.3f, want %.3f", tc.power, got, tc.want)
+		}
 	}
 }
 
@@ -110,7 +147,7 @@ func TestSurplusReserveWAllowsOnePhaseLadderClimb(t *testing.T) {
 	states := []State{
 		{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1380, MaxChargeW: 11000},
 	}
-	reserve := SurplusReserveW(states)
+	reserve := SurplusReserveW(states, nil)
 	reserveRemaining := reserve - states[0].CurrentPowerW
 	const ladderClimbW = 3220 - 1380 // 1Φ × 6 A → 1Φ × 14 A ≈ 1840 W
 	if reserveRemaining < ladderClimbW {

--- a/go/internal/loadpoint/surplus_reserve_test.go
+++ b/go/internal/loadpoint/surplus_reserve_test.go
@@ -29,11 +29,19 @@ func TestSurplusReserveW(t *testing.T) {
 			want: 2500 + EVRampHeadroomW,
 		},
 		{
-			name: "EV at 0W with 11kW max → just the headroom",
+			// Updated 2026-05: when EV is plugged but not actually
+			// drawing, no reserve. The 2 kW idle headroom otherwise
+			// hangs around for a Tesla that's Complete / a vehicle
+			// driver that went offline / a car refusing the offer,
+			// blocking the home battery from absorbing PV. Wake-kick
+			// path (controller.tickOne) materialises EV draw to
+			// >50 W within a tick if the EV is actually going to
+			// start, at which point the reserve re-engages.
+			name: "EV at 0W → no reserve (not drawing)",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},
 			},
-			want: EVRampHeadroomW,
+			want: 0,
 		},
 		{
 			name: "EV close to max → clamped to MaxChargeW (no overshoot)",
@@ -50,12 +58,12 @@ func TestSurplusReserveW(t *testing.T) {
 			want: 11000,
 		},
 		{
-			name: "multiple LPs sum",
+			name: "multiple LPs sum — only active ones contribute",
 			states: []State{
 				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 1500, MaxChargeW: 3700}, // 1500 + 2000 = 3500, under cap
-				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},   // 0 + 2000 = 2000
+				{SurplusOnly: true, PluggedIn: true, CurrentPowerW: 0, MaxChargeW: 11000},   // not drawing → 0
 			},
-			want: (1500 + EVRampHeadroomW) + (0 + EVRampHeadroomW),
+			want: 1500 + EVRampHeadroomW,
 		},
 	}
 	for _, tt := range tests {

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -875,19 +875,29 @@ func annotateCurtailment(plan *Plan, exportOrePerKWh float64) {
 //	actW          = battery command (+ charge, − discharge)
 func modeAllows(m Mode, baselineGridW, gridW, actW float64) bool {
 	const eps = 1e-6
+	// modeTolW absorbs action-grid discretization at the boundary so a
+	// 50 W overshoot doesn't disqualify an otherwise-correct action.
+	// Without it, ActionLevels=41 (450 W step) frequently can't find a
+	// legal self_consumption action when |baselineGridW| isn't a multiple
+	// of the action step — DP picks idle and the operator sees PV
+	// exporting / grid importing instead of the battery covering. The
+	// 50 W matches the surplus-only / no-battery-to-EV checks elsewhere
+	// in the DP and the dispatch-side reserve epsilon, keeping the
+	// tolerance budget consistent across the planner.
+	const modeTolW = 50.0
 	switch m {
 	case ModeSelfConsumption:
 		// Battery must only move the grid toward zero, never past it:
-		//   if baseline > 0 (import): grid must be in [0, baseline]
-		//   if baseline < 0 (export): grid must be in [baseline, 0]
-		//   if baseline == 0: battery must be 0
+		//   if baseline > 0 (import): grid must be in [-tol, baseline+tol]
+		//   if baseline < 0 (export): grid must be in [baseline-tol, +tol]
+		//   if baseline == 0: battery must be 0 (± tol)
 		if baselineGridW > eps {
-			return gridW >= -eps && gridW <= baselineGridW+eps
+			return gridW >= -modeTolW && gridW <= baselineGridW+modeTolW
 		}
 		if baselineGridW < -eps {
-			return gridW <= eps && gridW >= baselineGridW-eps
+			return gridW <= modeTolW && gridW >= baselineGridW-modeTolW
 		}
-		return math.Abs(actW) < eps
+		return math.Abs(actW) < modeTolW
 	case ModeCheapCharge:
 		// Allow charging from grid (any actW ≥ 0), but never discharge past
 		// the local load: i.e. gridW must stay ≥ 0 when we'd otherwise be

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -607,6 +607,38 @@ func Optimize(slots []Slot, p Params) Plan {
 								houseKWh := houseGridW * dtH / 1000.0
 								cost += 2.0 * effPrice(slot) * houseKWh
 							}
+							// Symmetric bias on the export side: when the
+							// battery has room (battSoc2 < SoCMaxPct) and
+							// we'd be exporting PV that could be stored,
+							// penalise the wasted PV at effPrice. Without
+							// this, the DP happily exports cheap midday PV
+							// at spot (~2 öre) instead of storing it to
+							// cover the same evening / night load that
+							// would otherwise be imported at retail
+							// (150-290 öre). Operator-stated intent for
+							// SC mode: "fill up to cover nightly loads"
+							// — exporting cheap PV while SoC sits well
+							// below SoCMaxPct contradicts that.
+							//
+							// Headroom-scaled so the bias fades to 0 as
+							// SoC approaches the cap (no penalty at
+							// SoCMaxPct — exporting is the right move
+							// when the battery is full). The 1.0 ×
+							// effPrice coefficient (vs 2.0 on the import
+							// side) is intentional: import is a hard
+							// "battery should have covered this" miss;
+							// export-while-not-full is the softer "should
+							// have stored this" miss — both push the same
+							// direction without over-coupling the two.
+							if houseGridW < 0 && battSoc2 < p.SoCMaxPct {
+								headroomFrac := (p.SoCMaxPct - battSoc2) /
+									(p.SoCMaxPct - p.SoCMinPct)
+								if headroomFrac > 1 {
+									headroomFrac = 1
+								}
+								wastedKWh := -houseGridW * dtH / 1000.0
+								cost += headroomFrac * effPrice(slot) * wastedKWh
+							}
 						}
 
 						// Deadline slot: if this slot is the EV's

--- a/go/internal/mpc/self_consumption_horizon_test.go
+++ b/go/internal/mpc/self_consumption_horizon_test.go
@@ -14,8 +14,9 @@ import "testing"
 //
 // With ActionLevels=21 (900 W step) the DP picked idle because the only
 // legal charge action (+900 W) didn't visibly improve V over 192 slots
-// vs. 0. ActionLevels=41 (450 W step) lets the DP land on +1350 W and
-// the math correctly favours storing for the evening peak.
+// vs. 0. Production now runs ActionLevels=81 (225 W step) — this test
+// pins that value so a future regression that drops it back to 21 or
+// 41 (or any coarser grid that re-introduces the bug) trips the test.
 func TestSelfConsumptionAbsorbsCheapPVOver48hHorizon(t *testing.T) {
 	slots := make([]Slot, 192)
 	for i := range slots {
@@ -63,7 +64,7 @@ func TestSelfConsumptionAbsorbsCheapPVOver48hHorizon(t *testing.T) {
 		SoCLevels:           41,
 		MaxChargeW:          9000,
 		MaxDischargeW:       9000,
-		ActionLevels:        41, // main.go uses this same value
+		ActionLevels:        81, // matches main.go's buildMPC default
 		ChargeEfficiency:    0.95,
 		DischargeEfficiency: 0.95,
 		TerminalSoCPrice:    163.99,

--- a/go/internal/mpc/self_consumption_horizon_test.go
+++ b/go/internal/mpc/self_consumption_horizon_test.go
@@ -1,0 +1,80 @@
+package mpc
+
+import "testing"
+
+// TestSelfConsumptionAbsorbsCheapPVOver48hHorizon is the regression guard
+// for the 2026-05-23 production bug where a 1.7 kW exporting slot saw
+// the DP pick idle instead of absorbing the surplus into the battery.
+//
+// Scenario mirrors the production observation:
+//   - SoC 65 % (room to 90 %)
+//   - Slot 0 has cheap midday spot (2 öre, retail 152 öre) with strong PV
+//   - Evening peak (slots 13-21) at retail 260 öre forecasts heavy import
+//   - Day 2 is cloudy — no chance to defer charging
+//
+// With ActionLevels=21 (900 W step) the DP picked idle because the only
+// legal charge action (+900 W) didn't visibly improve V over 192 slots
+// vs. 0. ActionLevels=41 (450 W step) lets the DP land on +1350 W and
+// the math correctly favours storing for the evening peak.
+func TestSelfConsumptionAbsorbsCheapPVOver48hHorizon(t *testing.T) {
+	slots := make([]Slot, 192)
+	for i := range slots {
+		var price, spot, pv, load float64
+		d := i % 96
+		switch {
+		case d < 6:
+			price, spot, pv, load = 152, 2, -2300, 693
+		case d < 13:
+			price, spot, pv, load = 170, 15, -1500, 800
+		case d < 22:
+			price, spot, pv, load = 260, 90, -200, 1800
+		case d < 30:
+			price, spot, pv, load = 170, 12, 0, 500
+		case d < 40:
+			price, spot, pv, load = 150, 5, 0, 500
+		case d < 55:
+			price, spot, pv, load = 130, 3, 0, 500
+		case d < 70:
+			price, spot, pv, load = 200, 50, -800, 1100
+		case d < 85:
+			price, spot, pv, load = 145, 1, -3500, 693
+		default:
+			price, spot, pv, load = 150, 2, -2900, 693
+		}
+		if i >= 96 { // Day 2: cloudy — no PV.
+			pv = 0
+		}
+		slots[i] = Slot{
+			LenMin:     15,
+			PriceOre:   price,
+			SpotOre:    spot,
+			PVW:        pv,
+			LoadW:      load,
+			Confidence: 1.0,
+		}
+	}
+
+	p := Params{
+		Mode:                ModeSelfConsumption,
+		CapacityWh:          20000,
+		InitialSoCPct:       65,
+		SoCMinPct:           10,
+		SoCMaxPct:           90,
+		SoCLevels:           41,
+		MaxChargeW:          9000,
+		MaxDischargeW:       9000,
+		ActionLevels:        41, // main.go uses this same value
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    163.99,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) == 0 {
+		t.Fatal("plan empty")
+	}
+	a := plan.Actions[0]
+	if a.BatteryW <= 0 {
+		t.Fatalf("DP must charge battery in slot 0 (cheap PV + expensive evening peak ahead), got batt=%v reason=%q",
+			a.BatteryW, a.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

11 commits stacking on top of v0.79.4 that together:

1. Stop the Easee 1Φ↔3Φ contactor flap (the original symptom)
2. Make the EV gate aware of the home battery's PV allocation
3. Give the operator a force_start API + EV-stop replan hook
4. Fix the MPC's planning bias so it actually fills the home battery to cover nightly loads in `self_consumption` mode (the bug-of-the-day)

## What was broken

A borderline-cloud day reproduced two stacked bugs in production:

- The Easee phase-switching gate had no hysteresis on its forecast peak vs. 3Φ-min threshold. With forecast PV hovering around 4140 W, the contactor flipped 1Φ↔3Φ every ~2 min — wearing the contactor, paging the battery PI with load-step transients, and visibly oscillating EV power.
- The MPC's `self_consumption` mode kept the home battery at 0 W while exporting cheap midday PV at ~2 öre, then planned to import the same energy back at 150-290 öre overnight. Three independent causes layered up:
  - `ActionLevels=21` (900 W discretization step) — DP couldn't land on a charge action inside the legal range when the export window was a non-multiple of 900 W
  - `modeAllows` strict eps=1e-6 tolerance — discharge actions that overshot the import-cover target by even 1 W got rejected
  - One-directional SC bias — penalty on house import, nothing on PV waste
- The dispatch's `EVSurplusOnlyReserveW` continued reserving 2 kW for a Tesla that had finished charging (`vehicle_charging_state="Complete"`), so the home battery clamped at ~1.5 kW while the reserved 2 kW exported to grid.

## What changed (11 commits, none touch v0.79.4's surfaces)

| Commit | What |
|---|---|
| `d9e8b3e` | 30-min minimum-dwell on 1Φ↔3Φ near-term gate |
| `ddca0a1` | test: cover 30-min dwell |
| `e4fe1f1` | pin driver phase_mode to dwell selection (prevents cmd=0 auto-flip) |
| `efefbcb` | subtract planned battery charge from near-term EV surplus |
| `8086bde` | POST /api/loadpoints/{id}/force_start (cooldown bypass) |
| `234764f` | replan on EV-draw falling edge |
| `047eb02` | ActionLevels 21→41 (450 W step, regression test added) |
| `8b9f13f` | modeAllows 50 W tolerance |
| `48b0e19` | symmetric SC bias — penalise PV export while battery has room |
| `1a52f47` | drop EV surplus reserve when vehicle is Complete |
| `9f630bb` | decorate LP states with VehicleChargingState before reserve calc |

## Production behaviour change

Pre-fix (borderline PV day, SoC 65%, evening peak ahead):

```
16:30  pv=-2399 load=693 batt=0     grid=-1706  reason="idle — export PV surplus"
17:30  pv=-1401 load=1853 batt=0    grid=  452  reason="idle — import to cover load"
22:00  pv=    0 load=757  batt=0    grid=  757  reason="idle — import to cover load"
```

Post-fix, same conditions:

```
16:45  pv=-2775 load=1702 batt=  900  grid= -173  reason="absorb PV surplus"
17:30  pv=-1406 load=1853 batt= -450  grid=   -3  reason="discharge — cover local load"
22:00  pv=    0 load=757  batt= -450  grid=  307  reason="discharge — cover local load"
00:00  pv=    0 load=561  batt= -450  grid=  111  reason="discharge — cover local load"
```

Battery now absorbs cheap PV, holds for evening peak, then discharges through the night to cover house load — operator's stated intent for `self_consumption` mode (\"fill up to cover nightly loads\").

## Test plan

- [x] `go test ./internal/loadpoint/ ./internal/mpc/ ./internal/control/ ./internal/api/` clean
- [x] New regression tests: `TestPickSurplusSteps_NearTermDwell`, `TestSelfConsumptionAbsorbsCheapPVOver48hHorizon`
- [x] Production verification on operator's Pi (running `v0.79.4-11-g9f630bb`): phase-flip count over a 2 h window dropped from ~6/10min to 0; battery now absorbs PV with grid near 0; planned discharge schedule covers evening + night loads from stored PV.
- [ ] PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)