### PR TITLE
[codex] add load profile modes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -604,7 +604,7 @@ PV digital-twin self-learner status. See `docs/ml-twins.md`
   "samples": 4320,
   "mae_w": 85.2,
   "rated_w": 8500,
-  "quality": "good",
+  "quality": 0.84,
   "last_ms": 1744579200000,
   "forgetting": 0.999,
   "beta": [0.8, 0.1, -0.05]
@@ -644,31 +644,56 @@ Load digital-twin self-learner status. Buckets are per-hour-of-week;
 ```json
 {
   "enabled": true,
+  "profile": "home",
   "samples": 10800,
   "mae_w": 140.0,
   "peak_w": 6800,
-  "quality": "good",
+  "quality": 0.84,
   "last_ms": 1744579200000,
   "heating_w_per_degc": 45.0,
   "buckets_warm": 98,
-  "buckets_total": 168
+  "buckets_total": 168,
+  "profiles": {
+    "home": { "samples": 10800, "quality": 0.84 },
+    "away": { "samples": 1440, "quality": 0.42 }
+  }
 }
 ```
 
 **Response (200), disabled:** `{ "enabled": false }`
 
-Handler: `go/internal/api/api.go:830`
+Handler: `go/internal/api/api_loadmodel.go`
+
+### POST /api/loadmodel/profile
+
+Switch the active load profile. The active profile is the one that trains
+from live telemetry and feeds MPC predictions. The choice is persisted in
+the state DB and triggers an immediate MPC replan when MPC is enabled.
+
+**Request body:**
+
+```json
+{ "profile": "away" }
+```
+
+Allowed values: `home`, `away`.
+
+**Response (200):** `{ "status": "ok", "profile": "away" }`
+
+**Errors:** `400` `{ "error": "unknown load profile: …" }`
+
+Handler: `go/internal/api/api_loadmodel.go`
 
 ### POST /api/loadmodel/reset
 
-Clear the load twin while preserving the configured
+Clear the active load profile while preserving the configured
 `heating_w_per_degc`. Same semantics as `/api/pvmodel/reset`.
 
-**Response (200):** `{ "status": "reset" }`
+**Response (200):** `{ "status": "reset", "profile": "away" }`
 
 **Errors:** `400` `{ "error": "loadmodel disabled" }`
 
-Handler: `go/internal/api/api.go:856`
+Handler: `go/internal/api/api_loadmodel.go`
 
 ### GET /api/research/load/dump
 

--- a/docs/ml-models.md
+++ b/docs/ml-models.md
@@ -137,7 +137,7 @@ Trust-weighted blend with the baked prior at prediction time:
 
 ```go
 trust := bucket.Samples / MinTrustSamples    // capped at 1
-base  := trust*bucket.Mean + (1-trust)*typicalPrior(idx)
+base  := trust*bucket.Mean + (1-trust)*profilePrior(idx)
 heat  := HeatingW_per_degC * max(18 - tempC, 0)
 return base + heat
 ```
@@ -178,11 +178,27 @@ Baked single-family Swedish-home prior at `model.go:67`:
 Every bucket starts at that prior, so day-0 MPC gets a plausible load
 curve.
 
+### Occupancy profiles
+
+The service maintains two independent profiles:
+
+- `home` — default profile, seeded with the normal household prior.
+- `away` — manual away profile, seeded with a lower unoccupied-house
+  prior and trained only while selected.
+
+The active profile controls both online training and MPC predictions.
+Switching profile through `POST /api/loadmodel/profile` persists the
+selection and triggers an immediate MPC replan so the next dispatch cycle
+uses the matching load forecast.
+
 ### Persistence + reset
 
-- Config key: `loadmodel/state_utc` (`service.go:19`).
-- `POST /api/loadmodel/reset` (`go/internal/api/api.go:122`) — reseeds
-  via `NewModel(peakW)` while preserving the configured peak and heating
+- Config keys: `loadmodel/profile` and
+  `loadmodel/state_utc:<profile>` (`service.go`).
+- Legacy `loadmodel/state_utc` migrates into the `home` profile when no
+  profile-specific home model has been stored yet.
+- `POST /api/loadmodel/reset` (`go/internal/api/api_loadmodel.go`) — reseeds
+  the active profile while preserving the configured peak and heating
   coefficient.
 
 ---

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -234,6 +234,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/pvmodel", s.handlePVModel)
 	s.handle("POST /api/pvmodel/reset", s.handlePVModelReset)
 	s.handle("GET  /api/loadmodel", s.handleLoadModel)
+	s.handle("POST /api/loadmodel/profile", s.handleLoadModelProfile)
 	s.handle("POST /api/loadmodel/reset", s.handleLoadModelReset)
 	s.handle("GET  /api/research/load/dump", s.handleLoadResearchDump)
 	s.handle("GET  /api/series", s.handleSeries)
@@ -1914,43 +1915,6 @@ func (s *Server) handlePVModelReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.deps.PVModel.Reset()
-	writeJSON(w, 200, map[string]string{"status": "reset"})
-}
-
-// ---- Load digital twin ----
-
-func (s *Server) handleLoadModel(w http.ResponseWriter, r *http.Request) {
-	if s.deps.LoadModel == nil {
-		writeJSON(w, 200, map[string]any{"enabled": false})
-		return
-	}
-	m := s.deps.LoadModel.Model()
-	// Count warmed-up buckets (≥ MinTrustSamples).
-	warm := 0
-	for i := 0; i < loadmodel.Buckets; i++ {
-		if m.Bucket[i].Samples >= loadmodel.MinTrustSamples {
-			warm++
-		}
-	}
-	writeJSON(w, 200, map[string]any{
-		"enabled":            true,
-		"samples":            m.Samples,
-		"mae_w":              m.MAE,
-		"peak_w":             m.PeakW,
-		"quality":            m.Quality(),
-		"last_ms":            m.LastMs,
-		"heating_w_per_degc": m.HeatingW_per_degC,
-		"buckets_warm":       warm,
-		"buckets_total":      loadmodel.Buckets,
-	})
-}
-
-func (s *Server) handleLoadModelReset(w http.ResponseWriter, r *http.Request) {
-	if s.deps.LoadModel == nil {
-		writeJSON(w, 400, map[string]string{"error": "loadmodel disabled"})
-		return
-	}
-	s.deps.LoadModel.Reset()
 	writeJSON(w, 200, map[string]string{"status": "reset"})
 }
 

--- a/go/internal/api/api_loadmodel.go
+++ b/go/internal/api/api_loadmodel.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/frahlg/forty-two-watts/go/internal/loadmodel"
+)
+
+type loadModelStats struct {
+	Samples         int64   `json:"samples"`
+	MAEW            float64 `json:"mae_w"`
+	PeakW           float64 `json:"peak_w"`
+	Quality         float64 `json:"quality"`
+	LastMs          int64   `json:"last_ms"`
+	HeatingWPerDegC float64 `json:"heating_w_per_degc"`
+	BucketsWarm     int     `json:"buckets_warm"`
+	BucketsTotal    int     `json:"buckets_total"`
+}
+
+func (s *Server) handleLoadModel(w http.ResponseWriter, r *http.Request) {
+	if s.deps.LoadModel == nil {
+		writeJSON(w, 200, map[string]any{"enabled": false})
+		return
+	}
+	snap := s.deps.LoadModel.Snapshot()
+	active := snap.Profiles[snap.ActiveProfile]
+	profiles := make(map[loadmodel.Profile]loadModelStats, len(snap.Profiles))
+	for _, profile := range loadmodel.Profiles() {
+		if m, ok := snap.Profiles[profile]; ok {
+			profiles[profile] = loadModelStatsFrom(m)
+		}
+	}
+	stats := loadModelStatsFrom(active)
+	writeJSON(w, 200, map[string]any{
+		"enabled":            true,
+		"profile":            snap.ActiveProfile,
+		"active_profile":     snap.ActiveProfile,
+		"profiles":           profiles,
+		"samples":            stats.Samples,
+		"mae_w":              stats.MAEW,
+		"peak_w":             stats.PeakW,
+		"quality":            stats.Quality,
+		"last_ms":            stats.LastMs,
+		"heating_w_per_degc": stats.HeatingWPerDegC,
+		"buckets_warm":       stats.BucketsWarm,
+		"buckets_total":      stats.BucketsTotal,
+	})
+}
+
+func (s *Server) handleLoadModelProfile(w http.ResponseWriter, r *http.Request) {
+	if s.deps.LoadModel == nil {
+		writeJSON(w, 400, map[string]string{"error": "loadmodel disabled"})
+		return
+	}
+	var req struct {
+		Profile string `json:"profile"`
+		Mode    string `json:"mode"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	raw := req.Profile
+	if raw == "" {
+		raw = req.Mode
+	}
+	profile, ok := loadmodel.ParseProfile(raw)
+	if !ok {
+		writeJSON(w, 400, map[string]string{"error": "unknown load profile: " + raw})
+		return
+	}
+	if err := s.deps.LoadModel.SetProfile(profile); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "persist failed: " + err.Error()})
+		return
+	}
+	if s.deps.MPC != nil {
+		s.deps.MPC.ReplanWithReason(r.Context(), "load_profile_changed")
+	}
+	writeJSON(w, 200, map[string]any{"status": "ok", "profile": profile})
+}
+
+func (s *Server) handleLoadModelReset(w http.ResponseWriter, r *http.Request) {
+	if s.deps.LoadModel == nil {
+		writeJSON(w, 400, map[string]string{"error": "loadmodel disabled"})
+		return
+	}
+	profile := s.deps.LoadModel.Profile()
+	s.deps.LoadModel.Reset()
+	if s.deps.MPC != nil {
+		s.deps.MPC.ReplanWithReason(r.Context(), "load_profile_reset")
+	}
+	writeJSON(w, 200, map[string]any{"status": "reset", "profile": profile})
+}
+
+func loadModelStatsFrom(m loadmodel.Model) loadModelStats {
+	warm := 0
+	for i := 0; i < loadmodel.Buckets; i++ {
+		if m.Bucket[i].Samples >= loadmodel.MinTrustSamples {
+			warm++
+		}
+	}
+	return loadModelStats{
+		Samples:         m.Samples,
+		MAEW:            m.MAE,
+		PeakW:           m.PeakW,
+		Quality:         m.Quality(),
+		LastMs:          m.LastMs,
+		HeatingWPerDegC: m.HeatingW_per_degC,
+		BucketsWarm:     warm,
+		BucketsTotal:    loadmodel.Buckets,
+	}
+}

--- a/go/internal/api/api_loadmodel_test.go
+++ b/go/internal/api/api_loadmodel_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/loadmodel"
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+func TestHandleLoadModelProfileSwitch(t *testing.T) {
+	lm := loadmodel.NewService(nil, telemetry.NewStore(), "site", 4000)
+	srv := New(&Deps{LoadModel: lm})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/loadmodel/profile", strings.NewReader(`{"profile":"away"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("set profile status = %d, body: %s", rr.Code, rr.Body.String())
+	}
+	if got := lm.Profile(); got != loadmodel.ProfileAway {
+		t.Fatalf("profile = %q, want away", got)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/loadmodel", nil)
+	getRR := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("get loadmodel status = %d, body: %s", getRR.Code, getRR.Body.String())
+	}
+	var resp struct {
+		Profile  string                     `json:"profile"`
+		Profiles map[string]json.RawMessage `json:"profiles"`
+	}
+	if err := json.Unmarshal(getRR.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Profile != "away" {
+		t.Fatalf("response profile = %q, want away", resp.Profile)
+	}
+	if _, ok := resp.Profiles["home"]; !ok {
+		t.Fatalf("home profile missing from response: %s", getRR.Body.String())
+	}
+	if _, ok := resp.Profiles["away"]; !ok {
+		t.Fatalf("away profile missing from response: %s", getRR.Body.String())
+	}
+}
+
+func TestHandleLoadModelProfileRejectsUnknown(t *testing.T) {
+	lm := loadmodel.NewService(nil, telemetry.NewStore(), "site", 4000)
+	srv := New(&Deps{LoadModel: lm})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/loadmodel/profile", strings.NewReader(`{"profile":"vacation"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rr.Code, rr.Body.String())
+	}
+}

--- a/go/internal/api/api_research.go
+++ b/go/internal/api/api_research.go
@@ -126,7 +126,7 @@ func (s *Server) handleLoadResearchDump(w http.ResponseWriter, r *http.Request) 
 	addFile("timeseries_15m.csv", []byte(formatLoadResearchCSV(buckets, forecasts, prices)))
 
 	if s.deps.LoadModel != nil {
-		modelBody, _ := json.MarshalIndent(s.deps.LoadModel.Model(), "", "  ")
+		modelBody, _ := json.MarshalIndent(s.deps.LoadModel.Snapshot(), "", "  ")
 		addFile("loadmodel_state.json", modelBody)
 	} else {
 		addFile("loadmodel_state.json", []byte("{}\n"))

--- a/go/internal/loadmodel/model.go
+++ b/go/internal/loadmodel/model.go
@@ -43,9 +43,34 @@ const MinTrustSamples = 8
 // relative to. Load proportional to max(setpoint − outdoor, 0).
 const HeatingReferenceC = 18.0
 
+// Profile selects which learned occupancy profile is used for training
+// and prediction.
+type Profile string
+
+const (
+	ProfileHome Profile = "home"
+	ProfileAway Profile = "away"
+)
+
+const awayPriorScale = 0.25
+
+// Profiles returns the supported load-model profiles in display order.
+func Profiles() []Profile {
+	return []Profile{ProfileHome, ProfileAway}
+}
+
+func (p Profile) valid() bool {
+	switch p {
+	case ProfileHome, ProfileAway:
+		return true
+	default:
+		return false
+	}
+}
+
 // Bucket holds one hour-of-week's learned state.
 type Bucket struct {
-	Mean    float64 `json:"mean"`     // EMA of observed load (W)
+	Mean    float64 `json:"mean"` // EMA of observed load (W)
 	Samples int64   `json:"samples"`
 }
 
@@ -58,6 +83,7 @@ type Model struct {
 	LastMs            int64           `json:"last_ms"`
 	MAE               float64         `json:"mae"`
 	Alpha             float64         `json:"alpha"` // EMA coefficient for bucket updates
+	PriorScale        float64         `json:"prior_scale,omitempty"`
 }
 
 // typicalPrior returns an approximate W load for a given hour-of-week
@@ -82,18 +108,39 @@ func typicalPrior(hourOfWeek int) float64 {
 
 // NewModel returns a model seeded with the typical prior on every bucket.
 func NewModel(peakW float64) *Model {
+	return newModel(peakW, 1)
+}
+
+func newProfileModel(peakW float64, profile Profile) *Model {
+	scale := 1.0
+	if profile == ProfileAway {
+		scale = awayPriorScale
+	}
+	return newModel(peakW, scale)
+}
+
+func newModel(peakW, priorScale float64) *Model {
 	m := &Model{
-		PeakW: peakW,
-		Alpha: 0.1, // new sample gets 10% weight in EMA
+		PeakW:      peakW,
+		Alpha:      0.1, // new sample gets 10% weight in EMA
+		PriorScale: priorScale,
 	}
 	if m.PeakW <= 0 {
 		m.PeakW = 5000
 	}
 	for i := 0; i < Buckets; i++ {
-		m.Bucket[i].Mean = typicalPrior(i)
+		m.Bucket[i].Mean = m.prior(i)
 		m.Bucket[i].Samples = 0
 	}
 	return m
+}
+
+func (m Model) prior(hourOfWeek int) float64 {
+	scale := m.PriorScale
+	if scale <= 0 {
+		scale = 1
+	}
+	return typicalPrior(hourOfWeek) * scale
 }
 
 // HourOfWeek computes 0..167 for a time. Monday = 0 through Sunday.
@@ -117,7 +164,7 @@ func (m Model) Predict(t time.Time, tempC float64) float64 {
 	if trust > 1 {
 		trust = 1
 	}
-	prior := typicalPrior(idx)
+	prior := m.prior(idx)
 	base := trust*b.Mean + (1-trust)*prior
 	heating := 0.0
 	if tempC < HeatingReferenceC {
@@ -146,7 +193,6 @@ func (m *Model) Update(t time.Time, actualLoadW, tempC float64) (updated bool) {
 	}
 	idx := HourOfWeek(t)
 	b := &m.Bucket[idx]
-	prior := typicalPrior(idx)
 	// Outlier filter: once we have some history, reject 10× MAE residuals.
 	predicted := m.Predict(t, tempC)
 	err := actualLoadW - predicted
@@ -176,8 +222,6 @@ func (m *Model) Update(t time.Time, actualLoadW, tempC float64) (updated bool) {
 		b.Mean = (1-m.Alpha)*b.Mean + m.Alpha*baseSample
 	}
 	b.Samples++
-	_ = prior
-
 	// Heating coefficient is operator-configured (Planner.HeatingWPerDegC
 	// in config). We don't try to identify it from data here because
 	// online fit is noisy + entangled with the bucket baseline. The

--- a/go/internal/loadmodel/service.go
+++ b/go/internal/loadmodel/service.go
@@ -3,7 +3,9 @@ package loadmodel
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,10 +18,29 @@ import (
 // package from the forecast module.
 type TempFunc func(t time.Time) (float64, bool)
 
-// Bumped from "loadmodel/state" after HourOfWeek switched to UTC
-// coercion: pre-switch buckets were indexed in local zone and would
-// silently misalign if restored. Fresh init retrains from telemetry.
-const stateKey = "loadmodel/state_utc"
+// legacyStateKey was bumped from "loadmodel/state" after HourOfWeek
+// switched to UTC coercion. It remains as the one-time migration source
+// for the default home profile.
+const legacyStateKey = "loadmodel/state_utc"
+
+const (
+	stateKeyPrefix  = "loadmodel/state_utc:"
+	profileStateKey = "loadmodel/profile"
+)
+
+func stateKey(profile Profile) string { return stateKeyPrefix + string(profile) }
+
+// ParseProfile normalizes a user/API supplied load-model profile.
+func ParseProfile(v string) (Profile, bool) {
+	p := Profile(strings.ToLower(strings.TrimSpace(v)))
+	return p, p.valid()
+}
+
+// Snapshot is a concurrency-safe copy of the service state.
+type Snapshot struct {
+	ActiveProfile Profile           `json:"active_profile"`
+	Profiles      map[Profile]Model `json:"profiles"`
+}
 
 // Service trains the load model online from telemetry. Mirrors
 // pvmodel.Service so operators + future code have one pattern.
@@ -31,8 +52,9 @@ type Service struct {
 	SampleInterval time.Duration
 	PersistEvery   int64
 
-	mu    sync.RWMutex
-	model *Model
+	mu     sync.RWMutex
+	active Profile
+	models map[Profile]*Model
 
 	stop chan struct{}
 	done chan struct{}
@@ -48,28 +70,126 @@ func NewService(st *state.Store, tel *telemetry.Store, siteMeter string, peakW f
 		PersistEvery:   10,
 		stop:           make(chan struct{}),
 		done:           make(chan struct{}),
+		active:         ProfileHome,
+		models:         make(map[Profile]*Model),
+	}
+	for _, profile := range Profiles() {
+		s.models[profile] = newProfileModel(peakW, profile)
 	}
 	if st != nil {
-		if js, ok := st.LoadConfig(stateKey); ok && js != "" {
-			var m Model
-			if err := json.Unmarshal([]byte(js), &m); err == nil && m.Alpha > 0 {
-				m.PeakW = peakW // config may have changed
-				s.model = &m
-				slog.Info("loadmodel restored", "samples", m.Samples, "mae_w", m.MAE, "quality", m.Quality())
+		loadedProfiles := make(map[Profile]bool)
+		if v, ok := st.LoadConfig(profileStateKey); ok {
+			if profile, valid := ParseProfile(v); valid {
+				s.active = profile
 			}
 		}
-	}
-	if s.model == nil {
-		s.model = NewModel(peakW)
+		for _, profile := range Profiles() {
+			if js, ok := st.LoadConfig(stateKey(profile)); ok && js != "" {
+				if m, ok := restoreModel(js, peakW, profile); ok {
+					s.models[profile] = m
+					loadedProfiles[profile] = true
+					slog.Info("loadmodel restored",
+						"profile", profile, "samples", m.Samples,
+						"mae_w", m.MAE, "quality", m.Quality())
+				}
+			}
+		}
+		if js, ok := st.LoadConfig(legacyStateKey); ok && js != "" {
+			var m Model
+			if err := json.Unmarshal([]byte(js), &m); err == nil && m.Alpha > 0 {
+				if !loadedProfiles[ProfileHome] {
+					m.PeakW = peakW // config may have changed
+					if m.PriorScale <= 0 {
+						m.PriorScale = 1
+					}
+					s.models[ProfileHome] = &m
+					slog.Info("loadmodel migrated legacy state",
+						"profile", ProfileHome, "samples", m.Samples,
+						"mae_w", m.MAE, "quality", m.Quality())
+				}
+			}
+		}
 	}
 	return s
 }
 
+func restoreModel(js string, peakW float64, profile Profile) (*Model, bool) {
+	var m Model
+	if err := json.Unmarshal([]byte(js), &m); err != nil || m.Alpha <= 0 {
+		return nil, false
+	}
+	m.PeakW = peakW // config may have changed
+	if m.PriorScale <= 0 {
+		m.PriorScale = newProfileModel(peakW, profile).PriorScale
+	}
+	return &m, true
+}
+
 // Model returns a snapshot.
 func (s *Service) Model() Model {
+	if s == nil {
+		return Model{}
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return *s.model
+	return *s.activeModelLocked()
+}
+
+// Snapshot returns all profile models plus the active profile.
+func (s *Service) Snapshot() Snapshot {
+	if s == nil {
+		return Snapshot{}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := Snapshot{
+		ActiveProfile: s.active,
+		Profiles:      make(map[Profile]Model, len(s.models)),
+	}
+	for _, profile := range Profiles() {
+		if m := s.models[profile]; m != nil {
+			out.Profiles[profile] = *m
+		}
+	}
+	return out
+}
+
+// Profile returns the currently active load-model profile.
+func (s *Service) Profile() Profile {
+	if s == nil {
+		return ProfileHome
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.active
+}
+
+// SetProfile changes which profile trains and predicts from now on.
+func (s *Service) SetProfile(profile Profile) error {
+	if s == nil {
+		return nil
+	}
+	if !profile.valid() {
+		return fmt.Errorf("unknown load profile: %s", profile)
+	}
+	s.mu.Lock()
+	if _, ok := s.models[profile]; !ok {
+		peak := s.activeModelLocked().PeakW
+		s.models[profile] = newProfileModel(peak, profile)
+	}
+	s.active = profile
+	s.mu.Unlock()
+	return s.persistProfile(profile)
+}
+
+func (s *Service) activeModelLocked() *Model {
+	if m := s.models[s.active]; m != nil {
+		return m
+	}
+	if m := s.models[ProfileHome]; m != nil {
+		return m
+	}
+	return NewModel(5000)
 }
 
 // Predict is the MPC's integration point — expected load at time t.
@@ -87,7 +207,7 @@ func (s *Service) Predict(t time.Time) float64 {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.model.Predict(t, temp)
+	return s.activeModelLocked().Predict(t, temp)
 }
 
 // Start kicks off the online-learning goroutine.
@@ -115,10 +235,14 @@ func (s *Service) loop(ctx context.Context) {
 	for {
 		select {
 		case <-s.stop:
-			s.persist()
+			if err := s.persist(); err != nil {
+				slog.Warn("loadmodel persist", "err", err)
+			}
 			return
 		case <-ctx.Done():
-			s.persist()
+			if err := s.persist(); err != nil {
+				slog.Warn("loadmodel persist", "err", err)
+			}
 			return
 		case <-t.C:
 			s.sample()
@@ -187,32 +311,63 @@ func (s *Service) sampleAt(now time.Time) {
 	}
 
 	s.mu.Lock()
-	updated := s.model.Update(now, loadW, temp)
-	samples := s.model.Samples
-	mae := s.model.MAE
-	heating := s.model.HeatingW_per_degC
+	profile := s.active
+	model := s.activeModelLocked()
+	updated := model.Update(now, loadW, temp)
+	samples := model.Samples
+	mae := model.MAE
+	heating := model.HeatingW_per_degC
 	s.mu.Unlock()
 
-	slog.Info("loadmodel: sample", "load_w", loadW, "temp_c", temp, "samples", samples, "mae_w", mae, "heat_w_per_c", heating, "updated", updated)
+	slog.Info("loadmodel: sample",
+		"profile", profile, "load_w", loadW, "temp_c", temp,
+		"samples", samples, "mae_w", mae,
+		"heat_w_per_c", heating, "updated", updated)
 
 	if updated && samples%s.PersistEvery == 0 {
-		s.persist()
+		if err := s.persist(); err != nil {
+			slog.Warn("loadmodel persist", "err", err)
+		}
 	}
 }
 
-func (s *Service) persist() {
+func (s *Service) persistProfile(profile Profile) error {
 	if s.Store == nil {
-		return
+		return nil
+	}
+	return s.Store.SaveConfig(profileStateKey, string(profile))
+}
+
+func (s *Service) persist() error {
+	if s.Store == nil {
+		return nil
 	}
 	s.mu.RLock()
-	js, err := json.Marshal(s.model)
+	active := s.active
+	models := make(map[Profile]string, len(s.models))
+	for _, profile := range Profiles() {
+		if s.models[profile] == nil {
+			continue
+		}
+		js, err := json.Marshal(s.models[profile])
+		if err != nil {
+			s.mu.RUnlock()
+			return err
+		}
+		models[profile] = string(js)
+	}
 	s.mu.RUnlock()
-	if err != nil {
-		return
+	if err := s.Store.SaveConfig(profileStateKey, string(active)); err != nil {
+		return err
 	}
-	if err := s.Store.SaveConfig(stateKey, string(js)); err != nil {
-		slog.Warn("loadmodel persist", "err", err)
+	for _, profile := range Profiles() {
+		if js, ok := models[profile]; ok {
+			if err := s.Store.SaveConfig(stateKey(profile), js); err != nil {
+				return err
+			}
+		}
 	}
+	return nil
 }
 
 // SetHeatingCoef lets the operator declare heating-load sensitivity
@@ -222,20 +377,27 @@ func (s *Service) SetHeatingCoef(w float64) {
 		return
 	}
 	s.mu.Lock()
-	s.model.HeatingW_per_degC = w
+	for _, model := range s.models {
+		model.HeatingW_per_degC = w
+	}
 	s.mu.Unlock()
 }
 
-// Reset clears the model (e.g. after a big appliance change).
+// Reset clears the active profile model (e.g. after a big appliance
+// or occupancy-pattern change).
 func (s *Service) Reset() {
 	if s == nil {
 		return
 	}
 	s.mu.Lock()
-	peak := s.model.PeakW
-	heating := s.model.HeatingW_per_degC
-	s.model = NewModel(peak)
-	s.model.HeatingW_per_degC = heating
+	profile := s.active
+	old := s.activeModelLocked()
+	peak := old.PeakW
+	heating := old.HeatingW_per_degC
+	s.models[profile] = newProfileModel(peak, profile)
+	s.models[profile].HeatingW_per_degC = heating
 	s.mu.Unlock()
-	s.persist()
+	if err := s.persist(); err != nil {
+		slog.Warn("loadmodel persist", "err", err)
+	}
 }

--- a/go/internal/loadmodel/service_test.go
+++ b/go/internal/loadmodel/service_test.go
@@ -2,9 +2,11 @@ package loadmodel
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/frahlg/forty-two-watts/go/internal/state"
 	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
 )
 
@@ -16,6 +18,64 @@ func TestResetPreservesHeatingCoefficient(t *testing.T) {
 
 	if got := s.Model().HeatingW_per_degC; got != 275 {
 		t.Fatalf("heating coefficient after reset = %v, want 275", got)
+	}
+}
+
+func TestProfileSwitchTrainsOnlyActiveProfile(t *testing.T) {
+	tel := telemetry.NewStore()
+	tel.Update("site", telemetry.DerMeter, 1000, nil, nil)
+	tel.RecordDriverSuccess("site")
+
+	s := NewService(nil, tel, "site", 4000)
+	now := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+	s.sampleAt(now)
+
+	if err := s.SetProfile(ProfileAway); err != nil {
+		t.Fatalf("set profile: %v", err)
+	}
+	tel.Update("site", telemetry.DerMeter, 200, nil, nil)
+	tel.RecordDriverSuccess("site")
+	s.sampleAt(now.Add(time.Hour))
+
+	snap := s.Snapshot()
+	if snap.ActiveProfile != ProfileAway {
+		t.Fatalf("active profile = %q, want %q", snap.ActiveProfile, ProfileAway)
+	}
+	if got := snap.Profiles[ProfileHome].Samples; got != 1 {
+		t.Fatalf("home samples = %d, want 1", got)
+	}
+	if got := snap.Profiles[ProfileAway].Samples; got != 1 {
+		t.Fatalf("away samples = %d, want 1", got)
+	}
+}
+
+func TestProfileAndModelsPersist(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	defer st.Close()
+
+	s := NewService(st, telemetry.NewStore(), "site", 4000)
+	if err := s.SetProfile(ProfileAway); err != nil {
+		t.Fatalf("set profile: %v", err)
+	}
+	t0 := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+	s.mu.Lock()
+	for i := 0; i < 8; i++ {
+		s.activeModelLocked().Update(t0.AddDate(0, 0, 7*i), 250, HeatingReferenceC)
+	}
+	s.mu.Unlock()
+	if err := s.persist(); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	restored := NewService(st, telemetry.NewStore(), "site", 4000)
+	if got := restored.Profile(); got != ProfileAway {
+		t.Fatalf("restored profile = %q, want %q", got, ProfileAway)
+	}
+	if got := restored.Model().Samples; got != 8 {
+		t.Fatalf("restored away samples = %d, want 8", got)
 	}
 }
 

--- a/web/next.css
+++ b/web/next.css
@@ -1623,6 +1623,49 @@ body.ftw-next .btn-reset-model:focus-visible {
   outline-offset: 2px;
 }
 
+body.ftw-next .twin-profile-row {
+  align-items: center;
+}
+
+body.ftw-next .twin-profile-toggle {
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(54px, 1fr));
+  width: 132px;
+  padding: 2px;
+  gap: 2px;
+  background: var(--ink-sunken);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+body.ftw-next .twin-profile-toggle button {
+  min-width: 0;
+  height: 24px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-dim);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+
+body.ftw-next .twin-profile-toggle button.active {
+  background: var(--accent-e);
+  color: #0a0a0a;
+}
+
+body.ftw-next .twin-profile-toggle button:not(.active):hover {
+  color: var(--fg);
+}
+
+body.ftw-next .twin-profile-toggle button:focus-visible {
+  outline: 1px solid var(--accent-e);
+  outline-offset: 2px;
+}
+
 /* ---- Fuse card — vertical bars on small screens ----
    Desktop shows each phase as a separate card with a big current
    read-out and a horizontal bar underneath; that stacks three tall

--- a/web/twins.js
+++ b/web/twins.js
@@ -38,7 +38,21 @@
       '</button>';
   }
 
-  function twinCard(title, d, resetEndpoint, resetLabel) {
+  function loadProfileControl(d) {
+    if (!d || !d.enabled) return '';
+    const active = d.profile || d.active_profile || 'home';
+    function btn(profile, label) {
+      const cls = profile === active ? ' class="active"' : '';
+      return `<button type="button" data-loadmodel-profile="${profile}"${cls}>${label}</button>`;
+    }
+    return '<div class="twin-row twin-profile-row"><span>profile</span>' +
+      `<div class="twin-profile-toggle" role="tablist" data-active="${active}">` +
+      btn('home', 'Home') +
+      btn('away', 'Away') +
+      '</div></div>';
+  }
+
+  function twinCard(title, d, resetEndpoint, resetLabel, extraHtml) {
     if (!d || !d.enabled) return `<div class="twin-card"><h3>${title}</h3><div class="twin-row"><span>disabled</span></div></div>`;
     const q = Math.max(0, Math.min(1, d.quality || 0));
     const qPct = (q * 100).toFixed(0);
@@ -56,21 +70,35 @@
     rows.push(`<div class="twin-row"><span>quality</span><b>${qPct}%</b></div>`);
     rows.push(`<div class="twin-quality"><div class="twin-quality-fill" style="width:${qPct}%;background:${qColor}"></div></div>`);
     const btn = resetEndpoint ? resetButton(resetEndpoint, resetLabel) : '';
-    return `<div class="twin-card"><h3>${title}</h3>${rows.join('')}${btn}</div>`;
+    return `<div class="twin-card"><h3>${title}</h3>${extraHtml || ''}${rows.join('')}${btn}</div>`;
   }
 
   function render(pv, load) {
     const grid = document.getElementById('twins-grid');
     if (!grid) return;
     grid.innerHTML = twinCard('PV twin', pv, '/api/pvmodel/reset', 'PV twin')
-      + twinCard('Load twin', load, '/api/loadmodel/reset', 'load twin');
+      + twinCard('Load twin', load, '/api/loadmodel/reset', 'load twin', loadProfileControl(load));
     const sub = document.getElementById('twins-subtitle');
     if (sub) sub.textContent = 'self-learning digital twins — feed MPC + UI forecasts';
   }
 
   // Wired once on init — delegation off the grid so dynamically-rendered
   // buttons pick up the handler without rebinding each refresh.
-  function onResetClick(e) {
+  function onGridClick(e) {
+    const profile = e.target && e.target.dataset && e.target.dataset.loadmodelProfile;
+    if (profile) {
+      if (e.target.classList.contains('active')) return;
+      fetch('/api/loadmodel/profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile })
+      })
+        .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+        .then(() => fetchAll())
+        .catch(err => alert('Load profile switch failed: ' + err.message));
+      return;
+    }
+
     const endpoint = e.target && e.target.dataset && e.target.dataset.resetTwin;
     if (!endpoint) return;
     const twinName = endpoint.indexOf('pv') >= 0 ? 'PV twin' : 'load twin';
@@ -90,7 +118,7 @@
     fetchAll();
     setInterval(fetchAll, REFRESH_MS);
     const grid = document.getElementById('twins-grid');
-    if (grid) grid.addEventListener('click', onResetClick);
+    if (grid) grid.addEventListener('click', onGridClick);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

- Add separate `home` and `away` Load twin profiles with persisted active profile selection.
- Route active-profile training and MPC predictions through the selected profile, with legacy `loadmodel/state_utc` migrated into `home`.
- Add `POST /api/loadmodel/profile`, active-profile reset semantics, UI toggle in the ML twins panel, and docs/tests.

## Validation

- `go test ./internal/loadmodel ./internal/api -run 'Test(Profile|HandleLoadModel)'`
- `go test ./cmd/forty-two-watts ./internal/mpc`
- `go test ./internal/api`
- `node --check web/twins.js`
- `git diff --check`
- Browser smoke check against a local mock API for the Home/Away toggle.