### PR TITLE
fix(ferroamp): force idle on zero target, do not delegate to auto

### DIFF
--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -169,6 +169,19 @@ local function publish_auto(trans_id)
     return err
 end
 
+-- Force the EnergyHub to hold the battery at 0 W instead of handing
+-- control back to autonomous self-consumption. `auto` reads the
+-- house load and discharges to cover it, which silently overrides
+-- any planner slot that wants the battery idle so PV surplus can
+-- export. `discharge` with arg=0 keeps the inverter in forced mode
+-- but locked at zero — equivalent to Sungrow's forced-idle path.
+local function publish_idle(trans_id)
+    local err = host.mqtt_publish("extapi/control/request",
+        string.format('{"transId":"%s","cmd":{"name":"discharge","arg":0}}', trans_id))
+    if not err then last_control_mode = "idle" end
+    return err
+end
+
 ----------------------------------------------------------------------------
 -- Driver interface
 ----------------------------------------------------------------------------
@@ -424,11 +437,13 @@ function driver_command(action, power_w, cmd)
             if not err then last_control_mode = "discharge" end
             return err
         else
-            -- Zero: return to auto mode
-            if last_control_mode == "auto" then
+            -- Zero: force idle at 0 W. Do NOT fall back to autonomous
+            -- self-consumption — that would let the EnergyHub discharge
+            -- to cover load and silently override the planner.
+            if last_control_mode == "idle" then
                 return true
             end
-            return publish_auto(tid)
+            return publish_idle(tid)
         end
     elseif action == "curtail" then
         local payload = string.format(

--- a/go/internal/drivers/lua_mqtt_stale_test.go
+++ b/go/internal/drivers/lua_mqtt_stale_test.go
@@ -283,7 +283,13 @@ func TestFerroampDriverEmitsStateRelayAndFaultDiagnostics(t *testing.T) {
 	assertMetric("sso_pv_a", 0)
 }
 
-func TestFerroampZeroBatteryCommandDoesNotRepublishAutoWhenAlreadyAuto(t *testing.T) {
+// Live-system regression (2026-05-24): with power_w=0 the driver
+// used to publish `auto`, which puts the EnergyHub in autonomous
+// self-consumption. That silently overrode every planner slot that
+// wanted the battery idle so PV surplus could export — Ferroamp
+// kept covering local load and discharged ~500 W against target 0.
+// power_w=0 must mean "hold the battery at 0 W, do not delegate".
+func TestFerroampZeroBatteryCommandForcesIdleNotAuto(t *testing.T) {
 	tel := telemetry.NewStore()
 	mqtt := &fakeMQTT{}
 	d, _ := newTestFerroampDriver(t, tel, mqtt)
@@ -296,37 +302,50 @@ func TestFerroampZeroBatteryCommandDoesNotRepublishAutoWhenAlreadyAuto(t *testin
 	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":0}`)); err != nil {
 		t.Fatalf("zero command: %v", err)
 	}
-	if got := len(mqtt.Published()); got != initial {
-		t.Fatalf("zero command while already auto published %d new messages, want 0", got-initial)
+	pubs := mqtt.Published()
+	if got := len(pubs); got != initial+1 {
+		t.Fatalf("zero command publish count = %d, want %d (must transition out of init auto into forced idle)", got, initial+1)
+	}
+	last := pubs[len(pubs)-1].Payload
+	if !strings.Contains(last, `"name":"discharge"`) || !strings.Contains(last, `"arg":0`) {
+		t.Fatalf("zero command payload = %s, want discharge with arg=0 (force idle, not auto)", last)
+	}
+	if strings.Contains(last, `"name":"auto"`) {
+		t.Fatalf("zero command payload = %s, must NOT publish auto (regression: auto lets EnergyHub self-consume)", last)
+	}
+
+	// Idempotent: once we're in forced idle, another power_w=0 must not
+	// republish — that would churn MQTT on every dispatch tick.
+	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":0}`)); err != nil {
+		t.Fatalf("second zero command: %v", err)
+	}
+	if got := len(mqtt.Published()); got != initial+1 {
+		t.Fatalf("second zero command published %d new messages, want 0 (idempotent)", got-(initial+1))
 	}
 
 	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":-1200}`)); err != nil {
 		t.Fatalf("discharge command: %v", err)
 	}
-	pubs := mqtt.Published()
-	if got := len(pubs); got != initial+1 {
-		t.Fatalf("discharge publish count = %d, want %d", got, initial+1)
+	pubs = mqtt.Published()
+	if got := len(pubs); got != initial+2 {
+		t.Fatalf("discharge publish count = %d, want %d", got, initial+2)
 	}
 	if !strings.Contains(pubs[len(pubs)-1].Payload, `"name":"discharge"`) {
 		t.Fatalf("last payload = %s, want discharge command", pubs[len(pubs)-1].Payload)
 	}
 
+	// Back to zero from a real discharge: must publish forced idle again
+	// (last_control_mode is now "discharge", not "idle").
 	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":0}`)); err != nil {
-		t.Fatalf("release command: %v", err)
+		t.Fatalf("release-to-idle command: %v", err)
 	}
 	pubs = mqtt.Published()
-	if got := len(pubs); got != initial+2 {
-		t.Fatalf("release publish count = %d, want %d", got, initial+2)
+	if got := len(pubs); got != initial+3 {
+		t.Fatalf("release-to-idle publish count = %d, want %d", got, initial+3)
 	}
-	if !strings.Contains(pubs[len(pubs)-1].Payload, `"name":"auto"`) {
-		t.Fatalf("last payload = %s, want auto command", pubs[len(pubs)-1].Payload)
-	}
-
-	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":0}`)); err != nil {
-		t.Fatalf("second zero command: %v", err)
-	}
-	if got := len(mqtt.Published()); got != initial+2 {
-		t.Fatalf("second zero command published %d new messages, want 0", got-(initial+2))
+	last = pubs[len(pubs)-1].Payload
+	if !strings.Contains(last, `"name":"discharge"`) || !strings.Contains(last, `"arg":0`) {
+		t.Fatalf("release-to-idle payload = %s, want forced idle (discharge arg=0)", last)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `drivers/ferroamp.lua` published `auto` on `power_w=0`, handing control back to the EnergyHub's autonomous self-consumption. That silently overrode every planner slot that wanted the battery held idle for PV export — Ferroamp covered local load instead and discharged ~500 W against target 0.
- Now publishes `discharge` with `arg=0` — explicit forced-idle, equivalent to Sungrow's path from 7e59f93. Watchdog default-mode and cleanup still publish `auto`, so a stale EMS still falls back to autonomous.
- Updated the existing zero-command test to assert forced-idle behaviour and idempotency.

## Live evidence (2026-05-24, homelab-rpi)

```
mode: planner_self          plan_stale: false
grid_target_w: 0            bat_w: -526 W  ← discharge against target 0
dispatch.ferroamp.target_w: 0    dispatch.sungrow.target_w: 0
drivers.ferroamp.bat_soc: 0.45   drivers.sungrow.bat_soc: 0.975
today: pv_wh=60.5 kWh, export_wh=27.7 kWh, import_wh=4.5 kWh
       bat_charged_wh=13 kWh, bat_discharged_wh=1.3 kWh
```

Sungrow honoured target=0 (already fixed in 7e59f93). Ferroamp did not — it discharged 526 W. Plan slot wanted `battery_w=0, reason: "idle — export PV surplus"`; Ferroamp instead ran its own self-consumption.

## Test plan

- [x] `go test ./internal/drivers/ -run TestFerroamp -count=1`
- [x] Full suite: `go test ./... -count=1`
- [ ] Deploy to homelab-rpi and confirm `bat_w` follows `target_w=0` within one dispatch tick
- [ ] Confirm tomorrow's PV is absorbed into Ferroamp during planned idle/export slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)