### PR TITLE
fix(15min-settlement): render slot import and export separately

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -700,6 +700,15 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, 200, resp)
 }
 
+// currentGridEnergySlot integrates per-direction grid energy across the
+// active 15-minute settlement window. Under 15-min settlement the bill is
+//
+//	import_wh × import_price  +  export_wh × export_price
+//
+// — import and export are independent accumulators, never netted.
+// `net_wh` is kept as a backwards-compat observational delta only; UI and
+// downstream consumers MUST render or price import_wh and export_wh
+// separately, never `net_wh` alone.
 func currentGridEnergySlot(st *state.Store, now time.Time) (map[string]any, error) {
 	slotStart := now.Truncate(15 * time.Minute)
 	slotEnd := slotStart.Add(15 * time.Minute)
@@ -713,7 +722,8 @@ func currentGridEnergySlot(st *state.Store, now time.Time) (map[string]any, erro
 		"elapsed_s":     now.Sub(slotStart).Seconds(),
 		"import_wh":     d.ImportWh,
 		"export_wh":     d.ExportWh,
-		"net_wh":        d.ImportWh - d.ExportWh,
+		// Observational only — see comment above. Do not bill against this.
+		"net_wh": d.ImportWh - d.ExportWh,
 	}, nil
 }
 

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -339,6 +339,11 @@
     if (abs >= 1000) return sign + (abs / 1000).toFixed(2) + " kWh";
     return sign + Math.round(abs) + " Wh";
   }
+  function formatWhMagnitude(wh) {
+    var abs = Math.abs(Number(wh) || 0);
+    if (abs >= 1000) return (abs / 1000).toFixed(2) + " kWh";
+    return Math.round(abs) + " Wh";
+  }
   function batteryStateLabel(w) {
     var watts = Number(w) || 0;
     var idleW = flowIdleKw() * 1000;
@@ -510,10 +515,15 @@
     if (slotBadge) {
       var slot = data.energy && data.energy.current_slot;
       if (slot) {
-        var netWh = Number(slot.net_wh) || 0;
-        slotBadge.textContent = "15m " + formatSignedWh(netWh);
+        // 15-min settlement: import_wh and export_wh accumulate
+        // SEPARATELY within the slot — the bill is import × import_price
+        // plus export × export_price, never their net. Render both
+        // directions so the operator sees the slot's true exposure.
+        var impWh = Number(slot.import_wh) || 0;
+        var expWh = Number(slot.export_wh) || 0;
+        slotBadge.textContent = "15m ↑" + formatWhMagnitude(impWh) + " ↓" + formatWhMagnitude(expWh);
         slotBadge.className = "grid-slot-badge" +
-          (netWh > 5 ? " slot-import" : netWh < -5 ? " slot-export" : "");
+          (impWh > expWh + 5 ? " slot-import" : expWh > impWh + 5 ? " slot-export" : "");
       } else {
         slotBadge.textContent = "";
         slotBadge.className = "grid-slot-badge";


### PR DESCRIPTION
## Summary

Under 15-min settlement (Svk), import and export accumulate as **independent registers** within a slot — the bill is `import_wh × import_price + export_wh × export_price`, never their net. The dashboard's \"15m\" badge was rendering `ImportWh - ExportWh` as a single signed value, silently hiding the operator's true settlement-window exposure.

Reported live (2026-05-24): a slot showing \"15m +139 Wh\" was actually `import_wh=156, export_wh=17` — these are billed independently and netting them is wrong.

## Changes

- **`web/next-app.js`** — badge renders `15m ↑156 Wh ↓17 Wh`; tints to import-red or export-green based on which direction dominates.
- **`go/internal/api/api.go`** — keep `net_wh` in the response for backwards compat but document it as observational only; never bill against it.
- `state/cost.go` already integrates per-direction correctly — no change there.

## Test plan

- [x] `go test ./internal/api/ -count=1`
- [x] Full suite green
- [ ] Visual check on homelab-rpi after deploy: badge shows both arrows during a mixed-direction slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)