### PR TITLE
chore(config): faster control loop defaults — 2 s / 2 s / 500 W

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,13 +3,13 @@
 
 site:
   name: "Home"
-  control_interval_s: 5
+  control_interval_s: 2         # 2 s matches Ferroamp ehub ~1 Hz; drop to 1 for snappier response
   grid_target_w: 0              # 0 = self-consumption
   grid_tolerance_w: 42          # deadband (The Answer)
   watchdog_timeout_s: 60
   smoothing_alpha: 0.3
-  slew_rate_w: 500
-  min_dispatch_interval_s: 5
+  slew_rate_w: 500              # W per cycle (≈ 250 W/s at 2 s cycle)
+  min_dispatch_interval_s: 2    # debounce; keep == control_interval_s
 
 fuse:
   max_amps: 16

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -796,7 +796,10 @@ func relToBaseDir(baseDir, p string) string {
 // applyDefaults fills in sensible zero-value defaults.
 func applyDefaults(c *Config) {
 	if c.Site.ControlIntervalS == 0 {
-		c.Site.ControlIntervalS = 5
+		// 2 s matches Ferroamp's ehub MQTT cadence (~1 Hz) without
+		// dispatching twice on the same telemetry sample, and halves
+		// the perceived response lag operators saw at the original 5 s.
+		c.Site.ControlIntervalS = 2
 	}
 	if c.Site.GridToleranceW == 0 {
 		c.Site.GridToleranceW = 42 // The Answer
@@ -814,7 +817,11 @@ func applyDefaults(c *Config) {
 		c.Site.SlewRateW = 500
 	}
 	if c.Site.MinDispatchIntervalS == 0 {
-		c.Site.MinDispatchIntervalS = 5
+		// Match control_interval_s. The holdoff exists to suppress
+		// command-spam when the tick is faster than the battery's
+		// response — at 2 s ticks the natural cadence is already the
+		// minimum, so the holdoff is a no-op debouncer in practice.
+		c.Site.MinDispatchIntervalS = 2
 	}
 	if c.Fuse.Phases == 0 {
 		c.Fuse.Phases = 3

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -32,8 +32,8 @@ func TestLoadMinimalYAML(t *testing.T) {
 		t.Errorf("site name: got %q", c.Site.Name)
 	}
 	// Defaults applied
-	if c.Site.ControlIntervalS != 5 {
-		t.Errorf("default control_interval_s: got %d", c.Site.ControlIntervalS)
+	if c.Site.ControlIntervalS != 2 {
+		t.Errorf("default control_interval_s: got %d, want 2", c.Site.ControlIntervalS)
 	}
 	if c.Site.GridToleranceW != 42 {
 		t.Errorf("default grid_tolerance_w: got %f", c.Site.GridToleranceW)


### PR DESCRIPTION
## Summary

The 5 s default `control_interval_s` + 5 s `min_dispatch_interval_s` were inherited from the Rust port and predate the ~1 Hz site-meter cadences in production today. Drop both to 2 s — what most live installs (homelab-rpi, dev) have been running for weeks.

`slew_rate_w` stays at 500 → ~250 W/s ramp at 2 s ticks; gentle enough that inverters tolerate it.

For a snappier site, an operator can drop `control_interval_s` to 1 s (matches the Ferroamp ehub MQTT cadence). Documented in the example config.

## Scope

Defaults-only. Any operator with an explicit `control_interval_s` / `min_dispatch_interval_s` in their config keeps exactly what they had.

## Test plan

- [x] `go test ./...`
- [x] `applyDefaults` test updated to assert 2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)