### PR TITLE
fix(driver): ferroamp aggregates battery across N ESOs

### DIFF
--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -41,8 +41,19 @@ PROTOCOL = "mqtt"
 
 -- Cached state from each topic
 local ehub_data = nil
-local eso_data = nil
 local sso_data = nil
+
+-- ESO state is per-unit. Ferroamp publishes one extapi/data/eso message
+-- per ESO; a single-slot cache always reflected only the most-recently-
+-- published unit, halving (or worse) reported battery power in N-ESO
+-- installations. Real incident 2026-05-24 at a 2×ESO site: 42's bat_w
+-- was exactly half of ehub.pbat, the controller's grid-chase loop fed
+-- on the wrong number, and dispatch never converged on grid_target.
+-- The fix is to key each ESO by its `id` field and aggregate at emit
+-- time; messages without an `id` fall under a synthetic key so
+-- single-ESO firmware / sims keep behaving identically.
+local eso_data_by_id = {}  -- id -> payload table
+local eso_ts_by_id   = {}  -- id -> last arrival ms
 
 -- Last-arrival timestamp per topic (host.millis()). The EnergyHub
 -- normally publishes ehub at ~1 Hz; if it goes silent (power off,
@@ -54,7 +65,6 @@ local sso_data = nil
 -- pv_w=-3996.7040 / meter_w=-7294.0490 identical to four decimals
 -- for 30+ minutes while the EnergyHub itself was unpowered.
 local ehub_ts = 0
-local eso_ts  = 0
 local sso_ts  = 0
 
 -- Treat cached topic data as stale beyond this age. EnergyHub
@@ -146,6 +156,15 @@ local function eso_battery_power(data)
     return ubat * ibat
 end
 
+-- Returns the id of an ESO payload, or "_default_" when the firmware
+-- omits the `id` field. The synthetic key keeps single-ESO sims /
+-- old firmware on the same code path as a 1-entry map.
+local function eso_id_of(data)
+    local id = extract_val(data, "id")
+    if id == nil or id == "" then return "_default_" end
+    return tostring(id)
+end
+
 local function sso_power(data)
     if not data then return nil end
     local ppv = extract_val(data, "ppv")
@@ -228,7 +247,9 @@ function driver_poll()
             if msg.topic == "extapi/data/ehub" then
                 ehub_data = data; ehub_ts = now
             elseif msg.topic == "extapi/data/eso" then
-                eso_data = data; eso_ts = now
+                local eid = eso_id_of(data)
+                eso_data_by_id[eid] = data
+                eso_ts_by_id[eid]   = now
             elseif msg.topic == "extapi/data/sso" then
                 sso_data = data; sso_ts = now
             end
@@ -243,8 +264,17 @@ function driver_poll()
         host.log("warn", "Ferroamp: ehub stale (" .. (now - ehub_ts) .. " ms) — dropping cache")
         ehub_data = nil
     end
-    if eso_data and (now - eso_ts) > STALE_AFTER_MS then
-        eso_data = nil
+    -- Evict per-ESO entries individually so one silent ESO does not
+    -- drag the others' contribution out of the aggregate. The freshest
+    -- ESO timestamp is then used for the topic-level age metric.
+    local eso_ts = 0
+    for eid, ts in pairs(eso_ts_by_id) do
+        if (now - ts) > STALE_AFTER_MS then
+            eso_data_by_id[eid] = nil
+            eso_ts_by_id[eid]   = nil
+        elseif ts > eso_ts then
+            eso_ts = ts
+        end
     end
     if sso_data and (now - sso_ts) > STALE_AFTER_MS then
         sso_data = nil
@@ -336,52 +366,91 @@ function driver_poll()
     end
 
     --------------------------------------------------------------------------
-    -- Battery
+    -- Battery  (aggregated across N ESOs)
     --------------------------------------------------------------------------
-    if (ehub_data or eso_data) and not SKIP_BATTERY then
-        local pbat = eso_battery_power(eso_data)
-        if pbat == nil then
-            pbat = choose_power(extract_val(ehub_data, "pbat"), extract_val(eso_data, "pbat"))
-        end
-        if pbat then
-            local battery = {}
-            -- Ferroamp: positive pbat = discharging, negate for convention
-            -- Convention: positive = charging, negative = discharging
-            battery.w = -pbat
+    if not SKIP_BATTERY and (ehub_data or next(eso_data_by_id)) then
+        -- Walk every live ESO once and accumulate the aggregate.
+        -- Power is summed (parallel DC strings each push their own
+        -- current onto the inverter); voltage / SoC / dc-link / temp
+        -- are averaged because cells across ESOs run in lock-step in
+        -- a healthy cluster and we want a single representative number
+        -- for the dashboard. Cumulative Wh counters are summed so the
+        -- battery's lifetime production/consumption reflects all units.
+        local pbat_sum = 0
+        local pbat_has_any = false
+        local v_sum, v_n   = 0, 0
+        local a_sum, a_n   = 0, 0
+        local soc_sum, soc_n = 0, 0
+        local udc_sum, udc_n = 0, 0
+        local wprod_sum, wprod_n = 0, 0
+        local wcons_sum, wcons_n = 0, 0
+        local relay_worst, fault_worst = nil, nil
+        local n_eso = 0
 
-            -- Enrich with ESO data (battery-specific telemetry)
-            if eso_data then
-                local soc = extract_val(eso_data, "soc")
-                if soc then
-                    local soc_val = tonumber(soc) or 0
-                    -- Ferroamp reports SoC as 0-100%, convert to 0.0-1.0 fraction
-                    if soc_val > 1 then soc_val = soc_val / 100 end
-                    battery.soc = soc_val
-                end
-
-                local ubat = extract_val(eso_data, "ubat")
-                if ubat then battery.v = tonumber(ubat) or 0 end
-
-                local ibat = extract_val(eso_data, "ibat")
-                if ibat then battery.a = tonumber(ibat) or 0 end
-
-                local eso_udc = extract_val(eso_data, "udc")
-                if eso_udc then host.emit_metric("eso_dc_link_v", tonumber(eso_udc) or 0) end
-                local eso_relay = extract_val(eso_data, "relaystatus")
-                if eso_relay then host.emit_metric("eso_relaystatus", tonumber(eso_relay) or 0) end
-                local eso_fault = extract_val(eso_data, "faultcode")
-                if eso_fault then host.emit_metric("eso_faultcode", tonumber(eso_fault) or 0) end
-
-                -- Battery energy counters (mJ → Wh)
-                local wbatprod = extract_val(eso_data, "wbatprod")
-                local wbatcons = extract_val(eso_data, "wbatcons")
-                if wbatprod then battery.discharge_wh = mj_to_wh(wbatprod) end
-                if wbatcons then battery.charge_wh    = mj_to_wh(wbatcons) end
+        for _, d in pairs(eso_data_by_id) do
+            n_eso = n_eso + 1
+            local u = tonumber(extract_val(d, "ubat"))
+            local i = tonumber(extract_val(d, "ibat"))
+            if u and i then
+                pbat_sum = pbat_sum + (u * i)
+                pbat_has_any = true
             end
+            if u then v_sum = v_sum + u; v_n = v_n + 1 end
+            if i then a_sum = a_sum + i; a_n = a_n + 1 end
+
+            local soc = tonumber(extract_val(d, "soc"))
+            if soc then
+                if soc > 1 then soc = soc / 100 end
+                soc_sum = soc_sum + soc; soc_n = soc_n + 1
+            end
+            local udc = tonumber(extract_val(d, "udc"))
+            if udc then udc_sum = udc_sum + udc; udc_n = udc_n + 1 end
+            local wp = tonumber(extract_val(d, "wbatprod"))
+            if wp then wprod_sum = wprod_sum + wp; wprod_n = wprod_n + 1 end
+            local wc = tonumber(extract_val(d, "wbatcons"))
+            if wc then wcons_sum = wcons_sum + wc; wcons_n = wcons_n + 1 end
+
+            -- relaystatus + faultcode: worst-of so a single faulted
+            -- ESO surfaces in the diagnostic, instead of being averaged
+            -- away by its still-healthy peers.
+            local relay = tonumber(extract_val(d, "relaystatus"))
+            if relay then relay_worst = math.max(relay_worst or 0, relay) end
+            local fault = tonumber(extract_val(d, "faultcode"))
+            if fault then fault_worst = math.max(fault_worst or 0, fault) end
+        end
+
+        local battery = nil
+        if pbat_has_any then
+            -- Prefer per-ESO ubat*ibat because the cell-monitor numbers
+            -- update at the ESO's own publish cadence and don't get
+            -- rounded through ehub's aggregate. Ferroamp convention:
+            -- positive pbat = discharging, negate for site convention
+            -- (positive = charging).
+            battery = { w = -pbat_sum }
+        elseif ehub_data then
+            -- No live per-ESO measurement: fall back to ehub.pbat
+            -- (also positive = discharging on Ferroamp's side).
+            local ehub_pbat = tonumber(extract_val(ehub_data, "pbat"))
+            if ehub_pbat then battery = { w = -ehub_pbat } end
+        end
+
+        if battery then
+            if v_n   > 0 then battery.v = v_sum / v_n end
+            if a_n   > 0 then battery.a = a_sum end           -- sum, not avg: parallel currents add
+            if soc_n > 0 then battery.soc = soc_sum / soc_n end
+            if wprod_n > 0 then battery.discharge_wh = mj_to_wh(wprod_sum) end
+            if wcons_n > 0 then battery.charge_wh    = mj_to_wh(wcons_sum) end
 
             host.emit("battery", battery)
             if battery.v then host.emit_metric("battery_dc_v", battery.v) end
             if battery.a then host.emit_metric("battery_dc_a", battery.a) end
+
+            if n_eso > 0 then
+                host.emit_metric("eso_count", n_eso)
+                if udc_n > 0     then host.emit_metric("eso_dc_link_v",   udc_sum / udc_n) end
+                if relay_worst ~= nil then host.emit_metric("eso_relaystatus", relay_worst) end
+                if fault_worst ~= nil then host.emit_metric("eso_faultcode",   fault_worst) end
+            end
         end
     end
 

--- a/go/internal/drivers/lua_mqtt_stale_test.go
+++ b/go/internal/drivers/lua_mqtt_stale_test.go
@@ -283,6 +283,120 @@ func TestFerroampDriverEmitsStateRelayAndFaultDiagnostics(t *testing.T) {
 	assertMetric("sso_pv_a", 0)
 }
 
+// Live-system regression (2026-05-24, 2×ESO site): a single-slot
+// `eso_data` cache made the driver report ONLY the most-recently-
+// published ESO's ubat*ibat as battery power. With two ESOs publishing
+// on extapi/data/eso the driver halved bat_w, the controller's grid-
+// chase loop fed on the wrong number, and dispatch stuck ~190 W of
+// grid import against a 0 W target. ehub.pbat aggregated correctly
+// (~306 W) but the driver preferred ESO ubat*ibat (~153 W).
+func TestFerroampDriverSumsBatteryPowerAcrossMultipleESOs(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	// Two ESOs each at 400 V × 0.375 A = 150 W → aggregate 300 W
+	// discharging. ehub.pbat is intentionally inconsistent to prove
+	// we prefer the summed per-ESO measurement.
+	ehub := `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":999}}`
+	eso1 := `{"id":{"val":"21030026"},"soc":{"val":50},"ubat":{"val":400},"ibat":{"val":0.375},` +
+		`"wbatprod":{"val":3600000000},"wbatcons":{"val":7200000000},` +
+		`"relaystatus":{"val":0},"faultcode":{"val":0},"udc":{"val":760}}`
+	eso2 := `{"id":{"val":"23010216"},"soc":{"val":50},"ubat":{"val":400},"ibat":{"val":0.375},` +
+		`"wbatprod":{"val":3600000000},"wbatcons":{"val":7200000000},` +
+		`"relaystatus":{"val":0},"faultcode":{"val":0},"udc":{"val":760}}`
+	mqtt.Push("extapi/data/ehub", ehub)
+	mqtt.Push("extapi/data/eso", eso1)
+	mqtt.Push("extapi/data/eso", eso2)
+
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	bat := tel.Get("ferroamp", telemetry.DerBattery)
+	if bat == nil {
+		t.Fatal("expected battery reading")
+	}
+	if bat.RawW != -300 {
+		t.Fatalf("battery RawW = %v, want -300 (sum 150+150 across both ESOs, discharging)", bat.RawW)
+	}
+	// Current sums (parallel strings), voltage averages.
+	gotA, _, ok := tel.LatestMetric("ferroamp", "battery_dc_a")
+	if !ok {
+		t.Fatal("missing battery_dc_a metric")
+	}
+	if gotA != 0.75 {
+		t.Fatalf("battery_dc_a = %v, want 0.75 (sum of both ibat)", gotA)
+	}
+	gotV, _, ok := tel.LatestMetric("ferroamp", "battery_dc_v")
+	if !ok {
+		t.Fatal("missing battery_dc_v metric")
+	}
+	if gotV != 400 {
+		t.Fatalf("battery_dc_v = %v, want 400 (avg of equal ubats)", gotV)
+	}
+	// Wh counters sum across ESOs (Data carries the per-emit raw JSON).
+	// Each ESO publishes 3.6e9 mJ produced + 7.2e9 mJ consumed; summing
+	// over 2 ESOs and converting mJ → Wh gives 2 Wh produced + 4 Wh
+	// consumed.
+	if !strings.Contains(string(bat.Data), `"discharge_wh":2`) {
+		t.Fatalf("battery Data missing discharge_wh=2: %s", string(bat.Data))
+	}
+	if !strings.Contains(string(bat.Data), `"charge_wh":4`) {
+		t.Fatalf("battery Data missing charge_wh=4: %s", string(bat.Data))
+	}
+	// Diagnostic: operators must see how many ESOs the driver is summing.
+	gotCount, _, ok := tel.LatestMetric("ferroamp", "eso_count")
+	if !ok {
+		t.Fatal("missing eso_count metric")
+	}
+	if gotCount != 2 {
+		t.Fatalf("eso_count = %v, want 2", gotCount)
+	}
+}
+
+// One ESO faulted in a 2-ESO cluster: the worst-of relay/fault metric
+// must surface the fault rather than be averaged away by the healthy
+// peer, and the aggregate must still include the healthy ESO's power.
+func TestFerroampDriverSurfacesPerESOFaultsWorstOf(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	ehub := `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`
+	healthy := `{"id":{"val":"AAA"},"soc":{"val":80},"ubat":{"val":400},"ibat":{"val":1.0},` +
+		`"relaystatus":{"val":0},"faultcode":{"val":0},"udc":{"val":760}}`
+	faulted := `{"id":{"val":"BBB"},"soc":{"val":80},"ubat":{"val":400},"ibat":{"val":0},` +
+		`"relaystatus":{"val":1},"faultcode":{"val":42},"udc":{"val":760}}`
+	mqtt.Push("extapi/data/ehub", ehub)
+	mqtt.Push("extapi/data/eso", healthy)
+	mqtt.Push("extapi/data/eso", faulted)
+
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	gotFault, _, ok := tel.LatestMetric("ferroamp", "eso_faultcode")
+	if !ok {
+		t.Fatal("missing eso_faultcode")
+	}
+	if gotFault != 42 {
+		t.Fatalf("eso_faultcode = %v, want 42 (worst-of so a single faulted ESO is visible)", gotFault)
+	}
+	gotRelay, _, ok := tel.LatestMetric("ferroamp", "eso_relaystatus")
+	if !ok {
+		t.Fatal("missing eso_relaystatus")
+	}
+	if gotRelay != 1 {
+		t.Fatalf("eso_relaystatus = %v, want 1 (worst-of)", gotRelay)
+	}
+	// Healthy ESO still contributes its 400 W of discharge.
+	bat := tel.Get("ferroamp", telemetry.DerBattery)
+	if bat == nil || bat.RawW != -400 {
+		t.Fatalf("battery RawW = %v, want -400 (healthy ESO 400×1.0 + faulted 400×0)", bat.RawW)
+	}
+}
+
 // Live-system regression (2026-05-24): with power_w=0 the driver
 // used to publish `auto`, which puts the EnergyHub in autonomous
 // self-consumption. That silently overrode every planner slot that


### PR DESCRIPTION
## Summary
- `ferroamp.lua` cached only the most-recently-published ESO in a single `eso_data` slot, so the battery power readout was the per-unit number instead of the cluster aggregate. On a 2×ESO site this halved `bat_w`; the controller's grid-chase loop fed on the wrong number and dispatch stuck ~190 W of import against a 0 W target.
- Replace the single slot with `eso_data_by_id` keyed on each ESO's `id` field. Sum DC power across all live ESOs (cell-monitor `ubat × ibat`), average voltage / SoC / DC-link, sum currents and Wh counters, surface per-ESO faults via worst-of relay/faultcode.
- Backward-compatible: messages without an `id` field land under a synthetic key, so single-ESO firmware and sims keep behaving identically.
- New `eso_count` diagnostic metric so operators can see how many ESOs the driver is summing.

## How it was discovered
Live debugging session on a 2×ESO (`21030026` + `23010216`) Ferroamp install:

| Source | Battery output |
|---|---|
| 42 `bat_w` | 153 W |
| Ferroamp `ehub.pbat` (aggregate DC) | 306 W |
| Σ per-ESO `ubat × ibat` | 305.8 W |

After the fix the same site shows ratio `1.00` between 42 and `ehub.pbat`, and the grid chase converges normally.

## Test plan
- [x] `go test ./internal/drivers/ -run Ferroamp -v` — 8 existing tests + 2 new (`TestFerroampDriverSumsBatteryPowerAcrossMultipleESOs`, `TestFerroampDriverSurfacesPerESOFaultsWorstOf`)
- [x] `go test ./...` — full suite green
- [x] Deployed to a live 2×ESO site; `bat_w` matches `ehub.pbat` 1:1 over multiple snapshots; dispatch target tracks delivered discharge; grid converged inside `grid_tolerance_w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)