### PR TITLE
fix(control): unwind PI integrator on mode change and on wrong-direction windup

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1040,6 +1040,16 @@ func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
 		// battery manual hold so the new mode takes effect on the very
 		// next dispatch tick. Mirrors the loadpoint manual_hold UX.
 		s.deps.Ctrl.ClearBatteryManualHold()
+		// Reset the PI integrator. The integral accumulated under the
+		// previous mode's error signal is meaningless to the new mode
+		// — keeping it caused integrator windup → wrong-direction stuck
+		// output across the 2026-05-24 evening mode switch (live
+		// regression: discharged the fleet to 7 % overnight while the
+		// PI integral was pinned in the wrong direction). Mode change
+		// is a discrete event; start the new regime from a clean PI.
+		if s.deps.Ctrl.PI != nil {
+			s.deps.Ctrl.PI.Reset()
+		}
 		s.deps.CtrlMu.Unlock()
 		if err := s.deps.State.SaveConfig("mode", req.Mode); err != nil {
 			slog.Warn("failed to persist mode", "err", err)

--- a/go/internal/api/api_test.go
+++ b/go/internal/api/api_test.go
@@ -517,3 +517,48 @@ func TestHandleEnergyDailyDaysClamping(t *testing.T) {
 		})
 	}
 }
+
+// 2026-05-24 evening regression: PI integrator state carried across an
+// operator mode switch, so the new mode inherited a saturated integral
+// from the previous mode's stuck-import accumulation and commanded
+// wrong-direction battery moves for minutes after the switch (overnight
+// the fleet drained to 7 %). Mode change is a discrete event; the PI
+// integral has no meaning under the new control regime.
+func TestHandleSetModeResetsPIIntegral(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctrl := control.NewState(0, 50, "meter")
+	ctrl.Mode = control.ModeSelfConsumption
+	// Wind PI integral to near saturation under a sustained positive
+	// measurement (PI's internal err = setpoint - measurement = negative,
+	// so integral drives negative).
+	for i := 0; i < 200; i++ {
+		ctrl.PI.Update(700)
+	}
+	if ctrl.PI.Integral() > -2900 {
+		t.Fatalf("setup: expected integral pinned near -3000, got %f", ctrl.PI.Integral())
+	}
+
+	srv := New(&Deps{
+		Ctrl:   ctrl,
+		CtrlMu: &sync.Mutex{},
+		State:  st,
+		CfgMu:  &sync.RWMutex{},
+		Cfg:    &config.Config{},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mode",
+		strings.NewReader(`{"mode":"self_consumption"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rr.Code, rr.Body.String())
+	}
+	if got := ctrl.PI.Integral(); got != 0 {
+		t.Errorf("PI integral after mode change = %f, want 0 (mode change must clear PI state)", got)
+	}
+}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -49,6 +49,111 @@ func TestPIReset(t *testing.T) {
 	}
 }
 
+// DecayIntegral is the live-system anti-windup escape hatch — wind the
+// integral up to saturation, then call DecayIntegral a few times to verify
+// it drops geometrically toward 0 without snapping it to 0 instantly.
+func TestPIDecayIntegralUnwindsSaturation(t *testing.T) {
+	p := NewPI(0.5, 0.1, 3000, 10000)
+	p.Setpoint = 0
+	// Drive into negative saturation with a sustained positive measurement
+	// (PI's internal err = setpoint - measurement = negative).
+	for i := 0; i < 200; i++ {
+		p.Update(700)
+	}
+	if p.Integral() > -2900 {
+		t.Fatalf("setup: expected integral pinned near -3000 after 200 cycles, got %f", p.Integral())
+	}
+	p.DecayIntegral(0.5)
+	if got := p.Integral(); math.Abs(got-(-1500)) > 1 {
+		t.Errorf("after one 0.5 decay from -3000, integral = %f, want ≈ -1500", got)
+	}
+	p.DecayIntegral(0.5)
+	p.DecayIntegral(0.5)
+	if got := p.Integral(); math.Abs(got-(-375)) > 1 {
+		t.Errorf("after three 0.5 decays from -3000, integral = %f, want ≈ -375", got)
+	}
+}
+
+func TestPIDecayIntegralClampsFactor(t *testing.T) {
+	p := NewPI(0.5, 0.1, 3000, 10000)
+	p.Setpoint = 0
+	for i := 0; i < 50; i++ {
+		p.Update(500)
+	}
+	before := p.Integral()
+	p.DecayIntegral(-1.0)
+	if p.Integral() != 0 {
+		t.Errorf("DecayIntegral(-1) should clamp to factor=0 (i.e. zero the integral), got %f", p.Integral())
+	}
+	p.integral = before
+	p.DecayIntegral(5.0)
+	if p.Integral() != before {
+		t.Errorf("DecayIntegral(5) should clamp to factor=1 (no-op), got %f vs before=%f", p.Integral(), before)
+	}
+}
+
+// 2026-05-25 morning regression: yesterday's mode-switch wound the PI
+// integral to negative saturation while the system was importing under a
+// stale plan; once the morning sun flipped grid to export, the saturated
+// integral kept commanding discharge for ~3 min until natural decay
+// drained it. Dispatch already detects the wrong-direction case and
+// clamps the OUTPUT to currentTotal, but it left the integral untouched,
+// so the next cycle was just as wound up.
+//
+// Active integral decay on wrong-direction-windup means the controller
+// converges within a handful of cycles instead of minutes.
+func TestDispatchWrongDirectionWindupDecaysPIIntegral(t *testing.T) {
+	store := seedStore(-1000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 60, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	// Pre-wind the integral hard negative — simulates yesterday's
+	// load-side import accumulation persisting into a now-exporting
+	// grid this morning.
+	for i := 0; i < 100; i++ {
+		st.PI.Update(800)
+	}
+	beforeI := st.PI.Integral()
+	if beforeI > -2500 {
+		t.Fatalf("setup: expected integral wound past -2500, got %f", beforeI)
+	}
+
+	// Single dispatch cycle: live grid is -1000 (exporting), errW=-1000.
+	// PI's pre-wound -3000 integral will still drag the output negative,
+	// so correctionDir would be negative → matches the "exporting but PI
+	// wants discharge" wrong-direction case → integral must decay.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	afterI := st.PI.Integral()
+	// Both numbers negative — "closer to 0" means a larger (less negative) value.
+	if math.Abs(afterI) >= math.Abs(beforeI) {
+		t.Errorf("integral after wrong-dir clamp = %f, want strictly closer to 0 than before=%f", afterI, beforeI)
+	}
+	// Behavioural assertion: a few cycles of geometric decay + normal
+	// integration should be enough that dispatch is no longer commanding
+	// the wrong direction. Without decay, the integral stays saturated
+	// at -3000 and PI keeps emitting the wrong-signed output across
+	// every subsequent cycle (that's the 2026-05-25 sunrise regression).
+	var lastTarget float64
+	for i := 0; i < 5; i++ {
+		targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+		if len(targets) == 1 {
+			lastTarget = targets[0].TargetW
+		}
+	}
+	// grid_w = -1000 (exporting); a correctly-recovered PI must command
+	// charge, not discharge. Pre-fix this test scenario would emit
+	// target ≤ 0 for ~3 min until natural integral drain.
+	if lastTarget <= 0 {
+		t.Errorf("after 6 cycles, target = %f W — controller still stuck in wrong direction (need positive charge command against -1000 W export)", lastTarget)
+	}
+}
+
 // ---- Dispatch tests ----
 
 // helper: build a store with one site meter + N batteries at given SoC

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1388,9 +1388,18 @@ func ComputeDispatch(
 		case errW > 0 && correctionDir > wrongDirEpsW:
 			// Importing but PI wants to charge — wrong-direction windup.
 			allowed = currentTotal
+			// Actively unwind the integral. Without this the integral
+			// stays load-bearing in the wrong direction across every
+			// subsequent cycle and the controller is "stuck" until the
+			// next opposite-signed error happens to drain it naturally
+			// — that took ~3 min during the 2026-05-25 morning sunrise
+			// after the prior evening's mode-switch windup. Decay to
+			// half each cycle the clamp fires.
+			state.PI.DecayIntegral(0.5)
 		case errW < 0 && correctionDir < -wrongDirEpsW:
 			// Exporting but PI wants to discharge — wrong-direction windup.
 			allowed = currentTotal
+			state.PI.DecayIntegral(0.5)
 		case errW > 0 && targetTotal < idealTarget:
 			// Importing: discharge needed. PI wants more than will land
 			// us on target — cap so we don't punch through into export.

--- a/go/internal/control/pi.go
+++ b/go/internal/control/pi.go
@@ -60,6 +60,31 @@ func (p *PIController) Update(measurement float64) PIOutput {
 // Reset zeroes the integral. Use when retuning or after a long idle.
 func (p *PIController) Reset() { p.integral = 0 }
 
+// DecayIntegral multiplies the integral by factor (0 ≤ factor ≤ 1).
+// Use when the controller is observed to be commanding the wrong
+// direction relative to live error sign — the accumulated integral is
+// load-bearing in the wrong direction and clamping the output alone
+// leaves it stuck. A factor in the 0.3–0.6 range unwinds saturation
+// over a few cycles without dropping memory of legitimate offsets.
+//
+// Conditional integration (skip-on-clamp) would be cleaner in theory
+// but doesn't help our specific case: the dispatch wrong-direction
+// clamp only catches the IS-wrong condition after the integral has
+// already saturated. Active decay is what gets us out.
+func (p *PIController) DecayIntegral(factor float64) {
+	if factor < 0 {
+		factor = 0
+	}
+	if factor > 1 {
+		factor = 1
+	}
+	p.integral *= factor
+}
+
+// Integral exposes the current integral term. Read-only outside the
+// controller — set/reset through Reset / DecayIntegral.
+func (p *PIController) Integral() float64 { return p.integral }
+
 // PIOutput is one update's full breakdown.
 type PIOutput struct {
 	P, I, Output, Error float64


### PR DESCRIPTION
## Live regression — root cause

Spanning 2026-05-24 evening → 2026-05-25 morning. Fleet drained from ~60 % SoC to **7 %**, importing 3.2 kWh at 250+ öre/kWh overnight.

### What happened

```
yesterday 18:00     operator: planner_self → self_consumption
                    handleSetMode: state.Mode = m; PI.Reset() NOT called
                    PI integral state carries from prior loop's accumulation

yesterday ~18:30    reactive PI on grid_w = +697 (importing)
                    integral runs to negative saturation (-3000) within ~30 cycles

overnight           load drains battery, grid swings between import/export
                    PI integral keeps fighting per-cycle err, oscillates around saturation

today 04:51 UTC     sunrise, grid_w = -1000 (exporting), should command CHARGE
                    PI: output = Kp×err + integral_pinned_negative ≈ -1080  (DISCHARGE)
                    meter-clamp detects wrong-direction → clamps output to 0
                    BUT integral is left at -3000, next cycle is just as wound up

today 04:53 UTC     ~3 minutes of natural Ki·err drain later, integral finally crosses
                    zero, PI flips to commanding charge. SoC at 7 %.
```

The meter-clamp anti-windup logic already detected the wrong-direction case (\`errW > 0 && correctionDir > epsilon\` etc.) and clamped the OUTPUT to \`currentTotal\` — but the integral was untouched, so the controller stayed stuck across every subsequent cycle.

## Two narrow fixes

1. **\`handleSetMode\` calls \`PI.Reset()\` under \`CtrlMu\`.** Mode change is a discrete control-regime change; the prior integral has no meaning under the new regime.

2. **The wrong-direction branch in \`dispatch.go\` now calls \`state.PI.DecayIntegral(0.5)\`.** Geometric drain unwinds a saturated integral within a handful of dispatch ticks instead of minutes, without snapping to zero (which would drop legitimate steady-state offsets).

## New API on PIController

- \`DecayIntegral(factor)\` — multiplies integral by factor ∈ [0, 1]. Clamped defensively.
- \`Integral()\` — read-only accessor.

## Tests

- \`TestPIDecayIntegralUnwindsSaturation\` — geometric 0.5 decay from -3000.
- \`TestPIDecayIntegralClampsFactor\` — factor clamped to [0, 1].
- \`TestDispatchWrongDirectionWindupDecaysPIIntegral\` — the live regression: pre-wind integral, fire one dispatch cycle, assert integral has unwound; behavioural: after 6 cycles PI must command charge (positive) against -1000 W live export, not stay stuck discharging.
- \`TestHandleSetModeResetsPIIntegral\` — POST /api/mode resets a saturated integral.

Full suite green: \`go test ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)