### PR TITLE
experiment(control): default slew → 3000 W/cycle + slew_enabled opt-out

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,7 +8,8 @@ site:
   grid_tolerance_w: 42          # deadband (The Answer)
   watchdog_timeout_s: 60
   smoothing_alpha: 0.3
-  slew_rate_w: 500              # W per cycle (≈ 250 W/s at 2 s cycle)
+  slew_rate_w: 3000             # W per cycle. Both Ferroamp and Sungrow ramp internally — this is a soft ceiling, not the primary protection
+  # slew_enabled: false         # disable the external slew limiter entirely and trust the inverter's internal ramp control (experimental)
   min_dispatch_interval_s: 2    # debounce; keep == control_interval_s
 
 fuse:

--- a/go/cmd/forty-two-watts/control_state.go
+++ b/go/cmd/forty-two-watts/control_state.go
@@ -11,6 +11,10 @@ func newControlStateFromConfig(cfg *config.Config) *control.State {
 		ctrl.PI.Kp = cfg.Site.Gain
 	}
 	ctrl.SlewRateW = cfg.Site.SlewRateW
+	// applyDefaults() ensures SlewEnabled is non-nil at this point.
+	if cfg.Site.SlewEnabled != nil {
+		ctrl.SlewEnabled = *cfg.Site.SlewEnabled
+	}
 	ctrl.MinDispatchIntervalS = cfg.Site.MinDispatchIntervalS
 	ctrl.InverterGroups = inverterGroupsFrom(cfg.Drivers)
 	ctrl.SupportsPVCurtail = supportsPVCurtailFrom(cfg.Drivers)

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -288,6 +288,20 @@ type Site struct {
 	SlewRateW            float64 `yaml:"slew_rate_w" json:"slew_rate_w"`
 	MinDispatchIntervalS int     `yaml:"min_dispatch_interval_s" json:"min_dispatch_interval_s"`
 
+	// SlewEnabled gates the external per-cycle ramp limiter. Both
+	// supported inverter families (Ferroamp, Sungrow) have their own
+	// internal power-ramp control loops; the external slew was
+	// originally added to dampen reactive-PI oscillation under noisy
+	// meter sampling, but it also slows legitimate step-response and
+	// can interact badly with PI integrator state (the 2026-05-25
+	// recovery took ~3 min of slew-bounded ramping after the integral
+	// finally unwound).
+	//
+	// Pointer so we can distinguish "unset → default true" from
+	// "explicitly false". Defaults to enabled to preserve back-compat
+	// on existing installs.
+	SlewEnabled *bool `yaml:"slew_enabled,omitempty" json:"slew_enabled,omitempty"`
+
 	// PVSurplusAbsorbSoCCapPct enables the opt-in PV-surplus absorber
 	// underlay in the energy-dispatch path (planner_cheap /
 	// planner_arbitrage). When the planner's slot allocation would still
@@ -814,7 +828,17 @@ func applyDefaults(c *Config) {
 		c.Site.Gain = 0.5
 	}
 	if c.Site.SlewRateW == 0 {
-		c.Site.SlewRateW = 500
+		// 3000 W/cycle at the 2 s default control interval = 1500 W/s
+		// ramp ceiling. Both Ferroamp and Sungrow internal EMS loops
+		// ramp slower than this naturally (Sungrow spec: ~1000 W/s),
+		// so the external slew rarely fires under normal conditions
+		// but still bounds the post-windup recovery from snapping to
+		// full output in a single cycle.
+		c.Site.SlewRateW = 3000
+	}
+	if c.Site.SlewEnabled == nil {
+		t := true
+		c.Site.SlewEnabled = &t
 	}
 	if c.Site.MinDispatchIntervalS == 0 {
 		// Match control_interval_s. The holdoff exists to suppress

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -457,6 +457,26 @@ func TestUnresolveDriverPathsRoundtrip(t *testing.T) {
 	}
 }
 
+func TestSlewDefaults(t *testing.T) {
+	c := &Config{}
+	applyDefaults(c)
+	if c.Site.SlewRateW != 3000 {
+		t.Errorf("default slew_rate_w: got %f, want 3000", c.Site.SlewRateW)
+	}
+	if c.Site.SlewEnabled == nil || *c.Site.SlewEnabled != true {
+		t.Errorf("default slew_enabled: got %v, want *true", c.Site.SlewEnabled)
+	}
+}
+
+func TestSlewExplicitDisablePreserved(t *testing.T) {
+	f := false
+	c := &Config{Site: Site{SlewEnabled: &f}}
+	applyDefaults(c)
+	if c.Site.SlewEnabled == nil || *c.Site.SlewEnabled != false {
+		t.Errorf("explicit slew_enabled=false must survive applyDefaults, got %v", c.Site.SlewEnabled)
+	}
+}
+
 func TestNotificationsDefaults(t *testing.T) {
 	c := &Config{Notifications: &Notifications{Enabled: false}}
 	applyDefaults(c)

--- a/go/internal/configreload/watcher.go
+++ b/go/internal/configreload/watcher.go
@@ -121,6 +121,18 @@ func (w *Watcher) reload() {
 	if newCfg.Site.SlewRateW != oldCfg.Site.SlewRateW {
 		w.ctrl.SlewRateW = newCfg.Site.SlewRateW
 	}
+	newEnabled := true
+	if newCfg.Site.SlewEnabled != nil {
+		newEnabled = *newCfg.Site.SlewEnabled
+	}
+	oldEnabled := true
+	if oldCfg.Site.SlewEnabled != nil {
+		oldEnabled = *oldCfg.Site.SlewEnabled
+	}
+	if newEnabled != oldEnabled {
+		slog.Info("config reload: slew_enabled", "old", oldEnabled, "new", newEnabled)
+		w.ctrl.SlewEnabled = newEnabled
+	}
 	if newCfg.Site.MinDispatchIntervalS != oldCfg.Site.MinDispatchIntervalS {
 		w.ctrl.MinDispatchIntervalS = newCfg.Site.MinDispatchIntervalS
 	}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -375,6 +375,61 @@ func TestChargePlanNeverDischargesIndividualBatteryAfterSlew(t *testing.T) {
 	}
 }
 
+// SlewEnabled=false: PI's computed target reaches the inverter in one
+// cycle. Both supported inverter families ramp internally, so the
+// external slew was double-limiting on top of their own protection.
+// Smoke test that a large step (battery 0 → -3000 over a single cycle)
+// passes through without the slew clamp.
+func TestSlewDisabledPassesLargeStepThrough(t *testing.T) {
+	// Grid importing 3 kW — PI wants to discharge heavily.
+	store := seedStore(3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 500  // intentionally tight — if SlewEnabled wins, target lands at -500
+	st.SlewEnabled = false
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if math.Abs(targets[0].TargetW) <= 500 {
+		t.Errorf("TargetW = %f W — slew_enabled=false must let PI exceed the 500 W slew step in a single cycle", targets[0].TargetW)
+	}
+	if targets[0].Clamped {
+		t.Errorf("Clamped=true with slew_enabled=false — only fuse/SoC/per-driver caps should clamp now")
+	}
+}
+
+// SlewEnabled=true (default) still rate-limits step responses to the
+// configured ramp.
+func TestSlewEnabledClampsLargeStep(t *testing.T) {
+	store := seedStore(3000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 500
+	st.SlewEnabled = true
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if math.Abs(targets[0].TargetW) > 510 {
+		t.Errorf("TargetW = %f W — slew_enabled=true should cap step at ~500 W", targets[0].TargetW)
+	}
+}
+
 func TestProportionalSplitByCapacity(t *testing.T) {
 	bats := []batteryInfo{
 		{driver: "big", capacityWh: 15000, currentW: 0, soc: 0.5, online: true},

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -252,7 +252,12 @@ type State struct {
 	PI *PIController
 
 	// Slew + holdoff
-	SlewRateW            float64
+	SlewRateW float64
+	// SlewEnabled gates the per-cycle ramp limiter. Disabled = trust
+	// the inverter's internal ramp control entirely (commands jump to
+	// the PI's computed target). See Site.SlewEnabled in config for
+	// the operator-facing rationale.
+	SlewEnabled          bool
 	MinDispatchIntervalS int
 	LastDispatch         *time.Time
 	PrevTargets          map[string]float64
@@ -681,6 +686,7 @@ func NewState(gridTargetW, gridToleranceW float64, siteMeter string) *State {
 		EVChargingW:                    0,
 		PI:                             pi,
 		SlewRateW:                      500,
+		SlewEnabled:                    true,
 		MinDispatchIntervalS:           5,
 		PrevTargets:                    map[string]float64{},
 		UseCascade:                     true,
@@ -1600,6 +1606,14 @@ func ComputeDispatch(
 			(manualHoldActive && math.Abs(manualHold.PowerW) < 1)) &&
 			math.Abs(raw[i].TargetW) < 1 {
 			raw[i].TargetW = 0
+			continue
+		}
+		// Slew limiter is opt-out. Both inverter families ramp internally;
+		// disabling the external slew lets PI's computed target reach the
+		// inverter in one cycle, which the inverter then ramps at its own
+		// safe rate. Saves the windup-recovery delay we observed on
+		// 2026-05-25.
+		if !state.SlewEnabled {
 			continue
 		}
 		delta := raw[i].TargetW - anchor


### PR DESCRIPTION
## What

Two changes, both back-compat preserved:

1. **Default \`slew_rate_w\` 500 → 3000 W/cycle.** At the 2 s default control interval that's a 1500 W/s ceiling — above Sungrow's internal ramp (~1000 W/s spec) and well above Ferroamp's ~200 ms EMS response, so the external slew rarely fires under normal operation but still bounds catastrophic post-windup snaps.

2. **New \`site.slew_enabled\` knob (default true).** Operators can set it to \`false\` to disable the external slew entirely and trust the inverter's internal ramp control. Pointer typing preserves "unset → default" semantics on upgrade. Hot-reloadable via the configreload watcher.

## Why

Operator question (2026-05-25): *"does the external slew actually do anything useful when the inverter has its own ramp control?"*

The honest answer: less than the 500 W/cycle default implied. Both production inverter families have internal ramp control loops; the external slew was originally a damper on reactive-PI swing under noisy meter sampling. It also interacts badly with PI integrator state — the 2026-05-25 morning recovery took ~3 min of slew-bounded ramping after the integral finally unwound, because each cycle could only contribute 500 W of correction even when PI was finally pointing the right way (paired fix in #297 unwinds the integral; this PR is the speed-up half).

This is structured as an experiment: bump the default to a less aggressive value AND provide an off-switch for live A/B comparison without redeploy.

## Test plan

- [x] \`go test ./...\` green
- [x] \`TestSlewDisabledPassesLargeStepThrough\` — opt-out path lets a 3 kW step pass in one cycle
- [x] \`TestSlewEnabledClampsLargeStep\` — default path still caps step at slew_rate_w
- [x] \`TestSlewDefaults\` / \`TestSlewExplicitDisablePreserved\` — defaults + pointer semantics
- [ ] Deploy on homelab-rpi; verify live step responses are faster but inverter doesn't protest
- [ ] Try \`slew_enabled: false\` for a few hours and compare convergence latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)