### PR TITLE
fix(mpc): self-consumption terminal SoC price = mean import, not spread

### DIFF
--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -955,34 +955,38 @@ const (
 )
 
 // selfConsumptionTerminalPrice is the per-kWh öre value of leftover SoC at
-// the end of the horizon, for the modes where the battery cannot export.
-// Equals the mean retail-import price minus the mean export price
-// (spot + bonus − fee, floored at 0). That's what one kWh in the battery
-// actually earns you: it displaces one kWh of future retail import
-// instead of one kWh that would otherwise have been exported.
+// the end of the horizon, for self-consumption mode. Returns the mean
+// retail-import price across the horizon — matching the mpc/CLAUDE.md
+// design intent: "every kWh kept in the battery at horizon end is worth
+// what it would have cost to import during a typical hour".
 //
-// Floored at 0 so we never credit SoC negatively; if export rates exceed
-// retail (rare, subsidy edge cases) the planner in these modes should just
-// stay SoC-neutral rather than actively drain.
+// The prior implementation returned mean(import) − mean(export) — the
+// arbitrage spread. That understates self-consumption value by ~2× on
+// realistic SE retail tariffs (210 öre/kWh import, 100 öre/kWh export;
+// spread = 110 öre, mean import = 210 öre). On 2026-05-25 the
+// understatement let the DP pick "idle — export PV surplus" over
+// "charge from PV" by a 1-öre margin in a slot where SoC was 7.5 %
+// (below operator floor) and 4 kW of PV surplus was available.
+//
+// Grid-charging is not encouraged by the larger terminal credit
+// because mpc.go's strict self-consumption bias (line 583) triples the
+// cost of HOUSE-driven grid import — including the implicit import
+// required to grid-charge. PV-fed charging stays free and dominates.
+//
+// bonus/fee are accepted for signature compatibility with the arbitrage
+// path; they don't enter the self-consumption value because the
+// operator never sells stored energy in this mode.
 func selfConsumptionTerminalPrice(prices []state.PricePoint, bonus, fee float64) float64 {
+	_ = bonus
+	_ = fee
 	if len(prices) == 0 {
 		return 0
 	}
-	var importSum, exportSum float64
+	var importSum float64
 	for _, pr := range prices {
 		importSum += pr.TotalOreKwh
-		exp := pr.SpotOreKwh + bonus - fee
-		if exp < 0 {
-			exp = 0
-		}
-		exportSum += exp
 	}
-	n := float64(len(prices))
-	spread := (importSum - exportSum) / n
-	if spread < 0 {
-		spread = 0
-	}
-	return spread
+	return importSum / float64(len(prices))
 }
 
 // upperHalfMeanPrice returns the arithmetic mean of the upper half of

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -122,26 +122,28 @@ func TestUpperHalfMeanEmptyReturnsZero(t *testing.T) {
 
 // ---- Terminal SoC valuation ----
 
-func TestSelfConsumptionTerminalPriceIsImportMinusExport(t *testing.T) {
-	// Retail 300 öre/kWh, spot 80 öre/kWh, bonus 60, fee 6.
-	// Per slot: export rate = 80 + 60 − 6 = 134. Spread = 300 − 134 = 166.
+func TestSelfConsumptionTerminalPriceIsMeanImport(t *testing.T) {
+	// Retail 300 öre/kWh average across the horizon. Spot/bonus/fee are
+	// irrelevant in self-consumption mode (operator never sells stored
+	// energy, so the export side doesn't enter the value of a kept kWh).
 	prices := []state.PricePoint{
 		{SpotOreKwh: 80, TotalOreKwh: 300},
 		{SpotOreKwh: 80, TotalOreKwh: 300},
 	}
 	got := selfConsumptionTerminalPrice(prices, 60, 6)
-	if math.Abs(got-166) > 1e-9 {
-		t.Fatalf("terminal price = %f, want 166", got)
+	if math.Abs(got-300) > 1e-9 {
+		t.Fatalf("terminal price = %f, want 300 (mean import)", got)
 	}
 }
 
-func TestSelfConsumptionTerminalPriceClampsToZero(t *testing.T) {
-	// Export rate (spot+bonus−fee) > retail → spread would be negative.
-	// Must floor at 0 so we never actively credit draining the battery.
+func TestSelfConsumptionTerminalPriceIgnoresExportRate(t *testing.T) {
+	// Even when export rate (spot+bonus−fee) exceeds retail, the
+	// terminal value of stored SoC is still mean import — self-consumption
+	// mode never sells stored energy, so the export side is moot.
 	prices := []state.PricePoint{{SpotOreKwh: 500, TotalOreKwh: 100}}
 	got := selfConsumptionTerminalPrice(prices, 0, 0)
-	if got != 0 {
-		t.Fatalf("terminal price = %f, want 0", got)
+	if math.Abs(got-100) > 1e-9 {
+		t.Fatalf("terminal price = %f, want 100 (mean import) regardless of export rate", got)
 	}
 }
 


### PR DESCRIPTION
## Live regression — root cause

Active right now on homelab-rpi: 4 kWh of PV exported today while batteries sit at 7.5 % SoC. The planner picked \"idle — export PV surplus\" for every slot.

\`selfConsumptionTerminalPrice\` returned **mean(import) − mean(export)** (the arbitrage spread). On SE retail tariffs that's ~110 öre/kWh — *half* the value mpc/CLAUDE.md documents (\"mean import price over horizon so the planner is SoC-neutral\").

### DP cost comparison per kWh of PV in slot 0

| | spread terminal (~110) | mean-import terminal (~210) |
|---|---|---|
| charge (η × terminal) | 0.95 × 110 = **104 öre** | 0.95 × 210 = **200 öre** |
| export (spot)         | **98 öre** | **98 öre** |
| margin to charge      | +6 öre | +102 öre |

Spread's 6 öre margin sits *inside* the DP's action-quantization noise — it picks export. Mean-import gives a solid +100 öre/kWh preference for charging from PV surplus.

## Why this doesn't open the door to grid-charging

\`mpc.go\` line 583 already triples the cost of HOUSE-driven grid import for self-consumption mode. That includes implicit imports required for grid-charging:

- PV-fed charge: cost 0, terminal credit +200 öre → strong win
- Grid-fed charge (cheap night, spot 30, import 80): cost 60 öre (×3 penalty), terminal credit +50 öre → net **−10 öre** → DP declines

PV charging stays free and dominates; import charging stays uneconomic.

## Tests

- \`TestSelfConsumptionTerminalPriceIsMeanImport\` (replaces \`IsImportMinusExport\`) — assert mean(import) regardless of spot/bonus/fee
- \`TestSelfConsumptionTerminalPriceIgnoresExportRate\` (replaces \`ClampsToZero\`) — even when spot > retail, value is mean import
- \`TestSelfConsumptionTerminalPriceEmpty\` — unchanged
- Full suite green: \`go test ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)