### PR TITLE
feat(mode): add passive_arbitrage — merges planner_self + planner_cheap

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -182,7 +182,8 @@ func main() {
 		switch control.Mode(v) {
 		case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
 			control.ModeCharge, control.ModePriority, control.ModeWeighted,
-			control.ModePlannerSelf, control.ModePlannerCheap, control.ModePlannerArbitrage:
+			control.ModePlannerSelf, control.ModePlannerCheap,
+			control.ModePlannerPassiveArbitrage, control.ModePlannerArbitrage:
 			ctrl.Mode = control.Mode(v)
 		}
 	}
@@ -965,6 +966,8 @@ func main() {
 				mm = mpc.ModeSelfConsumption
 			case control.ModePlannerCheap:
 				mm = mpc.ModeCheapCharge
+			case control.ModePlannerPassiveArbitrage:
+				mm = mpc.ModePassiveArbitrage
 			case control.ModePlannerArbitrage:
 				mm = mpc.ModeArbitrage
 			}

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1033,7 +1033,8 @@ func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
 	switch m {
 	case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
 		control.ModeCharge, control.ModePriority, control.ModeWeighted,
-		control.ModePlannerSelf, control.ModePlannerCheap, control.ModePlannerArbitrage:
+		control.ModePlannerSelf, control.ModePlannerCheap,
+		control.ModePlannerPassiveArbitrage, control.ModePlannerArbitrage:
 		s.deps.CtrlMu.Lock()
 		s.deps.Ctrl.Mode = m
 		// An explicit mode change is a reset signal: drop any active
@@ -1063,6 +1064,8 @@ func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
 				mm = mpc.ModeSelfConsumption
 			case control.ModePlannerCheap:
 				mm = mpc.ModeCheapCharge
+			case control.ModePlannerPassiveArbitrage:
+				mm = mpc.ModePassiveArbitrage
 			case control.ModePlannerArbitrage:
 				mm = mpc.ModeArbitrage
 			}

--- a/go/internal/api/api_test.go
+++ b/go/internal/api/api_test.go
@@ -518,6 +518,40 @@ func TestHandleEnergyDailyDaysClamping(t *testing.T) {
 	}
 }
 
+// passive_arbitrage merges planner_self + planner_cheap into one
+// operator-facing mode. The API must accept the new value and propagate
+// the corresponding mpc.Mode to the planner service.
+func TestHandleSetModeAcceptsPassiveArbitrage(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("state.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctrl := control.NewState(0, 50, "meter")
+	srv := New(&Deps{
+		Ctrl:   ctrl,
+		CtrlMu: &sync.Mutex{},
+		State:  st,
+		CfgMu:  &sync.RWMutex{},
+		Cfg:    &config.Config{},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mode",
+		strings.NewReader(`{"mode":"planner_passive_arbitrage"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", rr.Code, rr.Body.String())
+	}
+	if ctrl.Mode != control.ModePlannerPassiveArbitrage {
+		t.Errorf("ctrl.Mode = %q, want %q", ctrl.Mode, control.ModePlannerPassiveArbitrage)
+	}
+	if !ctrl.Mode.IsPlannerMode() {
+		t.Errorf("passive_arbitrage must register as a planner mode for the dispatch energy-path")
+	}
+}
+
 // 2026-05-24 evening regression: PI integrator state carried across an
 // operator mode switch, so the new mode inherited a saturated integral
 // from the previous mode's stuck-import accumulation and commanded

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2062,6 +2062,45 @@ func TestPlannerSelfPlanChargeStillDischargesOnLiveImport(t *testing.T) {
 	}
 }
 
+// passive_arbitrage HONOURS plan grid-charge intent (this is the
+// key difference from planner_self). When the planner deliberately
+// picked a cheap slot to refill the battery via grid, the dispatch
+// must execute that, even if the meter is currently importing more
+// than expected — the import IS the intent. Operators who want
+// strict "never grid-charge regardless of price" should keep
+// planner_self.
+func TestPlannerPassiveArbitrageHonoursPlannedGridCharge(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 800, // plan: charge 800 Wh = 3200 W avg
+		Strategy:        "passive_arbitrage",
+	}
+	// Live: importing 1200 W. For passive_arbitrage this is FINE — the
+	// plan deliberately scheduled grid-charge during a cheap slot.
+	store := seedStore(1200, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if targets[0].TargetW <= 0 {
+		t.Errorf("TargetW = %f W — passive_arbitrage must execute planned grid-charge (not undo it as reactive discharge)", targets[0].TargetW)
+	}
+}
+
 // Symmetric case: if the plan expected discharge but the live meter says the
 // site is exporting, planner_self should absorb the live surplus. The plan
 // only says "participate this slot", not "force discharge direction".

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -29,17 +29,24 @@ const (
 	// Other planner modes fall back to self_consumption behavior and log.
 	// The three flavors mirror mpc.Mode — the difference is only what
 	// the planner is allowed to do when it builds the plan:
-	//   - planner_self:      no grid-charging, no battery export
-	//   - planner_cheap:     grid-charge ok, no export discharge
-	//   - planner_arbitrage: full freedom within SoC + power limits
-	ModePlannerSelf      Mode = "planner_self"
-	ModePlannerCheap     Mode = "planner_cheap"
-	ModePlannerArbitrage Mode = "planner_arbitrage"
+	//   - planner_self:        no grid-charging, no battery export
+	//   - planner_cheap:       grid-charge ok, no export discharge
+	//   - planner_passive_arb: charge from cheapest (PV or grid), no
+	//                          export discharge (merges planner_self
+	//                          and planner_cheap as of v0.82)
+	//   - planner_arbitrage:   full freedom within SoC + power limits
+	ModePlannerSelf             Mode = "planner_self"
+	ModePlannerCheap            Mode = "planner_cheap"
+	ModePlannerPassiveArbitrage Mode = "planner_passive_arbitrage"
+	ModePlannerArbitrage        Mode = "planner_arbitrage"
 )
 
 // IsPlannerMode reports whether the mode is one of the planner modes.
 func (m Mode) IsPlannerMode() bool {
-	return m == ModePlannerSelf || m == ModePlannerCheap || m == ModePlannerArbitrage
+	return m == ModePlannerSelf ||
+		m == ModePlannerCheap ||
+		m == ModePlannerPassiveArbitrage ||
+		m == ModePlannerArbitrage
 }
 
 // PlanTargetFunc is injected by main.go: given the current time, returns
@@ -2206,6 +2213,15 @@ func planHasNonDischargeIntent(state *State) bool {
 	// discharge even when the cloud rolled in and the live meter is
 	// importing 500 W — the symptom the operator hit on v0.79.5
 	// before this carve-out.
+	//
+	// planner_passive_arbitrage is intentionally NOT in the carve-out.
+	// Its contract differs from planner_self: it CAN grid-charge when
+	// the DP picked cheap hours for refilling, so a plan slot of
+	// "charge X Wh" is realisable intent (not just a forecast that
+	// happened to land positive). Overriding it with reactive
+	// discharge would undo the deliberate grid-charge decision.
+	// Operators who want strict "never grid-charge regardless of
+	// price" should keep planner_self.
 	if state.Mode == ModePlannerSelf {
 		return false
 	}
@@ -2678,7 +2694,8 @@ func perPhaseOverageW(store *telemetry.Store, state *State) float64 {
 // against. Threshold of 100 W matches mpc.IdleGateThresholdW so a
 // near-zero plan target counts as "idle, no opinion on sign".
 func applyPlanSignFloor(targets []DispatchTarget, state *State) []DispatchTarget {
-	if len(targets) == 0 || state == nil || !state.Mode.IsPlannerMode() || state.Mode == ModePlannerSelf {
+	if len(targets) == 0 || state == nil || !state.Mode.IsPlannerMode() ||
+		state.Mode == ModePlannerSelf {
 		return targets
 	}
 	intent := planSignIntent(state)

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -53,11 +53,36 @@ const (
 	// ModeCheapCharge: allow importing to charge when prices are low
 	// (the DP decides based on forecast). Still never export battery to
 	// grid — discharge stays ≤ local load.
+	//
+	// Superseded by ModePassiveArbitrage as of v0.82 — the merged mode
+	// covers the same use case (charge from cheapest available source,
+	// never export battery) and removes the operator-facing choice
+	// between "smart self-consumption" and "cheap charge" that the
+	// planner is already capable of making on its own. Kept here for
+	// existing-config compatibility.
 	ModeCheapCharge Mode = "cheap_charge"
+
+	// ModePassiveArbitrage: charge the battery from the cheapest
+	// available energy source — PV surplus when there's sun, grid
+	// during cheap night hours when not — for use BY THE HOUSE.
+	// Battery never exports to grid. Subsumes both self_consumption
+	// (summer behavior, PV always wins) and cheap_charge (winter
+	// behavior, grid wins during off-peak). The DP picks per slot.
+	//
+	// Uses the strict-self-consumption bias (battery prefers covering
+	// house load over letting the grid do it) and the mean-import
+	// terminal price (every stored kWh is worth a typical retail
+	// import that it'll later displace).
+	ModePassiveArbitrage Mode = "passive_arbitrage"
 
 	// ModeArbitrage: unrestricted. Charge from grid, discharge to grid —
 	// whatever minimizes total cost over the horizon, subject to SoC and
 	// power limits.
+	//
+	// "Active arbitrage" in the v0.82 UI rename. Same DP behavior;
+	// difference vs ModePassiveArbitrage is solely battery-export
+	// permission. Operator opts in here when they want full timing
+	// arbitrage on both directions.
 	ModeArbitrage Mode = "arbitrage"
 )
 
@@ -603,7 +628,7 @@ func Optimize(slots []Slot, p Params) Plan {
 						// check above (line 357), so the bias can only
 						// push discharge *toward* the floor, never
 						// past it.
-						if p.Mode == ModeSelfConsumption {
+						if p.Mode == ModeSelfConsumption || p.Mode == ModePassiveArbitrage {
 							houseGridW := slot.LoadW + slot.PVW + battW
 							if houseGridW > 0 {
 								houseKWh := houseGridW * dtH / 1000.0
@@ -920,11 +945,17 @@ func modeAllows(m Mode, baselineGridW, gridW, actW float64) bool {
 			return gridW <= modeTolW && gridW >= baselineGridW-modeTolW
 		}
 		return math.Abs(actW) < modeTolW
-	case ModeCheapCharge:
+	case ModeCheapCharge, ModePassiveArbitrage:
 		// Allow charging from grid (any actW ≥ 0), but never discharge past
 		// the local load: i.e. gridW must stay ≥ 0 when we'd otherwise be
 		// importing, OR ≥ baseline when we'd otherwise be exporting.
 		// Simpler rule: no battery-driven export, i.e. gridW ≥ min(0, baseline).
+		//
+		// ModePassiveArbitrage shares this contract with ModeCheapCharge —
+		// "charge from cheapest, never export from battery". The two
+		// constants exist for back-compat during the v0.82 deprecation
+		// window; semantically the merged mode IS cheap_charge plus the
+		// strict-SC house-import bias (handled in the DP cost above).
 		minGrid := 0.0
 		if baselineGridW < 0 {
 			minGrid = baselineGridW

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -93,6 +93,122 @@ func TestSelfConsumptionAbsorbsPVSurplus(t *testing.T) {
 // per-slot penalty for every kWh-hour the SoC ends below the floor on
 // a PV-surplus slot — so deferring to a later slot costs strictly more
 // than charging in slot 0.
+// passive_arbitrage merges planner_self + planner_cheap into one mode
+// where the DP picks the cheapest charging source per slot (PV when
+// surplus exists, grid otherwise). Discharge is still confined to
+// local load — no battery export to grid. The strict-SC bias still
+// applies so house load is preferentially served from battery.
+//
+// Summer-like scenario: PV surplus throughout. DP should charge from
+// PV, never from grid.
+func TestPassiveArbitrageChargesFromPVWhenSurplusAvailable(t *testing.T) {
+	slots := make([]Slot, 8)
+	for i := range slots {
+		slots[i] = Slot{
+			StartMs:    int64(i) * 15 * 60 * 1000,
+			LenMin:     15,
+			PriceOre:   100, // would be cheap to import too
+			SpotOre:    10,
+			LoadW:      500,
+			PVW:        -3000, // PV >> load
+			Confidence: 1,
+		}
+	}
+	p := baseParams(ModePassiveArbitrage)
+	p.InitialSoCPct = 20
+	p.TerminalSoCPrice = 100
+
+	plan := Optimize(slots, p)
+	// Should charge in early slots from PV.
+	if plan.Actions[0].BatteryW <= 0 {
+		t.Errorf("slot 0: BatteryW = %f W, should charge from PV surplus", plan.Actions[0].BatteryW)
+	}
+	// Should NEVER export from battery (grid <= 0 only when PV exports it).
+	for i, a := range plan.Actions {
+		// In passive_arbitrage, gridW = baseline + battW must be >= min(0, baseline).
+		baseline := a.LoadW + a.PVW
+		minGrid := baseline
+		if minGrid > 0 {
+			minGrid = 0
+		}
+		if a.GridW < minGrid-50 {
+			t.Errorf("slot %d: gridW = %f W < minGrid = %f W — battery is exporting (forbidden in passive_arbitrage)", i, a.GridW, minGrid)
+		}
+	}
+}
+
+// Winter-like scenario: no PV, cheap night prices followed by expensive
+// morning. DP should grid-charge during the cheap window for use during
+// the expensive window. This is what differentiates passive_arbitrage
+// from planner_self (which forbids grid-charge entirely).
+func TestPassiveArbitrageGridChargesAtCheapHours(t *testing.T) {
+	// 4 cheap-night slots (spot 5 öre, retail 30) + 4 expensive-morning
+	// slots (spot 200 öre, retail 250). No PV throughout. Load 500 W.
+	slots := make([]Slot, 8)
+	for i := range slots {
+		if i < 4 {
+			slots[i] = Slot{
+				StartMs: int64(i) * 60 * 60 * 1000, LenMin: 60,
+				PriceOre: 30, SpotOre: 5, LoadW: 500, PVW: 0, Confidence: 1,
+			}
+		} else {
+			slots[i] = Slot{
+				StartMs: int64(i) * 60 * 60 * 1000, LenMin: 60,
+				PriceOre: 250, SpotOre: 200, LoadW: 500, PVW: 0, Confidence: 1,
+			}
+		}
+	}
+	p := baseParams(ModePassiveArbitrage)
+	p.InitialSoCPct = 20
+	p.TerminalSoCPrice = 50 // low so terminal credit doesn't dominate the test
+	// Big enough buffer so a charge during cheap hours fits.
+	p.SoCMinPct = 10
+	p.SoCMaxPct = 95
+
+	plan := Optimize(slots, p)
+	// Sum charge during cheap slots, sum discharge during expensive slots.
+	var chargeCheap, dischargeExpensive float64
+	for i, a := range plan.Actions {
+		if i < 4 && a.BatteryW > 0 {
+			chargeCheap += a.BatteryW
+		}
+		if i >= 4 && a.BatteryW < 0 {
+			dischargeExpensive += -a.BatteryW
+		}
+	}
+	if chargeCheap < 500 {
+		t.Errorf("expected grid-charge during cheap hours, got total %f W across cheap slots", chargeCheap)
+	}
+	if dischargeExpensive < 500 {
+		t.Errorf("expected discharge during expensive hours, got total %f W across expensive slots", dischargeExpensive)
+	}
+}
+
+// Critical invariant: passive_arbitrage must NEVER discharge into the
+// grid (no battery-export). This is what separates it from active
+// arbitrage and what the operator picked when they chose "passive".
+func TestPassiveArbitrageNeverExportsFromBattery(t *testing.T) {
+	// Battery starts charged; expensive slot with cheap export rate
+	// would tempt DP to discharge into grid for arbitrage. Mode must
+	// refuse.
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 100, SpotOre: 300, LoadW: 100, PVW: 0, Confidence: 1},
+	}
+	p := baseParams(ModePassiveArbitrage)
+	p.InitialSoCPct = 80 // plenty of stored energy
+
+	plan := Optimize(slots, p)
+	a := plan.Actions[0]
+	// Battery may discharge to cover load (100 W), but no more — must
+	// not push grid into export.
+	if a.BatteryW < -150 {
+		t.Errorf("BatteryW = %f W — passive_arbitrage must not discharge beyond local load", a.BatteryW)
+	}
+	if a.GridW < -50 {
+		t.Errorf("gridW = %f W — passive_arbitrage must not push grid into export", a.GridW)
+	}
+}
+
 func TestSelfConsumptionSafetyFloorChargesEarlyWhenBelowFloor(t *testing.T) {
 	// 12 slots × 15 min = 3 hours. PV surplus throughout (PV 5 kW,
 	// load 500 W → 4.5 kW surplus). Without the safety floor, DP

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -362,13 +362,15 @@ func (s *Service) SlotAt(now time.Time) (string, float64, bool) {
 // actionToSlot translates an MPC action into (mode_string, grid_target_w, true).
 // The mapping from planner-mode + action to EMS mode:
 //   - self_consumption → always self_consumption with grid_target=0
-//   - cheap_charge → "charge" when the plan says charge, otherwise self_consumption
+//   - cheap_charge / passive_arbitrage → "charge" when the plan says
+//     charge, otherwise self_consumption (no battery-export branch —
+//     both modes forbid discharge past local load)
 //   - arbitrage → "charge" / "self_consumption" (with negative grid target for export) / self_consumption
 func actionToSlot(a Action, plannerMode Mode) (string, float64, bool) {
 	switch plannerMode {
 	case ModeSelfConsumption:
 		return "self_consumption", 0, true
-	case ModeCheapCharge:
+	case ModeCheapCharge, ModePassiveArbitrage:
 		if a.BatteryW > 100 {
 			return "charge", 0, true
 		}
@@ -675,7 +677,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 	if p.TerminalSoCPrice <= 0 {
 		terminalDefaulted = true
 		switch p.Mode {
-		case ModeSelfConsumption, ModeCheapCharge:
+		case ModeSelfConsumption, ModeCheapCharge, ModePassiveArbitrage:
 			p.TerminalSoCPrice = selfConsumptionTerminalPrice(prices,
 				s.ExportBonusOreKwh, s.ExportFeeOreKwh)
 		default:
@@ -727,7 +729,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// applies when we just defaulted above; an explicit caller-
 	// supplied TerminalSoCPrice is respected.
 	if terminalDefaulted && p.Loadpoint != nil && p.Loadpoint.SurplusOnly &&
-		p.Mode != ModeSelfConsumption && p.Mode != ModeCheapCharge {
+		p.Mode != ModeSelfConsumption && p.Mode != ModeCheapCharge && p.Mode != ModePassiveArbitrage {
 		p.TerminalSoCPrice = selfConsumptionTerminalPrice(prices,
 			s.ExportBonusOreKwh, s.ExportFeeOreKwh)
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -289,9 +289,10 @@
       <div class="card control-card control-strategy">
         <div class="card-label">Strategy</div>
         <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
-          <button data-mode="planner_self" title="Smart self-consumption with forecast-aware grid-zero control — never grid-charge, never battery-export">Smart self-consumption (planner)</button>
-          <button data-mode="planner_cheap" title="Plan charges batteries when grid prices are low (still never exports via battery)">Cheap charging</button>
-          <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours">Arbitrage</button>
+          <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
+          <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
+          <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
+          <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
         </div>
         <div class="strategy-hint" id="strategy-hint"></div>
         <div class="mode-advanced-toggle advanced-only">

--- a/web/legacy.html
+++ b/web/legacy.html
@@ -141,9 +141,10 @@
       <div class="card control-card control-strategy">
         <div class="card-label">Strategy</div>
         <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
-          <button data-mode="planner_self" title="Smart self-consumption with forecast-aware grid-zero control — never grid-charge, never battery-export">Smart self-consumption (planner)</button>
-          <button data-mode="planner_cheap" title="Plan charges batteries when grid prices are low (still never exports via battery)">Cheap charging</button>
-          <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours">Arbitrage</button>
+          <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
+          <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
+          <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
+          <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
         </div>
         <div class="strategy-hint" id="strategy-hint"></div>
         <div class="mode-advanced-toggle advanced-only">

--- a/web/plan.js
+++ b/web/plan.js
@@ -818,9 +818,10 @@
 
   // Strategy explanation — surfaces one-sentence logic for the current mode.
   const STRATEGY_DESC = {
-    planner_self: 'Smart self-consumption (planner). Forecast-aware grid-zero control: cover local import, charge PV only when the plan wants storage, and preserve export when the plan keeps battery headroom for cheaper surplus later.',
-    planner_cheap: 'Cheap charging. Plans to import during the cheapest upcoming hours to top up the battery, still never exports via the battery. Good when export tariffs are low.',
-    planner_arbitrage: 'Arbitrage. Full freedom: charges in the cheapest slots, discharges into the most expensive slots (including exporting). Biggest savings on volatile days; pays attention to battery efficiency + SoC bounds.',
+    planner_passive_arbitrage: 'Passive arbitrage. Charges the battery from the cheapest available energy each slot — PV when sunny, grid during cheap night hours — for your own use. Never exports from the battery. Subsumes smart self-consumption (summer behavior) and cheap charging (winter behavior); the planner picks per slot.',
+    planner_arbitrage: 'Active arbitrage. Full freedom: charges in the cheapest slots, discharges into the most expensive slots including export to grid. Biggest savings on volatile days; respects battery efficiency + SoC bounds.',
+    planner_self: 'Legacy: smart self-consumption. Forecast-aware grid-zero control with no grid-charge. Superseded by Passive arbitrage as of v0.82.',
+    planner_cheap: 'Legacy: cheap charging. Imports during cheap hours; never exports via battery. Superseded by Passive arbitrage as of v0.82.',
     self_consumption: 'Self (manual). Simple grid-zero controller with no planner; charges surplus and discharges to cover local import.',
     peak_shaving: 'Manual peak shaving. Limits grid import to the peak-limit setting.',
     charge: 'Manual full charge — forces the battery to charge regardless of price.',

--- a/web/settings/tabs/planner.js
+++ b/web/settings/tabs/planner.js
@@ -10,8 +10,8 @@
       return '<fieldset><legend>MPC Planner</legend>' +
         '<label><input type="checkbox" data-checkbox-path="planner.enabled"' + (config.planner.enabled ? ' checked' : '') + '> Enabled ' +
         help('Enable the MPC planner. When active it overrides manual mode with an optimised schedule.') + '</label>' +
-        selectField("Mode", "planner.mode", ["self_consumption", "cheap_charge", "arbitrage"], "self_consumption",
-          "self_consumption = minimise grid import. cheap_charge = charge batteries during cheapest hours. arbitrage = buy low / sell high.") +
+        selectField("Mode", "planner.mode", ["passive_arbitrage", "arbitrage", "self_consumption", "cheap_charge"], "passive_arbitrage",
+          "passive_arbitrage = charge from cheapest source (PV or cheap grid), never export from battery. arbitrage = full timing arbitrage including battery export. self_consumption / cheap_charge = legacy (use passive_arbitrage instead).") +
         '<div class="field-row"><div>' +
         field("SoC min (%)", "planner.soc_min_pct", "number", 10,
           "Lowest SoC the planner will discharge to (percent). 10 = 10%.") +


### PR DESCRIPTION
## Operator framing

> \"planner_self och planner_cheap borde rimligen vara samma mode. Vi kallar det Passive Arbitrage — vi fyller batterier med billigaste energin för eget bruk. På sommaren ger PV alltid det billigaste, på vintern blir det grid-charge under billiga timmar. Det här är bara ett mode som maximerar nyttan av batterierna och låser elpriset efter dygnets billigaste timmar.\"

Result:

| Old | New |
|---|---|
| planner_self (no grid-charge) | passive_arbitrage (DP picks cheapest source per slot, no battery-export) |
| planner_cheap (grid-charge ok) | (subsumed) |
| planner_arbitrage (full freedom) | planner_arbitrage (\"active\"; battery-export permitted) |

## What changes

- New \`mpc.ModePassiveArbitrage\` + \`control.ModePlannerPassiveArbitrage\` constants.
- modeAllows: passive_arbitrage shares the cheap_charge contract (grid-charge ok, no battery-export).
- Strict-SC bias (3× retail penalty on house import) now fires for both \`ModeSelfConsumption\` and \`ModePassiveArbitrage\` — summer behavior matches planner_self.
- Terminal SoC price uses \`selfConsumptionTerminalPrice\` (mean import) for the merged mode.
- actionToSlot translates the merged mode for the legacy-dispatch path.
- handleSetMode + startup mode-restore both accept the new constant.
- UI: \`web/index.html\` + \`legacy.html\` + \`plan.js\` + \`settings/tabs/planner.js\` updated. Old modes marked \"(legacy)\". The JS planner-active detector at \`next-app.js:749\` works without modification because the new string starts with \`planner_\`.

## Critical review gaps caught + fixed (Codex P0 pass)

1. Startup mode-restore allow-list was missing the new constant — would have dropped persisted selections on restart.
2. \`actionToSlot\` had no case → legacy-dispatch path fell back to \"self_consumption\" + ignored planned grid-charge.
3. Initial naming \`\"passive_arbitrage\"\` lacked the \`planner_\` prefix → web JS detector failed. Renamed to \`planner_passive_arbitrage\`.
4. UI files (4) didn't list the new mode.
5. \`service.go:730\` surplus-LP terminal-credit override carried a redundant condition; tidied.

## Design decision: carve-out NOT inherited

The reviewer suggested passive_arbitrage should inherit \`planner_self\`'s \"discharge to cover live import regardless of plan charge intent\" carve-out. **Rejected** — that would undo legitimate grid-charge intent during cheap hours, which IS the new feature. Operators who want strict \"never grid-charge\" should keep \`planner_self\`. The carve-out logic now explicitly documents why passive_arbitrage is excluded.

## Tests

- \`TestPassiveArbitrageChargesFromPVWhenSurplusAvailable\` — summer-like surplus → charges from PV
- \`TestPassiveArbitrageGridChargesAtCheapHours\` — winter-like cheap-night + expensive-morning → grid-charges then discharges
- \`TestPassiveArbitrageNeverExportsFromBattery\` — battery-export invariant
- \`TestPlannerPassiveArbitrageHonoursPlannedGridCharge\` — codifies the rejected-carve-out decision
- \`TestHandleSetModeAcceptsPassiveArbitrage\` — API accepts new mode + registers as planner mode

Full suite: \`go test ./...\` green.

## Backward compat

\`planner_self\` and \`planner_cheap\` remain functional with unchanged semantics. UI marks them \"(legacy)\". Settings selector defaults to \`passive_arbitrage\` for new installs but accepts the legacy values. No YAML migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)