### PR TITLE
fix: MPC restore merges newer Defaults + Plan UI shows mode + Strategy moves into Plan card

### DIFF
--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -223,6 +223,21 @@ func (s *Service) RestoreDiagnostic(d *Diagnostic, now time.Time, reason string)
 	if s.Defaults.Mode != "" && params.Mode != "" && params.Mode != s.Defaults.Mode {
 		return false
 	}
+	// Merge fields that exist in the current binary's Defaults but
+	// could be missing-or-zero in a persisted snapshot written by an
+	// older binary. Without this merge, a deploy that adds a new
+	// Params field (e.g. SoCSafetyFloorPct added in v0.82) lets the
+	// restored snapshot's zero overwrite the operator's intended
+	// default until the next successful replan rebuilds params from
+	// s.Defaults. Live regression 2026-05-25: a v0.82 deploy restored
+	// the v0.81 snapshot with SoCSafetyFloorPct=0; safety floor stayed
+	// inactive for ~10 minutes until manual /api/mpc/replan.
+	if params.SoCSafetyFloorPct == 0 && s.Defaults.SoCSafetyFloorPct > 0 {
+		params.SoCSafetyFloorPct = s.Defaults.SoCSafetyFloorPct
+	}
+	if params.SafetyFloorPenaltyOreKwhHour == 0 && s.Defaults.SafetyFloorPenaltyOreKwhHour > 0 {
+		params.SafetyFloorPenaltyOreKwhHour = s.Defaults.SafetyFloorPenaltyOreKwhHour
+	}
 	s.last = plan
 	s.lastSlots = slots
 	s.lastParams = params

--- a/go/internal/mpc/diagnose_test.go
+++ b/go/internal/mpc/diagnose_test.go
@@ -236,6 +236,125 @@ func TestRestoreDiagnosticRehydratesActivePlan(t *testing.T) {
 	}
 }
 
+// 2026-05-25 live regression: deploy of v0.82 added SoCSafetyFloorPct
+// to Params but persisted snapshots from v0.81 had no field for it.
+// RestoreDiagnostic re-hydrated lastParams from the old snapshot
+// (SoCSafetyFloorPct=0), so the safety-floor gate sat inactive until
+// the next scheduled replan (15 min later). Fix: when restoring,
+// merge fields that are zero-in-snapshot but non-zero-in-Defaults
+// with the current Defaults value.
+func TestRestoreDiagnosticMergesNewerDefaultsForMissingFields(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-5 * time.Minute).Truncate(time.Minute)
+	// Snapshot WITHOUT SoCSafetyFloorPct (simulates an older binary).
+	d := &Diagnostic{
+		ComputedAtMs:   now.Add(-1 * time.Minute).UnixMilli(),
+		Zone:           "SE4",
+		Horizon:        1,
+		LastReplanAtMs: now.Add(-1 * time.Minute).UnixMilli(),
+		Params: DiagnosticParams{
+			Mode:                ModeSelfConsumption,
+			InitialSoCPct:       8,
+			SoCMinPct:           10,
+			SoCMaxPct:           95,
+			SoCLevels:           41,
+			ActionLevels:        81,
+			MaxChargeW:          5000,
+			MaxDischargeW:       5000,
+			ChargeEfficiency:    0.95,
+			DischargeEfficiency: 0.95,
+			CapacityWh:          16000,
+			TerminalSoCPrice:    100,
+			// SoCSafetyFloorPct: 0 (field didn't exist when snapshot was written)
+			// SafetyFloorPenaltyOreKwhHour: 0
+		},
+		Slots: []DiagnosticSlot{{
+			Idx: 0, SlotStartMs: start.UnixMilli(),
+			SlotEndMs: start.Add(15 * time.Minute).UnixMilli(),
+			LenMin:    15, PriceOre: 100, Confidence: 1, PVW: -3000, LoadW: 500,
+			BatteryW: 0, GridW: -2500, SoCPct: 8,
+			EMSMode: "self_consumption",
+		}},
+	}
+	// Service has the newer defaults — operator picked 25% safety floor.
+	svc := &Service{
+		Zone: "SE4",
+		Defaults: Params{
+			Mode:                         ModeSelfConsumption,
+			SoCSafetyFloorPct:            25,
+			SafetyFloorPenaltyOreKwhHour: 100,
+		},
+	}
+	if ok := svc.RestoreDiagnostic(d, now, "restored_diagnostic"); !ok {
+		t.Fatal("RestoreDiagnostic returned false")
+	}
+	diag := svc.Diagnose()
+	if diag == nil {
+		t.Fatal("Diagnose returned nil after restore")
+	}
+	if diag.Params.SoCSafetyFloorPct != 25 {
+		t.Errorf("SoCSafetyFloorPct after restore = %v, want 25 (merged from Defaults; snapshot had 0)", diag.Params.SoCSafetyFloorPct)
+	}
+	if diag.Params.SafetyFloorPenaltyOreKwhHour != 100 {
+		t.Errorf("SafetyFloorPenaltyOreKwhHour after restore = %v, want 100 (merged from Defaults)", diag.Params.SafetyFloorPenaltyOreKwhHour)
+	}
+}
+
+// If the snapshot DOES have explicit values (operator persisted a
+// non-zero choice), restore must preserve them — not overwrite with
+// Defaults. Only zero-in-snapshot fields get the merge.
+func TestRestoreDiagnosticPreservesExplicitSnapshotValues(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-5 * time.Minute).Truncate(time.Minute)
+	d := &Diagnostic{
+		ComputedAtMs:   now.Add(-1 * time.Minute).UnixMilli(),
+		Zone:           "SE4",
+		Horizon:        1,
+		LastReplanAtMs: now.Add(-1 * time.Minute).UnixMilli(),
+		Params: DiagnosticParams{
+			Mode:                         ModeSelfConsumption,
+			InitialSoCPct:                30,
+			SoCMinPct:                    10,
+			SoCMaxPct:                    95,
+			SoCLevels:                    41,
+			ActionLevels:                 81,
+			MaxChargeW:                   5000,
+			MaxDischargeW:                5000,
+			ChargeEfficiency:             0.95,
+			DischargeEfficiency:          0.95,
+			CapacityWh:                   16000,
+			TerminalSoCPrice:             100,
+			SoCSafetyFloorPct:            15, // operator picked a different value
+			SafetyFloorPenaltyOreKwhHour: 50,
+		},
+		Slots: []DiagnosticSlot{{
+			Idx: 0, SlotStartMs: start.UnixMilli(),
+			SlotEndMs: start.Add(15 * time.Minute).UnixMilli(),
+			LenMin:    15, PriceOre: 100, Confidence: 1, PVW: -3000, LoadW: 500,
+			BatteryW: 0, GridW: -2500, SoCPct: 30,
+			EMSMode: "self_consumption",
+		}},
+	}
+	svc := &Service{
+		Zone: "SE4",
+		Defaults: Params{
+			Mode:                         ModeSelfConsumption,
+			SoCSafetyFloorPct:            25, // Defaults would say 25 but snapshot has 15
+			SafetyFloorPenaltyOreKwhHour: 100,
+		},
+	}
+	if ok := svc.RestoreDiagnostic(d, now, "restored_diagnostic"); !ok {
+		t.Fatal("RestoreDiagnostic returned false")
+	}
+	diag := svc.Diagnose()
+	if diag.Params.SoCSafetyFloorPct != 15 {
+		t.Errorf("SoCSafetyFloorPct = %v, want 15 (snapshot value must win over Defaults)", diag.Params.SoCSafetyFloorPct)
+	}
+	if diag.Params.SafetyFloorPenaltyOreKwhHour != 50 {
+		t.Errorf("SafetyFloorPenaltyOreKwhHour = %v, want 50 (snapshot value must win)", diag.Params.SafetyFloorPenaltyOreKwhHour)
+	}
+}
+
 // TestDiagnoseCarriesLoadpointFields — without this the plan table
 // hides EV columns because its `lpActive` gate is
 // `slots.some(x => x.loadpoint_w || x.loadpoint_soc_pct)`. Plumbing

--- a/web/index.html
+++ b/web/index.html
@@ -284,34 +284,15 @@
       <ftw-savings-card default-range="week"></ftw-savings-card>
     </section>
 
-    <!-- Controls — two-tier: primary strategy + manual advanced -->
-    <section class="controls-row">
-      <div class="card control-card control-strategy">
-        <div class="card-label">Strategy</div>
-        <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
-          <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
-          <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
-          <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
-          <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
-        </div>
-        <div class="strategy-hint" id="strategy-hint"></div>
-        <div class="mode-advanced-toggle advanced-only">
-          <button class="btn-link" id="mode-advanced-btn" title="Show manual modes">Manual…</button>
-        </div>
-        <div class="mode-buttons mode-buttons-advanced advanced-only" id="mode-buttons" style="display:none">
-          <button data-mode="idle" title="Do nothing — no dispatch">Idle</button>
-          <button data-mode="self_consumption" title="Manual self-consumption — PI chases grid_target, no plan">Self (manual)</button>
-          <button data-mode="peak_shaving" title="Limit import to peak-limit">Peak</button>
-          <button data-mode="charge" title="Force full charge regardless of price">Charge</button>
-        </div>
-      </div>
-      <!-- Grid-side knobs (peak limit, grid target) live inside the
-           Grid bubble modal — click the GRID planet in the energy-flow
-           hero to open. EV-side knob ("Let battery cover EV") lives
-           inside the EV bubble modal. Inline cards removed; the modals
-           own the markup so the JS hooks (#peak-limit-slider, etc.)
-           still resolve. -->
-    </section>
+    <!-- Strategy now lives inside the Plan card header (below) — it's
+         the operator-facing control that drives plan behaviour, so
+         visually attaching it to the Plan removes the standalone
+         "controls row" that felt disconnected from what it controlled.
+         Grid-side knobs (peak limit, grid target) live inside the Grid
+         bubble modal — click the GRID planet in the energy-flow hero.
+         EV-side knob ("Let battery cover EV") lives inside the EV
+         bubble modal. -->
+
 
     <!-- Live power + plan side-by-side -->
     <section id="live-plan-row" class="live-plan-row">
@@ -372,6 +353,32 @@
               <button type="button" data-horizon="tomorrow">Tomorrow</button>
             </div>
             <button id="plan-replan" class="btn-send" title="Force a fresh plan">Replan</button>
+          </div>
+        </div>
+
+        <!-- Strategy — the operator-facing knob that drives plan
+             behaviour. Lives inside the Plan card because that's what
+             it controls; the standalone "controls row" above
+             previously felt disconnected (operator note 2026-05-25).
+             Two-tier: planner strategies first, manual fallbacks
+             behind a "Manual…" toggle. -->
+        <div class="plan-strategy">
+          <span class="card-label plan-strategy-label">Strategy</span>
+          <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
+            <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
+            <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
+            <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
+            <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
+          </div>
+          <div class="strategy-hint" id="strategy-hint"></div>
+          <div class="mode-advanced-toggle advanced-only">
+            <button class="btn-link" id="mode-advanced-btn" title="Show manual modes">Manual…</button>
+          </div>
+          <div class="mode-buttons mode-buttons-advanced advanced-only" id="mode-buttons" style="display:none">
+            <button data-mode="idle" title="Do nothing — no dispatch">Idle</button>
+            <button data-mode="self_consumption" title="Manual self-consumption — PI chases grid_target, no plan">Self (manual)</button>
+            <button data-mode="peak_shaving" title="Limit import to peak-limit">Peak</button>
+            <button data-mode="charge" title="Force full charge regardless of price">Charge</button>
           </div>
         </div>
         <p class="plan-help">

--- a/web/plan.js
+++ b/web/plan.js
@@ -522,9 +522,22 @@
         const cost = plan.total_cost_ore / 100;
         const costLabel = cost >= 0 ? 'expected cost' : 'expected earnings';
         const parts = [];
+        // The /api/mpc/plan response carries the INTERNAL mpc.Mode (e.g.
+        // "self_consumption", "passive_arbitrage", "arbitrage"). Map to the
+        // operator-facing label so the badge matches the Strategy button
+        // the operator picked — "self_consumption" alone reads as the
+        // manual mode, not the Smart SC (legacy) planner setting that
+        // currently drives the plan.
+        const PLAN_MODE_LABEL = {
+          self_consumption: 'Smart self-consumption (legacy)',
+          cheap_charge: 'Cheap charging (legacy)',
+          passive_arbitrage: 'Passive arbitrage',
+          arbitrage: 'Active arbitrage',
+        };
+        const modeLabel = PLAN_MODE_LABEL[plan.mode] || plan.mode;
         parts.push(
-          `<span title="Active planner strategy — choose from the Mode picker above">` +
-          `<span class="s-value">${plan.mode}</span></span>`
+          `<span title="Active planner strategy — choose from the Mode picker">` +
+          `<span class="s-value">${modeLabel}</span></span>`
         );
         parts.push(
           `<span title="How far ahead the planner is optimising">` +

--- a/web/style.css
+++ b/web/style.css
@@ -1378,6 +1378,28 @@ footer {
   box-sizing: border-box;
 }
 .control-strategy { min-width: 320px; }
+
+/* Strategy block when embedded inside the Plan card. Sits between the
+ * chart-header and the plan-help paragraph; visually a thin separator
+ * rather than a full card so it reads as "configuration for the plan
+ * below", not a separate widget. */
+.plan-strategy {
+  margin: 8px 0 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--line, rgba(255,255,255,0.08));
+  border-radius: 6px;
+  background: var(--bg-raised, rgba(255,255,255,0.02));
+}
+.plan-strategy-label {
+  display: block;
+  font-family: var(--mono, monospace);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-dim, #94a3b8);
+  margin-bottom: 8px;
+}
+
 .mode-buttons-primary {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
Three operator-visible improvements after the 2026-05-25 deploys landed live.

## 1. MPC restore merges newer Defaults for missing snapshot fields

**The bug:** v0.82 deploy added \`SoCSafetyFloorPct\` to \`Params\`; persisted v0.81 snapshot didn't have the field. \`RestoreDiagnostic\` rehydrated \`lastParams\` with \`SoCSafetyFloorPct=0\` → safety floor stayed inactive until the next scheduled replan (~15 min). On the live system this morning the operator had to manually \`POST /api/mpc/replan\` to kick the planner into using the new floor.

**Fix:** \`RestoreDiagnostic\` now merges current \`Defaults\` for fields that are zero-in-snapshot but non-zero-in-Defaults. Explicit snapshot values still win — operators who deliberately set a different safety floor see it preserved across restarts.

\`\`\`go
if params.SoCSafetyFloorPct == 0 && s.Defaults.SoCSafetyFloorPct > 0 {
    params.SoCSafetyFloorPct = s.Defaults.SoCSafetyFloorPct
}
\`\`\`

Same treatment for \`SafetyFloorPenaltyOreKwhHour\`. Pattern documented in the comment so future Params additions can follow.

## 2. Plan card shows operator-facing mode label

**The bug:** Plan summary displayed raw \`mpc.Mode\` (\"self_consumption\") which reads as the manual mode, not the \`planner_self\` strategy actually driving the plan. Operator note: \"Plan säger 'self_consumption'. Jag vill ju att vi får med vilket mode det är tydligt.\"

**Fix:** \`PLAN_MODE_LABEL\` map in plan.js → \"Smart self-consumption (legacy)\", \"Passive arbitrage\", \"Active arbitrage\", \"Cheap charging (legacy)\". Matches the Strategy button the operator picked.

## 3. Strategy moves from standalone \"controls row\" into the Plan card header

**The framing:** Operator note: \"Strategy delen ska ligga som en naturlig del någon annanstans — känns som den är lite egen nu och udda.\" The Strategy block sat in its own \`controls-row\` section above the live-plan-row, disconnected from what it controls.

**Fix:** Strategy block moves inside \`#plan-section\`, between the chart-header and the plan-help paragraph. Visually a thin separator card (1px border, mono uppercase label) rather than a full card — reads as \"configuration for the plan below\".

The \"Manual…\" advanced fallback (Idle / Self / Peak / Charge) is preserved as a collapsed toggle within the same block.

## Tests

- \`TestRestoreDiagnosticMergesNewerDefaultsForMissingFields\` — the live regression
- \`TestRestoreDiagnosticPreservesExplicitSnapshotValues\` — invariant: explicit operator value always wins
- Full suite green: \`go test ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)