### PR TITLE
chore(ui): hide legacy mode buttons — only Passive / Active

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -367,8 +367,6 @@
           <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
             <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
             <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
-            <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
-            <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
           </div>
           <div class="strategy-hint" id="strategy-hint"></div>
           <div class="mode-advanced-toggle advanced-only">

--- a/web/legacy.html
+++ b/web/legacy.html
@@ -143,8 +143,6 @@
         <div class="mode-buttons mode-buttons-primary" id="mode-buttons-primary">
           <button data-mode="planner_passive_arbitrage" title="Charge from the cheapest available source (PV when sunny, grid during cheap hours). Never exports from battery.">Passive arbitrage</button>
           <button data-mode="planner_arbitrage" title="Full price arbitrage — charge cheap, discharge into expensive hours (battery may export to grid).">Active arbitrage</button>
-          <button data-mode="planner_self" title="Legacy: smart self-consumption (no grid-charge). Superseded by Passive arbitrage in v0.82.">Smart SC (legacy)</button>
-          <button data-mode="planner_cheap" title="Legacy: cheap charging. Superseded by Passive arbitrage in v0.82.">Cheap charging (legacy)</button>
         </div>
         <div class="strategy-hint" id="strategy-hint"></div>
         <div class="mode-advanced-toggle advanced-only">


### PR DESCRIPTION
Operator framing: \"Jag vill inte ha Smart SC (legacy). Hela grejen är ju att göra den enklare. Passive eller Active. That's it som ska kunna väljas.\"

Strategy block in both \`index.html\` and \`legacy.html\` now shows only:
- **Passive arbitrage** (the new merged mode)
- **Active arbitrage** (full timing arbitrage incl. battery export)

The underlying \`mpc.Mode\` and \`control.Mode\` constants for \`planner_self\` and \`planner_cheap\` stay — config files referencing them still parse, the API still accepts them. Operators with those values persisted will see no button highlighted but can switch to Passive arbitrage with one click. \`STRATEGY_DESC\` / \`PLAN_MODE_LABEL\` keep the legacy labels for the read path so the plan summary renders meaningfully if a legacy mode is somehow active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)