### PR TITLE
fix(plan): outlook badges — fix % sign bug, label as forecast, reframe verb

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -558,16 +558,16 @@
         Hover any bar for the exact split (spot / grid / VAT) plus PV, load, battery and SoC for that slot.
       </p>
 
-      <h3>Savings badges</h3>
-      <p>Each badge compares the plan's expected cost against an alternative scenario over the same horizon. All three numbers are computed by the same cost model, so they're directly comparable.</p>
+      <h3>48 h outlook badges</h3>
+      <p><b>Projections, not realised savings.</b> Each badge compares the plan's expected cost over the next 48 h against an alternative scenario, using the same cost model. For what the system <em>actually</em> saved, look at the Savings card above the chart.</p>
       <ul>
         <li><b>vs no battery</b> — what this horizon would cost with no battery at all (grid flow = load + PV each slot, priced normally). Captures the combined value of battery + planner.</li>
         <li><b>vs self-consumption</b> — what plain self-consumption mode would cost over the same forecast (same battery, same constraints, no arbitrage). Captures the extra value the planner adds on top of passive SC.</li>
         <li><b>vs flat avg price</b> — what no-battery import would cost if every kWh were priced at the horizon's average price. Captures the value of <em>timing</em> — shifting consumption into cheap hours — independently of the battery.</li>
       </ul>
       <p class="plan-help-note">
-        <span class="saving-pos-inline">Green +</span> means the plan saves vs that baseline.
-        <span class="saving-neg-inline">Red −</span> means it costs more (rare, usually a sign the baseline benefits from a lucky forecast).
+        <span class="saving-pos-inline">Green +</span> means the plan is better than that baseline (cheaper, or more revenue).
+        <span class="saving-neg-inline">Red −</span> means it would be worse than the baseline — typical on flat-price days where the battery's round-trip loss isn't recovered by timing arbitrage.
       </p>
     </div>
   </ftw-modal>

--- a/web/next.css
+++ b/web/next.css
@@ -1010,12 +1010,33 @@ body.ftw-next .plan-help {
   max-width: 68ch;
 }
 body.ftw-next .plan-savings {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
   margin: 6px 0 10px;
 }
 body.ftw-next .plan-savings:empty { display: none; }
+/* Forecast outlook block — own bordered surface so operators see it
+ * as "extra analysis", not part of the running plan summary. The
+ * "48 h outlook" label disambiguates from realised savings (which
+ * live in the Savings card above). */
+body.ftw-next .plan-outlook {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px dashed var(--line);
+  border-radius: 6px;
+  background: rgba(255,255,255,0.015);
+}
+body.ftw-next .plan-outlook-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--fg-dim);
+  opacity: 0.85;
+  margin-right: 4px;
+  cursor: help;
+}
 body.ftw-next .saving-badge {
   font-family: var(--mono);
   font-size: 11px;

--- a/web/plan.js
+++ b/web/plan.js
@@ -572,14 +572,24 @@
       }
     }
 
-    // ---- Savings badges ----
-    // Three baselines computed server-side in mpc.ComputeBaselines so the
-    // numbers are guaranteed apples-to-apples with plan.total_cost_ore
-    // (same cost model, including export pricing, and a real SC
-    // dispatch from the DP itself rather than a client-side
-    // approximation). Absent in self-consumption mode — the backend
-    // skips the extra Optimize call since the SC baseline would equal
-    // the plan itself.
+    // ---- Forecast outlook badges ----
+    // Three counter-factual costs over the planning horizon, computed
+    // server-side in mpc.ComputeBaselines. These are PROJECTIONS over
+    // the next 48 h — not historical savings. The historical
+    // counterpart is the Savings card above. We label this clearly so
+    // operators don't mistake the badges for "money saved already".
+    //
+    // Sign convention (fixed 2026-05-25):
+    //   saved = baseline_cost − plan_cost
+    //   saved > 0 → plan is cheaper (or earns more) → GREEN (positive
+    //               for the operator) → "+X.XX SEK better"
+    //   saved < 0 → plan is more expensive → RED → "-X.XX SEK worse"
+    //
+    // The percentage uses |base| as the denominator so the sign
+    // tracks `saved`. Previously `saved / base` flipped sign whenever
+    // the baseline was a net-revenue (negative öre) horizon — typical
+    // for a sunny summer day with export — so an operator saw
+    // "+10.52 SEK (-15%)" and reasonably read it as a contradiction.
     const savingsEl = document.getElementById('plan-savings');
     if (savingsEl) {
       const b = plan && plan.baselines;
@@ -593,35 +603,42 @@
         const savedFlat = sekFlat - sekPlan;
         const savedSC = sekSC - sekPlan;
         const savedNoBat = sekNoBat - sekPlan;
-        const pct = (saved, base) => Math.abs(base) > 0.01 ? (saved / base) * 100 : 0;
+        // Denominator: |base|. The sign of the percentage now always
+        // matches the sign of `saved`, so "+X.XX SEK (+Y%)" is internally
+        // consistent and an operator can read it at a glance.
+        const pct = (saved, base) => Math.abs(base) > 0.01 ? (saved / Math.abs(base)) * 100 : 0;
         const cls = v => v >= 0 ? 'saving-pos' : 'saving-neg';
         const sign = v => (v >= 0 ? '+' : '−');
         const fmt = v => Math.abs(v).toFixed(2);
+        const verbFor = (saved) => saved >= 0 ? 'better' : 'worse';
         const badge = (label, saved, base, title) => {
           const p = pct(saved, base);
           return `<span class="saving-badge ${cls(saved)}" title="${title}">` +
             `<span class="saving-label">${label}</span> ` +
-            `<b>${sign(saved)}${fmt(saved)} SEK</b>` +
+            `<b>${sign(saved)}${fmt(saved)} SEK ${verbFor(saved)}</b>` +
             (Math.abs(p) > 0.1 ? ` <span class="saving-pct">(${sign(p)}${Math.abs(p).toFixed(0)}%)</span>` : '') +
             `</span>`;
         };
-        savingsEl.innerHTML = [
+        const headerTitle = 'These compare the current plan against three counter-factual dispatches over the SAME 48 h horizon. They are projections, not realised savings — for what actually happened, scroll up to the Savings card.';
+        savingsEl.innerHTML =
+          `<div class="plan-outlook">` +
+          `<span class="plan-outlook-label" title="${headerTitle}">48 h outlook</span>` +
           badge(
             'vs no battery',
             savedNoBat, sekNoBat,
-            `What this horizon would cost with no battery at all — grid flow = load + PV each slot, priced at the actual spot + consumer tariffs. Captures the combined value of battery + planner.`
-          ),
+            `What this horizon would cost with no battery at all — grid flow = load + PV each slot, priced at the actual spot + consumer tariffs. Positive = battery + planner save vs going batteryless.`
+          ) +
           badge(
             'vs self-consumption',
             savedSC, sekSC,
-            `Cost of running self-consumption mode over the same forecast (re-computed by the planner with Mode=SelfConsumption — same battery, efficiency, and power constraints). Captures the extra value from arbitrage / cheap-charge on top of passive SC.`
-          ),
+            `Cost of running classic self_consumption mode over the same forecast (re-computed by the planner with Mode=SelfConsumption — same battery, efficiency, power constraints). Positive = current strategy beats passive SC.`
+          ) +
           badge(
             'vs flat avg price',
             savedFlat, sekFlat,
-            `No-battery imports priced at the horizon mean import price (${b.avg_price_ore.toFixed(1)} öre/kWh) and exports at the horizon mean export revenue, separately. Net no-battery flow is ${b.net_kwh.toFixed(1)} kWh. Captures the value of *timing* — shifting consumption into cheap hours — independently of battery.`
-          ),
-        ].join('');
+            `No-battery imports priced at the horizon mean import price (${b.avg_price_ore.toFixed(1)} öre/kWh) and exports at the horizon mean export revenue, separately. Net no-battery flow is ${b.net_kwh.toFixed(1)} kWh. Captures the value of timing — shifting consumption into cheap hours — independently of the battery.`
+          ) +
+          `</div>`;
       }
     }
   }


### PR DESCRIPTION
## Operator confusion (2026-05-25)

Badge showed \"vs no battery **+10.52 SEK (-15%)**\" — the SEK number suggested savings while the percentage looked like a loss. Visually contradictory.

Plus broader feedback:
- \"vad vi sparar borde väl vara baserat på vad som hände, inte framåt\" → forecast outlook is mislabeled as savings
- \"röd färg i savings för något som faktiskt är positivt\" → sign/colour mismatch
- \"besparingen som en egen liten ruta\" → visual separation from plan summary

## Three changes

**1. Percentage sign bug.** Old denominator was the raw baseline cost; on a sunny export-net day the baseline is negative, so positive savings divided by negative base flipped sign:

```js
// before:  saved/base  →  +10 / -70 = -14% (visual contradiction)
// after:   saved/|base| →  +10 / 70  = +14% (consistent with saved)
```

**2. Forecast framing.** These badges are projections over the next 48 h, not realised savings — the standalone Savings card up the page IS the historical counterpart. Wrap badges in a thin dashed surface labelled \"48 H OUTLOOK\" so an operator at a glance separates forecast (here) from actual (Savings card). Help-modal text + header tooltip updated to call this out explicitly.

**3. Verb instead of bare sign.** \"+10.52 SEK **better**\" / \"-3.40 SEK **worse**\". Negative case explained: typical on flat-price days where the battery's round-trip loss isn't recovered by timing arbitrage.

## Untouched

The Savings card (historical) was already using `|denom|` and the right colour logic. No change there — the bug was specific to plan.js's badge code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)