### PR TITLE
feat(mpc): PV-first bias — credit PV-fed battery charge in passive_arbitrage

### DIFF
--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -2386,6 +2386,14 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 	if safetyPenalty <= 0 {
 		safetyPenalty = 100
 	}
+	pvBonus := pl.PVChargeBonusOreKwh
+	if pvBonus <= 0 {
+		// 30 öre/kWh — beats typical PV-export spot prices and the
+		// round-trip efficiency cost (~20 öre/kWh against mean retail
+		// import), but small enough that genuine arbitrage spreads
+		// (>100 öre/kWh) still drive the DP.
+		pvBonus = 30
+	}
 	chgEff := pl.ChargeEfficiency
 	if chgEff <= 0 {
 		chgEff = 0.95
@@ -2402,6 +2410,7 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		SoCMaxPct:                    socMax,
 		SoCSafetyFloorPct:            socSafety,
 		SafetyFloorPenaltyOreKwhHour: safetyPenalty,
+		PVChargeBonusOreKwh:          pvBonus,
 		InitialSoCPct:                50,
 		// ActionLevels = 81 → 225 W discretization step on a ±9 kW
 		// action range. Coarser values (21=900 W, 41=450 W) lose

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -272,6 +272,15 @@ type Planner struct {
 	// floor value visible to operators.
 	SafetyFloorPenaltyOreKwhHour float64 `yaml:"safety_floor_penalty_ore_kwh_hour,omitempty" json:"safety_floor_penalty_ore_kwh_hour,omitempty"`
 
+	// PVChargeBonusOreKwh credits each kWh of battery charge fed from
+	// live PV surplus, in passive_arbitrage mode. Operator preference
+	// "always prefer PV first" — certain PV now beats forecast
+	// grid-charging later, even at economic parity. Default 30
+	// öre/kWh; set to 0 to disable the bias and let the DP optimise
+	// purely on price (which on flat-price days lets cheap PV export
+	// and refills from cheap grid later, losing efficiency).
+	PVChargeBonusOreKwh float64 `yaml:"pv_charge_bonus_ore_kwh,omitempty" json:"pv_charge_bonus_ore_kwh,omitempty"`
+
 	ChargeEfficiency    float64 `yaml:"charge_efficiency,omitempty" json:"charge_efficiency,omitempty"`
 	DischargeEfficiency float64 `yaml:"discharge_efficiency,omitempty" json:"discharge_efficiency,omitempty"`
 	ExportOrePerKWh     float64 `yaml:"export_ore_per_kwh,omitempty" json:"export_ore_per_kwh,omitempty"` // 0 = use mean spot

--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -51,6 +51,7 @@ type DiagnosticParams struct {
 	SoCMaxPct                    float64 `json:"soc_max_pct"`
 	SoCSafetyFloorPct            float64 `json:"soc_safety_floor_pct,omitempty"`
 	SafetyFloorPenaltyOreKwhHour float64 `json:"safety_floor_penalty_ore_kwh_hour,omitempty"`
+	PVChargeBonusOreKwh          float64 `json:"pv_charge_bonus_ore_kwh,omitempty"`
 	SoCLevels                    int     `json:"soc_levels"`
 	ActionLevels        int      `json:"action_levels"`
 	MaxChargeW          float64  `json:"max_charge_w"`
@@ -156,6 +157,7 @@ func buildDiagnostic(plan *Plan, slots []Slot, p Params, zone string,
 			SoCMaxPct:                    p.SoCMaxPct,
 			SoCSafetyFloorPct:            p.SoCSafetyFloorPct,
 			SafetyFloorPenaltyOreKwhHour: p.SafetyFloorPenaltyOreKwhHour,
+			PVChargeBonusOreKwh:          p.PVChargeBonusOreKwh,
 			SoCLevels:                    p.SoCLevels,
 			ActionLevels:                 p.ActionLevels,
 			MaxChargeW:                   p.MaxChargeW,
@@ -238,6 +240,9 @@ func (s *Service) RestoreDiagnostic(d *Diagnostic, now time.Time, reason string)
 	if params.SafetyFloorPenaltyOreKwhHour == 0 && s.Defaults.SafetyFloorPenaltyOreKwhHour > 0 {
 		params.SafetyFloorPenaltyOreKwhHour = s.Defaults.SafetyFloorPenaltyOreKwhHour
 	}
+	if params.PVChargeBonusOreKwh == 0 && s.Defaults.PVChargeBonusOreKwh > 0 {
+		params.PVChargeBonusOreKwh = s.Defaults.PVChargeBonusOreKwh
+	}
 	s.last = plan
 	s.lastSlots = slots
 	s.lastParams = params
@@ -266,6 +271,7 @@ func planFromDiagnostic(d *Diagnostic) (*Plan, []Slot, Params, time.Time, bool) 
 		SoCMaxPct:                    d.Params.SoCMaxPct,
 		SoCSafetyFloorPct:            d.Params.SoCSafetyFloorPct,
 		SafetyFloorPenaltyOreKwhHour: d.Params.SafetyFloorPenaltyOreKwhHour,
+		PVChargeBonusOreKwh:          d.Params.PVChargeBonusOreKwh,
 		SoCLevels:                    d.Params.SoCLevels,
 		ActionLevels:                 d.Params.ActionLevels,
 		MaxChargeW:                   d.Params.MaxChargeW,

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -151,6 +151,27 @@ type Params struct {
 	// economically expensive ways.
 	SafetyFloorPenaltyOreKwhHour float64
 
+	// PVChargeBonusOreKwh credits each kWh of battery charge that
+	// comes from live PV surplus. Operator preference: prefer using
+	// solar NOW (certain) over exporting cheap and refilling from
+	// grid LATER (forecast). Without this bias the DP is economically
+	// indifferent between the two when terminal credit is roughly
+	// equal — it would happily export 27 kWh at 10 öre/kWh and refill
+	// from a 30 öre/kWh cheap-night hour, losing ~10 % round-trip and
+	// dragging itself through forecast risk for no gain.
+	//
+	// Magnitude: ~30 öre/kWh by default. Large enough to dominate the
+	// typical PV-export spot price (5-30 öre/kWh) and the round-trip
+	// efficiency cost; small enough to leave the door open for
+	// genuine arbitrage (active_arbitrage paths still see spreads
+	// >100 öre/kWh).
+	//
+	// Only applies to ModePassiveArbitrage. 0 disables. The cost
+	// reduction is bounded by the live PV surplus this slot — DP
+	// can never claim a bonus larger than the surplus available, so
+	// the bias never converts to grid-charge incentive.
+	PVChargeBonusOreKwh float64
+
 	// Action grid (+charge, −discharge; site sign)
 	ActionLevels  int     // odd number preferred so 0 is represented (e.g. 21)
 	MaxChargeW    float64 // ≥ 0
@@ -658,6 +679,26 @@ func Optimize(slots []Slot, p Params) Plan {
 								deficitPct := p.SoCSafetyFloorPct - battSoc2
 								deficitKwh := deficitPct / 100.0 * p.CapacityWh / 1000.0
 								cost += deficitKwh * dtH * p.SafetyFloorPenaltyOreKwhHour
+							}
+						}
+
+						// PV-first bias: when this slot has PV surplus
+						// AND the action charges the battery, credit a
+						// bonus for the kWh that came from the surplus.
+						// Operator preference: certain PV now beats
+						// forecast grid later, even if the DP sees them
+						// as economically equivalent. The bonus is
+						// bounded by the live surplus so it never
+						// incentivises grid-charging.
+						if p.Mode == ModePassiveArbitrage && p.PVChargeBonusOreKwh > 0 && battW > 0 {
+							pvSurplusW := -slot.PVW - slot.LoadW
+							if pvSurplusW > 0 {
+								chargeFromPVW := battW
+								if chargeFromPVW > pvSurplusW {
+									chargeFromPVW = pvSurplusW
+								}
+								chargeFromPVkWh := chargeFromPVW * dtH / 1000.0
+								cost -= p.PVChargeBonusOreKwh * chargeFromPVkWh
 							}
 						}
 

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -83,6 +83,100 @@ func TestSelfConsumptionAbsorbsPVSurplus(t *testing.T) {
 	}
 }
 
+// Operator preference (2026-05-25): when PV surplus is available AND
+// the battery has room, the planner must prefer charging from the live
+// PV over exporting it and refilling from a forecast cheap-grid slot
+// later. Without the PVChargeBonus the DP saw the two as economically
+// equivalent on flat-price days and routinely exported 27+ kWh of
+// cheap-spot PV (10 öre/kWh) while leaving the battery half-empty —
+// then planned to refill from a 30 öre/kWh night slot, eating the
+// round-trip loss and forecast risk for no gain.
+func TestPassiveArbitragePVChargeBonusPrefersPVOverExport(t *testing.T) {
+	// Single slot with PV surplus. Terminal == export rate so the
+	// economic value of charging-and-holding exactly equals exporting.
+	// Without bonus, charging loses by the round-trip efficiency hit
+	// (0.95 vs 1.0) — DP picks export. With bonus, charging strictly
+	// wins by the bonus magnitude.
+	slots := []Slot{{
+		StartMs:    0,
+		LenMin:     60,
+		PriceOre:   100,
+		SpotOre:    20,
+		LoadW:      500,
+		PVW:        -5000,
+		Confidence: 1,
+	}}
+	pNoBonus := baseParams(ModePassiveArbitrage)
+	pNoBonus.InitialSoCPct = 60
+	pNoBonus.SoCSafetyFloorPct = 0 // disable safety floor — focus the test on the bonus
+	pNoBonus.TerminalSoCPrice = 20 // matches export revenue → DP indifferent without bonus
+	pNoBonus.PVChargeBonusOreKwh = 0
+	planNoBonus := Optimize(slots, pNoBonus)
+
+	// With PV bonus: DP strictly prefers charging from PV in every
+	// PV-surplus slot, even at parity terminal credit.
+	pBonus := pNoBonus
+	pBonus.PVChargeBonusOreKwh = 30
+	planBonus := Optimize(slots, pBonus)
+
+	sumCharge := func(actions []Action) float64 {
+		var s float64
+		for _, a := range actions {
+			if a.BatteryW > 0 {
+				s += a.BatteryW
+			}
+		}
+		return s
+	}
+	noBonusCharge := sumCharge(planNoBonus.Actions)
+	bonusCharge := sumCharge(planBonus.Actions)
+
+	if bonusCharge <= noBonusCharge {
+		t.Errorf("PV bonus should drive MORE charge: no-bonus=%fW, bonus=%fW", noBonusCharge, bonusCharge)
+	}
+	// Quantitative check: with 4.5 kW surplus per slot over 4 slots and
+	// the bonus active, the planner should grab a meaningful share of
+	// the available surplus.
+	if bonusCharge < 2000 {
+		t.Errorf("PV bonus drove only %fW total charge across 4 surplus slots — expected substantial absorption", bonusCharge)
+	}
+}
+
+// PV bonus must NOT motivate grid-charge during PV-less slots.
+// Bonus is bounded by live surplus; in a no-PV slot surplus=0 → no
+// bonus → no extra incentive to grid-charge.
+func TestPassiveArbitragePVChargeBonusDoesNotMotivateGridCharge(t *testing.T) {
+	slots := make([]Slot, 4)
+	for i := range slots {
+		slots[i] = Slot{
+			StartMs:    int64(i) * 15 * 60 * 1000,
+			LenMin:     15,
+			PriceOre:   30, // cheap-ish import
+			SpotOre:    5,
+			LoadW:      500,
+			PVW:        0, // no PV
+			Confidence: 1,
+		}
+	}
+	p := baseParams(ModePassiveArbitrage)
+	p.InitialSoCPct = 50
+	p.SoCSafetyFloorPct = 0 // disable safety floor — focus the test on the bonus
+	p.TerminalSoCPrice = 50 // moderate — SC bias must be what blocks grid-charge
+	p.PVChargeBonusOreKwh = 30
+
+	plan := Optimize(slots, p)
+	// No slot should command a grid-charge (battW must not exceed
+	// what could be PV-supplied, which is 0 here). The SC bias
+	// (3× house-import cost) makes grid-charging unprofitable at
+	// terminal=50 / import=30; the PV bonus does not change that
+	// because it is bounded by live PV surplus (= 0 here).
+	for i, a := range plan.Actions {
+		if a.BatteryW > 100 {
+			t.Errorf("slot %d: BatteryW = %fW — PV bonus must not motivate grid-charge", i, a.BatteryW)
+		}
+	}
+}
+
 // 2026-05-25 morning regression: with SoC below the operational safety
 // floor and PV surplus available NOW, the planner used to defer
 // charging to peak-PV hours because terminal credit alone gave only a


### PR DESCRIPTION
## Operator preference

> \"vi bör om det är likvärdigt ändå alltid prioritera sol. Jag skulle nästan vilja mena att vi bör prioritera sol som alltid första om vi har möjlighet under den tidsrymden det är.\"
> — *if economically equivalent we should always prefer solar. Almost: always prefer solar first if it's available during the planning window.*

## Today's loss

40.8 kWh PV produced. Only **8.23 kWh** charged into batteries. **27.2 kWh exported at ~10 öre/kWh** (= 2.70 SEK revenue) while the planner intended to refill from cheap night grid at ~30 öre/kWh × 3× SC penalty = ~90 öre/kWh (= 24 SEK cost). Net potential loss: ~21 SEK today.

## What changes

New parameter `PVChargeBonusOreKwh` (default 30 öre/kWh, configurable via `planner.pv_charge_bonus_ore_kwh`) credits each kWh of battery charge that came from live PV surplus.

Bounded by the per-slot surplus so it never converts to a grid-charge incentive — in a PV-less slot the surplus is 0, the bonus is 0, and the existing SC bias still blocks grid-charge.

### Magnitude rationale

| Threshold | Why |
|---|---|
| > 20 öre/kWh | Dominates round-trip loss (`1 − η_rt × mean_import`) |
| > 5-30 öre/kWh | Breaks tie against typical PV-export spot price |
| < 100 öre/kWh | Genuine arbitrage spreads (100+ öre/kWh) still win in active_arbitrage |

Only fires in `ModePassiveArbitrage`. Active arbitrage stays pure economic so the operator can time-arbitrage on both directions when they want.

## Tests

- `TestPassiveArbitragePVChargeBonusPrefersPVOverExport` — tie scenario flips from export → charge when bonus on
- `TestPassiveArbitragePVChargeBonusDoesNotMotivateGridCharge` — no PV → no bonus → no grid-charge
- Full suite: `go test ./...` green

## Plumbed end-to-end

`config.Planner.PVChargeBonusOreKwh` → `mpc.Params` → DP cost term → diagnose snapshot → `RestoreDiagnostic` merge with `Defaults` (new field survives the next deploy's first restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)