### PR TITLE
feat(web): Live card — stats strip + 24 h battery/SoC stack

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -313,6 +313,34 @@
             </div>
           </div>
         </div>
+
+        <!-- Live stats strip — mirrors the Plan card's summary line so
+             the two cards have matching information density. Five
+             current values, mono-typed for at-a-glance scanning. JS
+             populates these on every /api/status poll. -->
+        <div class="live-stats" id="live-stats">
+          <div class="live-stat" data-key="grid">
+            <span class="live-stat-label">GRID</span>
+            <span class="live-stat-value" id="live-stat-grid">—</span>
+          </div>
+          <div class="live-stat" data-key="pv">
+            <span class="live-stat-label">PV</span>
+            <span class="live-stat-value" id="live-stat-pv">—</span>
+          </div>
+          <div class="live-stat" data-key="load">
+            <span class="live-stat-label">LOAD</span>
+            <span class="live-stat-value" id="live-stat-load">—</span>
+          </div>
+          <div class="live-stat" data-key="bat">
+            <span class="live-stat-label">BATTERY</span>
+            <span class="live-stat-value" id="live-stat-bat">—</span>
+          </div>
+          <div class="live-stat" data-key="soc">
+            <span class="live-stat-label">SoC</span>
+            <span class="live-stat-value" id="live-stat-soc">—</span>
+          </div>
+        </div>
+
         <div class="chart-container">
           <canvas id="power-chart" width="800" height="260"></canvas>
         </div>
@@ -325,6 +353,20 @@
           <!-- Battery driver legend items are appended dynamically by app.js
                as each battery-capable driver appears in /api/status. -->
         </div>
+
+        <!-- 24h battery + SoC stack — mirrors the Plan card's lower
+             charts. Battery-action bars show the last 24 h of
+             actual charge/discharge; SoC strip plots the trajectory.
+             Renders from /api/history every poll. Self-contained
+             canvas so it can be hidden / collapsed without touching
+             the live power chart's render path. -->
+        <div class="live-history">
+          <div class="live-history-label">LAST 24 H · BATTERY + SoC</div>
+          <div class="chart-container chart-container-compact">
+            <canvas id="live-history-chart" width="800" height="140"></canvas>
+          </div>
+        </div>
+
         <!-- Hidden view toggle kept for app.js compatibility -->
         <div id="view-buttons" style="display:none">
           <button data-view="power" class="active"></button>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -344,6 +344,32 @@
     if (abs >= 1000) return (abs / 1000).toFixed(2) + " kWh";
     return Math.round(abs) + " Wh";
   }
+
+  // Live-stats strip helpers. signClass picks a colour class based on
+  // direction (import/export for grid, charging/discharging for
+  // battery). Used by the stats strip just above the live power
+  // chart. Threshold matches the live chart's idle band (±10 W) so
+  // tiny noise doesn't flip the colour every poll.
+  function signClass(kind, w) {
+    var v = Number(w) || 0;
+    if (Math.abs(v) <= 10) return "is-neutral";
+    if (kind === "grid") return v > 0 ? "is-import" : "is-export";
+    if (kind === "bat") return v > 0 ? "is-charging" : "is-discharging";
+    return "is-neutral";
+  }
+  function updateLiveStat(key, w, cls) {
+    var el = document.getElementById("live-stat-" + key);
+    if (!el) return;
+    el.textContent = formatW(w);
+    el.className = "live-stat-value " + (cls || "is-neutral");
+  }
+  function updateLiveSocStat(soc) {
+    var el = document.getElementById("live-stat-soc");
+    if (!el) return;
+    if (soc == null || !isFinite(soc)) { el.textContent = "—"; return; }
+    el.textContent = (soc * 100).toFixed(1) + " %";
+    el.className = "live-stat-value is-neutral";
+  }
   function batteryStateLabel(w) {
     var watts = Number(w) || 0;
     var idleW = flowIdleKw() * 1000;
@@ -569,6 +595,17 @@
     if (batTargetDisp) {
       batTargetDisp.textContent = hasBatteryTarget ? batteryTargetLine(totalBatteryTargetW) : "";
     }
+
+    // Live stats strip — mirrors the per-tile values up top but in one
+    // mono-typed line above the live chart, so the Live card matches
+    // the Plan card's information density. Each cell colours by sign
+    // / direction so an operator scans the row and immediately sees
+    // who's importing, exporting, charging, or idle.
+    updateLiveStat("grid", data.grid_w, signClass("grid", data.grid_w));
+    updateLiveStat("pv", -data.pv_w, "is-export"); // PV is site-signed negative; show as positive generation
+    updateLiveStat("load", data.load_w, "is-neutral");
+    updateLiveStat("bat", data.bat_w, signClass("bat", data.bat_w));
+    updateLiveSocStat(data.bat_soc);
 
     // Hero energy-flow diagram — build a flat "planets" list where each
     // entry declares which corner it orbits (top-left=PV, top-right=
@@ -3098,9 +3135,154 @@
     });
   }
 
+  // ---- Live 24h history (battery + SoC) ----
+  // Self-contained: fetches /api/history once a minute, draws a
+  // compact stacked canvas of (battery action bars, SoC line) over
+  // the last 24 h. Mirrors the Plan card's lower charts so the two
+  // cards have matching visual weight. Read-only — no interaction.
+  function renderLiveHistory(items) {
+    var canvas = document.getElementById("live-history-chart");
+    if (!canvas || !items || !items.length) return;
+    // Normalise the /api/history payload: `ts` for the timestamp and
+    // `bat_soc` (0–1 fraction) for the SoC field, plus `bat_w` from
+    // the row blob. Skip rows with no battery sample so the chart
+    // doesn't draw spurious zero bars.
+    var points = items
+      .filter(function (it) { return it.bat_w != null || it.bat_soc != null; })
+      .map(function (it) {
+        return {
+          ts_ms: it.ts || it.ts_ms,
+          bat_w: it.bat_w || 0,
+          soc_pct: (it.bat_soc != null) ? it.bat_soc * 100 : null,
+        };
+      });
+    if (!points.length) return;
+    var dpr = window.devicePixelRatio || 1;
+    var cssW = canvas.parentElement.clientWidth || canvas.width;
+    var cssH = 140;
+    if (canvas.width !== Math.round(cssW * dpr) || canvas.height !== Math.round(cssH * dpr)) {
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+    }
+    canvas.style.width = cssW + "px";
+    canvas.style.height = cssH + "px";
+    var ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    var pad = { left: 36, right: 36, top: 8, bottom: 18 };
+    var plotW = cssW - pad.left - pad.right;
+    var plotH = cssH - pad.top - pad.bottom;
+    if (plotW <= 0 || plotH <= 0) return;
+
+    // x: time. Use first/last point timestamps for the window.
+    var t0 = points[0].ts_ms;
+    var t1 = points[points.length - 1].ts_ms;
+    var span = Math.max(1, t1 - t0);
+    var xOf = function (ts) { return pad.left + (ts - t0) / span * plotW; };
+
+    // Battery action axis: symmetric around 0. Find absmax for bat_w.
+    var batMax = 0;
+    for (var i = 0; i < points.length; i++) {
+      var b = Math.abs(points[i].bat_w || 0);
+      if (b > batMax) batMax = b;
+    }
+    if (batMax < 1000) batMax = 1000; // sane minimum
+    var batMid = pad.top + plotH * 0.55;
+    var batH = plotH * 0.55;
+    var yOfBat = function (w) {
+      var frac = (w || 0) / batMax;
+      return batMid - frac * (batH / 2);
+    };
+
+    // Zero baseline for battery
+    ctx.strokeStyle = "rgba(255,255,255,0.08)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(pad.left, batMid);
+    ctx.lineTo(pad.left + plotW, batMid);
+    ctx.stroke();
+
+    // Battery action bars. Charge (positive) above zero in amber-ish
+    // (matches Plan's "charge" colour), discharge in violet-ish.
+    var barW = Math.max(1, plotW / points.length - 0.5);
+    for (var j = 0; j < points.length; j++) {
+      var p = points[j];
+      var bw = p.bat_w || 0;
+      if (Math.abs(bw) < 50) continue; // suppress noise
+      var x = xOf(p.ts_ms);
+      var y = yOfBat(bw);
+      ctx.fillStyle = bw > 0 ? "rgba(251,191,36,0.85)" : "rgba(167,139,250,0.85)";
+      var h = Math.abs(y - batMid);
+      var top = bw > 0 ? y : batMid;
+      ctx.fillRect(x - barW / 2, top, barW, h);
+    }
+
+    // SoC line. Plotted in a dedicated bottom strip with its own
+    // 0-100% scale and right-axis labels.
+    var socTop = pad.top + plotH * 0.62;
+    var socH = plotH * 0.38;
+    var socOf = function (pct) {
+      var v = Math.max(0, Math.min(100, pct || 0));
+      return socTop + socH - (v / 100) * socH;
+    };
+    ctx.strokeStyle = "rgba(34,211,238,0.95)";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    var started = false;
+    for (var k = 0; k < points.length; k++) {
+      var sp = points[k];
+      if (sp.soc_pct == null) continue;
+      var sx = xOf(sp.ts_ms);
+      var sy = socOf(sp.soc_pct);
+      if (!started) { ctx.moveTo(sx, sy); started = true; }
+      else { ctx.lineTo(sx, sy); }
+    }
+    ctx.stroke();
+
+    // Axis labels — small, mono, dim.
+    ctx.fillStyle = "rgba(255,255,255,0.5)";
+    ctx.font = "10px ui-monospace, SFMono-Regular, Menlo, Monaco, monospace";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "middle";
+    // battery: max charge / max discharge labels at the edges
+    ctx.fillText((batMax / 1000).toFixed(1) + "kW", pad.left - 4, pad.top + 6);
+    ctx.fillText("-" + (batMax / 1000).toFixed(1) + "kW", pad.left - 4, batMid + (batH / 2) - 6);
+    // SoC: 100% / 0% on the right
+    ctx.textAlign = "left";
+    ctx.fillText("100%", pad.left + plotW + 4, socTop + 6);
+    ctx.fillText("0%", pad.left + plotW + 4, socTop + socH - 6);
+    // time axis: 24h ago / now
+    ctx.fillStyle = "rgba(255,255,255,0.4)";
+    ctx.textAlign = "left";
+    ctx.fillText("24h ago", pad.left, cssH - 4);
+    ctx.textAlign = "right";
+    ctx.fillText("now", pad.left + plotW, cssH - 4);
+  }
+
+  var lastLiveHistFetch = 0;
+  function fetchLiveHistory() {
+    lastLiveHistFetch = Date.now();
+    return fetch("/api/history?range=24h&points=288") // 5-min cadence
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d || !d.items) return;
+        renderLiveHistory(d.items);
+      })
+      .catch(function () { /* silent — chart just shows last state */ });
+  }
+
   // ---- Init ----
   loadHistory(chartRange);
   fetchStatus();
+  fetchLiveHistory();
   setInterval(fetchStatus, POLL_INTERVAL);
+  setInterval(fetchLiveHistory, 60_000); // 1-min refresh
+  window.addEventListener("resize", function () {
+    // Last fetched points are not cached separately; trigger a fetch.
+    // 24h history is small (~288 points × ~50 bytes), zero-cost on
+    // every resize.
+    fetchLiveHistory();
+  });
   requestAnimationFrame(animationFrame);
 })();

--- a/web/next.css
+++ b/web/next.css
@@ -954,6 +954,79 @@ body.ftw-next .chart-container {
   border: none;
   padding: 4px 0 0;
 }
+
+/* Compact variant for the secondary chart stacks (Live's 24 h battery
+ * + SoC strip below the main power chart). Plays the same role as the
+ * Plan card's battery/SoC sub-charts: same vertical footprint, same
+ * border treatment, so the two cards are visually balanced. */
+body.ftw-next .chart-container-compact {
+  padding: 0;
+}
+
+/* Live stats strip — five tile-style values inline between the chart
+ * header and the chart canvas. Mono-typed and grid-aligned so an
+ * operator's eye can scan them at a glance, mirroring the Plan card's
+ * summary line directly above its own charts. */
+body.ftw-next .live-stats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin: 6px 0 4px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+}
+body.ftw-next .live-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+body.ftw-next .live-stat-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--fg-dim);
+  opacity: 0.7;
+}
+body.ftw-next .live-stat-value {
+  font-family: var(--mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+body.ftw-next .live-stat-value.is-import   { color: var(--red-e); }
+body.ftw-next .live-stat-value.is-export   { color: var(--green-e); }
+body.ftw-next .live-stat-value.is-charging { color: var(--accent-e); }
+body.ftw-next .live-stat-value.is-discharging { color: var(--blue-e, #60a5fa); }
+body.ftw-next .live-stat-value.is-neutral { color: var(--fg-dim); }
+
+/* 24 h battery + SoC history block — sits below the live power chart.
+ * Section label matches the Plan card's chart-section labels. */
+body.ftw-next .live-history {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--line);
+}
+body.ftw-next .live-history-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  color: var(--fg-dim);
+  opacity: 0.7;
+  margin-bottom: 4px;
+}
+@media (max-width: 720px) {
+  body.ftw-next .live-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  body.ftw-next .live-stat:nth-child(n + 4) {
+    grid-column: span 1;
+  }
+}
 body.ftw-next .range-buttons button {
   /* Ghost secondary per DESIGN.md: transparent bg, --line border,
      --fg text. Theme-aware so the buttons keep their chrome on both


### PR DESCRIPTION
Operator note: the Live card was visually thin next to the Plan card — just a power chart with empty space below, while Plan carries Strategy, three outlook badges, and a four-layer chart stack.

## What changes

**Live card gets two new sections to match Plan's density:**

1. **Stats strip** above the chart — five mono tiles for the current values (GRID / PV / LOAD / BATTERY / SoC), colour-coded by direction:
   - GRID: import-red / export-green / idle-neutral
   - PV: green (generation)
   - LOAD: neutral
   - BATTERY: charging-amber / discharging-violet / idle-neutral
   - SoC: neutral

2. **24 H battery + SoC stack** below the chart — compact canvas plotting the last 24 h of actual battery action (amber bars for charge, violet bars for discharge) plus the SoC trajectory as a cyan line on its own right-axis scale. Reuses `/api/history?range=24h` with a 1-min refresh; no new backend endpoints.

## Why

The two cards now have matching visual weight. The dashboard reads symmetrically — Live = \"what is happening now / last 24 h\", Plan = \"what will happen next 48 h\". Same chart stack (power + battery + SoC), same summary-line treatment.

## Implementation notes

- Read-only and decoupled from the live power chart's render path. `renderLiveHistory` runs against its own canvas with its own 1-min poll. If the new fetch fails, the strip + main chart keep updating on their own pollers.
- Mobile breakpoint at 720 px collapses the stats strip from 5 to 3 columns.
- No Go-side changes — pure UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)