### PR TITLE
perf(state): persist daily energy aggregates — kill the 25 s cold-start

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1546,11 +1546,22 @@ func (s *Server) handleEnergyDaily(w http.ResponseWriter, r *http.Request) {
 			}
 			de = d
 		} else {
+			// Two-tier cache: in-memory first, then the persistent
+			// energy_daily table. The persistent layer survives
+			// restarts — the 2026-05-25 baseline was 25 s for
+			// days=30 cold-start because every closed day re-ran a
+			// per-day DailyEnergy SQL pass; with the table populated
+			// the same query reduces to N PK lookups.
 			s.dailyCacheMu.Lock()
 			cached, ok := s.dailyCache[dayKey]
 			s.dailyCacheMu.Unlock()
 			if ok {
 				de = cached
+			} else if persisted, present, err := s.deps.State.LoadDailyEnergy(dayKey); err == nil && present {
+				de = persisted
+				s.dailyCacheMu.Lock()
+				s.dailyCache[dayKey] = de
+				s.dailyCacheMu.Unlock()
 			} else {
 				dayEnd := dayStart.AddDate(0, 0, 1)
 				d, err := s.deps.State.DailyEnergy(dayStart.UnixMilli(), dayEnd.UnixMilli())
@@ -1563,6 +1574,14 @@ func (s *Server) handleEnergyDaily(w http.ResponseWriter, r *http.Request) {
 				s.dailyCacheMu.Lock()
 				s.dailyCache[dayKey] = de
 				s.dailyCacheMu.Unlock()
+				// Persist for next restart. Closed days only —
+				// today is excluded via the isToday branch above.
+				// Best-effort: a write failure is logged but not
+				// surfaced to the operator since the in-memory
+				// cache still serves this request.
+				if err := s.deps.State.SaveDailyEnergy(dayKey, de); err != nil {
+					slog.Warn("handleEnergyDaily: persist daily aggregate failed", "err", err, "day", dayKey)
+				}
 			}
 		}
 

--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -259,6 +259,35 @@ func (s *Store) migrate() error {
 			synced_ms   INTEGER NOT NULL,
 			PRIMARY KEY (device_id, der_type)
 		) STRICT`,
+
+		// Persistent daily-energy aggregate cache.
+		//
+		// 2026-05-25 measurement: /api/energy/daily?days=30 took ~25 s
+		// on the live Pi cold-start because the handler did one
+		// DailyEnergy SQL call per day and the in-memory cache was
+		// empty after every restart. Each call walked history_hot +
+		// warm + cold for that day's window — slow on a 1 GB state.db.
+		//
+		// This table stores the integration result so closed days never
+		// have to be re-computed. The handler writes a row on first
+		// compute and reads it back forever — days are immutable once
+		// past the local-midnight rollover, so cache invalidation is
+		// trivially "always valid".
+		//
+		// Today's row is never persisted (the day is in progress); the
+		// handler still computes it on every request. Tomorrow's
+		// midnight rollover the previous day's final value lands here
+		// once, lazily, on the next /api/energy/daily request.
+		`CREATE TABLE IF NOT EXISTS energy_daily (
+			day               TEXT PRIMARY KEY,
+			import_wh         REAL NOT NULL,
+			export_wh         REAL NOT NULL,
+			pv_wh             REAL NOT NULL,
+			bat_charged_wh    REAL NOT NULL,
+			bat_discharged_wh REAL NOT NULL,
+			load_wh           REAL NOT NULL,
+			computed_at_ms    INTEGER NOT NULL
+		) STRICT`,
 	}
 	for _, stmt := range stmts {
 		if _, err := s.db.Exec(stmt); err != nil {
@@ -580,6 +609,57 @@ func (s *Store) DailyEnergy(sinceMs, untilMs int64) (DayEnergy, error) {
 		return DayEnergy{}, err
 	}
 	return d, nil
+}
+
+// LoadDailyEnergy returns the persisted aggregate for `day` (YYYY-MM-DD).
+// Second return is false when the day isn't cached yet. The caller
+// recomputes via DailyEnergy on miss and writes back via SaveDailyEnergy.
+//
+// Closed days are immutable, so callers can treat hit-rows as
+// authoritative — no TTL, no staleness check needed.
+func (s *Store) LoadDailyEnergy(day string) (DayEnergy, bool, error) {
+	const q = `
+		SELECT import_wh, export_wh, pv_wh, bat_charged_wh, bat_discharged_wh, load_wh
+		FROM energy_daily WHERE day = ?
+	`
+	var d DayEnergy
+	err := s.db.QueryRow(q, day).Scan(
+		&d.ImportWh, &d.ExportWh, &d.PVWh,
+		&d.BatChargedWh, &d.BatDischargedWh, &d.LoadWh,
+	)
+	if err == sql.ErrNoRows {
+		return DayEnergy{}, false, nil
+	}
+	if err != nil {
+		return DayEnergy{}, false, err
+	}
+	return d, true, nil
+}
+
+// SaveDailyEnergy persists `de` for `day`. Upserts on conflict — the
+// row is the latest authoritative aggregate. Today's row should NOT be
+// persisted via this method (the day is still accumulating); callers
+// should gate on "is closed day" before saving.
+func (s *Store) SaveDailyEnergy(day string, de DayEnergy) error {
+	const q = `
+		INSERT INTO energy_daily(
+			day, import_wh, export_wh, pv_wh, bat_charged_wh, bat_discharged_wh, load_wh, computed_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(day) DO UPDATE SET
+			import_wh         = excluded.import_wh,
+			export_wh         = excluded.export_wh,
+			pv_wh             = excluded.pv_wh,
+			bat_charged_wh    = excluded.bat_charged_wh,
+			bat_discharged_wh = excluded.bat_discharged_wh,
+			load_wh           = excluded.load_wh,
+			computed_at_ms    = excluded.computed_at_ms
+	`
+	_, err := s.db.Exec(q, day,
+		de.ImportWh, de.ExportWh, de.PVWh,
+		de.BatChargedWh, de.BatDischargedWh, de.LoadWh,
+		time.Now().UnixMilli(),
+	)
+	return err
 }
 
 // CountNonSyntheticHistory returns the number of history rows across all

--- a/go/internal/state/store_test.go
+++ b/go/internal/state/store_test.go
@@ -83,6 +83,57 @@ func TestConfigRoundtrip(t *testing.T) {
 	}
 }
 
+// 2026-05-25 performance regression: /api/energy/daily?days=30
+// cold-started at ~25 s on a 1 GB state.db because every closed day
+// re-ran a per-day DailyEnergy SQL pass. SaveDailyEnergy +
+// LoadDailyEnergy persist the aggregate so the same call after
+// restart resolves to N PK lookups instead.
+func TestDailyEnergyPersistRoundtrip(t *testing.T) {
+	s := freshStore(t)
+	de := DayEnergy{
+		ImportWh:        1234.5,
+		ExportWh:        678.9,
+		PVWh:            5000,
+		BatChargedWh:    1500,
+		BatDischargedWh: 1100,
+		LoadWh:          2222,
+	}
+	if err := s.SaveDailyEnergy("2026-05-25", de); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, ok, err := s.LoadDailyEnergy("2026-05-25")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true after save")
+	}
+	if got != de {
+		t.Errorf("roundtrip mismatch: got %+v, want %+v", got, de)
+	}
+	// Upsert with new values must overwrite, not append a duplicate.
+	de2 := de
+	de2.ImportWh = 9999
+	if err := s.SaveDailyEnergy("2026-05-25", de2); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got2, _, _ := s.LoadDailyEnergy("2026-05-25")
+	if got2.ImportWh != 9999 {
+		t.Errorf("upsert did not overwrite: got %f", got2.ImportWh)
+	}
+}
+
+func TestDailyEnergyMissReturnsFalse(t *testing.T) {
+	s := freshStore(t)
+	_, ok, err := s.LoadDailyEnergy("1999-01-01")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("ok should be false for a day never persisted")
+	}
+}
+
 func TestConfigPersistsAcrossReopen(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state.db")
 	s1, err := Open(path)


### PR DESCRIPTION
## Measured baseline (2026-05-25, live Pi, state.db = 1 GB)

| range | cold-start | warm |
|---|---|---|
| `/api/energy/daily?days=30` | **25 s** | ~50 ms |
| `/api/energy/daily?days=90` | **15 s** | ~50 ms |
| `/api/energy/daily?days=7` | 0.35 s | ~50 ms |

Snapshot dir = 6 GB (9 snapshots × ~670 MB each), state.db = 1 GB.

## Root cause

The handler already had an in-memory cache, but it dies on every restart. Closed days are immutable — recomputing the per-day SQL integration every cold start is pure waste.

## What this PR does

Persistent two-tier cache:

1. New SQLite table `energy_daily(day PRIMARY KEY, ...six Wh columns, computed_at_ms)`.
2. `state.LoadDailyEnergy(day)` / `state.SaveDailyEnergy(day, de)`.
3. `handleEnergyDaily` checks in-memory → persistent → recompute, and lazily writes a row on first computation for any **closed** day. Today's row is excluded (day still accumulating).

## Expected impact

Cold `/api/energy/daily?days=30` drops from ~25 s to the cost of 30 indexed PK lookups (<50 ms on the Pi). After the first warm load the persistent rows live forever — restart-free benefit accrues from there.

## Tests

- `TestDailyEnergyPersistRoundtrip` — save/load + upsert overwrite
- `TestDailyEnergyMissReturnsFalse` — miss semantics
- Full suite: `go test ./...` green

## Out of scope (follow-up)

- Snapshot speed / size (state.db = 1 GB, VACUUM INTO is the bottleneck). Existing PR #263 (gzip-compress snapshots) helps storage; truly faster snapshots would need either SQLite online backup API or excluding time-series tables (recoverable from cold parquet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)