### PR TITLE
feat(control): DC-link protective PV curtail — pre-empt Ferroamp fault

### DIFF
--- a/go/cmd/forty-two-watts/control_state.go
+++ b/go/cmd/forty-two-watts/control_state.go
@@ -32,5 +32,11 @@ func newControlStateFromConfig(cfg *config.Config) *control.State {
 	// PV surplus absorber underlay (opt-in). cap == 0 keeps it off.
 	ctrl.PVSurplusAbsorbSoCCapPct = cfg.Site.PVSurplusAbsorbSoCCapPct
 	ctrl.PVSurplusAbsorbThresholdW = cfg.Site.PVSurplusAbsorbThresholdW
+	// DC-link protective curtail — opt-in, default off. SoC threshold
+	// and margin fall back to dispatch defaults (0.80 / 1000 W) when
+	// unset, applied inside ComputePVCurtail.
+	ctrl.DCLinkProtectionEnabled = cfg.Site.DCLinkProtectionEnabled
+	ctrl.DCLinkProtectionSoCThreshold = cfg.Site.DCLinkProtectionSoCThreshold
+	ctrl.DCLinkProtectionMarginW = cfg.Site.DCLinkProtectionMarginW
 	return ctrl
 }

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -344,6 +344,27 @@ type Site struct {
 	// watts after the plan's target. Defaults to 100 W when the cap is
 	// set but this isn't.
 	PVSurplusAbsorbThresholdW float64 `yaml:"pv_surplus_absorb_threshold_w,omitempty" json:"pv_surplus_absorb_threshold_w,omitempty"`
+
+	// DCLinkProtectionEnabled opts into a live-state PV curtail that
+	// fires when SoC is near full AND PV significantly exceeds load
+	// — the configuration most exposed to a load-step-triggered
+	// inverter trip (real 2026-05-25 incident: Ferroamp EnergyHub
+	// fault from a 2.7 kW load step under 6 kW PV + 85 % SoC).
+	// Engaging pre-curtails PV to live load + margin so a sudden
+	// load step inside the margin lands without DC-link stress.
+	// Disabled by default — opt-in for sites that see repeated
+	// inverter trips.
+	DCLinkProtectionEnabled bool `yaml:"dc_link_protection_enabled,omitempty" json:"dc_link_protection_enabled,omitempty"`
+
+	// DCLinkProtectionSoCThreshold (0-1) is the SoC fraction at or
+	// above which the protective curtail engages. Default 0.80.
+	DCLinkProtectionSoCThreshold float64 `yaml:"dc_link_protection_soc_threshold,omitempty" json:"dc_link_protection_soc_threshold,omitempty"`
+
+	// DCLinkProtectionMarginW is the headroom (W) kept above live
+	// load when the protection fires. Larger margin = more PV
+	// allowed through, smaller load-step capacity before re-curtail.
+	// Default 1000.
+	DCLinkProtectionMarginW float64 `yaml:"dc_link_protection_margin_w,omitempty" json:"dc_link_protection_margin_w,omitempty"`
 }
 
 // DefaultFuseSafetyMarginA is the fall-back per-phase amp headroom

--- a/go/internal/configreload/watcher.go
+++ b/go/internal/configreload/watcher.go
@@ -145,6 +145,18 @@ func (w *Watcher) reload() {
 	if newCfg.Site.PVSurplusAbsorbThresholdW != oldCfg.Site.PVSurplusAbsorbThresholdW {
 		w.ctrl.PVSurplusAbsorbThresholdW = newCfg.Site.PVSurplusAbsorbThresholdW
 	}
+	if newCfg.Site.DCLinkProtectionEnabled != oldCfg.Site.DCLinkProtectionEnabled {
+		slog.Info("config reload: dc_link_protection_enabled",
+			"old", oldCfg.Site.DCLinkProtectionEnabled,
+			"new", newCfg.Site.DCLinkProtectionEnabled)
+		w.ctrl.DCLinkProtectionEnabled = newCfg.Site.DCLinkProtectionEnabled
+	}
+	if newCfg.Site.DCLinkProtectionSoCThreshold != oldCfg.Site.DCLinkProtectionSoCThreshold {
+		w.ctrl.DCLinkProtectionSoCThreshold = newCfg.Site.DCLinkProtectionSoCThreshold
+	}
+	if newCfg.Site.DCLinkProtectionMarginW != oldCfg.Site.DCLinkProtectionMarginW {
+		w.ctrl.DCLinkProtectionMarginW = newCfg.Site.DCLinkProtectionMarginW
+	}
 	w.ctrlMu.Unlock()
 
 	// Swap global pointer

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2687,6 +2687,95 @@ func TestInverterAffinity_IgnoresNonGeneratingPVTelemetry(t *testing.T) {
 
 // ---- PV curtailment ----
 
+// 2026-05-25 Ferroamp fault: 2.7 kW load step under 6 kW PV + 85 % SoC
+// triggered the inverter's internal DC-link protection. Operator opted
+// into DCLinkProtection to pre-curtail PV when SoC + surplus put the
+// inverter at risk. Verify the protection engages correctly in that
+// scenario.
+func TestProtectivePVCurtailEngagesAtHighSoCWithSurplus(t *testing.T) {
+	store := telemetry.NewStore()
+	// 6 kW PV producing
+	store.Update("ferroamp", telemetry.DerPV, -6000, nil, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	// Battery at 85 % SoC, online
+	soc := 0.85
+	store.Update("ferroamp", telemetry.DerBattery, 0, &soc, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	// Site meter showing 5.5 kW export (load 500 W, 5.5 kW out)
+	store.Update("ferroamp", telemetry.DerMeter, -5500, nil, nil)
+
+	st := NewState(0, 0, "ferroamp")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true}
+	st.DCLinkProtectionEnabled = true
+	st.DCLinkProtectionSoCThreshold = 0.80
+	st.DCLinkProtectionMarginW = 1000
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) {
+		// Planner asks for no curtail — protection fires anyway.
+		return SlotDirective{}, true
+	}
+
+	targets := ComputePVCurtail(st, store)
+	if len(targets) != 1 || targets[0].Driver != "ferroamp" {
+		t.Fatalf("want 1 target on ferroamp, got %+v", targets)
+	}
+	// Expected limit ≈ load (500) + margin (1000) = 1500 W
+	if got := targets[0].LimitW; math.Abs(got-1500) > 50 {
+		t.Errorf("protective curtail limit = %f, want ≈ 1500", got)
+	}
+}
+
+func TestProtectivePVCurtailSkipsBelowSoCThreshold(t *testing.T) {
+	store := telemetry.NewStore()
+	store.Update("ferroamp", telemetry.DerPV, -6000, nil, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	soc := 0.50 // below threshold
+	store.Update("ferroamp", telemetry.DerBattery, 0, &soc, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	store.Update("ferroamp", telemetry.DerMeter, -5500, nil, nil)
+
+	st := NewState(0, 0, "ferroamp")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true}
+	st.DCLinkProtectionEnabled = true
+	st.DCLinkProtectionSoCThreshold = 0.80
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return SlotDirective{}, true }
+
+	if got := ComputePVCurtail(st, store); len(got) != 0 {
+		t.Errorf("protection should not fire below SoC threshold, got %+v", got)
+	}
+}
+
+// Protection must NOT relax a tighter manual hold. If the operator
+// pinned a 500 W cap and protection would suggest 1500 W, the cap
+// wins. (We test against a manual hold rather than the planner
+// directive because liveCurtailLimitW already re-derives the planner
+// limit from live state, which makes the planner path's "is the limit
+// 500?" question opaque to a unit test.)
+func TestProtectivePVCurtailNeverRelaxesManualHold(t *testing.T) {
+	store := telemetry.NewStore()
+	store.Update("ferroamp", telemetry.DerPV, -6000, nil, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	soc := 0.85
+	store.Update("ferroamp", telemetry.DerBattery, 0, &soc, nil)
+	store.DriverHealthMut("ferroamp").RecordSuccess()
+	store.Update("ferroamp", telemetry.DerMeter, -5500, nil, nil)
+
+	st := NewState(0, 0, "ferroamp")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true}
+	st.DCLinkProtectionEnabled = true
+	st.DCLinkProtectionSoCThreshold = 0.80
+	st.DCLinkProtectionMarginW = 1000
+	// Site-wide operator hold at 500 W (tighter than protection's 1500).
+	st.SetPVManualHold(PVManualHold{LimitW: 500, ExpiresAt: time.Now().Add(time.Hour)})
+
+	targets := ComputePVCurtail(st, store)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %+v", targets)
+	}
+	if got := targets[0].LimitW; got > 600 {
+		t.Errorf("manual hold's 500 W cap got relaxed by protection to %f", got)
+	}
+}
+
 func TestPVCurtailAllocatesOnlinePVDrivers(t *testing.T) {
 	store := telemetry.NewStore()
 	store.Update("pv-a", telemetry.DerPV, -3000, nil, nil)

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -346,6 +346,28 @@ type State struct {
 	// hot-swappable via the config-reload watcher.
 	SupportsPVCurtail map[string]bool
 
+	// DCLinkProtectionEnabled opts into a live-state curtail trigger
+	// that fires INDEPENDENTLY of the planner directive when the
+	// inverter's DC link is most exposed to a load-step fault: SoC
+	// near full + PV significantly exceeds load. 2026-05-25 incident:
+	// a 2.7 kW load step under 6 kW PV + 85 % SoC tripped Ferroamp's
+	// internal protection. Pre-curtailing PV to load+margin keeps the
+	// inverter's headroom inside the safe window so the same step
+	// doesn't push it past the DC-link overvoltage threshold.
+	//
+	// Disabled by default — operators on hardware that doesn't trip
+	// or who'd rather lose a few % of PV-export revenue than absorb
+	// the risk can leave it off.
+	DCLinkProtectionEnabled bool
+	// DCLinkProtectionSoCThreshold is the SoC fraction (0-1) above
+	// which the protective curtail engages. 0 = use default 0.80.
+	DCLinkProtectionSoCThreshold float64
+	// DCLinkProtectionMarginW is the W of headroom kept above live
+	// load. The curtail limit becomes load + margin so a load step
+	// smaller than `margin` lands without curtail-recompute. 0 =
+	// use default 1000.
+	DCLinkProtectionMarginW float64
+
 	// LastCurtailedDrivers remembers which drivers got a non-zero
 	// curtail dispatch on the previous tick. ComputePVCurtail uses
 	// the diff to emit a `curtail_disable` exactly once when the
@@ -1796,6 +1818,102 @@ func ComputeDispatch(
 //
 // Idempotent: state mutation (LastCurtailedDrivers) reflects the
 // post-call set of actively-curtailed drivers.
+// protectiveCurtailLimitW returns (limit, true) when live state
+// triggers the DC-link protection: SoC at or above the configured
+// threshold AND PV surplus exceeds the safety margin. The limit
+// shrinks PV output to live-load + margin so a sudden load step
+// inside the margin lands without DC-link stress. Returns
+// (0, false) when protection is disabled, off-threshold, or there
+// is no PV-vs-load surplus to clamp.
+func protectiveCurtailLimitW(state *State, store *telemetry.Store) (float64, bool) {
+	if state == nil || store == nil || !state.DCLinkProtectionEnabled {
+		return 0, false
+	}
+	socThresh := state.DCLinkProtectionSoCThreshold
+	if socThresh <= 0 {
+		socThresh = 0.80
+	}
+	margin := state.DCLinkProtectionMarginW
+	if margin <= 0 {
+		margin = 1000
+	}
+
+	// Aggregate-SoC gate: protect only when batteries can no longer
+	// absorb the surplus themselves. Average across online batteries
+	// weighted by capacity, mirroring how the rest of dispatch
+	// reasons about the fleet.
+	var sumSoCWh, totalCap float64
+	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
+		h := store.DriverHealth(r.Driver)
+		if h == nil || !h.IsOnline() || r.SoC == nil {
+			continue
+		}
+		// Capacity must come from the per-driver map passed into
+		// dispatch — but ComputePVCurtail is called without it.
+		// Use a flat weight (1.0 per battery) here as the SoC-
+		// average proxy; in practice the operator's batteries are
+		// comparable in size, and the threshold check is coarse-
+		// grained anyway (80 % vs 70 % SoC isn't a precision call).
+		sumSoCWh += *r.SoC
+		totalCap += 1
+	}
+	if totalCap == 0 {
+		return 0, false
+	}
+	avgSoC := sumSoCWh / totalCap
+	if avgSoC < socThresh {
+		return 0, false
+	}
+
+	// PV-vs-load gate: only meaningful when PV is producing more
+	// than the household consumes — otherwise there's no surplus
+	// to curtail.
+	var pvAbs float64
+	for _, r := range store.ReadingsByType(telemetry.DerPV) {
+		h := store.DriverHealth(r.Driver)
+		if h == nil || !h.IsOnline() {
+			continue
+		}
+		if r.SmoothedW < 0 {
+			pvAbs += -r.SmoothedW
+		}
+	}
+	loadW := siteLoadW(state, store)
+	if pvAbs < loadW+2*margin {
+		// Surplus already inside the safe margin — no need to engage.
+		return 0, false
+	}
+	return loadW + margin, true
+}
+
+// siteLoadW reads the household load (W) from the site meter when
+// available. Mirrors the formula main.go uses for status: load =
+// gridW − battery − PV (site convention). Falls back to 0 on
+// missing telemetry, which makes protectiveCurtailLimitW degrade
+// safely to "don't engage" rather than to a bogus tiny limit.
+func siteLoadW(state *State, store *telemetry.Store) float64 {
+	if state == nil || store == nil || state.SiteMeterDriver == "" {
+		return 0
+	}
+	mtr := store.Get(state.SiteMeterDriver, telemetry.DerMeter)
+	if mtr == nil {
+		return 0
+	}
+	gridW := mtr.SmoothedW
+	var batW, pvW float64
+	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
+		batW += r.SmoothedW
+	}
+	for _, r := range store.ReadingsByType(telemetry.DerPV) {
+		pvW += r.SmoothedW
+	}
+	load := gridW - batW - pvW
+	if load < 0 {
+		return 0
+	}
+	return load
+}
+
 func ComputePVCurtail(state *State, store *telemetry.Store) []CurtailTarget {
 	if state == nil {
 		return nil
@@ -1834,6 +1952,25 @@ func ComputePVCurtail(state *State, store *telemetry.Store) []CurtailTarget {
 					// back to the planner's static cap.
 					limit = dir.PVLimitW
 				}
+			}
+		}
+	}
+
+	// DC-link protective curtail layered on top of any planner /
+	// manual-hold limit. Engages independently of the planner when
+	// SoC is near full + PV >> load. Honoured only when the operator
+	// hasn't pinned a driver-scoped hold (which is an explicit
+	// override), otherwise it composes as min(existing, protective)
+	// so we never relax a stronger cap.
+	if scopedDriver == "" {
+		if protLimit, protActive := protectiveCurtailLimitW(state, store); protActive {
+			if !holdActive && limit == 0 {
+				// No other curtail source — protection is the trigger.
+				limit = protLimit
+			} else if protLimit < limit {
+				// Existing curtail less restrictive than protection;
+				// tighten to the protective value.
+				limit = protLimit
 			}
 		}
 	}


### PR DESCRIPTION
## Live incident — 2026-05-25 14:53:20

Ferroamp EnergyHub tripped to fault state `0x8030` (DC-link safety). Reconstructed trigger:

```
14:53:11   load=  +456 W   PV=-6200   grid=-5750   (steady-state export)
14:53:17   load= +1131 W   PV=-6200   grid=-5070   ← load spike #1 (+660 W)
14:53:23   load= +2740 W   PV=-6200   grid=-3460   ← load spike #2 (+1600 W)
14:53:20   ehub_state → 0x8030 (FAULT)
14:53:32   PV collapses 6.2 → 3.4 kW (inverter trips)
```

A 2.7 kW load step under 6 kW PV + 85 % SoC dragged grid from -5.5 kW export to -3 kW; the inverter's DC-link couldn't ramp PV down in time. Operator framing: *\"prefer to lose a bit of PV revenue over having the inverter trip and stop charging entirely.\"*

## What this PR does

Adds an opt-in PV-curtail trigger that engages on the configurable risk window:

```
SoC ≥ DCLinkProtectionSoCThreshold   (default 0.80)
   AND
PV > load + 2 × DCLinkProtectionMarginW   (default 1000 W)
```

When it engages the PV limit becomes `load + margin`, so a load step inside `margin` lands without re-curtail recompute.

## Composes safely with existing curtail sources

| Existing source | Behaviour |
|---|---|
| Operator manual hold | Tighter cap wins; protection never relaxes |
| Planner directive | Min(...) layering; tighter planner cap stays |
| Driver-scoped hold | Bypassed (explicit operator override) |
| No PV-curtail-capable driver | No-op |

## Config

```yaml
site:
  dc_link_protection_enabled: true       # off by default
  dc_link_protection_soc_threshold: 0.80
  dc_link_protection_margin_w: 1000
```

All three hot-reload via the configreload watcher.

## Tests

- `TestProtectivePVCurtailEngagesAtHighSoCWithSurplus` — 85 % SoC + 5.5 kW surplus → curtail to load + margin
- `TestProtectivePVCurtailSkipsBelowSoCThreshold` — 50 % SoC, same surplus, no curtail
- `TestProtectivePVCurtailNeverRelaxesManualHold` — manual cap tighter than protection wins
- Full suite green

## Activation

After deploy, set `site.dc_link_protection_enabled: true` via the API (hot-reload). The fix only engages when the conditions hit — on a cloudy or low-SoC day it stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)