### PR TITLE
feat(pair): start pair sessions from the web UI

### DIFF
--- a/docs/ftw-pair.md
+++ b/docs/ftw-pair.md
@@ -30,26 +30,32 @@ how Sourceful tools install Python utilities.
 
 ## On the host
 
+Open the dashboard at `http://<pi>:8080`, scroll to the **Pair session**
+card, fill in an optional intent and pick a TTL, then click **Start pair
+session**. The card flips to active mode within a few seconds showing the
+wormhole code with a **Copy** button. Copy the code and send it to the
+friend over any channel — Signal, SMS, Slack DM.
+
+To end the session early, click **Abort** on the card.
+
+Or, if you prefer the terminal:
+
 ```bash
 forty-two-watts pair --intent "help me write a goodwe XS driver" --ttl 4h
 ```
 
-You'll see something like:
+The CLI prints the code directly:
 
 ```
 PAIR CODE: 7-crossover-clockwork
 TTL: 4h0m0s — sidecar will exit at expiry
 ```
 
-Send the code to the friend over any channel — Signal, SMS, Slack DM.
-
-To end the session early:
+To abort from the terminal:
 
 ```bash
 forty-two-watts pair --abort
 ```
-
-…or click **Abort** on the pair-session card in the web UI.
 
 ## On the friend
 
@@ -104,8 +110,8 @@ what changed on the owner's instance.
 
 | Step | Owner | Friend |
 |---|---|---|
-| Trigger pair session | `forty-two-watts pair --intent "..."` | — |
-| Share wormhole code | Send via Signal/SMS/Slack | Receive |
+| Trigger pair session | Click **Start pair session** in the dashboard (or `forty-two-watts pair --intent "..."`) | — |
+| Share wormhole code | Copy from the dashboard card, send via Signal/SMS/Slack | Receive |
 | Connect | — | `ftw-connect <code>` |
 | Develop the driver / debug | — | Drives Claude Code through the tunnel |
 | Open the PR | — | Clones repo locally, `gh pr create` from own machine |

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -149,6 +149,12 @@ type Deps struct {
 	// any). Nil is safe — routes are still registered; GET returns 404.
 	// T20/T21 can reach in via deps.PairStore for SSE heartbeat support.
 	PairStore *PairStatusStore
+
+	// PairSelfExe overrides the binary path used by POST /api/pair/start to
+	// spawn child pair sessions. Empty means "use os.Executable()". Tests
+	// inject "/bin/true" (or a fake echo binary) here so they don't actually
+	// launch a sidecar.
+	PairSelfExe string
 }
 
 // Server wraps the http.ServeMux and adds shared middleware (logging,
@@ -281,7 +287,13 @@ func (s *Server) routes() {
 	s.handle("POST /api/restart", s.handleRestart)
 
 	// ---- Pair sidecar endpoints ----
-	RegisterPairRoutes(s.mux, s.deps.PairStore)
+	// Pass the self-exe path so POST /api/pair/start can spawn "self pair ..."
+	// as a detached child. Tests inject a fake path via deps.PairSelfExe.
+	selfExe := s.deps.PairSelfExe
+	if selfExe == "" {
+		selfExe = resolvedSelfExe()
+	}
+	RegisterPairRoutes(s.mux, s.deps.PairStore, selfExe)
 
 	// ---- Static web UI ----
 	// Everything not matched above falls through to the static server.

--- a/go/internal/api/api_pair.go
+++ b/go/internal/api/api_pair.go
@@ -2,9 +2,27 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"os/exec"
 	"sync"
+	"time"
 )
+
+// resolvedSelfExe returns os.Executable() with symlinks resolved, or
+// os.Args[0] on error. Used as the default selfExe for spawning child
+// pair sessions; tests inject a fake path via Deps.PairSelfExe.
+func resolvedSelfExe() string {
+	if exe, err := os.Executable(); err == nil {
+		return exe
+	}
+	if len(os.Args) > 0 {
+		return os.Args[0]
+	}
+	return ""
+}
 
 // PairStatus is the metadata the ftw-pair sidecar POSTs to
 // /api/pair/status so the dashboard can render the active session.
@@ -59,7 +77,11 @@ func (s *PairStatusStore) Clear() {
 //	GET  /api/pair/status  — returns the active session or 404
 //	POST /api/pair/status  — sidecar registers/updates its session
 //	POST /api/pair/abort   — operator clears the session; sidecar exits on next poll
-func RegisterPairRoutes(mux *http.ServeMux, store *PairStatusStore) {
+//	POST /api/pair/start   — owner starts a new pair session from the web UI
+//
+// selfExe is the path to the running binary (os.Executable() result), used
+// to spawn "self pair --ttl <t> [--intent <i>]" as a detached child.
+func RegisterPairRoutes(mux *http.ServeMux, store *PairStatusStore, selfExe string) {
 	mux.HandleFunc("GET /api/pair/status", func(w http.ResponseWriter, r *http.Request) {
 		p, ok := store.Get()
 		if !ok {
@@ -85,4 +107,45 @@ func RegisterPairRoutes(mux *http.ServeMux, store *PairStatusStore) {
 		store.Clear()
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("POST /api/pair/start", handlePairStart(store, selfExe))
+}
+
+// handlePairStart returns an http.HandlerFunc that spawns
+// "<selfExe> pair --ttl <ttl> [--intent <intent>]" as a detached child
+// process. The child will register itself via POST /api/pair/status once
+// the wormhole tunnel is up; the card's fast-poll loop picks that up.
+func handlePairStart(store *PairStatusStore, selfExe string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Intent string `json:"intent"`
+			TTL    string `json:"ttl"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body.TTL == "" {
+			body.TTL = "4h"
+		}
+		if _, err := time.ParseDuration(body.TTL); err != nil {
+			http.Error(w, fmt.Sprintf("invalid ttl: %v", err), http.StatusBadRequest)
+			return
+		}
+		if _, ok := store.Get(); ok {
+			w.Header().Set("Content-Type", "application/json")
+			http.Error(w, `{"error":"pair session already active"}`, http.StatusConflict)
+			return
+		}
+		args := []string{"pair", "--ttl", body.TTL}
+		if body.Intent != "" {
+			args = append(args, "--intent", body.Intent)
+		}
+		go func() {
+			cmd := exec.Command(selfExe, args...)
+			_ = cmd.Run() // child writes to /api/pair/status itself
+		}()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]any{"status": "starting", "ttl": body.TTL})
+	}
 }

--- a/go/internal/api/api_pair_test.go
+++ b/go/internal/api/api_pair_test.go
@@ -12,7 +12,7 @@ import (
 func TestPairStatusPostThenGet(t *testing.T) {
 	store := NewPairStatusStore()
 	mux := http.NewServeMux()
-	RegisterPairRoutes(mux, store)
+	RegisterPairRoutes(mux, store, "/bin/true")
 
 	body := `{"session_id":"abc","code":"7-x","intent":"goodwe","started_at":"2026-05-25T10:00:00Z","ttl_s":14400}`
 	req := httptest.NewRequest("POST", "/api/pair/status", strings.NewReader(body))
@@ -38,7 +38,7 @@ func TestPairStatusPostThenGet(t *testing.T) {
 func TestPairStatusGet404WhenNoSession(t *testing.T) {
 	store := NewPairStatusStore()
 	mux := http.NewServeMux()
-	RegisterPairRoutes(mux, store)
+	RegisterPairRoutes(mux, store, "/bin/true")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/pair/status", nil))
 	if w.Code != 404 {
@@ -49,7 +49,7 @@ func TestPairStatusGet404WhenNoSession(t *testing.T) {
 func TestPairAbortClearsStatus(t *testing.T) {
 	store := NewPairStatusStore()
 	mux := http.NewServeMux()
-	RegisterPairRoutes(mux, store)
+	RegisterPairRoutes(mux, store, "/bin/true")
 	store.Set(PairStatus{SessionID: "abc", Code: "7-x"})
 
 	w := httptest.NewRecorder()
@@ -59,5 +59,65 @@ func TestPairAbortClearsStatus(t *testing.T) {
 	}
 	if _, ok := store.Get(); ok {
 		t.Fatal("status not cleared")
+	}
+}
+
+// --- POST /api/pair/start tests ---
+
+func TestPairStartReturns202(t *testing.T) {
+	store := NewPairStatusStore()
+	mux := http.NewServeMux()
+	// Use /bin/true as the fake selfExe — exits immediately with 0, never
+	// registers a status, but lets cmd.Run() succeed without blocking.
+	RegisterPairRoutes(mux, store, "/bin/true")
+
+	body := `{"intent":"write a goodwe driver","ttl":"2h"}`
+	req := httptest.NewRequest("POST", "/api/pair/start", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 202 {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response not JSON: %v", err)
+	}
+	if resp["status"] != "starting" {
+		t.Fatalf("expected status=starting, got %v", resp)
+	}
+	if resp["ttl"] != "2h" {
+		t.Fatalf("expected ttl=2h, got %v", resp)
+	}
+}
+
+func TestPairStartRejectsBadTTL(t *testing.T) {
+	store := NewPairStatusStore()
+	mux := http.NewServeMux()
+	RegisterPairRoutes(mux, store, "/bin/true")
+
+	body := `{"ttl":"notaduration"}`
+	req := httptest.NewRequest("POST", "/api/pair/start", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestPairStartConflictWhenActive(t *testing.T) {
+	store := NewPairStatusStore()
+	store.Set(PairStatus{SessionID: "existing", Code: "3-foo"})
+	mux := http.NewServeMux()
+	RegisterPairRoutes(mux, store, "/bin/true")
+
+	body := `{"ttl":"4h"}`
+	req := httptest.NewRequest("POST", "/api/pair/start", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != 409 {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body)
 	}
 }

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -1,19 +1,23 @@
-// <ftw-pair-card> — surfaces an active pair session on the dashboard.
+// <ftw-pair-card> — surfaces an active pair session on the dashboard, and
+// lets the owner start a new session without touching the CLI.
 //
-// Polls /api/pair/status every 5 s. Renders the wormhole code, the
-// owner-supplied intent, a TTL countdown, the running tool counter,
-// and an Abort button that POSTs /api/pair/abort. When the endpoint
-// returns 404 (no active session) the card hides itself entirely via
-// :host(.hidden) { display:none } — identical pattern to ftw-update-check.
+// When no session is active (GET /api/pair/status → 404) the card renders a
+// start form (intent textarea + TTL select + Start button). POST /api/pair/start
+// spawns the sidecar; three fast 1 s polls flip the card to active-mode as
+// soon as the sidecar registers itself via POST /api/pair/status.
+//
+// When a session is active the card renders the wormhole code (with a Copy
+// button), intent, TTL countdown, tool counter, and an Abort button.
 
 import { FtwElement } from "./ftw-element.js";
 
 const POLL_MS = 5000;
+const FAST_POLL_MS = 1000;
+const FAST_POLL_ROUNDS = 3;
 
 class FtwPairCard extends FtwElement {
   static styles = `
     :host { display: block; }
-    :host(.hidden) { display: none; }
 
     .pair-card {
       border: 1px solid var(--line);
@@ -41,6 +45,12 @@ class FtwPairCard extends FtwElement {
       margin: 0 0 8px;
       color: var(--fg);
       letter-spacing: 0.06em;
+    }
+    .code-row {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      margin-bottom: 8px;
     }
     .intent {
       font-family: var(--sans);
@@ -78,12 +88,83 @@ class FtwPairCard extends FtwElement {
     button.abort:hover {
       opacity: 0.85;
     }
+    button.copy {
+      background: transparent;
+      color: var(--fg);
+      border: 1px solid var(--line);
+      padding: 2px 8px;
+      font-family: var(--mono);
+      cursor: pointer;
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    button.copy:hover {
+      border-color: var(--accent-e);
+      color: var(--accent-e);
+    }
+    /* Start form */
+    .start-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .field label {
+      display: block;
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-raised2, var(--fg-dim, var(--fg)));
+      opacity: 0.6;
+      margin-bottom: 4px;
+    }
+    .field textarea,
+    .field select {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg, #111);
+      color: var(--fg);
+      border: 1px solid var(--line);
+      font-family: var(--sans);
+      font-size: 0.85rem;
+      padding: 6px 8px;
+    }
+    .field textarea {
+      resize: vertical;
+      min-height: 52px;
+    }
+    .field select {
+      appearance: none;
+      -webkit-appearance: none;
+      cursor: pointer;
+    }
+    button.start {
+      align-self: flex-start;
+      background: var(--accent-e);
+      color: #0a0a0a;
+      border: 0;
+      padding: 6px 14px;
+      font-family: var(--mono);
+      cursor: pointer;
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    button.start:hover {
+      opacity: 0.85;
+    }
+    button.start:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
   `;
 
   constructor() {
     super();
     this._state = null;
     this._tick = null;
+    this._fastRounds = 0;
   }
 
   connectedCallback() {
@@ -108,6 +189,50 @@ class FtwPairCard extends FtwElement {
     this.update();
   }
 
+  // _startFastPolls switches to 1 s polling for FAST_POLL_ROUNDS iterations,
+  // then reverts to the normal cadence. Call immediately after POST /api/pair/start
+  // so the card flips to active-mode as soon as the sidecar registers itself.
+  _startFastPolls() {
+    this._fastRounds = FAST_POLL_ROUNDS;
+    clearInterval(this._tick);
+    const fast = setInterval(() => {
+      this._refresh();
+      this._fastRounds--;
+      if (this._fastRounds <= 0) {
+        clearInterval(fast);
+        this._tick = setInterval(() => this._refresh(), POLL_MS);
+      }
+    }, FAST_POLL_MS);
+  }
+
+  async _start() {
+    const root = this.shadowRoot;
+    const intentEl = root.getElementById("intent-input");
+    const ttlEl = root.getElementById("ttl-select");
+    const btn = root.getElementById("start-btn");
+    if (!intentEl || !ttlEl || !btn) return;
+
+    btn.disabled = true;
+    try {
+      const resp = await fetch("/api/pair/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ intent: intentEl.value.trim(), ttl: ttlEl.value }),
+      });
+      if (!resp.ok) {
+        const txt = await resp.text();
+        alert("Failed to start pair session: " + txt);
+        btn.disabled = false;
+        return;
+      }
+    } catch (e) {
+      alert("Failed to start pair session: " + e.message);
+      btn.disabled = false;
+      return;
+    }
+    this._startFastPolls();
+  }
+
   async _abort() {
     if (!confirm("End the pair session now?")) return;
     await fetch("/api/pair/abort", { method: "POST" });
@@ -115,13 +240,39 @@ class FtwPairCard extends FtwElement {
     this.update();
   }
 
+  _copyCode() {
+    if (!this._state) return;
+    navigator.clipboard.writeText(this._state.code).catch(() => {});
+  }
+
   render() {
     if (!this._state) {
-      this.classList.add("hidden");
-      return "";
+      // No active session — show the start form.
+      return `
+        <div class="pair-card">
+          <header>
+            <span class="eyebrow">Pair session</span>
+          </header>
+          <div class="start-form">
+            <div class="field">
+              <label for="intent-input">Intent (optional)</label>
+              <textarea id="intent-input" rows="2" placeholder="e.g. help me write a GoodWe XS driver"></textarea>
+            </div>
+            <div class="field">
+              <label for="ttl-select">Session length</label>
+              <select id="ttl-select">
+                <option value="1h">1 hour</option>
+                <option value="4h" selected>4 hours</option>
+                <option value="12h">12 hours</option>
+              </select>
+            </div>
+            <button class="start" id="start-btn">Start pair session</button>
+          </div>
+        </div>
+      `;
     }
-    this.classList.remove("hidden");
 
+    // Active session — show code, intent, countdown, tools, abort + copy.
     const remaining = this._computeRemaining();
     const lastTools = (this._state.last_tools || [])
       .map((t) => escapeHTML(t))
@@ -133,7 +284,10 @@ class FtwPairCard extends FtwElement {
           <span class="eyebrow">Pair session active</span>
           <button class="abort" id="abort-btn">Abort</button>
         </header>
-        <p class="code">${escapeHTML(this._state.code)}</p>
+        <div class="code-row">
+          <p class="code">${escapeHTML(this._state.code)}</p>
+          <button class="copy" id="copy-btn">Copy</button>
+        </div>
         <p class="intent">${escapeHTML(this._state.intent || "(no intent set)")}</p>
         <dl>
           <dt>TTL</dt><dd>${escapeHTML(remaining)}</dd>
@@ -145,8 +299,14 @@ class FtwPairCard extends FtwElement {
   }
 
   afterRender() {
-    const btn = this.shadowRoot.getElementById("abort-btn");
-    if (btn) btn.addEventListener("click", () => this._abort());
+    const abortBtn = this.shadowRoot.getElementById("abort-btn");
+    if (abortBtn) abortBtn.addEventListener("click", () => this._abort());
+
+    const copyBtn = this.shadowRoot.getElementById("copy-btn");
+    if (copyBtn) copyBtn.addEventListener("click", () => this._copyCode());
+
+    const startBtn = this.shadowRoot.getElementById("start-btn");
+    if (startBtn) startBtn.addEventListener("click", () => this._start());
   }
 
   _computeRemaining() {


### PR DESCRIPTION
## Summary

Closes T30. Until now, starting a pair session required `docker exec` into the container and running `forty-two-watts pair ...` on the CLI — a barrier for owners who just want to hand the instance to a friend for an hour.

- **New endpoint `POST /api/pair/start`** (`go/internal/api/api_pair.go`): accepts `{intent, ttl}`, validates the TTL as a Go duration, rejects 409 if a session is already active, spawns `<self> pair --ttl <t> [--intent <i>]` as a detached goroutine, returns 202 immediately. The sidecar registers itself via the existing `POST /api/pair/status` heartbeat loop; no new protocol needed.

- **`<ftw-pair-card>` start form** (`web/components/ftw-pair-card.js`): when `GET /api/pair/status` returns 404 the card now renders an intent textarea + TTL select (1h/4h/12h) + Start button instead of hiding. After a successful POST, three fast 1 s polls flip the card to active-mode as soon as the sidecar is up. Active view gains a **Copy** button next to the code.

- **Docs** (`docs/ftw-pair.md`): "On the host" section now leads with the UI flow; CLI is demoted to "or, if you prefer the terminal". "Who does what" table updated.

## Background

PR #311 added the pair sidecar and the passive card. This PR adds the missing owner-facing trigger so the full flow lives in the dashboard.

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go test ./...` — passes (three new tests: `TestPairStartReturns202`, `TestPairStartRejectsBadTTL`, `TestPairStartConflictWhenActive`)
- [ ] `go vet ./...` — clean
- [ ] Smoke-test in browser: open dashboard, confirm pair card shows start form; click Start, confirm card flips to active-mode within ~5 s (requires `fowl` on PATH and a valid 42W instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)