### PR TITLE
fix(control): passive_arbitrage carve-out for idle plan slots

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -4381,3 +4381,90 @@ func TestPVSurplusAbsorberDoesNotReverseDischarge(t *testing.T) {
 		t.Errorf("TargetW = %.0f W — absorber must not blunt a discharge plan (want ≈ -4000 W)", got)
 	}
 }
+
+// Regression guard for the production v0.87.0 incident: PV forecast was off
+// by 7×, plan said battery idle (export the imaginary PV surplus), batteries
+// sat at 0 W while the site imported 648 W. The carve-out was only in
+// planner_self so passive_arbitrage didn't benefit.
+//
+// Fix: passive_arbitrage now participates in the reactive-discharge carve-out
+// when the plan slot is idle (non-charge). The battery should discharge to
+// cover the live import just as planner_self would.
+func TestPlannerPassiveArbitrageIdleSlotReactsToForecastMiss(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 0, // idle — plan expected PV export, battery hands-off
+		Strategy:        "self_consumption",
+	}
+	// Live: meter is importing 600 W — PV massively undershot forecast.
+	store := seedStore(600, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000 // unbounded for single-tick test
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Reactive PI on grid=+600 W with Kp=0.5 yields ~-300 W discharge
+	// after one tick. The key assertion is that the battery discharged at
+	// all — before the fix planHasNonDischargeIntent returned true and
+	// floored the target to 0.
+	if got >= 0 {
+		t.Errorf("TargetW = %.0f W — passive_arbitrage idle slot must discharge reactively when meter imports (forecast miss). Before fix: target was floored to 0.", got)
+	}
+}
+
+// When the plan slot for passive_arbitrage is a deliberate CHARGE slot
+// (e.g. the DP picked cheap grid hours to refill), live grid import is
+// expected — that's what grid-charging looks like. The carve-out must NOT
+// apply here: the charge command is the authoritative intent and reactive
+// discharge would undo it.
+func TestPlannerPassiveArbitrageChargeSlotPreservedAgainstReactiveDischarge(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 1000, // deliberate grid-charge: ~4 kW over the slot
+		Strategy:        "arbitrage",
+	}
+	// Live: meter importing 600 W. In a charge slot this is expected and
+	// intentional (grid → battery). Battery is currently at 0 W.
+	store := seedStore(600, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.4},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Energy-dispatch path computes targetTotalW = 1000*3600/900 ≈ 4000 W
+	// charge. Reactive discharge must NOT override this. The non-discharge
+	// block (planHasNonDischargeIntent=true) should floor to 0 at minimum —
+	// but the energy path itself drives positive, so we just verify the
+	// battery is commanded to CHARGE, not discharge.
+	if got < 0 {
+		t.Errorf("TargetW = %.0f W — passive_arbitrage charge slot must NOT discharge reactively; the grid-charge plan must remain authoritative", got)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -861,7 +861,22 @@ func ComputeDispatch(
 		if state.UseEnergyDispatch && state.SlotDirective != nil {
 			if dir, ok := state.SlotDirective(time.Now()); ok {
 				currentDirective = dir
-				useEnergyPath = true
+				// planner_passive_arbitrage idle slots: skip the energy path and
+				// fall through to reactive PI (same as planner_self does always).
+				// When the plan slot is idle (BatteryEnergyWh ≈ 0), the energy
+				// formula produces targetTotalW=0 and cannot react to live
+				// conditions — a PV forecast miss leaves the site importing while
+				// the battery sits at 0 W. The reactive PI path handles this
+				// correctly, and planHasNonDischargeIntent (below) permits
+				// discharge for non-charge passive_arbitrage slots.
+				// Charge slots (BatteryEnergyWh > idleWh) still use the energy
+				// path so the DP's deliberate grid-charge intent is honoured.
+				const idleWhGate = 50.0
+				isPassiveArbitrageIdleSlot := state.Mode == ModePlannerPassiveArbitrage &&
+					dir.BatteryEnergyWh <= idleWhGate
+				if !isPassiveArbitrageIdleSlot {
+					useEnergyPath = true
+				}
 				// Distribution mode is decoupled from planner strategy in
 				// the energy path — the operator-selected strategy drives
 				// the plan's DP, distribution is always proportional across
@@ -2365,14 +2380,26 @@ func planHasNonDischargeIntent(state *State) bool {
 	// importing 500 W — the symptom the operator hit on v0.79.5
 	// before this carve-out.
 	//
-	// planner_passive_arbitrage is intentionally NOT in the carve-out.
-	// Its contract differs from planner_self: it CAN grid-charge when
-	// the DP picked cheap hours for refilling, so a plan slot of
-	// "charge X Wh" is realisable intent (not just a forecast that
-	// happened to land positive). Overriding it with reactive
-	// discharge would undo the deliberate grid-charge decision.
-	// Operators who want strict "never grid-charge regardless of
-	// price" should keep planner_self.
+	// planner_passive_arbitrage was previously NOT in the carve-out to
+	// protect deliberate grid-charge decisions: when the DP picks cheap
+	// hours for refilling, a plan slot of "charge X Wh" is realisable
+	// intent (not just a forecast that happened to land positive), and
+	// overriding it with reactive discharge would undo that decision.
+	// Operators who want strict "never grid-charge regardless of price"
+	// should keep planner_self.
+	//
+	// However, that rationale only applies when the plan slot's intent
+	// is to charge. When the slot is idle (battery_w ≈ 0, e.g. "export
+	// the PV surplus") there is no protected charge decision — reactive
+	// discharge is safe and correct. Without the carve-out for idle
+	// slots, a forecast miss (PV overestimated, load underestimated)
+	// leaves the site importing while batteries sit at 0 W. Found in
+	// production v0.87.0: PV forecast off by 7×, plan idle, site
+	// imported 648 W continuously through the slot.
+	//
+	// Fix: planner_passive_arbitrage now participates in the carve-out
+	// for non-charge slots (BatteryEnergyWh ≤ idleWh). Charge slots
+	// remain authoritative — their non-discharge block is preserved.
 	if state.Mode == ModePlannerSelf {
 		return false
 	}
@@ -2380,6 +2407,12 @@ func planHasNonDischargeIntent(state *State) bool {
 	const idleGridW = 100.0
 	if state.SlotDirective != nil {
 		if dir, ok := state.SlotDirective(time.Now()); ok {
+			// For passive_arbitrage: only block reactive discharge when the
+			// plan slot has explicit charge intent. Idle and discharge slots
+			// get no non-discharge block — reactive discharge may cover load.
+			if state.Mode == ModePlannerPassiveArbitrage {
+				return dir.BatteryEnergyWh > idleWh
+			}
 			return dir.BatteryEnergyWh >= -idleWh
 		}
 	}
@@ -2389,6 +2422,13 @@ func planHasNonDischargeIntent(state *State) bool {
 			case ModeCharge:
 				return true
 			case ModeSelfConsumption:
+				// passive_arbitrage on a self_consumption slot: only block
+				// reactive discharge when the plan's grid target is
+				// import-directed (i.e. a deliberate grid-charge). Idle
+				// export slots (gridW near zero or negative) are free.
+				if state.Mode == ModePlannerPassiveArbitrage {
+					return gridW > idleGridW
+				}
 				return gridW >= -idleGridW
 			}
 		}


### PR DESCRIPTION
## Problem

In production v0.87.0, `planner_passive_arbitrage` sat at 0 W battery output through a slot where PV was forecast at ~500 W but delivered ~70 W (7× miss), and load was 47× higher than forecast. Site imported 648 W continuously while the batteries did nothing.

Root cause: the reactive-discharge carve-out in `planHasNonDischargeIntent` was scoped to `planner_self` only. The comment said passive_arbitrage was intentionally excluded to protect deliberate grid-charge slots. That rationale is correct for charge slots — but the production slot was **idle** (`battery_w: 0`). There was no grid-charge intent to protect, yet the carve-out still blocked reactive discharge.

A second issue compounded this: the energy-dispatch path (`useEnergyPath`) computes `targetTotalW = BatteryEnergyWh × 3600 / remainingS`. For an idle slot (`BatteryEnergyWh = 0`) that is always 0 W — the energy formula has no mechanism to react to live conditions. The `noSelfDischarge` floor that would otherwise catch this lives in the legacy PI path, which the energy path bypasses entirely.

## Fix

Two surgical changes in `dispatch.go`:

**1. Skip energy path for passive_arbitrage idle slots** (~line 861, mode switch):

When `ModePlannerPassiveArbitrage` and `dir.BatteryEnergyWh ≤ 50 Wh` (idle threshold), `useEnergyPath` is left `false`. The dispatch falls through to the reactive PI path on `ModeSelfConsumption`, grid target = 0 — same behaviour as `planner_self` always uses. Charge slots (`BatteryEnergyWh > 50 Wh`) continue to use the energy path so the DP's deliberate grid-charge intent is fully honoured.

**2. Refine `planHasNonDischargeIntent` for passive_arbitrage** (~line 2376):

For `SlotDirective`-sourced slots: passive_arbitrage only sets the non-discharge block when `BatteryEnergyWh > idleWh` (explicit charge). Idle and discharge slots return `false`, permitting the PI correction to flow through.

For `PlanTarget`-sourced (legacy) slots: same refinement — `ModeSelfConsumption` only blocks discharge when `gridW > idleGridW` (import-directed, i.e. deliberate grid-charge).

The original comment is updated to explain the refined rationale.

## Tests

Two new tests in `control_test.go`:

- **`TestPlannerPassiveArbitrageIdleSlotReactsToForecastMiss`** — mirrors the production incident: `passive_arbitrage`, idle slot (`battery_w=0`), live meter importing 600 W. Asserts battery discharges reactively. Before the fix this was floored to 0 W.

- **`TestPlannerPassiveArbitrageChargeSlotPreservedAgainstReactiveDischarge`** — charge slot (`BatteryEnergyWh=1000 Wh`), live meter importing 600 W (expected: that's what grid-charging looks like). Asserts battery commands are positive (charge), not flipped to discharge.

Existing regression guards `TestPlannerSelfReactsToForecastOverestimate` and `TestPlannerSelfPlannedPVExportDoesNotAbsorbLiveSurplus` still pass — `planner_self` behaviour is unchanged.

## Test output

```
=== RUN   TestPlannerSelfReactsToForecastOverestimate
--- PASS: TestPlannerSelfReactsToForecastOverestimate (0.00s)
=== RUN   TestPlannerSelfPlannedPVExportDoesNotAbsorbLiveSurplus
--- PASS: TestPlannerSelfPlannedPVExportDoesNotAbsorbLiveSurplus (0.00s)
=== RUN   TestPlannerPassiveArbitrageIdleSlotReactsToForecastMiss
--- PASS: TestPlannerPassiveArbitrageIdleSlotReactsToForecastMiss (0.00s)
=== RUN   TestPlannerPassiveArbitrageChargeSlotPreservedAgainstReactiveDischarge
--- PASS: TestPlannerPassiveArbitrageChargeSlotPreservedAgainstReactiveDischarge (0.00s)
ok  github.com/frahlg/forty-two-watts/go/internal/control
```

Full `go test ./...` and `go vet ./...` pass.