### PR TITLE
fix(mpc): cap radiation-backed forecast at 3× twin prediction to prevent NWP cloud miss from dominating plan

### DIFF
--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -1038,6 +1038,26 @@ func upperHalfMeanPrice(prices []state.PricePoint) float64 {
 // non-representative training data).
 const PlannerRadiationWeight = 0.3
 
+// PlannerForecastCapRatio caps how much the radiation-backed forecast may
+// exceed the twin's prediction before it's treated as a NWP error rather
+// than a calibration gap.
+//
+// When the NWP model is confidently wrong (e.g. predicts 1% cloud while
+// the site measures 300 W from a 13 kW array), the forecast can be 5–10×
+// higher than reality. The RLS twin — especially when its NowAnchor
+// correction has pulled it close to the live reading — is a more reliable
+// signal in those moments. Capping the forecast at this multiple prevents
+// the 70 % NWP weight from swamping the calibrated twin.
+//
+// 3× is chosen empirically: it covers a 2–3 string orientation difference
+// and a heavy soiling scenario, which are legitimate reasons for the twin
+// to under-predict relative to the NWP GHI × rated-kWp estimate. Beyond
+// 3× the NWP forecast is more likely wrong (cloud/shading mis-model) than
+// the twin is. This constant is intentionally conservative — tightening
+// it below ~2 risks degrading performance on normal sunny days where the
+// forecast is right and the twin is under-trained.
+const PlannerForecastCapRatio = 3.0
+
 func selectPlannerPVW(forecastPVW, predictedPVW float64, radiationBacked bool) float64 {
 	// Invalid predicted → fall back to forecast (unchanged).
 	switch {
@@ -1055,8 +1075,23 @@ func selectPlannerPVW(forecastPVW, predictedPVW float64, radiationBacked bool) f
 	// switch: forecast shows smooth bell curve 0–8 kW, an under-trained
 	// twin still spits random spikes from overfit feature vectors — and
 	// we want the smooth curve.
+	//
+	// Guard: if the forecast exceeds PlannerForecastCapRatio × the twin's
+	// prediction, and the twin has a meaningful signal (> 50 W — i.e. it
+	// is not night-gated or collapsed), cap the forecast before blending.
+	// This prevents a confidently-wrong NWP cloud-cover forecast from
+	// dominating the plan — the twin's NowAnchor-corrected value already
+	// reflects live irradiance conditions, and a 3–10× divergence between
+	// forecast and twin is a stronger signal of NWP error than calibration
+	// gap. See investigation in docs/pvmodel-overprediction-investigation.md
+	// (T33, 2026-05-25, open_meteo predicted 154 W/m2 / 1% cloud while
+	// site measured ~22 W/m2 effective irradiance → 7× blend over-shoot).
 	if radiationBacked && forecastPVW > 0 {
-		return (1-PlannerRadiationWeight)*forecastPVW + PlannerRadiationWeight*predictedPVW
+		cappedForecast := forecastPVW
+		if predictedPVW > 50 && forecastPVW > PlannerForecastCapRatio*predictedPVW {
+			cappedForecast = PlannerForecastCapRatio * predictedPVW
+		}
+		return (1-PlannerRadiationWeight)*cappedForecast + PlannerRadiationWeight*predictedPVW
 	}
 
 	// Cloud-only legacy path: prefer the twin when forecast is near zero

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -324,6 +324,71 @@ func TestSelectPlannerPVWRadiationZeroForecastIgnoresBlend(t *testing.T) {
 	}
 }
 
+// T33 regression: open_meteo predicted 2002 W (solar_wm2=154, cloud=1%) for a
+// 13 kW site while the trained RLS twin (NowAnchor-corrected via live telemetry)
+// predicted 290 W — actual measured PV was ~290 W.  The old code produced
+// 0.7*2002 + 0.3*290 = 1488 W (5× actual).  With the forecast cap, the forecast
+// is limited to PlannerForecastCapRatio (3×) × twin before blending:
+//
+//	cappedForecast = 3 × 290 = 870
+//	result         = 0.7×870 + 0.3×290 = 696 W   (2.4× actual — still an overshoot
+//	                                                but far better than 5×)
+//
+// The residual over-prediction is expected and acceptable: the cap only activates
+// when the NWP cloud forecast was catastrophically wrong.  On a normal day (forecast
+// and twin agree within 3×) the cap is a no-op and accuracy is unchanged.
+func TestSelectPlannerPVWForecastCapActivatesOnWildForecast(t *testing.T) {
+	// Reproduce T33 inputs (scaled to round numbers).
+	forecast := 2002.0
+	twin := 290.0 // NowAnchor-corrected RLS twin value
+
+	got := selectPlannerPVW(forecast, twin, true)
+
+	// With the cap at PlannerForecastCapRatio=3: capped = 3*290 = 870.
+	cappedForecast := PlannerForecastCapRatio * twin
+	want := (1-PlannerRadiationWeight)*cappedForecast + PlannerRadiationWeight*twin
+	if math.Abs(got-want) > 0.5 {
+		t.Errorf("T33 forecast-cap: got %.1f, want %.1f (capped at %.0fx twin=%g)",
+			got, want, PlannerForecastCapRatio, twin)
+	}
+
+	// Result must be materially less than the uncapped blend.
+	uncapped := (1-PlannerRadiationWeight)*forecast + PlannerRadiationWeight*twin
+	if got >= uncapped {
+		t.Errorf("capped result %.1f should be less than uncapped %.1f", got, uncapped)
+	}
+}
+
+// Cap must be a no-op when forecast and twin are within PlannerForecastCapRatio.
+// A well-trained twin slightly under-predicting because of orientation or
+// soiling should not trigger the cap.
+func TestSelectPlannerPVWForecastCapInactiveWhenRatioOK(t *testing.T) {
+	forecast := 4000.0
+	twin := 2000.0 // 2× — well below cap threshold of 3×
+
+	got := selectPlannerPVW(forecast, twin, true)
+	want := (1-PlannerRadiationWeight)*forecast + PlannerRadiationWeight*twin
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("cap should be inactive when forecast/twin=2x: got %.2f, want %.2f", got, want)
+	}
+}
+
+// Cap must not activate when the twin is near-zero (< 50 W):  that means the
+// physics night gate fired and the twin result is meaningless — the forecast
+// should dominate unchanged.
+func TestSelectPlannerPVWForecastCapInactiveWhenTwinNearZero(t *testing.T) {
+	// Twin near-zero (e.g. cs < 50 W/m² after physics gate) but forecast
+	// still has some radiation signal at twilight.
+	forecast := 300.0
+	twin := 30.0 // below the 50 W threshold
+
+	got := selectPlannerPVW(forecast, twin, true)
+	want := (1-PlannerRadiationWeight)*forecast + PlannerRadiationWeight*twin // no cap
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("cap should be inactive when twin < 50 W: got %.2f, want %.2f", got, want)
+	}
+}
+
 // Strict self_consumption: even with a high terminal price (= mean
 // import), the DP must still discharge when battery has headroom
 // (SoC > min + 20). This used to be a guardrail documenting the


### PR DESCRIPTION
## Summary

- Adds `PlannerForecastCapRatio = 3.0` constant in `selectPlannerPVW`: when a radiation-backed NWP forecast (open_meteo / forecast_solar) exceeds 3× the RLS twin's prediction **and** the twin has a meaningful signal (> 50 W), the forecast is capped at 3× before the 70/30 blend
- Leaves normal-day behavior unchanged — the cap is a no-op whenever forecast and twin agree within 3× (orientation gap, soiling, cloud enhancement)
- Adds three regression/guard tests: T33 scenario, cap-inactive-within-ratio, cap-inactive-when-twin-near-zero (night gate)

**Root cause (T33, 2026-05-25 18:00 UTC, Kalmar site):**
open_meteo predicted `shortwave_radiation = 154 W/m²` with `cloud_cover = 1%` — effectively clear-sky. Actual measured PV was ~290 W on a 13 kW rated array (implied effective irradiance ~22 W/m², actual cloud cover ~73%). The trained RLS twin with 783 samples predicted a reasonable 137 W; the NowAnchor correction pulled that to 290 W. But `selectPlannerPVW` still gave 70% weight to the 2002 W forecast, producing a plan prediction of **1488 W** (5× actual). The `POST /api/pvmodel/reset` call made it worse (to 1637 W) because the freshly seeded prior is even more optimistic than a trained twin.

**What the fix does:**
```
cappedForecast = min(2002, 3 × 290) = 870 W
blend          = 0.7×870 + 0.3×290 = 696 W   (2.4× actual — acceptable overshoot)
```
The residual over-prediction is intentional: the cap only activates when NWP was catastrophically wrong; on clear days the result is identical to before.

## Test plan

- [x] `go test ./internal/mpc/... -run TestSelectPlanner` — all 7 tests pass (4 existing + 3 new)
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] Deploy to production Pi and observe plan PV values at low-irradiance evening slots — should be materially closer to `pv_w_predicted` than before when NWP cloud forecast is wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)