### PR TITLE
feat(dev): local-first verify targets + git hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,9 @@ make e2e          # full-stack end-to-end test
 make dev          # start sims + main app locally
 make build-arm64  # cross-compile for RPi
 make release      # tarballs for deploy
+make verify       # pre-commit: vet + test + build (mirrors CI `go test + vet` workflow)
+make verify-all   # pre-push: verify + cross-compile for linux/arm64, linux/amd64, windows
+make install-hooks  # install git pre-commit + pre-push hooks (opt-in)
 ```
 
 Lua drivers need no build step — `drivers/*.lua` ships verbatim with the

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@
 #   make clean                — remove all build artifacts
 
 .PHONY: help test build build-arm64 build-amd64 build-windows-amd64 release \
-        run-sim dev fmt vet clean e2e ci ci-ui ci-hw-pi docs
+        run-sim dev fmt vet clean e2e ci ci-ui ci-hw-pi docs \
+        verify verify-all install-hooks
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.Version=$(VERSION)
@@ -30,6 +31,9 @@ help:
 	@echo "  run-sim              start Ferroamp + Sungrow simulators"
 	@echo "  dev                  start sims + main app against config.local.yaml"
 	@echo "  e2e                  run the full-stack e2e test"
+	@echo "  verify               pre-commit: vet + test + build (mirrors CI 'go test + vet' workflow)"
+	@echo "  verify-all           pre-push: verify + cross-compile linux/arm64, linux/amd64, windows"
+	@echo "  install-hooks        install git pre-commit + pre-push hooks (opt-in)"
 	@echo "  ci                   run local CI incl. browser smoke"
 	@echo "  ci-ui                browser smoke against FTW_BASE_URL"
 	@echo "  ci-hw-pi             deploy candidate to Pi CI slot + browser smoke"
@@ -52,6 +56,33 @@ ci-ui:
 
 ci-hw-pi:
 	./scripts/ci-hw-pi.sh
+
+# ---- Fast local verification (mirrors GitHub Actions) ----
+#
+# verify mirrors the "go test + vet" workflow in .github/workflows/test.yml.
+# When this passes, that CI workflow is guaranteed to pass (modulo network
+# deps or flakes). Keep the commands here in sync with that workflow file.
+#
+# verify-all adds cross-compile checks for all release targets, catching
+# platform-specific syscall/import mistakes before push.
+
+verify:
+	cd go && go vet ./...
+	cd go && go test ./...
+	cd go && go build ./...
+	@echo "verify: vet + test + build clean"
+
+verify-all: verify
+	cd go && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build ./...
+	cd go && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...
+	cd go && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./...
+	@echo "verify-all: cross-compile clean (linux/arm64, linux/amd64, windows/amd64)"
+
+install-hooks:
+	@cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+	@cp scripts/git-hooks/pre-push   .git/hooks/pre-push
+	@chmod +x .git/hooks/pre-commit .git/hooks/pre-push
+	@echo "git hooks installed — uninstall with: rm .git/hooks/pre-commit .git/hooks/pre-push"
 
 # ---- Native builds ----
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -4,6 +4,36 @@ This repo has a local CI path for fast confidence before deploy, plus a
 Raspberry Pi candidate slot for checking the real served UI against live
 read-only data.
 
+## Inner-loop verification (recommended for every commit)
+
+`make verify` runs the same `go vet ./...` + `go test ./...` + `go build ./...`
+that GitHub Actions runs as the `go test + vet` workflow
+(`.github/workflows/test.yml`). Use it before every `git commit` — passing
+locally means the workflow on the PR will pass too.
+
+```bash
+make verify
+```
+
+`make verify-all` adds cross-compile builds (linux/arm64, linux/amd64,
+windows/amd64) so you catch platform-specific issues — wrong syscall fields,
+OS-gated imports, missing build tags — before pushing. Use it before every
+`git push` on a feature branch.
+
+```bash
+make verify-all
+```
+
+`make install-hooks` installs git pre-commit + pre-push hooks that run these
+automatically. **Opt-in** — never auto-installed.
+
+```bash
+make install-hooks   # opt-in; uninstall: rm .git/hooks/pre-commit .git/hooks/pre-push
+```
+
+The pre-push hook also warns when your branch is behind `origin/master` so
+you know to rebase before the PR review.
+
 ## Local full pass
 
 ```bash

--- a/go/cmd/forty-two-watts/pair.go
+++ b/go/cmd/forty-two-watts/pair.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 )
 
 // runPair is the entry point for `forty-two-watts pair`.
@@ -59,7 +58,12 @@ func runPair(args []string) {
 	cmd := exec.Command(pairBin, cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// setpgid puts ftw-pair in its own process group so a Ctrl-C that
+	// kills the parent (forty-two-watts pair) doesn't also SIGINT the
+	// sidecar — the sidecar should keep running until the session TTL
+	// expires or an explicit --abort is sent. Platform-specific: only
+	// available on unix; the windows stub is a no-op.
+	setPairSysProcAttr(cmd)
 	if err := cmd.Run(); err != nil {
 		os.Exit(1)
 	}

--- a/go/cmd/forty-two-watts/pair_unix.go
+++ b/go/cmd/forty-two-watts/pair_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setPairSysProcAttr sets Setpgid=true so that ftw-pair runs in its own
+// process group. A Ctrl-C (SIGINT) delivered to the forty-two-watts parent
+// does not propagate to the sidecar — the sidecar keeps running until the
+// session TTL expires or the operator sends --abort.
+func setPairSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/go/cmd/forty-two-watts/pair_unix_test.go
+++ b/go/cmd/forty-two-watts/pair_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestSetPairSysProcAttrUnix verifies that setPairSysProcAttr sets Setpgid on unix
+// platforms, ensuring the sidecar runs in its own process group.
+func TestSetPairSysProcAttrUnix(t *testing.T) {
+	cmd := exec.Command("true")
+	setPairSysProcAttr(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected SysProcAttr to be set on unix")
+	}
+	if !cmd.SysProcAttr.Setpgid {
+		t.Fatal("expected Setpgid=true on unix")
+	}
+}

--- a/go/cmd/forty-two-watts/pair_windows.go
+++ b/go/cmd/forty-two-watts/pair_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package main
+
+import "os/exec"
+
+// setPairSysProcAttr is a no-op on Windows: SysProcAttr.Setpgid does not
+// exist in the Windows syscall package. The ftw-pair sidecar is a
+// Linux-only binary (uses journalctl, /proc/net/arp, etc.) and is not
+// shipped in the Windows release archive, so this path is never exercised
+// in practice. The stub exists only so that the forty-two-watts Windows
+// .exe compiles cleanly from a single module.
+//
+// If you ever invoke `forty-two-watts pair` on Windows you will get a
+// "ftw-pair binary not found" error from runPair before this function
+// is ever called.
+func setPairSysProcAttr(_ *exec.Cmd) {}

--- a/go/cmd/forty-two-watts/pair_windows_test.go
+++ b/go/cmd/forty-two-watts/pair_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestSetPairSysProcAttrWindows verifies that the Windows stub is a no-op
+// and does not panic. ftw-pair is not shipped on Windows, so this function
+// is never reached in production — but it must compile and not crash.
+func TestSetPairSysProcAttrWindows(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit 0")
+	// Should not panic, should leave SysProcAttr nil.
+	setPairSysProcAttr(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatal("expected SysProcAttr to remain nil on windows (no-op stub)")
+	}
+}

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# pre-commit — runs `make verify` before every commit.
+#
+# Install: make install-hooks
+# Bypass:  git commit --no-verify
+#
+# This hook mirrors the GitHub Actions "go test + vet" workflow
+# (.github/workflows/test.yml). If it passes here it will pass in CI.
+
+set -euo pipefail
+
+# Resolve repo root regardless of the working directory from which git was called.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "[pre-commit] running make verify..."
+if ! make -C "$REPO_ROOT" verify; then
+    echo ""
+    echo "[pre-commit] FAILED — commit blocked."
+    echo "  Fix the errors above and retry, or bypass with: git commit --no-verify"
+    exit 1
+fi
+
+echo "[pre-commit] passed."

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# pre-push — runs `make verify-all` and checks whether the branch is behind
+# master before every push.
+#
+# Install: make install-hooks
+# Bypass:  git push --no-verify
+#
+# Cross-compile check catches platform-specific build breakage (e.g. a Linux
+# syscall field that doesn't exist on Windows) before it lands in CI.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+REMOTE="${1:-origin}"
+
+echo "[pre-push] running make verify-all (vet + test + cross-compile)..."
+if ! make -C "$REPO_ROOT" verify-all; then
+    echo ""
+    echo "[pre-push] FAILED — push blocked."
+    echo "  Fix the errors above and retry, or bypass with: git push --no-verify"
+    exit 1
+fi
+
+# Check if the current branch is behind master on the remote. A behind
+# branch means the PR will not be immediately mergeable — better to know
+# before push than after CI green.
+echo "[pre-push] checking if branch is behind origin/master..."
+git fetch "$REMOTE" master --quiet 2>/dev/null || true
+
+BEHIND="$(git rev-list --count HEAD..origin/master 2>/dev/null || echo 0)"
+if [ "$BEHIND" -gt 0 ]; then
+    echo ""
+    echo "[pre-push] WARNING: '$CURRENT_BRANCH' is $BEHIND commit(s) behind origin/master."
+    echo "  The PR will need to be rebased before merge."
+    echo "  Rebase now:  git rebase origin/master"
+    echo "  (push continues — this is a warning, not a block)"
+fi
+
+echo "[pre-push] passed."


### PR DESCRIPTION
## Summary

- **`make verify`** — fast inner loop (vet + test + build) that exactly mirrors the GitHub Actions `go test + vet` workflow (`.github/workflows/test.yml`). If it passes locally, the CI workflow passes too. ~30 s wall-clock.
- **`make verify-all`** — pre-push loop that adds cross-compile for linux/arm64, linux/amd64, and windows/amd64. Catches platform-specific syscall/import issues before push. ~15 s wall-clock (cached tests).
- **`make install-hooks`** — opt-in installation of pre-commit + pre-push wrappers around the above. Never auto-installed.
- **`scripts/git-hooks/pre-commit`** — runs `make verify`; blocks commit on failure.
- **`scripts/git-hooks/pre-push`** — runs `make verify-all`; warns (non-blocking) if branch is behind `origin/master`.

## Windows .exe failure root cause

`cmd/forty-two-watts/pair.go:62` used `syscall.SysProcAttr{Setpgid: true}`, which does not exist in the Windows `syscall` package. The CI release workflow builds `cmd/forty-two-watts` for all three platforms including windows, so the build failed.

**Fix:** split the platform-specific line into `pair_unix.go` (`//go:build !windows`, sets `Setpgid: true`) and `pair_windows.go` (`//go:build windows`, no-op stub). Both have corresponding `_test.go` files that verify the expected behavior: unix confirms `Setpgid=true` is set, windows confirms the stub is a no-op and doesn't panic.

## Test plan

- [x] `make verify` passes locally (~31 s wall, including e2e)
- [x] `make verify-all` passes locally (~15 s wall with cached tests)
- [x] `make install-hooks` creates executable hooks under `.git/hooks/`
- [x] `git commit --allow-empty` triggers pre-commit hook and passes
- [x] `git push` triggers pre-push hook and runs verify-all
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/forty-two-watts` passes (was broken before this PR)
- [x] `go test ./cmd/forty-two-watts/...` includes the new pair_unix_test.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)