### PR TITLE
feat(pair-ui): footer launcher + copyable friend message

### DIFF
--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -158,6 +158,40 @@ class FtwPairCard extends FtwElement {
       opacity: 0.4;
       cursor: default;
     }
+    /* Friend-message block (active session only) */
+    .friend-message {
+      margin: 12px 0;
+    }
+    .friend-message .eyebrow {
+      display: block;
+      margin-bottom: 6px;
+    }
+    .message {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      line-height: 1.55;
+      background: var(--surface, var(--bg, #111));
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      margin: 0 0 8px;
+      white-space: pre;
+      overflow-x: auto;
+      color: var(--fg);
+    }
+    button.copy-msg {
+      background: var(--accent-e);
+      color: #0a0a0a;
+      border: 0;
+      padding: 4px 10px;
+      font-family: var(--mono);
+      cursor: pointer;
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    button.copy-msg:hover {
+      opacity: 0.85;
+    }
   `;
 
   constructor() {
@@ -278,6 +312,8 @@ class FtwPairCard extends FtwElement {
       .map((t) => escapeHTML(t))
       .join(", ") || "—";
 
+    const friendMsg = this._friendMessage(remaining);
+
     return `
       <div class="pair-card">
         <header>
@@ -289,6 +325,11 @@ class FtwPairCard extends FtwElement {
           <button class="copy" id="copy-btn">Copy</button>
         </div>
         <p class="intent">${escapeHTML(this._state.intent || "(no intent set)")}</p>
+        <section class="friend-message">
+          <span class="eyebrow">SHARE WITH YOUR FRIEND</span>
+          <pre class="message" id="friend-msg-pre">${escapeHTML(friendMsg)}</pre>
+          <button class="copy-msg" id="copy-msg-btn">Copy this message</button>
+        </section>
         <dl>
           <dt>TTL</dt><dd>${escapeHTML(remaining)}</dd>
           <dt>Tool calls</dt><dd>${this._state.tool_count ?? 0}</dd>
@@ -307,6 +348,46 @@ class FtwPairCard extends FtwElement {
 
     const startBtn = this.shadowRoot.getElementById("start-btn");
     if (startBtn) startBtn.addEventListener("click", () => this._start());
+
+    const copyMsgBtn = this.shadowRoot.getElementById("copy-msg-btn");
+    if (copyMsgBtn) {
+      copyMsgBtn.addEventListener("click", () => this._copyFriendMessage(copyMsgBtn));
+    }
+  }
+
+  _copyFriendMessage(btn) {
+    if (!this._state) return;
+    const remaining = this._computeRemaining();
+    const msg = this._friendMessage(remaining);
+    navigator.clipboard.writeText(msg).then(() => {
+      const original = btn.textContent;
+      btn.textContent = "Copied!";
+      setTimeout(() => { btn.textContent = original; }, 1500);
+    }).catch(() => {});
+  }
+
+  _friendMessage(remaining) {
+    const code = this._state ? this._state.code : "";
+    return `Send this in Signal/SMS/Slack to your friend:
+
+I need help with my home energy system. I've started a pair
+session — please join with this code:
+
+  ${code}
+
+One-time setup on your Mac/Linux:
+  brew install uv     (skip if already installed)
+  uv tool install fowl
+  go install github.com/frahlg/forty-two-watts/go/cmd/ftw-connect@latest
+
+Then run:
+  ftw-connect ${code}
+
+It'll open a tunnel, register an MCP server with your Claude Code,
+and copy a context prompt to your clipboard. Paste it into Claude
+Code and we're connected.
+
+Session expires in ${remaining} or when I click Abort.`;
   }
 
   _computeRemaining() {

--- a/web/components/ftw-pair-launcher.js
+++ b/web/components/ftw-pair-launcher.js
@@ -1,0 +1,155 @@
+// <ftw-pair-launcher> — footer-mounted launcher for the pair-session feature.
+//
+// Stays out of the way (rare feature) but discoverable. Polls
+// /api/pair/status every 30 s to know whether a session is currently
+// active and reflects that in its label.
+//
+// When idle:   "Need help? Start a pair session →"  (--ink-raised color)
+// When active: "Pair session active · {h}h {m}m left" (--accent-e color)
+//
+// Click → opens <ftw-modal> wrapping <ftw-pair-card>. The card handles
+// start / active / abort internally; the launcher only owns the entry
+// point and the active-state indicator.
+//
+// The launcher polls independently of the modal. Closing the modal while
+// a session is still active keeps the "active" label in the footer.
+
+import { FtwElement } from "./ftw-element.js";
+import "./ftw-pair-card.js";
+import "./ftw-modal.js";
+
+const POLL_MS = 30_000;
+
+class FtwPairLauncher extends FtwElement {
+  static styles = `
+    :host {
+      display: block;
+    }
+
+    .launcher-row {
+      display: flex;
+      justify-content: flex-end;
+      padding: 8px 0 4px;
+    }
+
+    .launcher-btn {
+      appearance: none;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      font-family: var(--sans);
+      font-size: 0.78rem;
+      color: var(--ink-raised2, var(--fg-dim, var(--fg)));
+      opacity: 0.65;
+      padding: 4px 0;
+      transition: opacity 0.15s;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 2px;
+    }
+
+    .launcher-btn:hover {
+      opacity: 1;
+    }
+
+    .launcher-btn.active {
+      color: var(--accent-e);
+      opacity: 1;
+      text-decoration: none;
+    }
+  `;
+
+  constructor() {
+    super();
+    this._session = null;
+    this._tick = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._poll();
+    this._tick = setInterval(() => this._poll(), POLL_MS);
+  }
+
+  disconnectedCallback() {
+    if (this._tick) clearInterval(this._tick);
+  }
+
+  async _poll() {
+    try {
+      const r = await fetch("/api/pair/status");
+      this._session = r.ok ? await r.json() : null;
+    } catch (_) {
+      this._session = null;
+    }
+    this.update();
+  }
+
+  _label() {
+    if (!this._session) {
+      return "Need help? Start a pair session →";
+    }
+    const remaining = this._remaining();
+    return `Pair session active · ${remaining} left`;
+  }
+
+  _remaining() {
+    if (!this._session || !this._session.started_at || !this._session.ttl_s) {
+      return "—";
+    }
+    const startedMs = Date.parse(this._session.started_at);
+    const expiry = startedMs + this._session.ttl_s * 1000;
+    const left = Math.max(0, Math.floor((expiry - Date.now()) / 1000));
+    const h = Math.floor(left / 3600);
+    const m = Math.floor((left % 3600) / 60);
+    return `${h}h ${m}m`;
+  }
+
+  _openModal() {
+    const modal = this.shadowRoot.getElementById("pair-modal");
+    if (modal) modal.setAttribute("open", "");
+  }
+
+  render() {
+    const active = !!this._session;
+    return `
+      <div class="launcher-row">
+        <button class="launcher-btn${active ? " active" : ""}" id="launcher-btn">
+          ${escapeHTML(this._label())}
+        </button>
+      </div>
+
+      <ftw-modal id="pair-modal" style="--ftw-modal-max-width:520px">
+        <span slot="title">Pair session</span>
+        <ftw-pair-card></ftw-pair-card>
+      </ftw-modal>
+    `;
+  }
+
+  afterRender() {
+    const btn = this.shadowRoot.getElementById("launcher-btn");
+    if (btn) btn.addEventListener("click", () => this._openModal());
+
+    // When the modal closes, re-poll so the label reflects any state
+    // change that happened while the card was open (e.g. session started
+    // or aborted). Debounce: poll once with a short delay to let the
+    // card's own abort/start call settle on the server.
+    const modal = this.shadowRoot.getElementById("pair-modal");
+    if (modal) {
+      modal.addEventListener("ftw-modal-close", () => {
+        setTimeout(() => this._poll(), 500);
+      });
+    }
+  }
+}
+
+function escapeHTML(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+customElements.define("ftw-pair-launcher", FtwPairLauncher);

--- a/web/components/index.js
+++ b/web/components/index.js
@@ -21,6 +21,7 @@ import "./ftw-history-card.js";
 import "./ftw-savings-card.js";
 import "./ftw-update-check.js";
 import "./ftw-pair-card.js";
+import "./ftw-pair-launcher.js";
 import "./ftw-notif-status.js";
 import "./ftw-notif-test-button.js";
 import "./ftw-notif-history.js";

--- a/web/index.html
+++ b/web/index.html
@@ -144,11 +144,6 @@
   </div>
 
   <main id="view-live">
-    <!-- Pair session banner — self-hides when no pair session is active.
-         Polls /api/pair/status every 5 s and surfaces the wormhole code,
-         intent, TTL, and tool counter while ftw-pair is connected. -->
-    <ftw-pair-card></ftw-pair-card>
-
     <!-- Energy-flow hero — central house, PV top, Grid left, Battery right,
          EV bottom. next-app.js calls el.setReadings(...) each status tick. -->
     <section class="flow-hero">
@@ -492,6 +487,11 @@
       </div>
       <div class="models-grid" id="models-grid"></div>
     </section>
+
+    <!-- Pair session launcher — footer-mounted entry point for the rare
+         pair-session feature. Idle: small dotted link. Active: accent
+         chip with remaining time. Click opens <ftw-pair-card> in a modal. -->
+    <ftw-pair-launcher></ftw-pair-launcher>
   </main>
 
   <!-- Diagnose view — time-travel through persisted planner snapshots -->


### PR DESCRIPTION
## Summary

- Removes `<ftw-pair-card>` from the top of `<main id="view-live">` where it occupied prominent dashboard real estate for a rarely-used feature
- Adds new `<ftw-pair-launcher>` component mounted at the bottom of the live view (after the Calibration section)
- Idle state: small dotted footer link "Need help? Start a pair session →" in muted `--ink-raised` color
- Active state: link flips to accent color with "Pair session active · {h}h {m}m left" — polls `/api/pair/status` every 30 s independently of modal state
- Click opens the existing `<ftw-pair-card>` inside a `<ftw-modal>` (reuses the existing modal component)
- Adds a "Share with your friend" block to the active-session view in `<ftw-pair-card>`: a scrollable `<pre>` with full install + connect instructions, and a "Copy this message" button that briefly shows "Copied!" for 1.5 s after click

## Files changed

- `web/index.html` — removed top-mounted `<ftw-pair-card>`, added `<ftw-pair-launcher>` at bottom
- `web/components/ftw-pair-launcher.js` — new component (shadow DOM, `FtwElement`, 30 s poll, modal wiring)
- `web/components/ftw-pair-card.js` — friend-message block + styles + `_friendMessage()` + `_copyFriendMessage()` helpers
- `web/components/index.js` — registers the new launcher

## Test plan

- [ ] Load dashboard — no pair card at the top; energy flow hero is the first element
- [ ] Small "Need help? Start a pair session →" link is visible at the bottom of the live view (right-aligned, muted)
- [ ] Clicking the link opens a modal with the pair-card UI (start form)
- [ ] After starting a session, the card shows the friend-message block above the dl; Copy button works
- [ ] Closing the modal with an active session keeps the launcher label showing "Pair session active · …" in accent color
- [ ] `make verify` passes (Go vet + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)