### PR TITLE
fix(pair-ui): clipboard fallback + stable modal lifecycle

### DIFF
--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -274,9 +274,15 @@ class FtwPairCard extends FtwElement {
     this.update();
   }
 
-  _copyCode() {
+  async _copyCode() {
     if (!this._state) return;
-    navigator.clipboard.writeText(this._state.code).catch(() => {});
+    const btn = this.shadowRoot.getElementById("copy-btn");
+    const ok = await copyToClipboard(this._state.code);
+    if (ok && btn) {
+      const original = btn.textContent;
+      btn.textContent = "Copied!";
+      setTimeout(() => { btn.textContent = original; }, 1500);
+    }
   }
 
   render() {
@@ -355,15 +361,16 @@ class FtwPairCard extends FtwElement {
     }
   }
 
-  _copyFriendMessage(btn) {
+  async _copyFriendMessage(btn) {
     if (!this._state) return;
     const remaining = this._computeRemaining();
     const msg = this._friendMessage(remaining);
-    navigator.clipboard.writeText(msg).then(() => {
+    const ok = await copyToClipboard(msg);
+    if (ok) {
       const original = btn.textContent;
       btn.textContent = "Copied!";
       setTimeout(() => { btn.textContent = original; }, 1500);
-    }).catch(() => {});
+    }
   }
 
   _friendMessage(remaining) {
@@ -408,6 +415,33 @@ function escapeHTML(s) {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+// copyToClipboard — works in both secure (HTTPS/localhost) and insecure
+// (plain HTTP LAN) contexts. Tries the modern Clipboard API first; falls
+// back to the legacy textarea+execCommand path when the secure-context
+// gate blocks the primary path.
+async function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch (_) {
+    // fall through to legacy path
+  }
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.top = "-9999px";
+  document.body.appendChild(ta);
+  ta.focus();
+  ta.select();
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(ta);
+  }
 }
 
 customElements.define("ftw-pair-card", FtwPairCard);

--- a/web/components/ftw-pair-launcher.js
+++ b/web/components/ftw-pair-launcher.js
@@ -13,6 +13,11 @@
 //
 // The launcher polls independently of the modal. Closing the modal while
 // a session is still active keeps the "active" label in the footer.
+//
+// Modal lifecycle: the <ftw-modal> element is created ONCE in
+// connectedCallback and appended to the shadow root directly. Poll
+// cycles only update the label text — they never touch or recreate the
+// modal element, so an open modal is not destroyed by a background poll.
 
 import { FtwElement } from "./ftw-element.js";
 import "./ftw-pair-card.js";
@@ -63,16 +68,48 @@ class FtwPairLauncher extends FtwElement {
     super();
     this._session = null;
     this._tick = null;
+    // Stable modal reference — created once, never destroyed by a poll cycle.
+    this._modal = null;
   }
 
   connectedCallback() {
+    // Perform the initial render (lays down the launcher-row button).
     super.connectedCallback();
+
+    // Create the modal element once and attach it to the shadow root.
+    // We do this here rather than in render() so that polling never
+    // destroys and recreates it. The modal stays alive for the lifetime
+    // of the launcher element.
+    if (!this._modal) {
+      this._modal = document.createElement("ftw-modal");
+      this._modal.id = "pair-modal";
+      this._modal.style.setProperty("--ftw-modal-max-width", "520px");
+
+      const titleSlot = document.createElement("span");
+      titleSlot.slot = "title";
+      titleSlot.textContent = "Pair session";
+      this._modal.appendChild(titleSlot);
+
+      const card = document.createElement("ftw-pair-card");
+      this._modal.appendChild(card);
+
+      this._modal.addEventListener("ftw-modal-close", () => {
+        // Re-poll after the modal closes so the label reflects any state
+        // change that happened while the card was open (e.g. session started
+        // or aborted). Short delay lets the card's abort/start call settle.
+        setTimeout(() => this._poll(), 500);
+      });
+
+      this.shadowRoot.appendChild(this._modal);
+    }
+
     this._poll();
     this._tick = setInterval(() => this._poll(), POLL_MS);
   }
 
   disconnectedCallback() {
     if (this._tick) clearInterval(this._tick);
+    this._modal = null;
   }
 
   async _poll() {
@@ -82,7 +119,24 @@ class FtwPairLauncher extends FtwElement {
     } catch (_) {
       this._session = null;
     }
-    this.update();
+    // Update only the label button — do NOT call this.update() here as that
+    // would wipe the shadow root and destroy the stable modal element.
+    this._updateLabel();
+  }
+
+  // _updateLabel refreshes only the launcher button text and active class.
+  // This is the surgical alternative to a full this.update() call so that
+  // the modal DOM is never touched by a background poll cycle.
+  _updateLabel() {
+    const btn = this.shadowRoot.getElementById("launcher-btn");
+    if (!btn) return;
+    const active = !!this._session;
+    btn.textContent = this._label();
+    if (active) {
+      btn.classList.add("active");
+    } else {
+      btn.classList.remove("active");
+    }
   }
 
   _label() {
@@ -106,40 +160,26 @@ class FtwPairLauncher extends FtwElement {
   }
 
   _openModal() {
-    const modal = this.shadowRoot.getElementById("pair-modal");
-    if (modal) modal.setAttribute("open", "");
+    if (this._modal) this._modal.setAttribute("open", "");
   }
 
   render() {
     const active = !!this._session;
+    // render() only produces the launcher button row. The modal is managed
+    // separately as a stable element in connectedCallback — it is not
+    // included here so that update() calls never affect it.
     return `
       <div class="launcher-row">
         <button class="launcher-btn${active ? " active" : ""}" id="launcher-btn">
           ${escapeHTML(this._label())}
         </button>
       </div>
-
-      <ftw-modal id="pair-modal" style="--ftw-modal-max-width:520px">
-        <span slot="title">Pair session</span>
-        <ftw-pair-card></ftw-pair-card>
-      </ftw-modal>
     `;
   }
 
   afterRender() {
     const btn = this.shadowRoot.getElementById("launcher-btn");
     if (btn) btn.addEventListener("click", () => this._openModal());
-
-    // When the modal closes, re-poll so the label reflects any state
-    // change that happened while the card was open (e.g. session started
-    // or aborted). Debounce: poll once with a short delay to let the
-    // card's own abort/start call settle on the server.
-    const modal = this.shadowRoot.getElementById("pair-modal");
-    if (modal) {
-      modal.addEventListener("ftw-modal-close", () => {
-        setTimeout(() => this._poll(), 500);
-      });
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Clipboard fallback for HTTP LAN access**: Both copy buttons in `ftw-pair-card.js` used `navigator.clipboard.writeText()` which requires a secure context (HTTPS or localhost). On `http://192.168.x.x:8080` this silently fails. Added a shared `copyToClipboard()` utility that tries the modern API first and falls back to `textarea + execCommand` for insecure contexts. The "Copied!" visual feedback only triggers on success.

- **Modal self-closing bug**: The pair modal closed itself after ~1 s because `_poll()` in `ftw-pair-launcher.js` called `this.update()`, which sets `shadowRoot.innerHTML` and destroys the entire shadow DOM — including the `<ftw-modal>` with its `open` attribute. Hoisted the modal to a stable element created once in `connectedCallback` and appended directly to the shadow root. Poll cycles now call `_updateLabel()` which surgically updates only the button text and CSS class; the modal DOM is never touched by background polls.

## Root cause (modal)

`ftw-pair-launcher.js` line 85 (`this.update()` inside `_poll()`) → `FtwElement.update()` sets `shadowRoot.innerHTML = html` → destroys the `<ftw-modal id="pair-modal">` element on every poll, losing the `open` attribute and all internal card state.

## Test plan

- [ ] Click the footer link → modal opens
- [ ] Leave the modal open for at least 15 s (covers ≥ 3 poll cycles at 5 s card cadence) — modal must remain open throughout
- [ ] On `http://<pi>:8080` (insecure context): click Copy next to the wormhole code — "Copied!" flash appears and clipboard has the code
- [ ] On `http://<pi>:8080`: click "Copy this message" — "Copied!" flash appears and clipboard has the full friend message
- [ ] In browser devtools console on a secure context: `window.isSecureContext === true` → primary Clipboard API path used
- [ ] In browser devtools console on an insecure context: `window.isSecureContext === false` → fallback `execCommand` path used; copy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)