### PR TITLE
fix(pair): pin fowl==25.4.0 + surface sidecar errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,11 @@ RUN apk add --no-cache ca-certificates tzdata python3 pipx libsodium && \
 # paths and is readable by all users (including root for debugging).
 ENV PIPX_HOME=/opt/pipx
 ENV PIPX_BIN_DIR=/usr/local/bin
-RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install fowl && \
+# Pinned to 25.4.0 — later versions (25.10+) removed the
+# `danger-disable-permission-check` fowld command our Go wrapper depends on.
+# Upgrading requires refactoring go/internal/wormhole to use `grant-permission`
+# with explicit port lists.
+RUN PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install 'fowl==25.4.0' && \
     chown -R ftw:ftw /opt/pipx
 
 # Image layout:

--- a/docs/ftw-pair.md
+++ b/docs/ftw-pair.md
@@ -21,7 +21,7 @@ Both sides need `fowl` (Forward Over Wormhole Locally) on `PATH`. It
 provides the actual wormhole-based TCP tunnel that `ftw-pair` wraps:
 
 ```bash
-uv tool install fowl
+uv tool install 'fowl==25.4.0'
 ```
 
 `fowl` is the canonical Python implementation of magic-wormhole TCP
@@ -63,7 +63,7 @@ One-time install (Mac or Linux):
 
 ```bash
 brew install uv                  # skip if already installed
-uv tool install fowl             # the wormhole transport
+uv tool install 'fowl==25.4.0'             # the wormhole transport
 curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install-ftw-connect.sh | bash
 ```
 
@@ -180,7 +180,7 @@ regardless of whether the PR is merged.
 
 ## Troubleshooting
 
-**`fowld not found on PATH`** — install with `uv tool install fowl`.
+**`fowld not found on PATH`** — install with `uv tool install 'fowl==25.4.0'`.
 
 **`claude mcp add failed`** — the Claude Code CLI isn't on PATH or
 isn't logged in. `ftw-connect` prints the manual command to run.

--- a/docs/future/own-relay-transport.md
+++ b/docs/future/own-relay-transport.md
@@ -1,0 +1,134 @@
+# Future option: own relay transport (replacing fowl/magic-wormhole)
+
+**Status:** documented option, not on the current roadmap. Recorded for future
+revisit if the Python `fowl` dependency becomes a meaningful pain point.
+
+## Context
+
+`ftw-pair` currently uses the Python `fowl` tool (built on magic-wormhole's
+Dilation protocol) as the cross-host TCP transport. The owner's Pi runs
+`fowld` as a subprocess of the pair sidecar; the friend's Mac runs another
+`fowld` for the receiver end. Both connect to the public
+`relay.magic-wormhole.io` rendezvous server and establish an
+end-to-end-encrypted tunnel via PAKE-derived key from a short shareable code.
+
+This works. It's also the canonical reference implementation of
+magic-wormhole. But it carries two costs:
+
+- **Python runtime dep** on both peers (`uv tool install 'fowl==25.4.0'`).
+- **Upstream protocol churn.** Pinning prevents drift (see PR #321), but
+  upgrading to support newer `fowl` versions requires refactoring our
+  permission-control commands. We've already seen this once — the
+  `danger-disable-permission-check` command was removed between 25.4.0 and
+  25.10.0.
+
+If either of those becomes more than a minor friction, this doc lays out an
+alternative.
+
+## Proposal: Sourceful-operated relay + simple PAKE-free token
+
+Replace fowl entirely with a small Go relay + client that:
+
+- Both peers connect outbound (TCP/443) to a Sourceful-operated relay
+  (`pair-relay.sourceful.energy` or similar)
+- A shared random token identifies the session — both peers send the token
+  during connection setup; the relay matches them and pipes bytes between
+  them
+- Traffic is end-to-end encrypted with an AEAD (chacha20-poly1305) keyed
+  from the token via HKDF — the relay sees only ciphertext
+- Tokens are **6 random English words** (e.g.
+  `garage-coffee-river-bicycle-window-cat`) — ~80 bits of entropy, no need
+  for PAKE because the token IS the key material
+
+## Architecture sketch
+
+```
+                   pair-relay.sourceful.energy
+                              |
+                  +-----------+-----------+
+                  |                       |
+              outbound                 outbound
+                  |                       |
+            OWNER's Pi              FRIEND's Mac
+       (ftw-pair sidecar)        (ftw-connect)
+```
+
+### Relay server (~300 LOC Go)
+
+- TCP listener on `:443` (TLS via cert-manager or LetsEncrypt)
+- For each incoming connection: read a 32-byte token prefix, lookup pending
+  matches
+- When two connections share a token: pipe `io.Copy` in both directions,
+  remove from match table
+- Idle timeout (5 min for unmatched, 4 h for matched), connection count
+  limits per source IP
+
+### Client (~200 LOC Go, embedded in ftw-pair + ftw-connect)
+
+- Generate token = 6 random words from a deterministic dictionary
+  (PGP wordlist or BIP39 subset)
+- HKDF-SHA256(token) → AEAD key + nonce-prefix
+- Dial relay, send token prefix, then start AEAD-framed bidirectional copy
+- On connection drop: simple reconnect (we accept brief gaps; this is not
+  Dilation's durable-stream property)
+
+No NAT-traversal, no direct P2P — always relay. Acceptable because:
+
+- The use case is a short-lived 4h pair session, not a long-running connection
+- Relay bandwidth cost for our scale (1–10 active sessions/day) is
+  negligible (~€5/month VPS)
+- Removes ~10x complexity vs Dilation
+
+## Trade-offs
+
+| Property | fowl/magic-wormhole (now) | Own relay (proposal) |
+|---|---|---|
+| Pure Go binaries | No (Python dep) | Yes |
+| Third-party dependency | `relay.magic-wormhole.io` | None (Sourceful relay) |
+| Code we maintain | Thin Go wrapper around fowld | Full relay + client + crypto |
+| Code review surface | ~600 LOC Go wrapper | ~500 LOC Go new code |
+| Operational burden | None | One small VPS to monitor |
+| Token UX | `3-retraction-sawdust` (short) | `garage-coffee-river-bicycle-window-cat` (long) |
+| Security review | Done by magic-wormhole project | Falls on us |
+| P2P direct connection | Yes, when NAT allows | No, always via relay |
+| Bandwidth efficiency | Direct when possible | Always through relay |
+| Resilience to client mobility | High (Dilation reconnect) | Low (simple reconnect only) |
+
+## Effort estimate
+
+- Relay server in Go: 1 day implementation + 0.5 day deployment (Docker,
+  systemd, certs) + 0.5 day monitoring + alarms = **~2 days**
+- Client integration in `go/internal/wormhole`: 1 day (replace fowld
+  subprocess wrapper with direct dial + AEAD frame loop) = **~1 day**
+- Tests (integration against real relay, fuzz on framing): **~0.5 day**
+- Docs + migration story: **~0.5 day**
+
+Total: **~4 days of focused work** to fully replace fowl.
+
+## When to pull the trigger
+
+Specific signals that would justify the migration:
+
+- Pinning fowl forces us behind on multiple security patches and we can't
+  safely upgrade
+- Pi-image size becomes a constraint and the Python+fowl stack (~80 MB)
+  matters
+- Operators consistently hit installation friction on the friend side
+  ("uv tool install fowl" trips up non-developers)
+- Sourceful starts running other peer-to-peer flows (e.g. site-to-site Nova
+  federation requiring TCP tunnels) where a shared relay is already
+  warranted
+
+Until one of these is real, the current pinned-fowl approach is the better
+trade — leverage 10 years of magic-wormhole protocol work for free in
+exchange for a small Python install.
+
+## Open questions for revisit
+
+- Is the longer token (6 words vs `7-foo-bar`) actually a problem in
+  practice? PGP-wordlist-style is more secure but less ergonomic.
+- Could we keep the `7-foo-bar` short-code by implementing SPAKE2 ourselves
+  (~500 LOC additional)? That gets us most of the wormhole UX without the
+  Dilation complexity.
+- Does the relay need authentication (rate-limit by IP only) or should
+  Sourceful-paired operators authenticate against Nova?

--- a/go/internal/api/api_pair.go
+++ b/go/internal/api/api_pair.go
@@ -1,15 +1,29 @@
 package api
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
 	"sync"
 	"time"
 )
+
+// pipeToLog scans the given reader line-by-line and emits each line at the
+// given level with the given source attr. Used to surface the ftw-pair
+// sidecar's stdout + stderr into the main service's log ring so silent
+// failures are visible via GET /api/logs.
+func pipeToLog(r io.Reader, source string, level slog.Level) {
+	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 64*1024), 1024*1024)
+	for s.Scan() {
+		slog.Log(nil, level, s.Text(), "source", source) //nolint:contextcheck
+	}
+}
 
 // resolvedSelfExe returns os.Executable() with symlinks resolved, or
 // os.Args[0] on error. Used as the default selfExe for spawning child
@@ -142,7 +156,23 @@ func handlePairStart(store *PairStatusStore, selfExe string) http.HandlerFunc {
 		}
 		go func() {
 			cmd := exec.Command(selfExe, args...)
-			_ = cmd.Run() // child writes to /api/pair/status itself
+			// Pipe child stdout + stderr into our slog. Previously these were
+			// discarded, which made silent fowld failures (e.g. unsupported
+			// command on a different fowl version) effectively invisible:
+			// /api/pair/status would stay at 404 forever and the operator
+			// had no way to see why. Now each child line lands in the log
+			// ring and surfaces via GET /api/logs.
+			stdout, _ := cmd.StdoutPipe()
+			stderr, _ := cmd.StderrPipe()
+			if err := cmd.Start(); err != nil {
+				slog.Error("pair: spawn sidecar", "err", err)
+				return
+			}
+			go pipeToLog(stdout, "pair.stdout", slog.LevelInfo)
+			go pipeToLog(stderr, "pair.stderr", slog.LevelWarn)
+			if err := cmd.Wait(); err != nil {
+				slog.Warn("pair: sidecar exited", "err", err)
+			}
 		}()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -384,7 +384,7 @@ session — please join with this code:
 
 One-time setup on your Mac/Linux:
   brew install uv     (skip if already installed)
-  uv tool install fowl
+  uv tool install 'fowl==25.4.0'
   curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install-ftw-connect.sh | bash
 
 Then run:


### PR DESCRIPTION
## Summary

Live e2e on v0.90.1 surfaced two real bugs.

1. **fowl version mismatch.** Container Dockerfile installed `fowl` unpinned → 25.10.0. Between 25.4.0 and 25.10.0 the upstream removed the `danger-disable-permission-check` fowld command our Go wrapper depends on, so every pair-start failed with:

   ```
   fowld error: non-JSON stdout (raw: b'{"kind":"danger-disable-permission-check"}': failed: 'danger-disable-permission-check')
   ```

   Pin to 25.4.0 for now. Followup: refactor `go/internal/wormhole` to use `grant-permission` with explicit port lists so we can support newer fowl versions.

2. **Sidecar errors disappeared into the void.** `POST /api/pair/start` spawned `ftw-pair` with stdout/stderr discarded. When fowld failed inside the sidecar nobody saw it — `/api/pair/status` stayed at 404 forever. Now both streams pipe into the main service's slog → `/api/logs`.

## Test plan

- [x] `make verify` clean (vet + test + build)
- [ ] After merge + auto-deploy: trigger pair start via UI, verify code is allocated AND friend `ftw-connect <code>` actually connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)