### PR TITLE
feat(ferroamp): scale dispatch by N_total/N_capable for multi-ESO sites

### DIFF
--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -94,11 +94,32 @@ local last_control_mode = nil
 -- to avoid oscillating at the edge — within ~2% of its limit an ESO
 -- already refuses dispatch, so a 5% margin is comfortably outside the
 -- "willing but limited" band.
+--
+-- Caveats this scaling has and does NOT solve:
+--   * Behaviour is empirical (single live observation, firmware vintage
+--     unknown). If EHub firmware ever rebalances to active units the
+--     scaling double-compensates — diff `eso_dispatch_commanded_w` vs
+--     the next tick's `battery.w` to spot that.
+--   * The upstream dispatch clamp (config.Driver.max_charge_w / fuse
+--     guard, dispatch.go ~1685) caps the *target* power, then we
+--     multiply on the wire by up to MAX_DISPATCH_SCALE. That bound
+--     protects fuse + inverter rating; if you raise it, also revisit
+--     the per-driver caps in config.yaml.
 local DISCHARGE_FLOOR_SOC = 0.15
 local CHARGE_CEIL_SOC     = 0.95
+-- Cap on the N_total/N_capable multiplier so a transient "only 1 of 4
+-- capable" snapshot can't quadruple the on-wire setpoint past inverter
+-- rating before the next poll corrects it. 2.0 covers the common
+-- 2-of-4 / 1-of-2 cases; deeper imbalance is left under-delivered (a
+-- safe failure mode — planner sees the gap and re-plans).
+local MAX_DISPATCH_SCALE  = 2.0
 local last_eso_count             = 0
 local last_eso_discharge_capable = 0
 local last_eso_charge_capable    = 0
+-- -1 = "no snapshot yet" sentinel. host.millis() can legitimately
+-- return 0 on the very first poll (sub-millisecond since startup), so
+-- we can't use 0 to mean "never set".
+local last_eso_counts_ms         = -1
 
 ----------------------------------------------------------------------------
 -- Helpers
@@ -429,6 +450,15 @@ function driver_poll()
                 if soc <= CHARGE_CEIL_SOC then
                     n_charge_capable = n_charge_capable + 1
                 end
+            else
+                -- Missing SoC: treat as capable in both directions. The
+                -- alternative (skip from capable counts but keep in
+                -- n_eso) inflates scale and overdelivers; counting as
+                -- capable only under-scales by one slot in the rare
+                -- transient where an ESO is genuinely floored AND its
+                -- soc field went missing in the same payload.
+                n_discharge_capable = n_discharge_capable + 1
+                n_charge_capable    = n_charge_capable    + 1
             end
             local udc = tonumber(extract_val(d, "udc"))
             if udc then udc_sum = udc_sum + udc; udc_n = udc_n + 1 end
@@ -483,9 +513,14 @@ function driver_poll()
         end
 
         -- Publish counts to module state so driver_command can scale.
+        -- Stamp the timestamp too — driver_command must refuse to scale
+        -- on stale data, otherwise a partial broker stall (some ESOs
+        -- evicted, others not) leaves an inflated scale persisting
+        -- between polls.
         last_eso_count             = n_eso
         last_eso_discharge_capable = n_discharge_capable
         last_eso_charge_capable    = n_charge_capable
+        last_eso_counts_ms         = now
     end
 
     if sso_data then
@@ -520,24 +555,57 @@ function driver_command(action, power_w, cmd)
     if action == "init" then
         return true
     elseif action == "battery" then
-        local tid = "ems-" .. tostring(host.millis())
+        local now = host.millis()
+        local tid = "ems-" .. tostring(now)
         -- Scale outgoing power to compensate for the EHub dividing the
         -- setpoint across ALL ESOs (including the floored ones, which
         -- contribute 0). See the multi-ESO comment near the top of the
-        -- file. We only scale when we have fresh per-ESO data AND a
-        -- subset of units is capable of the requested direction.
+        -- file. We only scale when:
+        --   1. per-ESO counts are fresh (<= STALE_AFTER_MS old) —
+        --      partial broker stalls between polls would otherwise
+        --      leave an inflated last_eso_count scaling later commands;
+        --   2. a strict subset of units is capable of the requested
+        --      direction;
+        --   3. capable > 0 — if EVERY unit is floored we deliberately
+        --      idle instead of publishing a non-zero command nothing
+        --      can honour.
+        -- The scale is capped at MAX_DISPATCH_SCALE so a transient
+        -- "only 1 of 4 capable" snapshot can't quadruple the on-wire
+        -- setpoint past inverter rating / fuse guard before the next
+        -- poll corrects.
         local on_wire_w = power_w
-        local scale = 1.0
-        if last_eso_count > 0 and power_w ~= 0 then
+        local scale     = 1.0
+        local fresh     = last_eso_counts_ms >= 0
+                          and (now - last_eso_counts_ms) <= STALE_AFTER_MS
+        if fresh and last_eso_count > 0 and power_w ~= 0 then
             local capable
             if power_w > 0 then capable = last_eso_charge_capable
             else                 capable = last_eso_discharge_capable end
-            if capable > 0 and capable < last_eso_count then
+            if capable == 0 then
+                -- All units refuse this direction — publish idle so we
+                -- don't waste an EHub round-trip on a command nothing
+                -- can fulfil, and surface the condition to the operator.
+                host.log("warn", string.format(
+                    "Ferroamp: all %d ESOs at SoC limit for requested %d W — idling",
+                    last_eso_count, math.floor(power_w)))
+                host.emit_metric("eso_dispatch_scale_x1000", 0)
+                host.emit_metric("eso_dispatch_commanded_w", 0)
+                if last_control_mode == "idle" then return true end
+                return publish_idle(tid)
+            end
+            if capable < last_eso_count then
                 scale = last_eso_count / capable
+                if scale > MAX_DISPATCH_SCALE then
+                    host.log("warn", string.format(
+                        "Ferroamp: dispatch scale %.2fx clamped to %.1fx (%d of %d ESOs capable)",
+                        scale, MAX_DISPATCH_SCALE, capable, last_eso_count))
+                    scale = MAX_DISPATCH_SCALE
+                end
                 on_wire_w = power_w * scale
             end
         end
-        host.emit_metric("eso_dispatch_scale_x1000", math.floor(scale * 1000 + 0.5))
+        host.emit_metric("eso_dispatch_scale_x1000",  math.floor(scale * 1000 + 0.5))
+        host.emit_metric("eso_dispatch_commanded_w",  math.floor(power_w))
         if power_w > 0 then
             -- Charge: use "charge" command with positive watts
             local payload = string.format(
@@ -592,4 +660,8 @@ function driver_cleanup()
     ehub_data = nil
     eso_data = nil
     sso_data = nil
+    last_eso_count             = 0
+    last_eso_discharge_capable = 0
+    last_eso_charge_capable    = 0
+    last_eso_counts_ms         = -1
 end

--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -80,6 +80,26 @@ local STALE_AFTER_MS = 30000
 local SKIP_BATTERY = false
 local last_control_mode = nil
 
+-- Multi-ESO dispatch scaling. The EnergyHub divides a discharge/charge
+-- setpoint evenly across ALL ESOs it knows about, including units pinned
+-- at their SoC floor/ceiling that physically refuse to respond. On a
+-- 4×ESO site with 2 units floored at min SoC, asking for 1.3 kW resulted
+-- in only ~0.66 kW delivered — the EHub commanded ~330 W per ESO, the
+-- two active units honored it, the two floored ones produced 0. Verified
+-- live on 2026-05-26 (Stefan's site). To compensate we count how many
+-- ESOs are *currently capable* of the requested direction and pre-scale
+-- the outgoing command by N_total / N_capable.
+--
+-- Margins are 5% inside the typical Ferroamp floor (10%) / ceiling (100%)
+-- to avoid oscillating at the edge — within ~2% of its limit an ESO
+-- already refuses dispatch, so a 5% margin is comfortably outside the
+-- "willing but limited" band.
+local DISCHARGE_FLOOR_SOC = 0.15
+local CHARGE_CEIL_SOC     = 0.95
+local last_eso_count             = 0
+local last_eso_discharge_capable = 0
+local last_eso_charge_capable    = 0
+
 ----------------------------------------------------------------------------
 -- Helpers
 ----------------------------------------------------------------------------
@@ -386,6 +406,7 @@ function driver_poll()
         local wcons_sum, wcons_n = 0, 0
         local relay_worst, fault_worst = nil, nil
         local n_eso = 0
+        local n_discharge_capable, n_charge_capable = 0, 0
 
         for _, d in pairs(eso_data_by_id) do
             n_eso = n_eso + 1
@@ -402,6 +423,12 @@ function driver_poll()
             if soc then
                 if soc > 1 then soc = soc / 100 end
                 soc_sum = soc_sum + soc; soc_n = soc_n + 1
+                if soc >= DISCHARGE_FLOOR_SOC then
+                    n_discharge_capable = n_discharge_capable + 1
+                end
+                if soc <= CHARGE_CEIL_SOC then
+                    n_charge_capable = n_charge_capable + 1
+                end
             end
             local udc = tonumber(extract_val(d, "udc"))
             if udc then udc_sum = udc_sum + udc; udc_n = udc_n + 1 end
@@ -447,11 +474,18 @@ function driver_poll()
 
             if n_eso > 0 then
                 host.emit_metric("eso_count", n_eso)
+                host.emit_metric("eso_discharge_capable", n_discharge_capable)
+                host.emit_metric("eso_charge_capable",    n_charge_capable)
                 if udc_n > 0     then host.emit_metric("eso_dc_link_v",   udc_sum / udc_n) end
                 if relay_worst ~= nil then host.emit_metric("eso_relaystatus", relay_worst) end
                 if fault_worst ~= nil then host.emit_metric("eso_faultcode",   fault_worst) end
             end
         end
+
+        -- Publish counts to module state so driver_command can scale.
+        last_eso_count             = n_eso
+        last_eso_discharge_capable = n_discharge_capable
+        last_eso_charge_capable    = n_charge_capable
     end
 
     if sso_data then
@@ -487,11 +521,28 @@ function driver_command(action, power_w, cmd)
         return true
     elseif action == "battery" then
         local tid = "ems-" .. tostring(host.millis())
+        -- Scale outgoing power to compensate for the EHub dividing the
+        -- setpoint across ALL ESOs (including the floored ones, which
+        -- contribute 0). See the multi-ESO comment near the top of the
+        -- file. We only scale when we have fresh per-ESO data AND a
+        -- subset of units is capable of the requested direction.
+        local on_wire_w = power_w
+        local scale = 1.0
+        if last_eso_count > 0 and power_w ~= 0 then
+            local capable
+            if power_w > 0 then capable = last_eso_charge_capable
+            else                 capable = last_eso_discharge_capable end
+            if capable > 0 and capable < last_eso_count then
+                scale = last_eso_count / capable
+                on_wire_w = power_w * scale
+            end
+        end
+        host.emit_metric("eso_dispatch_scale_x1000", math.floor(scale * 1000 + 0.5))
         if power_w > 0 then
             -- Charge: use "charge" command with positive watts
             local payload = string.format(
                 '{"transId":"%s","cmd":{"name":"charge","arg":%d}}',
-                tid, math.floor(power_w)
+                tid, math.floor(on_wire_w)
             )
             local err = host.mqtt_publish("extapi/control/request", payload)
             if not err then last_control_mode = "charge" end
@@ -500,7 +551,7 @@ function driver_command(action, power_w, cmd)
             -- Discharge: use "discharge" command with positive watts
             local payload = string.format(
                 '{"transId":"%s","cmd":{"name":"discharge","arg":%d}}',
-                tid, math.floor(math.abs(power_w))
+                tid, math.floor(math.abs(on_wire_w))
             )
             local err = host.mqtt_publish("extapi/control/request", payload)
             if not err then last_control_mode = "discharge" end

--- a/go/internal/drivers/lua_mqtt_stale_test.go
+++ b/go/internal/drivers/lua_mqtt_stale_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -460,6 +461,212 @@ func TestFerroampZeroBatteryCommandForcesIdleNotAuto(t *testing.T) {
 	last = pubs[len(pubs)-1].Payload
 	if !strings.Contains(last, `"name":"discharge"`) || !strings.Contains(last, `"arg":0`) {
 		t.Fatalf("release-to-idle payload = %s, want forced idle (discharge arg=0)", last)
+	}
+}
+
+// Helpers for the multi-ESO scaling tests below.
+
+// lastBatteryDispatch returns the most-recent control-request payload
+// that targets the battery (charge/discharge/idle), skipping the init
+// `auto` / `extapiversion` traffic.
+func lastBatteryDispatch(t *testing.T, mqtt *fakeMQTT) string {
+	t.Helper()
+	pubs := mqtt.Published()
+	for i := len(pubs) - 1; i >= 0; i-- {
+		p := pubs[i].Payload
+		if strings.Contains(p, `"name":"charge"`) ||
+			strings.Contains(p, `"name":"discharge"`) {
+			return p
+		}
+	}
+	t.Fatalf("no battery dispatch payload in %d published messages", len(pubs))
+	return ""
+}
+
+// esoPayload builds a minimal eso/data payload at the given SoC. udc /
+// ubat / ibat are kept consistent with the existing multi-ESO tests so
+// the battery emit path stays happy (otherwise n_eso never advances).
+func esoPayload(id string, soc float64) string {
+	return `{"id":{"val":"` + id + `"},"soc":{"val":` +
+		strconv.FormatFloat(soc, 'f', -1, 64) +
+		`},"ubat":{"val":400},"ibat":{"val":0.5},` +
+		`"relaystatus":{"val":0},"faultcode":{"val":0},"udc":{"val":760}}`
+}
+
+func esoPayloadNoSoC(id string) string {
+	return `{"id":{"val":"` + id + `"},"ubat":{"val":400},"ibat":{"val":0.5},` +
+		`"relaystatus":{"val":0},"faultcode":{"val":0},"udc":{"val":760}}`
+}
+
+// Live-system regression (Stefan's 4-ESO site, 2026-05-26): the
+// EnergyHub divides a dispatch setpoint evenly across all ESOs it knows
+// about, including units pinned at their SoC floor that physically
+// refuse to respond. Asking for 1.3 kW with 2 of 4 ESOs floored at min
+// SoC delivered ~0.66 kW. The driver now pre-scales by N_total/N_capable.
+func TestFerroampMultiESOScalingDoublesWhenHalfFloored(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	// 4 ESOs: two floored at 10% (below the 15% discharge floor), two
+	// active at 50%. ehub.pbat is irrelevant — n_eso comes from the per-
+	// ESO map.
+	mqtt.Push("extapi/data/ehub", `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`)
+	mqtt.Push("extapi/data/eso", esoPayload("A", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("B", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("C", 50))
+	mqtt.Push("extapi/data/eso", esoPayload("D", 50))
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if err := d.Command(context.Background(),
+		[]byte(`{"action":"battery","power_w":-1300}`)); err != nil {
+		t.Fatalf("discharge command: %v", err)
+	}
+
+	got := lastBatteryDispatch(t, mqtt)
+	if !strings.Contains(got, `"name":"discharge"`) || !strings.Contains(got, `"arg":2600`) {
+		t.Fatalf("dispatch payload = %s, want discharge arg=2600 (1300 * 4/2)", got)
+	}
+
+	// Diagnostic metric must reflect the 2.0x scale.
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_scale_x1000"); !ok || v != 2000 {
+		t.Fatalf("eso_dispatch_scale_x1000 = %v, want 2000", v)
+	}
+	// Commanded target (pre-scale, site convention) must be the planner's request.
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_commanded_w"); !ok || v != -1300 {
+		t.Fatalf("eso_dispatch_commanded_w = %v, want -1300", v)
+	}
+}
+
+// The scale is capped to MAX_DISPATCH_SCALE (2.0×) so a transient "only
+// 1 of 4 capable" snapshot can't quadruple the on-wire setpoint past
+// the per-driver MaxChargeW / fuse-guard ceiling enforced upstream in
+// dispatch.go. Deeper imbalance is left under-delivered (safe failure).
+func TestFerroampMultiESOScalingCappedAtMax(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	mqtt.Push("extapi/data/ehub", `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`)
+	mqtt.Push("extapi/data/eso", esoPayload("A", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("B", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("C", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("D", 50))
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if err := d.Command(context.Background(),
+		[]byte(`{"action":"battery","power_w":-1000}`)); err != nil {
+		t.Fatalf("discharge command: %v", err)
+	}
+
+	got := lastBatteryDispatch(t, mqtt)
+	// 4/1 = 4.0× uncapped; clamped to 2.0× → arg=2000.
+	if !strings.Contains(got, `"arg":2000`) {
+		t.Fatalf("dispatch payload = %s, want discharge arg=2000 (cap at 2.0x, not 4.0x)", got)
+	}
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_scale_x1000"); !ok || v != 2000 {
+		t.Fatalf("eso_dispatch_scale_x1000 = %v, want 2000 (clamped)", v)
+	}
+}
+
+// Freshness gate: between polls a partial broker stall could leave
+// last_eso_count high but last_eso_*_capable low, scaling all later
+// commands. driver_command must refuse to scale when the per-ESO
+// snapshot is older than STALE_AFTER_MS (30 s).
+func TestFerroampMultiESOScalingRefusesStaleSnapshot(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, env := newTestFerroampDriver(t, tel, mqtt)
+
+	mqtt.Push("extapi/data/ehub", `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`)
+	mqtt.Push("extapi/data/eso", esoPayload("A", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("B", 50))
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	// Rewind the host clock by > STALE_AFTER_MS so the snapshot from
+	// the poll above looks stale to driver_command.
+	env.Start = env.Start.Add(-31 * time.Second)
+
+	if err := d.Command(context.Background(),
+		[]byte(`{"action":"battery","power_w":-1000}`)); err != nil {
+		t.Fatalf("discharge command: %v", err)
+	}
+
+	got := lastBatteryDispatch(t, mqtt)
+	if !strings.Contains(got, `"arg":1000`) {
+		t.Fatalf("dispatch payload = %s, want raw arg=1000 (stale snapshot must not scale)", got)
+	}
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_scale_x1000"); !ok || v != 1000 {
+		t.Fatalf("eso_dispatch_scale_x1000 = %v, want 1000 (no scaling on stale data)", v)
+	}
+}
+
+// All ESOs floored: capable==0 in the requested direction. We must
+// idle instead of publishing a non-zero command nothing can fulfil —
+// otherwise the planner sees no SoC progress, the loop sets a higher
+// target, and we keep churning MQTT for nothing.
+func TestFerroampMultiESOAllFlooredIdles(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	mqtt.Push("extapi/data/ehub", `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`)
+	mqtt.Push("extapi/data/eso", esoPayload("A", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("B", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("C", 10))
+	mqtt.Push("extapi/data/eso", esoPayload("D", 10))
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if err := d.Command(context.Background(),
+		[]byte(`{"action":"battery","power_w":-1500}`)); err != nil {
+		t.Fatalf("discharge command: %v", err)
+	}
+
+	got := lastBatteryDispatch(t, mqtt)
+	if !strings.Contains(got, `"name":"discharge"`) || !strings.Contains(got, `"arg":0`) {
+		t.Fatalf("dispatch payload = %s, want forced idle (discharge arg=0) when all ESOs floored", got)
+	}
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_scale_x1000"); !ok || v != 0 {
+		t.Fatalf("eso_dispatch_scale_x1000 = %v, want 0 (no dispatch attempted)", v)
+	}
+}
+
+// ESOs with a missing `soc` field must count as capable in both
+// directions. The alternative (skip from capable counts but keep in
+// n_eso) inflates the scale on partial telemetry and overdelivers.
+func TestFerroampMultiESOMissingSocCountsCapable(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	mqtt.Push("extapi/data/ehub", `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`)
+	mqtt.Push("extapi/data/eso", esoPayload("A", 50))
+	mqtt.Push("extapi/data/eso", esoPayload("B", 50))
+	mqtt.Push("extapi/data/eso", esoPayloadNoSoC("C"))
+	mqtt.Push("extapi/data/eso", esoPayloadNoSoC("D"))
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if err := d.Command(context.Background(),
+		[]byte(`{"action":"battery","power_w":-1000}`)); err != nil {
+		t.Fatalf("discharge command: %v", err)
+	}
+
+	got := lastBatteryDispatch(t, mqtt)
+	if !strings.Contains(got, `"arg":1000`) {
+		t.Fatalf("dispatch payload = %s, want raw arg=1000 (missing-soc ESOs must count as capable)", got)
+	}
+	if v, _, ok := tel.LatestMetric("ferroamp", "eso_dispatch_scale_x1000"); !ok || v != 1000 {
+		t.Fatalf("eso_dispatch_scale_x1000 = %v, want 1000 (no scaling when all 4 are capable)", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

The Ferroamp EnergyHub divides a discharge/charge setpoint **evenly across all ESOs it knows about**, including units pinned at their SoC floor or ceiling that physically refuse to respond. On a 4×ESO site with 2 units floored at min SoC, a request for 1.3 kW delivered ~0.66 kW: the EHub commanded ~330 W per ESO, the two active units honored it, the two floored ones produced 0.

The driver now counts how many ESOs are *currently capable* of the requested direction (per-direction SoC headroom check) and pre-scales the outgoing setpoint by `N_total / N_capable`.

## Behaviour

- **SoC thresholds** are 5% inside typical Ferroamp limits — `discharge_capable` when `soc ≥ 0.15`, `charge_capable` when `soc ≤ 0.95`. The 5% margin sits comfortably outside the ~2% "taper / inhibit" band the ESOs themselves enforce.
- **Scale stays 1.0×** when the battery is idle (`power_w == 0`), when all units are capable for the requested direction, or when no per-ESO data has arrived yet. Single-ESO sites and healthy multi-ESO sites are unaffected.
- **Three new metrics** for visibility: `eso_discharge_capable`, `eso_charge_capable`, `eso_dispatch_scale_x1000` (×1000 because `host.emit_metric` is integer-friendly).

## Verified live

Deployed and verified against a 4×ESO site on 2026-05-26 (2 old PSM-10 ESOs floored at 10% SoC + faultcode 512, 2 new ESOs active at 47% SoC):

| reading | value |
|---|---:|
| dispatch target | −6871 W |
| `bat_w` actual | **−6868 W** |
| `eso_count` / `eso_discharge_capable` | 4 / 2 |
| `eso_dispatch_scale_x1000` | **2.00×** |
| per-ESO sum (broker direct) | 6870 W |
| `ehub.pbat` (broker direct) | 6863 W |

Pre-fix the same target would have produced ~3.4 kW.

## Test plan

- [x] `make verify` (vet + test + build) — clean
- [x] Loaded into gopher-lua — no parse errors
- [x] Live snapshot at scale=2.00× — dispatch target vs delivered power matches within 3 W
- [x] Per-ESO MQTT comparison — aggregation parity confirmed (v=avg, a=sum, pbat=sum, faultcode=worst-of)
- [x] Idle / charge paths still emit `scale=1.000` — no over-commanding when all units capable
- [ ] Multi-tick observation in production over a 24h window (manual, post-merge)

## Follow-ups (out of scope, separate PRs)

- The 512 faultcode on the older ESOs corresponds to "below operating SoC, inhibit" — undocumented in Ferroamp's API spec rev E (which calls bit 9 "Not used"). Worth a `faultcode & 0xFF` mask before worst-of'ing, plus a support ticket. Tracked separately.
- `surplus_only` + `battery_covers_ev` semantics don't compose as users expect — both flags can be on, but the surplus formula in `main.go:1282` ignores `battery_covers_ev`. Separate WIP branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)