### PR TITLE
docs(claude.md): update pair package descriptions for plan B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/cmd/ftw-updater` | Sidecar binary — runs docker compose pull + up -d on behalf of the main service |
 | `go/cmd/ftw-pair` | MCP sidecar — host side of the pair flow (`docs/ftw-pair.md`) |
 | `go/cmd/ftw-connect` | Friend-side CLI for joining a pair session |
-| `go/internal/wormhole` | fowld subprocess wrapper — wormhole TCP transport for `ftw-pair` |
+| `go/cmd/ftw-pair-relay` | Standalone relay server — matches two peers on a token and pipes encrypted bytes (`docs/pair-relay-deploy.md`) |
+| `go/internal/wormhole` | Pure-Go relay client: BIP39 token, HKDF-derived ChaCha20-Poly1305 AEAD, length-prefixed frames over TCP |
 | `drivers/` | Lua drivers (`ferroamp.lua`, `sungrow.lua`, …) |
 | `go/test/e2e` | Full-stack test: sims + main + drivers + HTTP |
 


### PR DESCRIPTION
Replaces leftover fowl/wormhole-william descriptions with plan B contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)