### PR TITLE
feat(pair): local HTTP API + drop friend-side MCP registration

### DIFF
--- a/docs/ftw-pair.md
+++ b/docs/ftw-pair.md
@@ -73,12 +73,19 @@ ftw-connect garage-coffee-river-bicycle-window-cat
 That:
 
 1. Connects to the Sourceful relay with the given token.
-2. Registers an MCP server named `ftw-remote` with Claude Code.
-3. Copies a context-priming prompt to the clipboard.
+2. Prints a local URL — the sidecar's HTTP API, tunnelled to the
+   friend's machine.
+3. Copies a ready-to-paste agent prompt to the clipboard (the prompt
+   teaches the agent to talk to the local URL with `curl`).
 
-Open Claude Code, paste the prompt, work. When done, **the friend
-opens the PR from their own machine** — they clone the 42W repo
-locally (Claude does this for them via its own `Bash` tool), apply
+`ftw-connect` writes **nothing** to disk on the friend's side — no
+config files, no MCP entries, no agent CLI mutations. The agent
+(Claude Code, Codex, Gemini Code, anything with Bash + curl) just
+follows the prompt and reaches the tools through the local URL.
+
+Open your agent of choice, paste the prompt, work. When done, **the
+friend opens the PR from their own machine** — they clone the 42W
+repo locally (the agent does this for them via its own shell), apply
 the changes they wrote on the owner's instance, and run `gh pr
 create` with the `pair-session.md` template.
 
@@ -117,7 +124,16 @@ local testing.
 
 ## What the friend gets
 
-A 17-tool MCP surface:
+A 17-tool HTTP surface (REST; MCP is also served at `/mcp` for
+agents that prefer it). All tool calls run on the **owner's** machine
+through the encrypted relay tunnel.
+
+```bash
+curl <local-url>/tools                                  # list tools + schemas
+curl -X POST <local-url>/tools/<name> -d '<json args>'  # invoke a tool
+```
+
+The 17 tools:
 
 - `ftw_api(method, path, body)` — full 42W HTTP API
 - `read_file` / `write_file` / `list_directory` — repo, state dir, /tmp
@@ -141,7 +157,7 @@ what changed on the owner's instance.
 | Trigger pair session | Click **Start pair session** in the dashboard (or `forty-two-watts pair --intent "..."`) | — |
 | Share token | Copy from the dashboard card, send via Signal/SMS/Slack | Receive |
 | Connect | — | `ftw-connect <token>` |
-| Develop the driver / debug | — | Drives Claude Code through the tunnel |
+| Develop the driver / debug | — | Drives their agent (Claude Code, Codex, …) through the tunnel |
 | Open the PR | — | Clones repo locally, `gh pr create` from own machine |
 | Review the PR | Reviews via GitHub web UI | — |
 
@@ -153,14 +169,16 @@ PR the friend opens.
 ## Architecture in one paragraph
 
 `forty-two-watts pair` spawns the `ftw-pair` sidecar. The sidecar runs
-the 17-tool MCP server on `localhost:9999`, then connects to the
-Sourceful relay (`subetha.fortytwowatts.com:7777`) using a randomly
-generated 6-word token. The relay holds the connection until the
-friend connects with the same token, then splices the two TCP streams.
-All bytes are ChaCha20-Poly1305 encrypted end-to-end using HKDF-derived
-keys from the shared token — the relay sees only ciphertext. The friend
-runs `ftw-connect <token>` which opens a local port on their machine;
-their Claude Code talks to that port as an ordinary HTTP MCP server.
+a 17-tool HTTP surface on `localhost:9999` (REST at `/tools/<name>` +
+MCP at `/mcp`, sharing the same Tool[] and audit log), then connects
+to the Sourceful relay (`subetha.fortytwowatts.com:7777`) using a
+randomly generated 6-word token. The relay holds the connection until
+the friend connects with the same token, then splices the two TCP
+streams. All bytes are ChaCha20-Poly1305 encrypted end-to-end using
+HKDF-derived keys from the shared token — the relay sees only
+ciphertext. The friend runs `ftw-connect <token>` which opens a local
+port on their machine; their agent of choice talks to that port over
+plain HTTP via `curl`. The friend's CLI config is never touched.
 
 ## When the work is done — driver persistence
 
@@ -199,8 +217,9 @@ regardless of whether the PR is merged.
 the relay is not yet deployed in this environment, or network access is
 blocked. Use `-relay-addr` to point at a local relay for testing.
 
-**`claude mcp add failed`** — the Claude Code CLI isn't on PATH or
-isn't logged in. `ftw-connect` prints the manual command to run.
+**Agent can't reach the local URL** — confirm the tunnel is still up
+(`ftw-connect` should be running in its terminal). `curl <local-url>/tools`
+from any shell to test directly; you should get a JSON tool catalog.
 
 **Card doesn't appear on the dashboard** — the sidecar posts to
 `/api/pair/status` every 5 s; check the main service is reachable on

--- a/go/cmd/ftw-connect/main.go
+++ b/go/cmd/ftw-connect/main.go
@@ -1,5 +1,6 @@
 // ftw-connect is the friend-side CLI that turns a 6-word relay token into
-// a live MCP endpoint Claude Code can talk to.
+// a live local HTTP endpoint an AI agent (Claude Code, Codex, Gemini, etc.)
+// can drive over Bash + curl.
 //
 // Usage:
 //
@@ -11,11 +12,16 @@
 //
 // On success it:
 //  1. connects to the Sourceful relay with the given token,
-//  2. exposes a local TCP port forwarded to the host's MCP server
-//     through the end-to-end encrypted relay tunnel,
-//  3. registers that port with Claude Code (`claude mcp add ...`),
-//  4. copies a context prompt to the clipboard,
-//  5. blocks until the tunnel closes (TTL, owner abort, ^C).
+//  2. exposes a local HTTP port forwarded to the host's sidecar through
+//     the end-to-end-encrypted relay tunnel,
+//  3. prints the local URL and copies a ready-to-paste agent prompt to
+//     the clipboard,
+//  4. blocks until the tunnel closes (TTL, owner abort, ^C).
+//
+// We deliberately do NOT touch the friend's agent CLI config (no
+// `claude mcp add`, no Codex config writes, nothing). The agent is told
+// in its prompt to talk to the local URL with plain HTTP — that keeps
+// ftw-connect tool-agnostic and leaves zero traces on the friend's disk.
 package main
 
 import (
@@ -23,7 +29,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -31,8 +36,6 @@ import (
 )
 
 var Version = "dev"
-
-const mcpName = "ftw-remote"
 
 func main() {
 	version := flag.Bool("version", false, "print version and exit")
@@ -65,87 +68,77 @@ func main() {
 	}
 	defer client.Close()
 
-	mcpURL := "http://" + client.LocalAddr + "/mcp"
-	fmt.Printf("Tunnel ready: %s\n", mcpURL)
+	baseURL := "http://" + client.LocalAddr
+	fmt.Printf("Tunnel ready: %s\n", baseURL)
 
-	// Drop any stale `ftw-remote` entry from a previous (possibly broken)
-	// run — e.g. one that got registered as stdio because of flag-order
-	// confusion. Ignored if it doesn't exist.
-	_ = exec.Command("claude", "mcp", "remove", mcpName).Run()
-
-	// Best-effort registration with Claude Code. Flag order matters: newer
-	// `claude` CLI versions parse positional args strictly and treat a URL
-	// that follows `mcp add <name>` without `--transport` as a stdio command
-	// (which then silently fails to come online). Put `--transport http`
-	// *before* the name so it binds correctly.
-	manualCmd := fmt.Sprintf("claude mcp add --transport http %s %s", mcpName, mcpURL)
-	if err := exec.Command("claude", "mcp", "add", "--transport", "http", mcpName, mcpURL).Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "claude mcp add failed: %v — register manually with:\n  %s\n", err, manualCmd)
-	} else {
-		fmt.Printf("Registered MCP server '%s' with Claude Code.\n", mcpName)
-	}
-	defer func() {
-		_ = exec.Command("claude", "mcp", "remove", mcpName).Run()
-	}()
-
-	prompt := buildPrompt("(see owner's message)", "(see session_remaining)")
+	prompt := buildPrompt(baseURL)
 	clipboardOK := copyClipboard(prompt) == nil
+
 	// Always print the prompt to stderr inside fenced markers so the user can
-	// scroll up and copy-paste manually if the clipboard didn't take (e.g.
-	// terminal-multiplexer focus issues, headless/SSH sessions, OS quirks).
+	// scroll up and copy it manually if the clipboard didn't take.
 	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "──────────────────── BEGIN CLAUDE CODE PROMPT ────────────────────")
+	fmt.Fprintln(os.Stderr, "──────────────────── BEGIN AGENT PROMPT ────────────────────")
 	fmt.Fprintln(os.Stderr, prompt)
-	fmt.Fprintln(os.Stderr, "───────────────────── END CLAUDE CODE PROMPT ─────────────────────")
+	fmt.Fprintln(os.Stderr, "───────────────────── END AGENT PROMPT ─────────────────────")
 	fmt.Fprintln(os.Stderr, "")
 	if clipboardOK {
-		fmt.Println("Context prompt above is also copied to your clipboard. Paste it into Claude Code now.")
+		fmt.Println("Prompt above is also copied to your clipboard — paste it into Claude Code / Codex / your agent of choice.")
 	} else {
-		fmt.Println("Clipboard copy failed — copy the prompt above manually and paste it into Claude Code.")
+		fmt.Println("Clipboard copy failed — copy the prompt above manually.")
 	}
 
 	fmt.Println("Tunnel open. Ctrl-C to disconnect.")
 	<-ctx.Done()
 }
 
-func buildPrompt(intent, ttl string) string {
-	// Intent and ttl are placeholders — the prompt instructs Claude to fetch
-	// them via ftw_api on its first turn.
-	_ = intent
-	_ = ttl
-	return `You are connected to a live forty-two-watts (42W) instance over the MCP server ` + "`" + mcpName + "`" + `.
+func buildPrompt(baseURL string) string {
+	return `You are connected to a live forty-two-watts (42W) home-energy system via a local HTTP API.
 
-You're helping the owner remotely. The owner is *not* expected to know git or GitHub — **you** open the PR at the end, from your own machine, not theirs. The owner's role here is to share their site with you and accept your help; you handle the development.
+LOCAL API: ` + baseURL + `
+
+You're helping the owner remotely. The owner is *not* expected to know git or GitHub — **you** open the PR at the end, from your own machine, not theirs. The owner's role is to share their site with you and accept your help; you handle the development.
+
+## How to call the API
+
+Discover the catalog:
+  curl ` + baseURL + `/tools
+
+Call a tool (JSON args in, JSON result out):
+  curl -X POST ` + baseURL + `/tools/<name> \
+    -H 'Content-Type: application/json' \
+    -d '<json args>'
+
+Status codes: 200 = ok, 400 = bad request, 404 = unknown tool, 502 = tool errored (body has ` + "`{\"error\":...}`" + `).
 
 ## First, orient yourself
 
 Run these in order on your first turn:
 
-1. ` + "`ftw_api`" + ` with ` + "`method: GET, path: /api/pair/status`" + ` — reads the owner's stated intent for this session and the time remaining.
-2. ` + "`ftw_api`" + ` with ` + "`method: GET, path: /api/status`" + ` — shows the running state of the instance (drivers, mode, grid/PV/battery readings).
-3. ` + "`read_file`" + ` at ` + "`/app/docs/api.md`" + ` (or wherever the repo is mounted — try ` + "`list_directory`" + ` from ` + "`/app`" + ` first) if you need a catalog of HTTP endpoints.
+1. ` + "`curl " + baseURL + `/tools` + "`" + ` — list available tools and their schemas (17 tools).
+2. ` + "`curl -X POST " + baseURL + `/tools/ftw_api -H 'Content-Type: application/json' -d '{"method":"GET","path":"/api/pair/status"}'` + "`" + ` — reads the owner's stated intent for this session and the time remaining.
+3. ` + "`curl -X POST " + baseURL + `/tools/ftw_api -d '{"method":"GET","path":"/api/status"}'` + "`" + ` — shows the running state of the instance (drivers, mode, grid/PV/battery readings).
 
 Tell the owner in chat what you found so they can confirm the plan before you start making changes.
 
-## Available MCP tools (17 — these run *on the owner's machine* through the tunnel)
+## What the tools can do (all run on the owner's machine through the tunnel)
 
-- ` + "`ftw_api(method, path, body?)`" + ` — proxy to the running 42W HTTP API (see docs/api.md)
+- ` + "`ftw_api`" + ` — proxy to the running 42W HTTP API (see docs/api.md)
 - ` + "`read_file`" + ` / ` + "`write_file`" + ` / ` + "`list_directory`" + ` — scoped to the owner's repo, state dir, and /tmp
-- ` + "`run_command(cmd, workdir)`" + ` — shell on the owner's machine, same scope, 30s default timeout
+- ` + "`run_command`" + ` — shell on the owner's machine, same scope, 30s default timeout
 - ` + "`restart_main_service`" + ` / ` + "`tail_service_logs`" + ` — restart the owner's service, read recent logs
 - ` + "`network_scan`" + ` / ` + "`http_probe`" + ` / ` + "`modbus_probe`" + ` / ` + "`modbus_write`" + ` / ` + "`mqtt_observe`" + ` / ` + "`pcap_capture`" + ` — LAN-level introspection from the owner's machine
-- ` + "`deploy_driver(name, lua_source, config)`" + ` — write a Lua driver, update config.yaml, wait for reload, verify it ticks against the owner's hardware
+- ` + "`deploy_driver`" + ` — write a Lua driver, update config.yaml, wait for reload, verify it ticks against the owner's hardware
 - ` + "`session_log`" + ` / ` + "`session_remaining`" + ` / ` + "`session_end`" + ` — session controls
 
-You also have your *own* local tools (Read/Write/Edit/Bash on your local filesystem) — those are how you'll prepare and submit the PR.
+You also have your *own* local tools (your editor, file system, shell) — that's how you'll prepare and submit the PR.
 
 ## When the work is done — opening the PR
 
-The driver source lives on the owner's machine after you ` + "`write_file`" + ` it there. To turn that into a PR from your own machine:
+The driver source lives on the owner's machine after you write it there. To turn that into a PR from your own machine:
 
 1. **Snapshot the final state.** Call ` + "`read_file`" + ` on every file you modified on the owner's machine, so you have the canonical text in this conversation. Also call ` + "`session_log`" + ` once to get the audit-log markdown.
-2. **Clone the repo locally** if you haven't already: ` + "`git clone https://github.com/frahlg/forty-two-watts.git /tmp/ftw-work`" + ` (use your local Bash tool, not ` + "`run_command`" + `).
-3. **Apply the changes** to that local clone using your local Write tool — drop the driver file into ` + "`drivers/`" + `, edit ` + "`config.yaml`" + ` to add the driver entry, etc. Match what's on the owner's machine.
+2. **Clone the repo locally** if you haven't already: ` + "`git clone https://github.com/frahlg/forty-two-watts.git /tmp/ftw-work`" + ` (use your *local* shell, not the ` + "`run_command`" + ` tool).
+3. **Apply the changes** to that local clone — drop the driver file into ` + "`drivers/`" + `, edit ` + "`config.yaml`" + ` to add the driver entry, etc. Match what's on the owner's machine.
 4. **Open the PR** with ` + "`gh pr create`" + ` against ` + "`master`" + `, picking the ` + "`pair-session.md`" + ` template and pasting the session-log markdown into the *Pair-session report* section. Use a ` + "`feat(driver): ...`" + ` style title.
 5. **Tell the owner** in chat: link to the PR, what was changed, what you'd like them to test, anything unexpected they should know.
 6. **Call ` + "`session_end`" + `** to close the tunnel. The owner's sidecar exits.

--- a/go/cmd/ftw-connect/main_test.go
+++ b/go/cmd/ftw-connect/main_test.go
@@ -6,31 +6,46 @@ import (
 )
 
 func TestBuildPrompt(t *testing.T) {
-	p := buildPrompt("write a goodwe driver", "3h45m")
+	p := buildPrompt("http://127.0.0.1:54321")
 
-	// MCP server name must appear so Claude knows which tools belong to this server.
-	if !strings.Contains(p, "ftw-remote") {
-		t.Fatal("server name missing")
+	// The local URL must appear so the agent knows where to curl.
+	if !strings.Contains(p, "http://127.0.0.1:54321") {
+		t.Fatal("local base URL missing")
 	}
-	// First-action guidance: Claude must be told to fetch intent + state via ftw_api.
+	// Discovery: curl /tools must be taught.
+	if !strings.Contains(p, "/tools") {
+		t.Fatal("missing /tools discovery instruction")
+	}
+	// Invocation: POST /tools/<name> must be taught.
+	if !strings.Contains(p, "POST") || !strings.Contains(p, "/tools/ftw_api") {
+		t.Fatal("missing POST /tools/<name> example")
+	}
+	// First-action guidance: agent must be told to fetch intent + state via ftw_api.
 	if !strings.Contains(p, "/api/pair/status") {
 		t.Fatal("missing instruction to fetch /api/pair/status")
 	}
 	if !strings.Contains(p, "/api/status") {
 		t.Fatal("missing instruction to read /api/status")
 	}
-	// Wrap-up guidance: Claude must snapshot the changes, clone locally,
-	// open the PR from the friend's own machine via gh.
+	// Wrap-up: snapshot, clone, gh pr create, session_log, pair-session.md.
 	if !strings.Contains(p, "gh pr create") {
 		t.Fatal("missing instruction to open PR via gh pr create")
 	}
 	if !strings.Contains(p, "git clone") {
-		t.Fatal("missing instruction to clone the repo locally on the friend's machine")
+		t.Fatal("missing instruction to clone the repo locally")
 	}
 	if !strings.Contains(p, "session_log") {
-		t.Fatal("missing instruction to call session_log before wrap-up")
+		t.Fatal("missing instruction to call session_log")
 	}
 	if !strings.Contains(p, "pair-session.md") {
 		t.Fatal("missing reference to the pair-session.md PR template")
+	}
+	// The new prompt must NOT mention claude mcp / MCP server — that's the
+	// whole point of this pivot (tool-agnostic, no friend-side config writes).
+	if strings.Contains(p, "claude mcp add") {
+		t.Fatal("prompt still mentions claude mcp add — should be agent-agnostic curl")
+	}
+	if strings.Contains(p, "MCP server") {
+		t.Fatal("prompt still mentions MCP server — should be agent-agnostic curl")
 	}
 }

--- a/go/cmd/ftw-pair/mcp.go
+++ b/go/cmd/ftw-pair/mcp.go
@@ -121,6 +121,11 @@ func StartMCP(ctx context.Context, cfg MCPConfig) (*MCPServer, error) {
 	}
 	mux.Handle("/mcp", mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server { return mcpSrv }, streamOpts))
 
+	// REST surface — sibling of /mcp, shares the same Tool[] and Audit.
+	// This is the primary path: any agent with Bash + curl can drive the
+	// sidecar without us touching their CLI config (no `claude mcp add`).
+	registerRESTHandlers(mux, cfg.Tools, cfg.Audit)
+
 	ln, err := net.Listen("tcp", cfg.Addr)
 	if err != nil {
 		return nil, fmt.Errorf("listen: %w", err)

--- a/go/cmd/ftw-pair/rest.go
+++ b/go/cmd/ftw-pair/rest.go
@@ -1,0 +1,126 @@
+// Package main — rest.go
+//
+// Local-HTTP tool surface, served alongside the MCP /mcp endpoint.
+//
+// The REST layer exists so a connecting agent (Claude Code, Codex, Gemini,
+// anything else with Bash + curl) can drive the sidecar without us having
+// to register an MCP server with their CLI. The friend runs ftw-connect,
+// gets a local URL, and the agent's prompt teaches it to:
+//
+//	curl <URL>/tools                          # list available tools + schemas
+//	curl -X POST <URL>/tools/<name> -d <json> # invoke a tool
+//
+// REST and MCP share the exact same Tool slice and Audit log — both routes
+// dispatch through Tool.Handle and call Audit.Append on completion.
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// registerRESTHandlers attaches /tools and /tools/<name> handlers to mux.
+// Tools share the supplied audit log with the MCP path.
+func registerRESTHandlers(mux *http.ServeMux, tools []Tool, audit *Audit) {
+	index := make(map[string]Tool, len(tools))
+	for _, t := range tools {
+		index[t.Name()] = t
+	}
+
+	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		catalog := buildToolCatalog(tools)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(catalog)
+	})
+
+	mux.HandleFunc("/tools/", func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, "/tools/")
+		if name == "" || strings.Contains(name, "/") {
+			writeJSONError(w, http.StatusNotFound, "unknown tool")
+			return
+		}
+		tool, ok := index[name]
+		if !ok {
+			writeJSONError(w, http.StatusNotFound, "unknown tool: "+name)
+			return
+		}
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "use POST with a JSON body")
+			return
+		}
+
+		args, err := decodeArgs(r.Body)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+			return
+		}
+
+		out, callErr := tool.Handle(r.Context(), args)
+		ok2 := callErr == nil
+		msg := "ok"
+		if callErr != nil {
+			msg = callErr.Error()
+		}
+		audit.Append(AuditEvent{Tool: tool.Name(), Args: args, OutcomeOK: ok2, OutcomeMsg: msg})
+
+		w.Header().Set("Content-Type", "application/json")
+		if callErr != nil {
+			w.WriteHeader(http.StatusBadGateway)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": callErr.Error()})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	})
+}
+
+// toolEntry is the per-tool catalog shape returned by GET /tools.
+type toolEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	InputSchema any    `json:"input_schema"`
+}
+
+type toolCatalog struct {
+	Tools []toolEntry `json:"tools"`
+}
+
+func buildToolCatalog(tools []Tool) toolCatalog {
+	out := toolCatalog{Tools: make([]toolEntry, 0, len(tools))}
+	for _, t := range tools {
+		s := t.Schema()
+		entry := toolEntry{Name: t.Name()}
+		if s != nil {
+			entry.Description = s.Description
+			entry.InputSchema = s.InputSchema
+		}
+		out.Tools = append(out.Tools, entry)
+	}
+	return out
+}
+
+func decodeArgs(body io.Reader) (map[string]any, error) {
+	buf, err := io.ReadAll(io.LimitReader(body, 1<<20)) // 1 MB cap
+	if err != nil {
+		return nil, err
+	}
+	args := map[string]any{}
+	if len(buf) == 0 {
+		return args, nil
+	}
+	if err := json.Unmarshal(buf, &args); err != nil {
+		return nil, err
+	}
+	return args, nil
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/go/cmd/ftw-pair/rest_test.go
+++ b/go/cmd/ftw-pair/rest_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// stubTool is a minimal Tool implementation for REST-layer testing — it
+// echoes back the args it was called with so we can assert dispatch + audit.
+type stubTool struct {
+	name    string
+	handler func(ctx context.Context, args map[string]any) (any, error)
+}
+
+func (s *stubTool) Name() string { return s.name }
+func (s *stubTool) Schema() *mcpsdk.Tool {
+	return &mcpsdk.Tool{
+		Name:        s.name,
+		Description: "stub tool for testing",
+		InputSchema: map[string]any{"type": "object"},
+	}
+}
+func (s *stubTool) Handle(ctx context.Context, args map[string]any) (any, error) {
+	return s.handler(ctx, args)
+}
+
+func startTestServer(t *testing.T, tools []Tool, audit *Audit) string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sess := NewSession(ctx, SessionConfig{TTL: time.Hour})
+	t.Cleanup(func() { sess.End("test_cleanup") })
+
+	srv, err := StartMCP(ctx, MCPConfig{
+		Addr:    "127.0.0.1:0",
+		Session: sess,
+		Audit:   audit,
+		Tools:   tools,
+	})
+	if err != nil {
+		t.Fatalf("start mcp: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+	return srv.Addr()
+}
+
+func TestRESTGetToolsCatalog(t *testing.T) {
+	tools := []Tool{
+		&stubTool{name: "echo", handler: func(ctx context.Context, args map[string]any) (any, error) { return args, nil }},
+	}
+	addr := startTestServer(t, tools, NewAudit())
+
+	resp, err := http.Get("http://" + addr + "/tools")
+	if err != nil {
+		t.Fatalf("get /tools: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var catalog toolCatalog
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(catalog.Tools) != 1 || catalog.Tools[0].Name != "echo" {
+		t.Fatalf("unexpected catalog: %+v", catalog)
+	}
+	if catalog.Tools[0].Description != "stub tool for testing" {
+		t.Fatalf("missing description: %+v", catalog.Tools[0])
+	}
+	if catalog.Tools[0].InputSchema == nil {
+		t.Fatalf("missing input_schema")
+	}
+}
+
+func TestRESTPostToolDispatches(t *testing.T) {
+	called := false
+	tools := []Tool{
+		&stubTool{
+			name: "echo",
+			handler: func(ctx context.Context, args map[string]any) (any, error) {
+				called = true
+				return map[string]any{"got": args}, nil
+			},
+		},
+	}
+	audit := NewAudit()
+	addr := startTestServer(t, tools, audit)
+
+	body := bytes.NewReader([]byte(`{"hello":"world"}`))
+	resp, err := http.Post("http://"+addr+"/tools/echo", "application/json", body)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, raw)
+	}
+	if !called {
+		t.Fatalf("tool handler was not invoked")
+	}
+	if audit.ToolCount() != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", audit.ToolCount())
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), `"hello":"world"`) {
+		t.Fatalf("response missing echoed args: %s", raw)
+	}
+}
+
+func TestRESTUnknownTool404(t *testing.T) {
+	addr := startTestServer(t, nil, NewAudit())
+	resp, err := http.Post("http://"+addr+"/tools/nope", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRESTMalformedBodyIs400(t *testing.T) {
+	tools := []Tool{
+		&stubTool{name: "echo", handler: func(ctx context.Context, args map[string]any) (any, error) { return nil, nil }},
+	}
+	addr := startTestServer(t, tools, NewAudit())
+	resp, err := http.Post("http://"+addr+"/tools/echo", "application/json", strings.NewReader("not-json"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestRESTToolErrorIs502(t *testing.T) {
+	tools := []Tool{
+		&stubTool{
+			name: "fail",
+			handler: func(ctx context.Context, args map[string]any) (any, error) {
+				return nil, errStub("boom")
+			},
+		},
+	}
+	audit := NewAudit()
+	addr := startTestServer(t, tools, audit)
+
+	resp, err := http.Post("http://"+addr+"/tools/fail", "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 502 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 502, got %d: %s", resp.StatusCode, raw)
+	}
+	// Audit still records the failure.
+	if audit.ToolCount() != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", audit.ToolCount())
+	}
+	if audit.Events()[0].OutcomeOK {
+		t.Fatalf("expected outcome_ok=false")
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/go/test/e2e/pair_test.go
+++ b/go/test/e2e/pair_test.go
@@ -78,7 +78,21 @@ func TestPairFlow(t *testing.T) {
 		t.Fatalf("expected /api/status body in ftw_api response, got: %s", resp)
 	}
 
-	// Render session_log and confirm it captured ftw_api + intent.
+	// Same call via the REST surface — this is the path agents will actually use.
+	restResp := callREST(t, "http://127.0.0.1:19999/tools/ftw_api", map[string]any{
+		"method": "GET", "path": "/api/status",
+	})
+	if !strings.Contains(restResp, "mode") {
+		t.Fatalf("REST: expected /api/status body, got: %s", restResp)
+	}
+
+	// REST catalog must list ftw_api.
+	catalog := getREST(t, "http://127.0.0.1:19999/tools")
+	if !strings.Contains(catalog, `"name":"ftw_api"`) {
+		t.Fatalf("REST: /tools missing ftw_api entry:\n%s", catalog)
+	}
+
+	// Render session_log and confirm it captured both calls + intent.
 	log := callMCP(t, "http://127.0.0.1:19999/mcp", "session_log", map[string]any{})
 	if !strings.Contains(log, "ftw_api") {
 		t.Fatalf("session_log missing ftw_api entry:\n%s", log)
@@ -139,6 +153,42 @@ func callMCP(t *testing.T, url, tool string, args map[string]any) string {
 	}
 	defer resp.Body.Close()
 	out, _ := io.ReadAll(resp.Body)
+	return string(out)
+}
+
+func callREST(t *testing.T, url string, args map[string]any) string {
+	t.Helper()
+	body, _ := json.Marshal(args)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("REST call: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("REST call %s: status %d body %s", url, resp.StatusCode, out)
+	}
+	return string(out)
+}
+
+func getREST(t *testing.T, url string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("REST get: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("REST get %s: status %d body %s", url, resp.StatusCode, out)
+	}
 	return string(out)
 }
 

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -462,9 +462,10 @@ One-time setup (Mac/Linux):
 Then run:
   ftw-connect ${code}
 
-It'll open a tunnel, register an MCP server with your Claude Code,
-and copy a context prompt to your clipboard. Paste it into Claude
-Code and we're connected.
+It opens an end-to-end-encrypted tunnel and prints a local URL.
+It also copies a ready-to-paste agent prompt to your clipboard —
+paste it into Claude Code, Codex, or whatever agent you use, and
+we're connected. No config files touched on your side.
 
 Session expires in ${remaining} or when I click Abort.`;
   }


### PR DESCRIPTION
## Summary

The friend's agent CLI (Claude Code, Codex, Gemini, anything with Bash + curl) no longer needs to be touched. `ftw-connect` exposes a local URL; the agent reaches the sidecar tools through plain HTTP. The friend's disk gets **zero** writes — no config files, no MCP entries, no agent CLI mutations.

## Why

- `claude mcp add` writes to `~/.claude.json` on the friend's machine. A rough Ctrl-C leaves stale stdio entries that tank the next session — exactly the kind of trace we don't want to leave on a stranger's dev environment.
- It's Claude-Code-specific. Codex and other agents can't use it. Binding our transport to one agent vendor is the wrong abstraction.
- Repeated transport / flag-order footguns (hit two of them on the first live e2e run).

## What changes

- **New REST surface in the sidecar** at \`/tools\` (GET catalog) and \`/tools/<name>\` (POST to invoke). Shares the same Tool[] and Audit log as the existing \`/mcp\` endpoint — MCP stays available for agents that prefer it; REST is the documented primary path.
- **ftw-connect drops \`claude mcp add\` / \`claude mcp remove\` entirely.** Prints the local URL and copies a curl-based prompt to the clipboard. Friend's disk untouched.
- **Prompt rewritten** to teach \`curl <url>/tools\` + \`curl -X POST <url>/tools/<name> -d <json>\` instead of MCP tool semantics. Dashboard friend-message mirror updated to match.
- **docs/ftw-pair.md** updated: architecture paragraph, troubleshooting, who-does-what table.

## Test plan

- [x] \`make verify\` — vet + unit + e2e + build all clean
- [x] Unit (\`rest_test.go\`): catalog shape, dispatch + audit, 404 on unknown tool, 400 on malformed body, 502 on tool error
- [x] E2E (\`pair_test.go\`): legacy MCP path still works, plus new REST assertions for \`ftw_api\` + \`/tools\` catalog through the full sidecar stack
- [ ] Manual: run \`ftw-connect <token>\`, paste prompt into Claude Code, verify it reaches \`ftw_api\` via curl
- [ ] Manual: same with Codex or other agent

## Note for reviewers

This stacks logically *after* #330 (small fixes) but is on its own branch from master. The \`_friendMessage\` text in \`ftw-pair-card.js\` will need a small merge resolve depending on which lands first — both PRs touch the preamble, but my rewrite is a superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)