### PR TITLE
fix(docker): drop stale ftw-pair-relay build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,11 @@ RUN cd go && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
     -o /out/ftw-pair ./cmd/ftw-pair
-# ftw-pair-relay is the standalone relay server (deployed separately — built
-# here so operators can extract the binary with `docker cp` if needed).
-RUN cd go && \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
-    -o /out/ftw-pair-relay ./cmd/ftw-pair-relay
+
+# Note: the standalone relay (ftw-subetha) is NOT bundled in this image.
+# It's deployed separately on a Lightsail nano — see docs/subetha-deploy.md.
+# The cross-platform binaries are published as GitHub release assets
+# (ftw-subetha-linux-{amd64,arm64}) for operators who self-host.
 
 # --- Runtime ---------------------------------------------------------------
 FROM alpine:3.20


### PR DESCRIPTION
## Summary

Dockerfile still built \`./cmd/ftw-pair-relay\` which doesn't exist — the relay binary was renamed to \`./cmd/ftw-subetha\` during the pure-Go pivot. The runtime image never COPYed the relay binary anyway (line 71 only copies forty-two-watts + ftw-pair), so this was dead code that's been silently failing every release since the rename.

## What Erik saw on Discord

> Run gh release upload \"\${TAG}\" \"\${ASSET}\" --clobber
> HTTP 403: Sorry. Your account was suspended ...

That earlier 403 was a transient GitHub anti-abuse trip from the burst of releases this morning — it resolved on its own. **Releases since v0.93.0 have been failing on a different job**: docker build + push (main), with:

\`\`\`
process \"/bin/sh -c cd go && ... -o /out/ftw-pair-relay ./cmd/ftw-pair-relay\"
  did not complete successfully: exit code: 1
\`\`\`

semantic-release still tagged + uploaded all 10 release assets correctly; only the GHCR image push died. Visible diff: \`gh release view v0.96.0\` lists every binary asset; \`docker pull ghcr.io/frahlg/forty-two-watts:0.96.0\` 404s.

## Fix

Drop the dead build step. The relay is deployed separately (see \`docs/subetha-deploy.md\`); its cross-platform binaries are already published as GitHub release assets (\`ftw-subetha-linux-{amd64,arm64}\`) for self-hosted relays.

## Test plan

- [x] \`make verify\` — vet + test + build clean
- [ ] CI: \`go test + vet\` should pass (no Go changes); \`docker build + push (main)\` should succeed
- [ ] Post-merge: next semantic-release should push the image to GHCR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)