### PR TITLE
fix(docker): point relay build at ftw-subetha after rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,12 @@ RUN cd go && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
     -o /out/ftw-pair ./cmd/ftw-pair
-# ftw-pair-relay is the standalone relay server (deployed separately — built
+# ftw-subetha is the standalone relay server (deployed separately — built
 # here so operators can extract the binary with `docker cp` if needed).
 RUN cd go && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
-    -o /out/ftw-pair-relay ./cmd/ftw-pair-relay
+    -o /out/ftw-subetha ./cmd/ftw-subetha
 
 # --- Runtime ---------------------------------------------------------------
 FROM alpine:3.20


### PR DESCRIPTION
## Summary
- Docker image build has been failing on master since PR #329 (merged 2026-05-26 14:52 CEST), which renamed `go/cmd/ftw-pair-relay` → `go/cmd/ftw-subetha` everywhere except in the Dockerfile.
- One-line rename of the build step + matching comment.

```
ERROR: failed to solve: process "/bin/sh -c cd go && ... go build ... -o /out/ftw-pair-relay ./cmd/ftw-pair-relay" did not complete successfully: exit code: 1
```

## Test plan
- [ ] CI docker build job goes green on this branch
- [ ] Resulting image still contains the relay binary at `/out/ftw-subetha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)