### PR TITLE
fix(control): harden fuse safety guards

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1095,6 +1095,12 @@ func (c *Config) Validate() error {
 	if c.Fuse.MaxAmps <= 0 {
 		return errors.New("fuse.max_amps must be > 0")
 	}
+	if c.Fuse.Phases <= 0 {
+		return errors.New("fuse.phases must be > 0")
+	}
+	if c.Fuse.Voltage <= 0 {
+		return errors.New("fuse.voltage must be > 0")
+	}
 	// safety_margin_a must be in [0, max_amps) when explicitly set.
 	// Negative would *raise* the per-phase threshold above the breaker
 	// rating (defeating the guard); >= max_amps zeroes the headroom

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -212,6 +212,34 @@ func TestFuseMaxPower(t *testing.T) {
 	}
 }
 
+func TestRejectsInvalidFusePowerInputs(t *testing.T) {
+	cases := []struct {
+		field string
+		value string
+	}{
+		{"max_amps", "-16"},
+		{"phases", "-3"},
+		{"voltage", "-230"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.field, func(t *testing.T) {
+			yaml := fmt.Sprintf(`
+site: { name: x }
+fuse: { max_amps: 16, phases: 3, voltage: 230, %s: %s }
+drivers:
+  - name: a
+    lua: a.lua
+    is_site_meter: true
+    capabilities: { mqtt: { host: 1.1.1.1 } }
+api: { port: 8080 }
+`, tc.field, tc.value)
+			if _, err := Parse([]byte(yaml), "."); err == nil {
+				t.Fatalf("expected validation error for fuse.%s=%s", tc.field, tc.value)
+			}
+		})
+	}
+}
+
 func TestSmoothingAlphaValidation(t *testing.T) {
 	// alpha=0 means "use default" via applyDefaults, so only test truly invalid values
 	for _, bad := range []float64{-0.1, 1.1, 2.0} {

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -2581,10 +2581,22 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 		return targets
 	}
 	siteMeter := state.SiteMeterDriver
-	// Aggregate live battery power so we can hold load+pv constant.
+	// Aggregate live battery power for the batteries this dispatch is
+	// about to control so we can hold load+pv+uncontrolled-batteries
+	// constant. Offline or otherwise untargeted batteries are already
+	// reflected in currentGrid; subtracting them here without adding a
+	// replacement target would double-remove their contribution and miss
+	// fuse overages.
+	seenBat := make(map[string]struct{}, len(targets))
 	var currentBat float64
-	for _, r := range store.ReadingsByType(telemetry.DerBattery) {
-		currentBat += r.SmoothedW
+	for _, t := range targets {
+		if _, seen := seenBat[t.Driver]; seen {
+			continue
+		}
+		seenBat[t.Driver] = struct{}{}
+		if r := store.Get(t.Driver, telemetry.DerBattery); r != nil {
+			currentBat += r.SmoothedW
+		}
 	}
 	var currentGrid float64
 	if siteMeter != "" {

--- a/go/internal/control/fuse_saver_test.go
+++ b/go/internal/control/fuse_saver_test.go
@@ -363,6 +363,36 @@ func TestPerPhaseClampFiresOnExportImbalance(t *testing.T) {
 	}
 }
 
+func TestFuseGuardPredictsAgainstControlledBatteriesOnly(t *testing.T) {
+	store := telemetry.NewStore()
+	store.Update("meter", telemetry.DerMeter, -8000, nil, nil)
+	store.DriverHealthMut("meter").RecordSuccess()
+
+	soc := 0.6
+	store.Update("online", telemetry.DerBattery, 0, &soc, nil)
+	store.DriverHealthMut("online").RecordSuccess()
+
+	// Stale/offline battery readings can still exist in the store and
+	// are already included in the live meter reading. applyFuseGuard must
+	// not subtract them unless it is also replacing them with a target.
+	store.Update("offline", telemetry.DerBattery, -3000, &soc, nil)
+	store.DriverHealthMut("offline").SetOffline()
+
+	state := NewState(0, 50, "meter")
+	targets := []DispatchTarget{{Driver: "online", TargetW: -3000}}
+	guarded := applyFuseGuard(targets, store, state, 10000)
+	if !guarded[0].Clamped {
+		t.Fatalf("expected export-side fuse guard to clamp controlled discharge")
+	}
+	// True post-dispatch grid is -8000 - current_online(0) + target(-3000)
+	// = -11000 W, so the 10 kW export fuse is exceeded by 1000 W.
+	expected := -2000.0
+	if math.Abs(guarded[0].TargetW-expected) > 1 {
+		t.Errorf("controlled discharge after fuse guard = %.0f W, want %.0f W",
+			guarded[0].TargetW, expected)
+	}
+}
+
 // forceFuseDischarge must NOT fire on export-side per-phase overage.
 // Its job is to relieve IMPORT — commanding more discharge during
 // export-side per-phase trip would push the over-current phase


### PR DESCRIPTION
## Summary
- Fix fuse guard prediction so stale/offline battery readings are not double-removed when predicting post-dispatch grid power
- Reject invalid non-positive `fuse.phases` and `fuse.voltage` so fuse protection cannot be effectively disabled by bad config
- Add focused regression tests for both safety cases

## Test plan
- `GOCACHE=/private/tmp/ftw-go-build-cache go test ./internal/control -run 'TestFuseGuardPredictsAgainstControlledBatteriesOnly|TestPerPhaseClampFiresOnExportImbalance|TestFuseGuard' -count=1 -v`
- `GOCACHE=/private/tmp/ftw-go-build-cache go test ./internal/config -run 'TestRejectsInvalidFusePowerInputs|TestFuseMaxPower|TestSmoothingAlphaValidation' -count=1 -v`
- `GOCACHE=/private/tmp/ftw-go-build-cache go test ./...`
