### PR TITLE
fix(api): defer EV secret persistence

### DIFF
--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -978,19 +978,21 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	restoreDriverConfigSecrets(&newCfg, s.deps.Cfg, s.driverSecretKeys())
 	s.deps.CfgMu.RUnlock()
 
-	// EV charger password: persist to state.db instead of config.yaml.
-	// Empty or the masked placeholder means "keep existing"; a new value
-	// means the user typed a real password.
+	// EV charger password lives in state.db instead of config.yaml. Empty
+	// or the masked placeholder means "keep existing"; a new value means
+	// the user typed a real password. Defer the state write until after
+	// validation + config save succeed so a rejected config cannot rotate
+	// credentials behind the operator's back.
+	var evPasswordToPersist string
+	var persistEVPassword bool
 	if newCfg.EVCharger != nil {
 		pw := newCfg.EVCharger.Password
 		if pw != "" && pw != maskedPlaceholder {
-			if err := s.deps.State.SaveConfig(evPasswordKey, pw); err != nil {
-				slog.Warn("failed to persist ev_charger_password", "err", err)
-			}
-		}
-		// Restore the real password into the in-memory config so the
-		// config-reload watcher sees it on the next apply.
-		if stored, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			evPasswordToPersist = pw
+			persistEVPassword = true
+		} else if stored, ok := s.deps.State.LoadConfig(evPasswordKey); ok {
+			// Restore the real password into the candidate config so the
+			// config-reload watcher sees it on the next apply.
 			newCfg.EVCharger.Password = stored
 		}
 	}
@@ -1010,6 +1012,11 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	if err := s.deps.SaveConfig(s.deps.ConfigPath, &newCfg); err != nil {
 		writeJSON(w, 500, map[string]string{"error": "save failed: " + err.Error()})
 		return
+	}
+	if persistEVPassword {
+		if err := s.deps.State.SaveConfig(evPasswordKey, evPasswordToPersist); err != nil {
+			slog.Warn("failed to persist ev_charger_password", "err", err)
+		}
 	}
 	// Apply control-level changes immediately (file watcher will also pick
 	// this up but we're snappier).

--- a/go/internal/api/api_test.go
+++ b/go/internal/api/api_test.go
@@ -112,6 +112,54 @@ func TestHandleEVStatusRejectsUnknownDriver(t *testing.T) {
 	}
 }
 
+func TestHandlePostConfigDoesNotPersistEVPasswordOnInvalidConfig(t *testing.T) {
+	st, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.SaveConfig(evPasswordKey, "old-secret"); err != nil {
+		t.Fatalf("seed password: %v", err)
+	}
+
+	cfg := &config.Config{
+		Site:      config.Site{SmoothingAlpha: 0.3},
+		Fuse:      config.Fuse{MaxAmps: 16},
+		EVCharger: &config.EVCharger{Provider: "easee", Username: "old@example.com", Password: "old-secret"},
+	}
+	srv := New(&Deps{
+		State:  st,
+		CfgMu:  &sync.RWMutex{},
+		Cfg:    cfg,
+		CtrlMu: &sync.Mutex{},
+		Ctrl:   control.NewState(0, 50, ""),
+	})
+
+	body, err := json.Marshal(config.Config{
+		Site:      config.Site{SmoothingAlpha: 2},
+		Fuse:      config.Fuse{MaxAmps: 16},
+		EVCharger: &config.EVCharger{Provider: "easee", Username: "new@example.com", Password: "new-secret"},
+	})
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/config", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", rr.Code, rr.Body.String())
+	}
+	got, ok := st.LoadConfig(evPasswordKey)
+	if !ok {
+		t.Fatalf("password key missing after invalid config")
+	}
+	if got != "old-secret" {
+		t.Fatalf("persisted password = %q, want old-secret", got)
+	}
+}
+
 func TestHandleStatusIgnoresOfflineDERInLiveBalance(t *testing.T) {
 	tel := telemetry.NewStore()
 	ctrl := &control.State{SiteMeterDriver: "site"}


### PR DESCRIPTION
## Summary
- Make `POST /api/config` avoid persisting a new EV charger password when config validation fails
- Preserve existing masked/empty password placeholder behavior
- Add a regression test for invalid config + changed password

## Test plan
- `GOCACHE=/private/tmp/ftw-go-cache-api-atomic go test ./internal/api -run TestHandlePostConfigDoesNotPersistEVPasswordOnInvalidConfig -count=1`
- `GOCACHE=/private/tmp/ftw-go-cache-api-atomic go test ./internal/api -run 'TestHandlePostConfigDoesNotPersistEVPasswordOnInvalidConfig|TestDriverSecretKeysIncludePortableDriverPathAlias' -count=1`
- `GOCACHE=/private/tmp/ftw-go-build-cache go test ./internal/api ./internal/config ./internal/state -count=1`
- `git diff --check`
