### PR TITLE
fix(subetha): close splice on first EOF — host pool no longer starves after 4 requests

### DIFF
--- a/go/cmd/ftw-subetha/relay.go
+++ b/go/cmd/ftw-subetha/relay.go
@@ -216,15 +216,30 @@ func (r *Relay) handleClient(conn net.Conn, ip, token string) {
 	close(host.matched)
 	slog.Info("relay: matched pair", "token_prefix", tokenPrefix(token))
 
-	// Splice — bidirectional io.Copy.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() { defer wg.Done(); _, _ = io.Copy(host.conn, conn) }()
-	go func() { defer wg.Done(); _, _ = io.Copy(conn, host.conn) }()
-	wg.Wait()
+	// Splice — bidirectional io.Copy with half-close handling.
+	//
+	// As soon as EITHER direction reaches EOF, close BOTH conns so the other
+	// io.Copy unblocks. Without this, a short-lived client (e.g. one-shot curl)
+	// that closes its side after the response would leave the splice deadlocked:
+	// the client→host Copy returns on EOF, but the host→client Copy stays
+	// blocked reading from a keep-alive HTTP conn on the host's MCP server,
+	// holding the host's relay socket open forever. The host's worker pool then
+	// fills up after a few requests and every new client gets "no host ready".
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(host.conn, conn)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(conn, host.conn)
+		done <- struct{}{}
+	}()
 
+	<-done
 	conn.Close()
 	host.conn.Close()
+	<-done // drain the second goroutine — its io.Copy returns once the close above lands
+
 	slog.Info("relay: pair disconnected", "token_prefix", tokenPrefix(token))
 }
 

--- a/go/cmd/ftw-subetha/relay_test.go
+++ b/go/cmd/ftw-subetha/relay_test.go
@@ -247,6 +247,158 @@ func TestRelayIdleCleanup(t *testing.T) {
 	}
 }
 
+// TestRelaySpliceHalfCloseUnblocksOtherSide is the regression test for the
+// host-pool starvation bug: when a one-shot client (curl) closes its side of
+// the splice after receiving the response, the host-side socket would stay
+// open forever — the host's HTTP keep-alive Read kept the other io.Copy
+// blocked, the relay's WaitGroup never finished, and the host's worker
+// couldn't re-queue. After 4 such requests, every new client got
+// "no host ready".
+//
+// The fix: close BOTH conns as soon as EITHER io.Copy returns. This test
+// verifies that the host's Read returns shortly after the client closes,
+// even when the host is idle (no traffic from host→client).
+func TestRelaySpliceHalfCloseUnblocksOtherSide(t *testing.T) {
+	addr := startTestRelay(t)
+	const token = "half-close-token"
+
+	host := connectRaw(t, addr, token, roleHost)
+	defer host.Close()
+	if ack := readAck(t, host); ack != 0x01 {
+		t.Fatalf("host: expected 0x01, got 0x%02x", ack)
+	}
+
+	client := connectRaw(t, addr, token, roleClient)
+	if ack := readAck(t, client); ack != 0x00 {
+		t.Fatalf("client: expected 0x00, got 0x%02x", ack)
+	}
+	if ack := readAck(t, host); ack != 0x00 {
+		t.Fatalf("host matched-ack: expected 0x00, got 0x%02x", ack)
+	}
+
+	// Client sends one byte (simulates HTTP request).
+	if _, err := client.Write([]byte{'x'}); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	buf := make([]byte, 1)
+	host.SetDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+	if _, err := io.ReadFull(host, buf); err != nil {
+		t.Fatalf("host read: %v", err)
+	}
+	host.SetDeadline(time.Time{}) //nolint:errcheck
+
+	// Host is idle — does NOT reply. Simulates HTTP keep-alive after the
+	// response has already been sent on a different short-lived conn.
+	// Client closes (curl finishes).
+	client.Close()
+
+	// Host MUST see EOF (or a closed-conn error) within a short window —
+	// not after the 60 s idle timeout. Before the fix, this read would
+	// block until the test timeout.
+	host.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	n, err := host.Read(buf)
+	if err == nil && n > 0 {
+		t.Fatalf("host read returned %d bytes %q without error — splice did not propagate close", n, buf[:n])
+	}
+	if err == nil {
+		t.Fatal("host read returned nil error — expected EOF after client close")
+	}
+	// Either io.EOF or a "use of closed network connection" — both are correct outcomes.
+
+	// And a fresh host can re-queue immediately, proving the splice released
+	// the queue slot.
+	host2 := connectRaw(t, addr, token, roleHost)
+	defer host2.Close()
+	if ack := readAck(t, host2); ack != 0x01 {
+		t.Fatalf("host2 (re-queue): expected 0x01, got 0x%02x", ack)
+	}
+}
+
+// TestRelaySpliceHalfCloseHostSide is the mirror of HalfCloseUnblocksOtherSide:
+// host closes first, client must see EOF promptly. This covers the case where
+// the host's worker decides to tear down (TTL expiry, abort) while the client
+// is mid-request.
+func TestRelaySpliceHalfCloseHostSide(t *testing.T) {
+	addr := startTestRelay(t)
+	const token = "half-close-host-token"
+
+	host := connectRaw(t, addr, token, roleHost)
+	if ack := readAck(t, host); ack != 0x01 {
+		t.Fatalf("host: expected 0x01, got 0x%02x", ack)
+	}
+
+	client := connectRaw(t, addr, token, roleClient)
+	defer client.Close()
+	if ack := readAck(t, client); ack != 0x00 {
+		t.Fatalf("client: expected 0x00, got 0x%02x", ack)
+	}
+	if ack := readAck(t, host); ack != 0x00 {
+		t.Fatalf("host matched-ack: expected 0x00, got 0x%02x", ack)
+	}
+
+	// Host closes while client is idle. Client must see EOF promptly.
+	host.Close()
+
+	buf := make([]byte, 1)
+	client.SetDeadline(time.Now().Add(3 * time.Second)) //nolint:errcheck
+	_, err := client.Read(buf)
+	if err == nil {
+		t.Fatal("client read returned nil error — expected EOF after host close")
+	}
+}
+
+// TestRelaySpliceSequentialRequests is the end-to-end regression for the bug
+// that caused "no host ready" after 4 requests: simulate the host's worker
+// pool re-queueing N times and verify each new client gets matched and the
+// pipe terminates promptly.
+func TestRelaySpliceSequentialRequests(t *testing.T) {
+	addr := startTestRelay(t)
+	const token = "sequential-token"
+	const N = 10
+
+	for i := 0; i < N; i++ {
+		host := connectRaw(t, addr, token, roleHost)
+		if ack := readAck(t, host); ack != 0x01 {
+			host.Close()
+			t.Fatalf("iter %d host: expected 0x01, got 0x%02x", i, ack)
+		}
+
+		client := connectRaw(t, addr, token, roleClient)
+		if ack := readAck(t, client); ack != 0x00 {
+			host.Close()
+			client.Close()
+			t.Fatalf("iter %d client: expected 0x00, got 0x%02x", i, ack)
+		}
+		if ack := readAck(t, host); ack != 0x00 {
+			host.Close()
+			client.Close()
+			t.Fatalf("iter %d host matched-ack: expected 0x00, got 0x%02x", i, ack)
+		}
+
+		// One byte each way to confirm the splice is live.
+		if _, err := client.Write([]byte{byte(i)}); err != nil {
+			t.Fatalf("iter %d client write: %v", i, err)
+		}
+		buf := make([]byte, 1)
+		host.SetDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+		if _, err := io.ReadFull(host, buf); err != nil {
+			t.Fatalf("iter %d host read: %v", i, err)
+		}
+		if buf[0] != byte(i) {
+			t.Errorf("iter %d: got 0x%02x, want 0x%02x", i, buf[0], byte(i))
+		}
+
+		// Client closes (curl finishes). Host MUST see EOF and the relay
+		// MUST release this slot so the next iteration's host can queue.
+		client.Close()
+		host.SetDeadline(time.Now().Add(2 * time.Second)) //nolint:errcheck
+		if _, err := host.Read(buf); err == nil {
+			t.Fatalf("iter %d: host read returned nil error after client close — splice did not propagate", i)
+		}
+		host.Close()
+	}
+}
+
 // TestRelayBadVersion verifies that connections with an unknown protocol version
 // are rejected with a 0x02 error.
 func TestRelayBadVersion(t *testing.T) {

--- a/go/test/e2e/pair_test.go
+++ b/go/test/e2e/pair_test.go
@@ -1,11 +1,13 @@
 package e2e
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -100,6 +102,172 @@ func TestPairFlow(t *testing.T) {
 	if !strings.Contains(log, "e2e smoke") {
 		t.Fatalf("session_log missing intent:\n%s", log)
 	}
+}
+
+// TestPairFlowThroughRelay is the full-stack regression for the host-pool
+// starvation bug. It runs a real ftw-subetha relay in-process, points
+// ftw-pair (host) and ftw-connect (client) at it, then issues N sequential
+// GET /healthz requests through the tunnel — every one MUST return 200.
+//
+// Before the relay-splice fix, the 5th request would return 000 because
+// the host's worker pool was deadlocked in pipeConns (the relay's splice
+// never closed the host side when the client closed, so the host's read
+// from the keep-alive HTTP conn blocked forever).
+func TestPairFlowThroughRelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: skipped in short mode")
+	}
+
+	repo := repoRoot(t)
+	pairBin := buildBinary(t, repo, "ftw-pair")
+	relayBin := buildBinary(t, repo, "ftw-subetha")
+	connectBin := buildBinary(t, repo, "ftw-connect")
+	mainBin := buildBinary(t, repo, "forty-two-watts")
+
+	work := t.TempDir()
+	stateDir := filepath.Join(work, "state")
+	_ = os.MkdirAll(stateDir, 0o755)
+	cfgPath := writeMinimalConfig(t, work, stateDir)
+
+	// 1. Relay on a random localhost port.
+	relayCmd := exec.Command(relayBin, "-addr", "127.0.0.1:27777")
+	relayCmd.Stdout = os.Stdout
+	relayCmd.Stderr = os.Stderr
+	if err := relayCmd.Start(); err != nil {
+		t.Fatalf("start relay: %v", err)
+	}
+	defer relayCmd.Process.Kill()
+
+	// Wait until the relay's TCP listener is up.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", "127.0.0.1:27777", 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// 2. 42W main service so ftw-pair has something to report to.
+	mainCmd := exec.Command(mainBin, "-config", cfgPath, "-web", filepath.Join(repo, "web"))
+	mainCmd.Stdout = os.Stdout
+	mainCmd.Stderr = os.Stderr
+	if err := mainCmd.Start(); err != nil {
+		t.Fatalf("start main: %v", err)
+	}
+	defer mainCmd.Process.Kill()
+	waitForAPI(t, "http://127.0.0.1:8080/api/status")
+
+	// 3. ftw-pair pointed at the in-process relay. Capture stderr to a pipe
+	//    so we can extract the PAIR CODE the sidecar prints.
+	pairCmd := exec.Command(pairBin,
+		"-addr", "127.0.0.1:29998",
+		"-api", "http://127.0.0.1:8080",
+		"-repo", repo,
+		"-state", stateDir,
+		"-config", cfgPath,
+		"-ttl", "2m",
+		"-intent", "relay e2e",
+		"-relay-addr", "127.0.0.1:27777",
+		"-stateless",
+	)
+	pairStderr, err := pairCmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("pair stderr pipe: %v", err)
+	}
+	pairCmd.Stdout = os.Stdout
+	if err := pairCmd.Start(); err != nil {
+		t.Fatalf("start pair: %v", err)
+	}
+	defer pairCmd.Process.Kill()
+
+	pairCode := readPairCode(t, pairStderr)
+
+	// 4. ftw-connect — picks its own random localhost port for the tunnel.
+	connectCmd := exec.Command(connectBin,
+		"-relay-addr", "127.0.0.1:27777",
+		pairCode,
+	)
+	connectStdout, err := connectCmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("connect stdout pipe: %v", err)
+	}
+	connectCmd.Stderr = os.Stderr
+	if err := connectCmd.Start(); err != nil {
+		t.Fatalf("start connect: %v", err)
+	}
+	defer connectCmd.Process.Kill()
+
+	tunnelURL := readTunnelURL(t, connectStdout)
+
+	// Give the connect listener a beat to bind before we hammer it.
+	time.Sleep(200 * time.Millisecond)
+
+	// 5. The actual regression assertion — N sequential requests through the tunnel.
+	const N = 10
+	for i := 0; i < N; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req, _ := http.NewRequestWithContext(ctx, "GET", tunnelURL+"/healthz", nil)
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err != nil {
+			t.Fatalf("req %d/%d failed: %v", i+1, N, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatalf("req %d/%d: status %d body %q", i+1, N, resp.StatusCode, body)
+		}
+	}
+}
+
+// readPairCode scans the ftw-pair stderr for the "PAIR CODE: …" line.
+func readPairCode(t *testing.T, r io.Reader) string {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) && scanner.Scan() {
+		line := scanner.Text()
+		os.Stderr.WriteString(line + "\n")
+		if strings.HasPrefix(line, "PAIR CODE: ") {
+			code := strings.TrimPrefix(line, "PAIR CODE: ")
+			// Drain remaining ftw-pair stderr in a background goroutine so the
+			// pipe doesn't fill up.
+			go func() {
+				for scanner.Scan() {
+					os.Stderr.WriteString(scanner.Text() + "\n")
+				}
+			}()
+			return code
+		}
+	}
+	t.Fatal("pair code not seen on ftw-pair stderr")
+	return ""
+}
+
+// readTunnelURL scans ftw-connect stdout for "Tunnel ready: …".
+func readTunnelURL(t *testing.T, r io.Reader) string {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) && scanner.Scan() {
+		line := scanner.Text()
+		os.Stdout.WriteString(line + "\n")
+		if strings.HasPrefix(line, "Tunnel ready: ") {
+			url := strings.TrimPrefix(line, "Tunnel ready: ")
+			go func() {
+				for scanner.Scan() {
+					os.Stdout.WriteString(scanner.Text() + "\n")
+				}
+			}()
+			return url
+		}
+	}
+	t.Fatal("tunnel URL not seen on ftw-connect stdout")
+	return ""
 }
 
 func buildBinary(t *testing.T, repo, name string) string {


### PR DESCRIPTION
## Summary

The 5th curl through a pair tunnel returned `connection refused` / `no host ready`, and every subsequent request did the same. Found while doing a real e2e of `/tools` through `ftw-connect` → live relay → `ftw-pair` after the agent reported only getting `404 page not found` on the friend side.

**Root cause:** the relay's bidirectional splice in `handleClient` used `sync.WaitGroup` to wait for both `io.Copy` directions before closing either conn. When a short-lived curl closed its side after the response, the client→host copy returned on EOF — but the host→client copy stayed blocked reading from a keep-alive HTTP socket on `ftw-pair`'s MCP/REST server. The WaitGroup never drained, neither conn closed, and the host worker never saw EOF on its `pipeConns` → never looped back to re-queue. After 4 such requests the entire 4-worker host pool was deadlocked and the relay correctly reported "no host queued" to every new client.

Confirmed via SIGQUIT goroutine dump on the host process — 4 pairs of `pipeConns.func{1,2}` stuck in `(*netFD).Read`, all the way down. Wall-clock symptom: 4 requests succeed, 5th onwards return `HTTP 000`.

**Fix:** close BOTH conns as soon as EITHER `io.Copy` returns. The other `io.Copy` then unblocks with a closed-conn error and the goroutines drain cleanly. Standard half-close handling.

## Tests added

- `TestRelaySpliceHalfCloseUnblocksOtherSide` — client closes first, host must see EOF promptly (was blocking until the 60 s idle reap).
- `TestRelaySpliceHalfCloseHostSide` — mirror case.
- `TestRelaySpliceSequentialRequests` — 10 sequential client/host pairs through the same token; proves the queue slot frees on each tear-down.
- `TestPairFlowThroughRelay` — full-stack e2e: in-process `ftw-subetha` + real `ftw-pair` + real `ftw-connect`, 10 sequential `GET /healthz` through the live tunnel. **Confirmed to fail at req 5/10 without the fix and pass with it.**

## Test plan

- [x] `make verify` — vet + test + build clean
- [x] Cross-compile clean (linux/arm64, linux/amd64, windows/amd64)
- [x] Manual repro before fix — reproduced exactly the user-reported symptom (4 successful, then dead)
- [x] Manual repro with fix — 10/10 requests through real `subetha.fortytwowatts.com:7777` succeed
- [x] New `TestPairFlowThroughRelay` fails without the fix (`req 5/10 failed: read: connection reset by peer`), passes with it

## Follow-ups (NOT in this PR)

1. Deploy the new `ftw-subetha` binary to `subetha.fortytwowatts.com:7777` — the live relay needs this fix too. See `docs/subetha-deploy.md`.
2. (Tracked separately) Dashboard `<ftw-pair-card>` should flip to "inactive" when TTL hits 0 instead of staying "active", and should surface client-connected status alongside tool-call count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)