### PR TITLE
feat(pair): TTL self-heal on dashboard + surface "friend connected" state

### DIFF
--- a/go/cmd/ftw-pair/main.go
+++ b/go/cmd/ftw-pair/main.go
@@ -94,6 +94,7 @@ func main() {
 	defer mcpSrv.Shutdown(context.Background())
 
 	var pairCode string
+	var subHost *SubethaHost // nil in -no-subetha mode; ActiveTunnels() reads through this
 	if *noSubetha || *noWormhole {
 		slog.Info("subetha relay skipped", "mcp_addr", mcpSrv.Addr())
 		pairCode = "local:" + mcpSrv.Addr()
@@ -104,6 +105,7 @@ func main() {
 			os.Exit(1)
 		}
 		defer host.Close()
+		subHost = host
 		pairCode = host.Code
 		fmt.Fprintf(os.Stderr, "PAIR CODE: %s\n", host.Code)
 	}
@@ -152,7 +154,11 @@ func main() {
 			case <-sess.Done():
 				return
 			case <-t.C:
-				_ = postPairStatusFull(*apiBase, pairCode, sess, audit)
+				clients := 0
+				if subHost != nil {
+					clients = subHost.ActiveTunnels()
+				}
+				_ = postPairStatusFull(*apiBase, pairCode, sess, audit, clients)
 			}
 		}
 	}()
@@ -176,17 +182,18 @@ func main() {
 }
 
 // postPairStatusFull is the heartbeat variant of postPairStatus: it
-// includes live tool_count + last_tools so the dashboard <ftw-pair-card>
-// can show real-time activity.
-func postPairStatusFull(apiBase, code string, sess *Session, audit *Audit) error {
+// includes live tool_count + last_tools + clients_connected so the
+// dashboard <ftw-pair-card> can show real-time activity.
+func postPairStatusFull(apiBase, code string, sess *Session, audit *Audit, clients int) error {
 	body := map[string]any{
-		"session_id": sess.ID,
-		"code":       code,
-		"intent":     sess.Intent(),
-		"started_at": sess.StartedAt.UTC().Format(time.RFC3339),
-		"ttl_s":      int(sess.Remaining().Seconds()),
-		"tool_count": audit.ToolCount(),
-		"last_tools": audit.LastTools(5),
+		"session_id":        sess.ID,
+		"code":              code,
+		"intent":            sess.Intent(),
+		"started_at":        sess.StartedAt.UTC().Format(time.RFC3339),
+		"ttl_s":             int(sess.Remaining().Seconds()),
+		"tool_count":        audit.ToolCount(),
+		"last_tools":        audit.LastTools(5),
+		"clients_connected": clients,
 	}
 	buf, _ := json.Marshal(body)
 	req, _ := http.NewRequest("POST", apiBase+"/api/pair/status", bytes.NewReader(buf))

--- a/go/cmd/ftw-pair/subetha.go
+++ b/go/cmd/ftw-pair/subetha.go
@@ -11,6 +11,9 @@ import (
 )
 
 // SubethaHost is an alias for subetha.Host — host-side tunnel handle.
+// The aliased type exposes ActiveTunnels(): the number of live client peers
+// currently piped through the relay, which the heartbeat surfaces to the
+// dashboard so the operator sees when a friend is actually connected.
 type SubethaHost = subetha.Host
 
 // SubethaClient is an alias for subetha.Client — client-side tunnel handle.

--- a/go/internal/api/api_pair.go
+++ b/go/internal/api/api_pair.go
@@ -41,13 +41,29 @@ func resolvedSelfExe() string {
 // PairStatus is the metadata the ftw-pair sidecar POSTs to
 // /api/pair/status so the dashboard can render the active session.
 type PairStatus struct {
-	SessionID string   `json:"session_id"`
-	Code      string   `json:"code"`
-	Intent    string   `json:"intent"`
-	StartedAt string   `json:"started_at"`
-	TTLS      int      `json:"ttl_s"`
-	ToolCount int      `json:"tool_count,omitempty"`
-	LastTools []string `json:"last_tools,omitempty"`
+	SessionID        string   `json:"session_id"`
+	Code             string   `json:"code"`
+	Intent           string   `json:"intent"`
+	StartedAt        string   `json:"started_at"`
+	TTLS             int      `json:"ttl_s"`
+	ToolCount        int      `json:"tool_count,omitempty"`
+	LastTools        []string `json:"last_tools,omitempty"`
+	ClientsConnected int      `json:"clients_connected"`
+}
+
+// isExpired returns true when StartedAt + TTLS is in the past.
+// Garbage strings are considered NOT expired (we don't want a parse glitch
+// to nuke a live session) — the sidecar's own TTL check is the source of truth.
+func (p PairStatus) isExpired(now time.Time) bool {
+	if p.StartedAt == "" || p.TTLS <= 0 {
+		return false
+	}
+	started, err := time.Parse(time.RFC3339, p.StartedAt)
+	if err != nil {
+		return false
+	}
+	expiry := started.Add(time.Duration(p.TTLS) * time.Second)
+	return now.After(expiry)
 }
 
 // PairStatusStore holds at most one active pair session in memory.
@@ -99,6 +115,16 @@ func RegisterPairRoutes(mux *http.ServeMux, store *PairStatusStore, selfExe stri
 	mux.HandleFunc("GET /api/pair/status", func(w http.ResponseWriter, r *http.Request) {
 		p, ok := store.Get()
 		if !ok {
+			http.Error(w, `{"error":"no active session"}`, http.StatusNotFound)
+			return
+		}
+		// Self-heal stale records: if the session's TTL has already elapsed
+		// the sidecar should have torn down by now. Treat as gone — flip the
+		// dashboard to the start form and unblock POST /api/pair/start.
+		// Without this, a sidecar that exited without posting /api/pair/abort
+		// (kill -9, container restart) leaves the card stuck at "active".
+		if p.isExpired(time.Now()) {
+			store.Clear()
 			http.Error(w, `{"error":"no active session"}`, http.StatusNotFound)
 			return
 		}

--- a/go/internal/api/api_pair_test.go
+++ b/go/internal/api/api_pair_test.go
@@ -3,10 +3,12 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPairStatusPostThenGet(t *testing.T) {
@@ -14,7 +16,8 @@ func TestPairStatusPostThenGet(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterPairRoutes(mux, store, "/bin/true")
 
-	body := `{"session_id":"abc","code":"7-x","intent":"goodwe","started_at":"2026-05-25T10:00:00Z","ttl_s":14400}`
+	now := time.Now().UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{"session_id":"abc","code":"7-x","intent":"goodwe","started_at":"%s","ttl_s":14400}`, now)
 	req := httptest.NewRequest("POST", "/api/pair/status", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -43,6 +46,58 @@ func TestPairStatusGet404WhenNoSession(t *testing.T) {
 	mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/pair/status", nil))
 	if w.Code != 404 {
 		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// TestPairStatusGet404WhenExpired verifies the self-heal behaviour: a stale
+// PairStatus whose started_at + ttl_s lies in the past should be treated as
+// gone and 404'd, with the store cleared as a side-effect. Without this, a
+// sidecar that died without posting /api/pair/abort (kill -9, crash, container
+// restart) would leave the dashboard stuck at "session active" forever and
+// block POST /api/pair/start with a 409.
+func TestPairStatusGet404WhenExpired(t *testing.T) {
+	store := NewPairStatusStore()
+	mux := http.NewServeMux()
+	RegisterPairRoutes(mux, store, "/bin/true")
+
+	stale := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	store.Set(PairStatus{
+		SessionID: "expired-abc",
+		Code:      "7-x",
+		StartedAt: stale,
+		TTLS:      3600, // 1h TTL, started 2h ago → expired
+	})
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/pair/status", nil))
+	if w.Code != 404 {
+		t.Fatalf("expected 404 for expired session, got %d body %q", w.Code, w.Body)
+	}
+	// Side-effect: store was cleared so a follow-up POST /api/pair/start works.
+	if _, ok := store.Get(); ok {
+		t.Fatal("expected store to be cleared by GET after expiry")
+	}
+}
+
+// TestPairStatusGetServesUnexpiredSession is the happy-path counterpart — make
+// sure the expiry guard doesn't accidentally nuke live sessions.
+func TestPairStatusGetServesUnexpiredSession(t *testing.T) {
+	store := NewPairStatusStore()
+	mux := http.NewServeMux()
+	RegisterPairRoutes(mux, store, "/bin/true")
+
+	fresh := time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339)
+	store.Set(PairStatus{
+		SessionID: "fresh-abc",
+		Code:      "7-x",
+		StartedAt: fresh,
+		TTLS:      14400, // 4h TTL, started 30s ago → live
+	})
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/pair/status", nil))
+	if w.Code != 200 {
+		t.Fatalf("expected 200 for unexpired session, got %d body %q", w.Code, w.Body)
 	}
 }
 

--- a/go/internal/subetha/relay_client.go
+++ b/go/internal/subetha/relay_client.go
@@ -42,6 +42,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -244,6 +245,7 @@ type Host struct {
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+	active atomic.Int64 // live client tunnel pairs (incremented on match, decremented on tear-down)
 }
 
 // Close shuts down the host tunnel.
@@ -251,6 +253,13 @@ func (h *Host) Close() {
 	h.cancel()
 	h.wg.Wait()
 }
+
+// ActiveTunnels returns the number of client peers currently piped through this
+// host. Each value reflects one in-flight HTTP-like exchange — short bursts of
+// concurrent reads/writes during MCP's streaming transport will spike the count
+// for a few hundred ms; idle sessions sit at 0. The dashboard's pair-card uses
+// this to show "a friend is currently connected" alongside the tool-call count.
+func (h *Host) ActiveTunnels() int { return int(h.active.Load()) }
 
 // Option configures StartHost or Connect behaviour.
 type Option func(*relayOptions)
@@ -316,12 +325,12 @@ func StartHost(ctx context.Context, remoteAddr string, opts ...Option) (*Host, e
 
 	// Worker 0 uses the connection we already opened (firstRaw).
 	h.wg.Add(1)
-	go hostWorker(cctx, &h.wg, addr, token, remoteAddr, firstRaw, firstWaiting)
+	go hostWorker(cctx, h, addr, token, remoteAddr, firstRaw, firstWaiting)
 
 	// Remaining workers open their own first connection lazily.
 	for i := 1; i < hostPoolSize; i++ {
 		h.wg.Add(1)
-		go hostWorker(cctx, &h.wg, addr, token, remoteAddr, nil, false)
+		go hostWorker(cctx, h, addr, token, remoteAddr, nil, false)
 	}
 
 	return h, nil
@@ -331,8 +340,8 @@ func StartHost(ctx context.Context, remoteAddr string, opts ...Option) (*Host, e
 // pool of workers, the relay can match several concurrent peers for the same
 // token (required for MCP's streamable HTTP transport where SSE-response and
 // follow-up POSTs are concurrent).
-func hostWorker(ctx context.Context, wg *sync.WaitGroup, addr, token, remoteAddr string, initialRaw net.Conn, initialWaiting bool) {
-	defer wg.Done()
+func hostWorker(ctx context.Context, h *Host, addr, token, remoteAddr string, initialRaw net.Conn, initialWaiting bool) {
+	defer h.wg.Done()
 	raw, waiting := initialRaw, initialWaiting
 
 	for {
@@ -357,7 +366,7 @@ func hostWorker(ctx context.Context, wg *sync.WaitGroup, addr, token, remoteAddr
 			}
 		}
 
-		if err := hostHandleOnePair(ctx, raw, waiting, token, remoteAddr); err != nil {
+		if err := hostHandleOnePair(ctx, h, raw, waiting, token, remoteAddr); err != nil {
 			if ctx.Err() == nil {
 				slog.Debug("subetha host: pair iteration ended", "err", err)
 			}
@@ -371,7 +380,7 @@ func hostWorker(ctx context.Context, wg *sync.WaitGroup, addr, token, remoteAddr
 // hostHandleOnePair waits for a peer (if needed), wraps with AEAD, dials the
 // local MCP server, and pipes both directions until either side closes.
 // Returns when the pair is torn down. The host loop calls this repeatedly.
-func hostHandleOnePair(ctx context.Context, rawConn net.Conn, isWaiting bool, token, remoteAddr string) error {
+func hostHandleOnePair(ctx context.Context, h *Host, rawConn net.Conn, isWaiting bool, token, remoteAddr string) error {
 	defer rawConn.Close()
 
 	if isWaiting {
@@ -405,9 +414,11 @@ func hostHandleOnePair(ctx context.Context, rawConn net.Conn, isWaiting bool, to
 	}
 	defer localConn.Close()
 
-	slog.Info("subetha host: tunnel established", "remote", remoteAddr)
+	h.active.Add(1)
+	slog.Info("subetha host: tunnel established", "remote", remoteAddr, "active", h.active.Load())
 	pipeConns(ctx, relayConn, localConn)
-	slog.Info("subetha host: tunnel closed")
+	h.active.Add(-1)
+	slog.Info("subetha host: tunnel closed", "active", h.active.Load())
 	return nil
 }
 

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -198,6 +198,13 @@ class FtwPairCard extends FtwElement {
       color: var(--ink-raised);
       font-family: var(--sans, var(--mono));
     }
+    .muted {
+      color: var(--ink-raised2, var(--fg-dim, var(--fg)));
+      opacity: 0.6;
+    }
+    .live {
+      color: var(--accent-e);
+    }
   `;
 
   constructor() {
@@ -350,6 +357,7 @@ class FtwPairCard extends FtwElement {
         </section>
         <dl>
           <dt>TTL</dt><dd>${escapeHTML(remaining)}</dd>
+          <dt>Friend</dt><dd>${this._renderClients()}</dd>
           <dt>Tool calls</dt><dd>${this._state.tool_count ?? 0}</dd>
           <dt>Last tools</dt><dd>${lastTools}</dd>
         </dl>
@@ -478,6 +486,17 @@ Session expires in ${remaining} or when I click Abort.`;
     const h = Math.floor(left / 3600);
     const m = Math.floor((left % 3600) / 60);
     return `${h}h ${m}m`;
+  }
+
+  // _renderClients surfaces the subetha host's ActiveTunnels() count: it tells
+  // the operator whether a friend is currently piping bytes through the tunnel.
+  // 0 = nobody's connected right now (still normal — agents poll, they don't
+  // keep a long-lived conn); ≥ 1 = at least one in-flight request being served.
+  _renderClients() {
+    const n = this._state.clients_connected ?? 0;
+    if (n <= 0) return `<span class="muted">idle</span>`;
+    if (n === 1) return `<span class="live">● connected</span>`;
+    return `<span class="live">● connected (${n} in flight)</span>`;
   }
 }
 


### PR DESCRIPTION
## Summary

Two pair-card UX papercuts spotted while exercising the live tunnel:

1. **Expired sessions linger as \"active\".** When a sidecar exits without posting `/api/pair/abort` (kill -9, crash, container restart), the in-memory `PairStatus` stayed forever. Countdown reached \`0h 0m\` but the card still rendered as active and a fresh \"Start pair session\" was blocked by 409.

   **Fix:** `GET /api/pair/status` now treats a record whose `started_at + ttl_s` is in the past as gone — it clears the store inline and returns 404. The dashboard's poll loop already maps 404 → start form, so the card flips to inactive on the next 5 s tick after expiry. Garbage timestamps stay considered NOT expired so a parse glitch can't nuke a live session.

2. **No \"someone's connected\" indicator.** Previously the heartbeat only carried `tool_count`, so the operator saw activity only after the agent made tool calls. There was no signal whether a friend was actually CONNECTED to the tunnel.

   **Fix:** `subetha.Host` now tracks `ActiveTunnels()` (atomic counter, ++ on each matched peer, -- on splice tear-down). The sidecar's 5 s heartbeat posts it as `clients_connected`, and the card renders an amber \"● connected\" pill next to the tool-call line. `0 ⇒ \"idle\"` (normal — agents poll, they don't hold long-lived conns); `≥ 1 ⇒ in-flight requests being served right now`.

## Test plan

- [x] `make verify` — vet + test + build clean
- [x] Cross-compile clean (linux/arm64, linux/amd64, windows/amd64)
- [x] New unit tests:
  - `TestPairStatusGet404WhenExpired` — stale record self-heals to 404 + store clears as a side-effect
  - `TestPairStatusGetServesUnexpiredSession` — guard doesn't accidentally nuke live sessions
- [x] Existing `TestPairStatusPostThenGet` rewritten to use `time.Now()` so it doesn't time-bomb future test runs

## Depends on

Stacked behind #339 (relay-splice half-close fix) only logically — they touch disjoint files so this merges cleanly either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)