### PR TITLE
docs(subetha): scrub Sourceful-specific deploy details from public runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ in YAML or re-adding it doesn't orphan a trained model. See
 | `go/cmd/ftw-updater` | Sidecar binary — runs docker compose pull + up -d on behalf of the main service |
 | `go/cmd/ftw-pair` | MCP sidecar — host side of the pair flow (`docs/ftw-pair.md`) |
 | `go/cmd/ftw-connect` | Friend-side CLI for joining a pair session |
-| `go/cmd/ftw-subetha` | Standalone relay server — matches two peers on a token and pipes encrypted bytes (`docs/pair-relay-deploy.md`) |
+| `go/cmd/ftw-subetha` | Standalone relay server — matches two peers on a token and pipes encrypted bytes (`docs/subetha-deploy.md`) |
 | `go/internal/subetha` | Subetha — pure-Go relay client: BIP39 token, HKDF-derived ChaCha20-Poly1305 AEAD, length-prefixed frames over TCP |
 | `drivers/` | Lua drivers (`ferroamp.lua`, `sungrow.lua`, …) |
 | `go/test/e2e` | Full-stack test: sims + main + drivers + HTTP |

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN cd go && \
     -o /out/ftw-pair ./cmd/ftw-pair
 
 # Note: the standalone relay (ftw-subetha) is NOT bundled in this image.
-# It's deployed separately on a Lightsail nano — see docs/subetha-deploy.md.
+# It's deployed separately — see docs/subetha-deploy.md for the "run your
+# own relay" guide.
 # The cross-platform binaries are published as GitHub release assets
 # (ftw-subetha-linux-{amd64,arm64}) for operators who self-host.
 

--- a/docs/future/subetha-design-history.md
+++ b/docs/future/subetha-design-history.md
@@ -4,7 +4,7 @@
 This doc captures the original proposal and trade-off analysis that led to
 adopting this transport over the fowl/magic-wormhole approach. Kept for
 historical context. Live implementation details live in
-`go/internal/subetha/` and `docs/pair-relay-deploy.md`.
+`go/internal/subetha/` and `docs/subetha-deploy.md`.
 
 ## Context
 

--- a/docs/subetha-deploy.md
+++ b/docs/subetha-deploy.md
@@ -1,79 +1,70 @@
-# Deploying `ftw-subetha`
+# Running a `ftw-subetha` relay
 
 The pair relay is a single Go binary that matches two peers on a shared
 token and pipes encrypted bytes between them. Stateless, ~5 MB, runs on
 anything that speaks TCP. End-to-end-encrypted traffic transits via this
 relay — the relay sees only ciphertext.
 
-## Production relay (Sourceful-operated)
+Most operators **don't need to deploy their own** — `ftw-pair` and
+`ftw-connect` ship with a default public relay built in (see below).
+This document is for the cases where you want to run your own: a private
+deployment for a team, a fork that needs an isolated transport, or just
+"I'd rather not depend on someone else's infrastructure".
 
-Current deployment:
+## Default public relay
 
-- **Host:** AWS Lightsail nano in `eu-north-1` (Stockholm)
-- **Static IP:** `16.170.137.95`
-- **DNS:** `subetha.fortytwowatts.com` → `16.170.137.95` (Cloudflare, free tier)
-- **Cost:** $3.50/mo (nano bundle) + $0.005/h elastic IP (~$0 while attached)
-- **systemd unit:** `ftw-subetha.service`, auto-restarts on failure
+`ftw-pair` and `ftw-connect` default to a Sourceful-operated public relay
+at `subetha.fortytwowatts.com:7777`. It's a single small VM running this
+exact binary; we redeploy it from `master` as needed.
 
-Operators don't need to do anything — `ftw-pair` and `ftw-connect`
-default to this host.
+Because traffic is end-to-end-encrypted with a token-derived AEAD key,
+the relay operator (us) cannot read or tamper with session bytes — they
+see only ciphertext. The trust model is therefore "relay is a passthrough,
+not a participant". A compromise of the relay means denial of service,
+not data exfiltration.
 
-## DNS (Cloudflare)
+If that trust model isn't acceptable for your use case, run your own.
 
-Add a single A-record on `fortytwowatts.com`:
+## Running your own relay
 
-| Type | Name                 | Content        | Proxy status |
-|------|----------------------|----------------|--------------|
-| A    | pair-relay           | 16.170.137.95  | DNS only (grey cloud) |
-
-**Important:** Set the proxy status to "DNS only" (grey cloud). Orange-cloud
-(Cloudflare proxy) only handles HTTP — it will not pass the raw TCP traffic
-our relay needs.
-
-## Reproducing the deployment from scratch
+The binary is published as a GitHub release asset
+(`ftw-subetha-linux-{amd64,arm64}`, plus mac/windows variants) for every
+forty-two-watts release. You can also build from source:
 
 ```bash
-REGION=eu-north-1
+cd go
+CGO_ENABLED=0 go build -ldflags="-s -w" -o ftw-subetha ./cmd/ftw-subetha
+```
 
-# 1. Create instance
-aws lightsail create-instances \
-  --region $REGION \
-  --instance-names ftw-subetha \
-  --availability-zone ${REGION}a \
-  --blueprint-id ubuntu_24_04 \
-  --bundle-id nano_3_0 \
-  --tags key=role,value=pair-relay
+Run it bound to a TCP port reachable from both ends of the pair session:
 
-# 2. Wait for `running`, then open port 7777
-aws lightsail open-instance-public-ports \
-  --region $REGION \
-  --instance-name ftw-subetha \
-  --port-info fromPort=7777,toPort=7777,protocol=TCP
+```bash
+./ftw-subetha -addr :7777
+```
 
-# 3. Allocate + attach static IP
-aws lightsail allocate-static-ip --region $REGION --static-ip-name ftw-subetha-ip
-aws lightsail attach-static-ip   --region $REGION --static-ip-name ftw-subetha-ip --instance-name ftw-subetha
-STATIC=$(aws lightsail get-static-ip --region $REGION --static-ip-name ftw-subetha-ip --query 'staticIp.ipAddress' --output text)
+That's it. Stateless. No config file, no database, no secrets to provision.
 
-# 4. Download default SSH key
-aws lightsail download-default-key-pair --region $REGION \
-  | python3 -c "import json,sys; print(json.load(sys.stdin)['privateKeyBase64'])" \
-  > /tmp/lightsail-key.pem
-chmod 600 /tmp/lightsail-key.pem
+### Point clients at your relay
 
-# 5. Build relay (linux/amd64 for Lightsail nano)
-cd go && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-  go build -ldflags="-s -w" -o /tmp/ftw-subetha-amd64 ./cmd/ftw-subetha
+Both `ftw-pair` (host side) and `ftw-connect` (friend side) take a
+`-relay-addr` flag, or read the `FTW_PAIR_RELAY` environment variable:
 
-# 6. SCP + systemd
-scp -i /tmp/lightsail-key.pem /tmp/ftw-subetha-amd64 ubuntu@$STATIC:/tmp/ftw-subetha
-ssh -i /tmp/lightsail-key.pem ubuntu@$STATIC <<'EOF'
-  sudo install -m 755 -o root -g root /tmp/ftw-subetha /usr/local/bin/ftw-subetha
-  sudo tee /etc/systemd/system/ftw-subetha.service > /dev/null <<UNIT
+```bash
+# Host side
+ftw-pair -relay-addr relay.example.com:7777 ...
+
+# Friend side
+ftw-connect -relay-addr relay.example.com:7777 <token>
+
+# Or via env
+export FTW_PAIR_RELAY=relay.example.com:7777
+```
+
+### systemd unit (optional)
+
+```ini
 [Unit]
-Description=Sourceful subetha relay — pair-session match server for forty-two-watts
-Documentation=https://github.com/frahlg/forty-two-watts/blob/master/docs/subetha-deploy.md
-Documentation=https://github.com/frahlg/forty-two-watts/blob/master/docs/ftw-pair.md
+Description=ftw-subetha relay
 After=network.target
 
 [Service]
@@ -85,100 +76,69 @@ DynamicUser=yes
 
 [Install]
 WantedBy=multi-user.target
-UNIT
-  sudo systemctl daemon-reload && sudo systemctl enable --now ftw-subetha
-EOF
-
-# 7. MOTD + README so anyone landing on the box understands what's running
-ssh -i /tmp/lightsail-key.pem ubuntu@$STATIC 'sudo tee /etc/motd > /dev/null <<MOTD
-
-============================================================================
- Sourceful subetha relay
-============================================================================
-
- This Lightsail nano runs ONE process: ftw-subetha (systemd service).
- It matches two TCP peers on a shared token and pipes encrypted bytes
- between them, so a friend can join a forty-two-watts pair session
- from anywhere on the internet.
-
- Service status:    sudo systemctl status ftw-subetha
- Live logs:         sudo journalctl -u ftw-subetha -f
- Binary:            /usr/local/bin/ftw-subetha
- Listens on:        :7777 (TCP)
- Public DNS:        subetha.fortytwowatts.com (also pair-relay.fortytwowatts.com)
- Repo:              https://github.com/frahlg/forty-two-watts
- Deploy runbook:    docs/subetha-deploy.md in the repo
- Protocol:          docs/ftw-pair.md in the repo
-
- Stateless. End-to-end-encrypted. The relay sees only ciphertext.
- Safe to restart at any time — active pair sessions reconnect.
-============================================================================
-MOTD'
-ssh -i /tmp/lightsail-key.pem ubuntu@$STATIC 'sudo install -d /etc/sourceful && sudo tee /etc/sourceful/README.md > /dev/null <<README
-# Sourceful subetha relay
-
-This box runs **ftw-subetha** — see /etc/motd for a one-screen summary and
-\`docs/subetha-deploy.md\` in the forty-two-watts repo for the full runbook
-and ops notes.
-README'
-
-# 8. AWS instance tags so the role is visible in the Lightsail console
-aws lightsail tag-resource \
-  --region $REGION \
-  --resource-name ftw-pair-relay \
-  --tags key=Role,value=subetha-relay \
-         key=Project,value=forty-two-watts \
-         key=Service,value=ftw-subetha \
-         key=Repo,value=github.com/frahlg/forty-two-watts \
-         key=Docs,value=docs/subetha-deploy.md
-
-# 9. Set DNS (manual via Cloudflare dashboard)
-echo "Now add A-record: subetha → $STATIC at Cloudflare (DNS only, grey cloud)"
 ```
+
+`DynamicUser=yes` means systemd allocates a fresh unprivileged UID per
+run — the binary needs no filesystem access and no persistent identity.
+
+### DNS
+
+If you expose the relay under a name, use a plain A-record. Do **not**
+proxy it through Cloudflare's HTTP CDN (orange-cloud) — that path only
+forwards HTTPS. Subetha is raw TCP, so the proxy will drop the traffic.
 
 ## Operations
 
-**Update the relay binary:**
+The relay is effectively stateless, so operations is mostly "restart it
+if you change the binary":
 
 ```bash
-ssh ubuntu@subetha.fortytwowatts.com \
-  'sudo systemctl stop ftw-subetha; \
-   sudo install -m 755 /tmp/ftw-subetha-new /usr/local/bin/ftw-subetha; \
-   sudo systemctl start ftw-subetha'
+sudo systemctl stop ftw-subetha
+sudo install -m 755 ftw-subetha-new /usr/local/bin/ftw-subetha
+sudo systemctl start ftw-subetha
 ```
 
-Brief downtime (~5 s) — any active pair session breaks and needs to be
-re-paired. No state persists across restarts.
+Brief downtime (~5 s). Any active pair session breaks and needs to
+re-pair. Nothing persists across restarts.
 
 **Monitor:**
 
 ```bash
-ssh ubuntu@subetha.fortytwowatts.com 'sudo journalctl -u ftw-subetha -f'
+sudo journalctl -u ftw-subetha -f
 ```
 
-Look for `relay: matched pair` events (= a session connected end-to-end)
-and `relay: pair disconnected` (= clean teardown).
+Look for `relay: matched pair` (a session connected end-to-end) and
+`relay: pair disconnected` (clean teardown). The half-close handling
+landed in v0.100.0 — without it, `pair disconnected` events were
+delayed up to the idle-reaper timeout under load.
 
 **Resource usage:**
 
-- Memory: ~2 MB resident per active session (just two TCP socket buffers)
-- CPU: negligible (`io.Copy` is a syscall loop)
-- Bandwidth: depends on session load; MCP tool-call traffic is text JSON
-  at < 100 kbps; pcap-capture can spike to MB/s briefly
+- Memory: ~2 MB resident per active pair session (two TCP socket buffers).
+- CPU: negligible — `io.Copy` is a syscall loop.
+- Bandwidth: depends on session traffic. MCP tool-call JSON sits at
+  < 100 kbps; `pcap_capture` tool calls can spike to MB/s briefly.
 
-The nano bundle handles tens of concurrent sessions comfortably.
+A small VM (the cheapest tier on any cloud provider) handles tens of
+concurrent sessions comfortably. Choose a region close to your users
+to keep round-trip latency low.
 
 ## TLS
 
-Not needed for the relay itself — the bytes between peers are already
-encrypted with ChaCha20-Poly1305 (key derived from the shared token via
-HKDF-SHA256). The relay sees only ciphertext and can't read or tamper with
-the traffic.
+Not needed for confidentiality — bytes are already encrypted with
+ChaCha20-Poly1305 (key derived from the shared token via HKDF-SHA256).
+The relay sees only ciphertext and can't read or tamper with the traffic.
 
 The reason to add TLS would be **firewall traversal**: some restrictive
 networks (cafés, conference WiFi, corporate proxies) block non-HTTPS TCP.
-Running the relay on `:443` with a real TLS cert (via the `-tls-cert` and
-`-tls-key` flags, or Let's Encrypt autocert) would help these users connect.
+Running the relay on `:443` with a real TLS cert would help these users
+connect. The binary doesn't ship with TLS today — if you need it, wrap
+the listener in `stunnel`, `nginx stream`, or similar.
 
-If we see real-world reports of `connection refused` from friends, that's
-the signal to flip TLS on. Not before.
+## Protocol reference
+
+The wire protocol is documented in `go/internal/subetha/relay_client.go`
+and `go/cmd/ftw-subetha/relay.go`. Short version: 4-byte handshake
+(version + role + token-length + token), then raw bytes piped between
+matched peers until either side closes. The AEAD framing lives one layer
+above the relay; the relay doesn't know or care about it.


### PR DESCRIPTION
## Summary

\`docs/subetha-deploy.md\` documented the exact Sourceful production deployment of the public relay — AWS region, Lightsail instance name, static IP, MOTD wording, ssh-as-ubuntu recipes. Nothing in there was a hard secret, but it was free recon on our internet-facing infrastructure, and that infra isn't really \"forty-two-watts\" anyway — it's shared subetha infra that happens to be operated by Sourceful.

Rewritten as a generic **\"run your own \`ftw-subetha\` relay\"** guide:

- Explains the default public relay + the trust model (relay sees only ciphertext → worst case = DoS, not data exfiltration).
- Shows how to build / run / systemd / DNS for an independent deployment.
- Documents the \`-relay-addr\` flag and \`FTW_PAIR_RELAY\` env var so users can point their own \`ftw-pair\` / \`ftw-connect\` at their own relay.
- Keeps protocol reference, resource-usage notes, and TLS rationale (those are general-purpose).

Also fixed two stale cross-refs to the pre-#328 filename \`docs/pair-relay-deploy.md\` (in \`CLAUDE.md\` and the design-history doc), and de-Lightsail'd a Dockerfile comment.

## What lands publicly vs. privately

| Was public | Now |
|---|---|
| AWS region, instance name, static IP | Removed from repo |
| Lightsail-specific CLI recipe | Removed from repo |
| MOTD with Sourceful-specific wording | Removed from repo |
| Default-relay hostname | Kept — DNS is by definition public |
| Run-your-own recipe (generic) | Kept |
| Protocol notes, trust model, TLS rationale | Kept |

The Sourceful-specific deploy recipe lives outside this repo now (saved locally to \`~/sourceful-subetha-deploy-PRIVATE.md\` — to be filed in whatever private repo / vault Sourceful ops uses).

## Follow-ups (not in this PR)

- Eventually split \`internal/subetha\` + \`cmd/ftw-subetha\` into a standalone repo when the protocol stabilises. Criterion: 4 weeks without a transport/protocol PR. Discussed; not actionable today.
- Git history still contains the previous version. Acceptable trade-off (no hard secrets in the scrubbed content) → no force-rewrite. Flag if you'd rather BFG-clean.

## Test plan

- [x] \`make verify\` clean (vet + test + build, including the in-process e2e relay test from #339).
- [x] grep'd for any remaining mentions of \`16.170.137.95 / eu-north-1 / ftw-pair-relay / Lightsail\` across \`*.md *.go *.yaml *.lua *.sh\` — zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)