### PR TITLE
[codex] harden fuse safety guards

### DIFF
--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -213,6 +213,27 @@ func TestChargeModeForcesAllBatteriesPositive5kW(t *testing.T) {
 	}
 }
 
+func TestChargeModeRespectsFuseGuard(t *testing.T) {
+	store := seedStore(10000, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModeCharge
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if !targets[0].Clamped {
+		t.Fatalf("charge target should be clamped by fuse guard: %+v", targets[0])
+	}
+	if math.Abs(targets[0].TargetW-1040) > 1 {
+		t.Fatalf("charge target = %.0f W, want remaining fuse headroom 1040 W", targets[0].TargetW)
+	}
+}
+
 func TestDeadbandSkipsWithinTolerance(t *testing.T) {
 	store := seedStore(30, []struct {
 		name          string

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -931,6 +931,13 @@ func ComputeDispatch(
 	case ModeCharge:
 		state.resetSettlementAccounting()
 		targets := chargeAll(store, driverCapacities, state.DriverLimits)
+		targets = applyFuseGuard(targets, store, state, fuseMaxW)
+		targets = forceFuseDischarge(targets, store, state, driverCapacities, fuseMaxW)
+		now := time.Now()
+		state.LastDispatch = &now
+		for _, t := range targets {
+			state.PrevTargets[t.Driver] = t.TargetW
+		}
 		state.LastTargets = targets
 		return targets
 	}

--- a/go/internal/control/forecast_scenarios_test.go
+++ b/go/internal/control/forecast_scenarios_test.go
@@ -605,9 +605,6 @@ func TestScenario_D21_LoadModel_AboveFloor_NotRepaired(t *testing.T) {
 // E22. Site never imports above fuse limit. Checked across planner modes and
 // several adversarial grid + battery states from the matrix above.
 //
-// NOTE: ModeCharge (chargeAll) returns before applyFuseGuard by design — it is
-// a manual operator override that trusts the operator to have checked the fuse.
-// The fuse guard only applies to the PI-driven and energy-dispatch paths.
 func TestScenario_E22_FuseNeverExceeded(t *testing.T) {
 	const fuseMaxW = 11040.0
 
@@ -645,6 +642,12 @@ func TestScenario_E22_FuseNeverExceeded(t *testing.T) {
 			name:  "peak_shaving_over_limit",
 			gridW: 9000, pvW: 0,
 			mode: ModePeakShaving, dir: nil,
+			battW: 0, soc: 0.60,
+		},
+		{
+			name:  "manual_charge_high_import",
+			gridW: 10000, pvW: 0,
+			mode: ModeCharge, dir: nil,
 			battW: 0, soc: 0.60,
 		},
 	}


### PR DESCRIPTION
## Summary

- Reject invalid `fuse.phases` and `fuse.voltage` values during config validation.
- Fix `applyFuseGuard` prediction to subtract only the batteries that are actually controlled in the current dispatch target set.
- Route manual `ModeCharge` targets through the same fuse guard and reactive fuse-saver as normal dispatch paths.
- Add regression coverage for stale/offline battery readings already included in the site meter, plus manual charge under high import.

## Root cause

The fuse-guard prediction summed every battery reading in telemetry, including stale/offline batteries that were not receiving a replacement target. Because those stale readings are already reflected in the live grid meter, subtracting them again could under-predict fuse pressure and miss an overage.

A second audit finding showed `ModeCharge` returned `chargeAll(...)` directly before the safety post-processing path, so a manual fill command could push import past the configured fuse.

## Validation

- `cd go && go test ./internal/control`
- `make test`