### PR TITLE
fix(mpc): sanitize non-finite optimizer inputs

### DIFF
--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -315,6 +315,41 @@ func exportPricingFromParams(p Params) gridcost.ExportPricing {
 	}
 }
 
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
+func sanitizeOptimizeSlots(slots []Slot) []Slot {
+	out := make([]Slot, 0, len(slots))
+	for _, s := range slots {
+		if s.LenMin <= 0 {
+			s.LenMin = 60
+		}
+		if !finite(s.PriceOre) || !finite(s.SpotOre) {
+			continue
+		}
+		if !finite(s.PVW) {
+			s.PVW = 0
+		}
+		if !finite(s.LoadW) || s.LoadW < 0 {
+			s.LoadW = 0
+		}
+		if !finite(s.Confidence) || s.Confidence <= 0 {
+			s.Confidence = 1.0
+		} else if s.Confidence > 1 {
+			s.Confidence = 1.0
+		}
+		if !finite(s.Limits.MaxImportW) {
+			s.Limits.MaxImportW = 0
+		}
+		if !finite(s.Limits.MaxExportW) {
+			s.Limits.MaxExportW = 0
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // Optimize runs DP and returns the cost-minimizing plan.
 //
 // Complexity: O(N × S × A) where N = len(slots), S = SoCLevels, A = ActionLevels.
@@ -322,6 +357,7 @@ func exportPricingFromParams(p Params) gridcost.ExportPricing {
 // ~82k evaluations — well under 10ms.
 func Optimize(slots []Slot, p Params) Plan {
 	now := time.Now().UnixMilli()
+	slots = sanitizeOptimizeSlots(slots)
 	if len(slots) == 0 || p.CapacityWh <= 0 {
 		return Plan{GeneratedAtMs: now, Mode: p.Mode}
 	}

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -1021,10 +1021,35 @@ func TestOptimizeWithNaNPVDoesNotPanic(t *testing.T) {
 		{StartMs: 3600 * 1000, LenMin: 60, PriceOre: 100, LoadW: 1000, PVW: 0},
 	}
 	p := baseParams(ModeArbitrage)
-	// Must not panic — NaN propagates through arithmetic without crashing.
 	plan := Optimize(slots, p)
 	if len(plan.Actions) != 2 {
 		t.Errorf("expected 2 actions, got %d", len(plan.Actions))
+	}
+	for i, a := range plan.Actions {
+		if math.IsNaN(a.GridW) || math.IsInf(a.GridW, 0) {
+			t.Fatalf("slot %d: grid_w is non-finite: %v", i, a.GridW)
+		}
+		if math.IsNaN(a.CostOre) || math.IsInf(a.CostOre, 0) {
+			t.Fatalf("slot %d: cost_ore is non-finite: %v", i, a.CostOre)
+		}
+		if math.IsNaN(a.PVW) || math.IsInf(a.PVW, 0) {
+			t.Fatalf("slot %d: pv_w is non-finite: %v", i, a.PVW)
+		}
+	}
+}
+
+func TestOptimizeDropsNonFinitePriceSlots(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: math.NaN(), SpotOre: 100, LoadW: 1000, PVW: 0},
+		{StartMs: 3600 * 1000, LenMin: 60, PriceOre: 100, SpotOre: math.Inf(1), LoadW: 1000, PVW: 0},
+		{StartMs: 2 * 3600 * 1000, LenMin: 60, PriceOre: 100, SpotOre: 100, LoadW: 1000, PVW: 0},
+	}
+	plan := Optimize(slots, baseParams(ModeArbitrage))
+	if len(plan.Actions) != 1 {
+		t.Fatalf("got %d actions, want only the finite-price slot", len(plan.Actions))
+	}
+	if plan.Actions[0].SlotStartMs != 2*3600*1000 {
+		t.Fatalf("kept slot start %d, want final finite slot", plan.Actions[0].SlotStartMs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Sanitize optimizer slot inputs at the `Optimize` boundary.
- Drop slots with non-finite import/export prices.
- Convert non-finite PV/load to zero, clamp negative load to zero, and normalize invalid confidence/limits.
- Tighten NaN regression coverage so plans do not contain non-finite grid, PV, or cost values.

## Root cause

The DP planner used raw forecast and price slot fields directly. A NaN or Inf in a forecast slot could poison grid flow, mean price, costs, and diagnostics without panicking, leaving downstream EMS code with non-finite plan values.

## Validation

- `go test -run 'TestOptimizeWithNaNPVDoesNotPanic|TestOptimizeDropsNonFinitePriceSlots' ./internal/mpc`
- `go test ./internal/mpc ./internal/loadmodel ./internal/pvmodel ./internal/priceforecast`
- `git diff --check`
- `make test`