### PR TITLE
fix(drivers): surface Lua command + Modbus register-kind failures

### DIFF
--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -134,8 +134,13 @@ func (d *LuaDriver) Command(ctx context.Context, cmdJSON []byte) error {
 		power, _ = cmd["w"].(float64)
 	}
 	t := goToLua(d.L, cmd)
-	return d.L.CallByParam(lua.P{Fn: fn, NRet: 0, Protect: true},
-		lua.LString(action), lua.LNumber(power), t)
+	if err := d.L.CallByParam(lua.P{Fn: fn, NRet: 1, Protect: true},
+		lua.LString(action), lua.LNumber(power), t); err != nil {
+		return err
+	}
+	ret := d.L.Get(-1)
+	d.L.Pop(1)
+	return luaReturnError("driver_command", ret)
 }
 
 // Cleanup calls driver_cleanup() and closes the VM.
@@ -160,7 +165,26 @@ func (d *LuaDriver) call(name string) error {
 	if fn == lua.LNil {
 		return nil
 	}
-	return d.L.CallByParam(lua.P{Fn: fn, NRet: 0, Protect: true})
+	if err := d.L.CallByParam(lua.P{Fn: fn, NRet: 1, Protect: true}); err != nil {
+		return err
+	}
+	ret := d.L.Get(-1)
+	d.L.Pop(1)
+	return luaReturnError(name, ret)
+}
+
+func luaReturnError(name string, ret lua.LValue) error {
+	switch v := ret.(type) {
+	case lua.LBool:
+		if !bool(v) {
+			return fmt.Errorf("%s returned false", name)
+		}
+	case lua.LString:
+		if s := string(v); s != "" {
+			return fmt.Errorf("%s: %s", name, s)
+		}
+	}
+	return nil
 }
 
 // ---- host.* API exposed to Lua ----
@@ -341,7 +365,12 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			L.Push(lua.LString("no modbus capability"))
 			return 2
 		}
-		kind := modbusKindFromString(kindS)
+		kind, ok := modbusKindFromString(kindS)
+		if !ok {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("unknown modbus kind: " + kindS))
+			return 2
+		}
 		regs, err := env.Modbus.Read(uint16(addr), uint16(count), kind)
 		if err != nil {
 			L.Push(lua.LNil)
@@ -662,18 +691,18 @@ func splitHostPortLower(s string) (host, port string, hasPort bool) {
 	return s[:i], maybePort, true
 }
 
-func modbusKindFromString(s string) int32 {
+func modbusKindFromString(s string) (int32, bool) {
 	switch s {
 	case "coil":
-		return 0
+		return 0, true
 	case "discrete":
-		return 1
+		return 1, true
 	case "holding":
-		return 2
+		return 2, true
 	case "input":
-		return 3
+		return 3, true
 	}
-	return 2 // default holding
+	return 0, false
 }
 
 // goToLua / luaToGo — minimal JSON-shaped bridge (string, number, bool,

--- a/go/internal/drivers/lua_test.go
+++ b/go/internal/drivers/lua_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +84,78 @@ func TestLuaDriverLifecycle(t *testing.T) {
 	err = d.Command(context.Background(), []byte(`{"action":"set","w":-1500}`))
 	if err != nil {
 		t.Fatalf("command: %v", err)
+	}
+}
+
+func TestLuaDriverCommandAndDefaultModeReturnErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "failing.lua")
+	src := `
+function driver_command(action, w, cmd)
+    return "write failed"
+end
+function driver_default_mode()
+    return false
+end
+`
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, NewHostEnv("failing", telemetry.NewStore()))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	err = d.Command(context.Background(), []byte(`{"action":"battery","power_w":1000}`))
+	if err == nil || !strings.Contains(err.Error(), "write failed") {
+		t.Fatalf("Command error = %v, want write failed", err)
+	}
+	err = d.DefaultMode()
+	if err == nil || !strings.Contains(err.Error(), "returned false") {
+		t.Fatalf("DefaultMode error = %v, want returned false", err)
+	}
+}
+
+type luaKindTestModbus struct {
+	called bool
+}
+
+func (m *luaKindTestModbus) Read(uint16, uint16, int32) ([]uint16, error) {
+	m.called = true
+	return []uint16{1}, nil
+}
+
+func (m *luaKindTestModbus) WriteSingle(uint16, uint16) error  { return nil }
+func (m *luaKindTestModbus) WriteMulti(uint16, []uint16) error { return nil }
+func (m *luaKindTestModbus) Close() error                      { return nil }
+
+func TestLuaModbusReadRejectsUnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad_kind.lua")
+	src := `
+function driver_command(action, w, cmd)
+    local regs, err = host.modbus_read(1, 1, "inputs")
+    if err then return err end
+    return "expected unknown kind error"
+end
+`
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	modbus := &luaKindTestModbus{}
+	d, err := NewLuaDriver(path, NewHostEnv("bad-kind", telemetry.NewStore()).WithModbus(modbus))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	err = d.Command(context.Background(), []byte(`{"action":"test"}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown modbus kind") {
+		t.Fatalf("Command error = %v, want unknown modbus kind", err)
+	}
+	if modbus.called {
+		t.Fatal("modbus Read was called for an unknown kind")
 	}
 }
 

--- a/go/internal/drivers/solaredge_curtail_test.go
+++ b/go/internal/drivers/solaredge_curtail_test.go
@@ -173,7 +173,12 @@ func TestSolarEdgeCurtailDisable(t *testing.T) {
 func TestSolarEdgeCurtailWithoutNominalRejected(t *testing.T) {
 	d, mb := loadSolarEdgeDriver(t, "../../../drivers/solaredge.lua", 0)
 	defer d.Cleanup()
-	runCmd(t, d, "curtail", 5000)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd, _ := json.Marshal(map[string]any{"action": "curtail", "power_w": 5000.0})
+	if err := d.Command(ctx, cmd); err == nil {
+		t.Fatal("curtail without nominal_w should return an error")
+	}
 	if len(mb.snapshot()) != 0 {
 		t.Errorf("curtail without nominal_w should write nothing, got %+v", mb.snapshot())
 	}


### PR DESCRIPTION
## Summary

- Propagate optional return values from `driver_command` and `driver_default_mode`.
- Treat `false` and non-empty string returns as Go errors so registry send/default-mode callers can see failed hardware writes.
- Reject unknown `host.modbus_read` register kinds instead of silently defaulting to holding registers.
- Update SolarEdge curtail rejection coverage to expect an explicit command error when `nominal_w` is missing.

## Root cause

The Lua host called command/default lifecycle hooks with `NRet: 0`, discarding return values from drivers that already reported failures with `false` or an error string. Separately, a typo in the Modbus register kind argument defaulted to holding registers, hiding driver bugs behind reads from the wrong register space.

## Validation

- `cd go && go test ./internal/drivers`
- `make test`