### PR TITLE
fix(battery): reject non-finite and out-of-range model observations

### DIFF
--- a/go/internal/battery/model.go
+++ b/go/internal/battery/model.go
@@ -3,8 +3,10 @@
 // Port of the Rust src/battery_model.rs + src/control.rs cascade parts.
 //
 // Under the site sign convention (+ = into site, − = out of site):
-//   command u = charge (+) or discharge (−)
-//   actual  y = same convention
+//
+//	command u = charge (+) or discharge (−)
+//	actual  y = same convention
+//
 // The ARX(1) model y(t+1) = a·y(t) + b·u(t) is sign-agnostic — we learn the
 // same `a` and `b` regardless of convention. Only the curves and clamps need
 // to be convention-aware.
@@ -17,15 +19,15 @@ import (
 
 // Constants tuned to match Rust src/battery_model.rs exactly.
 const (
-	DefaultForgetting = 0.99    // ~100-cycle effective window
-	InitialCov        = 1000.0  // high initial uncertainty
-	SoCBucket         = 0.05    // 5% SoC buckets for saturation curve
-	SatDecay          = 0.9999  // slow decay so old peaks fade
-	MinCommandForRLS  = 100.0   // W
-	MinDeltaForRLS    = 20.0    // W after warmup
-	OutlierSigma      = 5.0     // σ threshold for rejecting a residual
+	DefaultForgetting = 0.99   // ~100-cycle effective window
+	InitialCov        = 1000.0 // high initial uncertainty
+	SoCBucket         = 0.05   // 5% SoC buckets for saturation curve
+	SatDecay          = 0.9999 // slow decay so old peaks fade
+	MinCommandForRLS  = 100.0  // W
+	MinDeltaForRLS    = 20.0   // W after warmup
+	OutlierSigma      = 5.0    // σ threshold for rejecting a residual
 	GainHistoryLen    = 2000
-	MinSatSeedW       = 1000.0  // regression guard (see clamp_to_saturation comment)
+	MinSatSeedW       = 1000.0 // regression guard (see clamp_to_saturation comment)
 )
 
 // Model holds the per-battery ARX(1) state + saturation envelope + health baseline.
@@ -82,11 +84,11 @@ type GainPoint struct {
 // New creates a fresh model with sensible defaults.
 func New(name string) *Model {
 	return &Model{
-		Name: name,
-		A:    0.7,  // moderate memory
-		B:    0.3,  // moderate gain (steady-state ≈ 1.0)
-		P:    [2][2]float64{{InitialCov, 0}, {0, InitialCov}},
-		ResidualVarEMA:   1000,
+		Name:              name,
+		A:                 0.7, // moderate memory
+		B:                 0.3, // moderate gain (steady-state ≈ 1.0)
+		P:                 [2][2]float64{{InitialCov, 0}, {0, InitialCov}},
+		ResidualVarEMA:    1000,
 		MaxChargeCurve:    []SoCPoint{},
 		MaxDischargeCurve: []SoCPoint{},
 		DeadbandW:         50,
@@ -134,10 +136,16 @@ func (m *Model) TimeConstantS(dtS float64) float64 {
 // Confidence in [0,1] from sample count and residual variance.
 func (m *Model) Confidence() float64 {
 	n := float64(m.NSamples) / 200.0
-	if n > 1 { n = 1 }
+	if n > 1 {
+		n = 1
+	}
 	v := 1 - (m.ResidualVarEMA / 10000.0)
-	if v < 0 { v = 0 }
-	if v > 1 { v = 1 }
+	if v < 0 {
+		v = 0
+	}
+	if v > 1 {
+		v = 1
+	}
 	return n * v
 }
 
@@ -149,29 +157,38 @@ func (m *Model) HealthScore() float64 {
 	}
 	drift := math.Abs(m.SteadyStateGain()-*m.BaselineGain) / math.Abs(*m.BaselineGain)
 	h := 1.0 - 2.0*drift
-	if h < 0 { h = 0 }
-	if h > 1 { h = 1 }
+	if h < 0 {
+		h = 0
+	}
+	if h > 1 {
+		h = 1
+	}
 	return h
 }
 
 // HealthDriftPerDay = linear regression slope over GainHistory (gain/day).
 // Negative = gain is declining over time (aging).
 func (m *Model) HealthDriftPerDay() float64 {
-	if len(m.GainHistory) < 10 { return 0 }
+	if len(m.GainHistory) < 10 {
+		return 0
+	}
 	n := float64(len(m.GainHistory))
 	var meanT, meanG float64
 	for _, p := range m.GainHistory {
 		meanT += float64(p.TsMs)
 		meanG += p.Gain
 	}
-	meanT /= n; meanG /= n
+	meanT /= n
+	meanG /= n
 	var num, den float64
 	for _, p := range m.GainHistory {
 		dt := float64(p.TsMs) - meanT
 		num += dt * (p.Gain - meanG)
 		den += dt * dt
 	}
-	if den < 1 { return 0 }
+	if den < 1 {
+		return 0
+	}
 	slopePerMs := num / den
 	return slopePerMs * 86400_000
 }
@@ -209,6 +226,11 @@ func (m *Model) ClampToSaturation(target, soc float64) (clamped float64, wasClam
 // derived state. Returns true if the model was updated, false if the
 // observation was filtered out (too small to be informative).
 func (m *Model) Update(command, actual, soc, dtS float64, nowMs int64) bool {
+	if !finite(command) || !finite(actual) || !finite(soc) || !finite(dtS) ||
+		soc < 0 || soc > 1 || dtS <= 0 {
+		return false
+	}
+
 	// Saturation curve is always updated (decoupled from RLS gating)
 	m.updateSaturationCurves(actual, soc)
 
@@ -239,7 +261,9 @@ func (m *Model) Update(command, actual, soc, dtS float64, nowMs int64) bool {
 
 	// Outlier rejection
 	std := math.Sqrt(m.ResidualVarEMA)
-	if std < 10 { std = 10 }
+	if std < 10 {
+		std = 10
+	}
 	if math.Abs(err) > OutlierSigma*std && m.NSamples > 20 {
 		m.LastU = command
 		m.LastY = actual
@@ -321,8 +345,12 @@ func (m *Model) SetFromStepFit(gain, tauS, dtS float64) {
 
 func (m *Model) updateSaturationCurves(actual, soc float64) {
 	bucket := math.Round(soc/SoCBucket) * SoCBucket
-	if bucket < 0 { bucket = 0 }
-	if bucket > 1 { bucket = 1 }
+	if bucket < 0 {
+		bucket = 0
+	}
+	if bucket > 1 {
+		bucket = 1
+	}
 
 	if actual > 0 {
 		m.MaxChargeCurve = updateCurve(m.MaxChargeCurve, bucket, actual)
@@ -330,8 +358,12 @@ func (m *Model) updateSaturationCurves(actual, soc float64) {
 		m.MaxDischargeCurve = updateCurve(m.MaxDischargeCurve, bucket, -actual)
 	}
 	// Decay so old over-optimistic peaks fade
-	for i := range m.MaxChargeCurve { m.MaxChargeCurve[i].Value *= SatDecay }
-	for i := range m.MaxDischargeCurve { m.MaxDischargeCurve[i].Value *= SatDecay }
+	for i := range m.MaxChargeCurve {
+		m.MaxChargeCurve[i].Value *= SatDecay
+	}
+	for i := range m.MaxDischargeCurve {
+		m.MaxDischargeCurve[i].Value *= SatDecay
+	}
 }
 
 // updateCurve inserts or raises a bucket; NEVER seeds a new bucket with small
@@ -357,14 +389,22 @@ func updateCurve(curve []SoCPoint, bucket, value float64) []SoCPoint {
 }
 
 func interpolate(curve []SoCPoint, soc, fallback float64) float64 {
-	if len(curve) == 0 { return fallback }
-	if soc <= curve[0].SoC { return curve[0].Value }
-	if soc >= curve[len(curve)-1].SoC { return curve[len(curve)-1].Value }
+	if len(curve) == 0 {
+		return fallback
+	}
+	if soc <= curve[0].SoC {
+		return curve[0].Value
+	}
+	if soc >= curve[len(curve)-1].SoC {
+		return curve[len(curve)-1].Value
+	}
 	for i := 0; i < len(curve)-1; i++ {
 		a, b := curve[i], curve[i+1]
 		if soc >= a.SoC && soc <= b.SoC {
 			denom := b.SoC - a.SoC
-			if denom < 1e-6 { return a.Value }
+			if denom < 1e-6 {
+				return a.Value
+			}
 			t := (soc - a.SoC) / denom
 			return a.Value + t*(b.Value-a.Value)
 		}
@@ -373,9 +413,17 @@ func interpolate(curve []SoCPoint, soc, fallback float64) float64 {
 }
 
 func clamp(v, lo, hi float64) float64 {
-	if v < lo { return lo }
-	if v > hi { return hi }
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
 	return v
+}
+
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
 }
 
 // Duration helper for test readability

--- a/go/internal/battery/model_test.go
+++ b/go/internal/battery/model_test.go
@@ -26,10 +26,14 @@ func TestRLSConvergesOnSyntheticARX(t *testing.T) {
 	// Known plant: a=0.6, b=0.4 → gain = 1.0
 	m := simulateAndFit(0.6, 0.4, 500, func(i int) float64 {
 		switch (i / 30) % 4 {
-		case 0: return 1000
-		case 1: return -1000
-		case 2: return 500
-		default: return -500
+		case 0:
+			return 1000
+		case 1:
+			return -1000
+		case 2:
+			return 500
+		default:
+			return -500
 		}
 	})
 	if math.Abs(m.A-0.6) > 0.1 {
@@ -47,7 +51,9 @@ func TestRLSConvergesOnSyntheticARX(t *testing.T) {
 func TestRLSRecoversLowerGain(t *testing.T) {
 	// Typical efficiency-loss battery: a=0.5, b=0.425 → gain 0.85
 	m := simulateAndFit(0.5, 0.425, 500, func(i int) float64 {
-		if (i/20)%2 == 0 { return 1500 }
+		if (i/20)%2 == 0 {
+			return 1500
+		}
 		return -1500
 	})
 	g := m.SteadyStateGain()
@@ -68,15 +74,56 @@ func TestSkipsLowSignalObservations(t *testing.T) {
 	}
 }
 
+func TestUpdateRejectsInvalidInputsWithoutMutation(t *testing.T) {
+	cases := []struct {
+		name    string
+		command float64
+		actual  float64
+		soc     float64
+		dtS     float64
+	}{
+		{"nan_command", math.NaN(), 800, 0.5, 5},
+		{"inf_actual", 1000, math.Inf(1), 0.5, 5},
+		{"nan_soc", 1000, 800, math.NaN(), 5},
+		{"low_soc", 1000, 800, -0.1, 5},
+		{"high_soc", 1000, 800, 1.1, 5},
+		{"zero_dt", 1000, 800, 0.5, 0},
+		{"nan_dt", 1000, 800, 0.5, math.NaN()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := New("guard")
+			m.Update(1000, 800, 0.5, 5, 1000)
+			before, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("marshal before: %v", err)
+			}
+			if m.Update(tc.command, tc.actual, tc.soc, tc.dtS, 2000) {
+				t.Fatal("invalid input should not update model")
+			}
+			after, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("marshal after: %v", err)
+			}
+			if string(after) != string(before) {
+				t.Fatalf("model mutated on invalid input\nbefore: %s\nafter:  %s", before, after)
+			}
+		})
+	}
+}
+
 func TestOutlierRejection(t *testing.T) {
 	// Warmup with good data
 	m := simulateAndFit(0.6, 0.4, 200, func(i int) float64 {
-		if i%2 == 0 { return 1000 }
+		if i%2 == 0 {
+			return 1000
+		}
 		return -1000
 	})
 	before := m.NSamples
 	// Inject obvious outlier
-	m.LastU = 1000; m.LastY = 600
+	m.LastU = 1000
+	m.LastY = 600
 	m.Update(1000, 10000, 0.5, 5, 9999)
 	if m.NSamples != before {
 		t.Error("outlier should not bump sample count")
@@ -94,8 +141,12 @@ func TestParamsStayBounded(t *testing.T) {
 		m.Update(u, y, 0.5, 5, now)
 		now += 5000
 	}
-	if m.A < 0.1 || m.A > 0.99 { t.Errorf("a: %.3f", m.A) }
-	if m.B < -1.5 || m.B > 1.5 { t.Errorf("b: %.3f", m.B) }
+	if m.A < 0.1 || m.A > 0.99 {
+		t.Errorf("a: %.3f", m.A)
+	}
+	if m.B < -1.5 || m.B > 1.5 {
+		t.Errorf("b: %.3f", m.B)
+	}
 }
 
 // ---- Inverse + clamp ----
@@ -171,7 +222,8 @@ func TestHealthScoreNeutralWithoutBaseline(t *testing.T) {
 
 func TestHealthScoreDegradesWithDrift(t *testing.T) {
 	m := New("drift")
-	m.A = 0.5; m.B = 0.5 // gain 1.0
+	m.A = 0.5
+	m.B = 0.5 // gain 1.0
 	m.SetBaseline(1.0, 2.0, 1000)
 	if math.Abs(m.HealthScore()-1.0) > 0.01 {
 		t.Errorf("at baseline, health=1; got %f", m.HealthScore())
@@ -188,8 +240,8 @@ func TestDriftPerDayDetectsFallingGain(t *testing.T) {
 	m := New("falling")
 	day := int64(86400_000)
 	for i := 0; i < 100; i++ {
-		t := int64(i) * day / 10 // 10 days worth of points
-		g := 1.0 - float64(i)/1000.0  // 1.0 → 0.9 over 100 points
+		t := int64(i) * day / 10     // 10 days worth of points
+		g := 1.0 - float64(i)/1000.0 // 1.0 → 0.9 over 100 points
 		m.GainHistory = append(m.GainHistory, GainPoint{TsMs: t, Gain: g})
 	}
 	drift := m.HealthDriftPerDay()
@@ -206,13 +258,25 @@ func TestJSONRoundtrip(t *testing.T) {
 	m.Update(1000, 900, 0.5, 5, 1000)
 	m.Update(1000, 920, 0.5, 5, 6000)
 	data, err := json.Marshal(m)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	var back Model
-	if err := json.Unmarshal(data, &back); err != nil { t.Fatal(err) }
-	if back.Name != "rt" { t.Errorf("name: %s", back.Name) }
-	if math.Abs(back.A-m.A) > 1e-9 { t.Errorf("a") }
-	if math.Abs(back.B-m.B) > 1e-9 { t.Errorf("b") }
-	if back.NSamples != m.NSamples { t.Errorf("samples") }
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Name != "rt" {
+		t.Errorf("name: %s", back.Name)
+	}
+	if math.Abs(back.A-m.A) > 1e-9 {
+		t.Errorf("a")
+	}
+	if math.Abs(back.B-m.B) > 1e-9 {
+		t.Errorf("b")
+	}
+	if back.NSamples != m.NSamples {
+		t.Errorf("samples")
+	}
 }
 
 // ---- SetFromStepFit ----
@@ -245,7 +309,13 @@ func TestTimeConstantRelationship(t *testing.T) {
 func TestSetBaselineStoresValues(t *testing.T) {
 	m := New("cal")
 	m.SetBaseline(0.95, 2.0, 1700000)
-	if m.BaselineGain == nil || *m.BaselineGain != 0.95 { t.Error("baseline gain") }
-	if m.BaselineTauS == nil || *m.BaselineTauS != 2.0 { t.Error("baseline τ") }
-	if m.LastCalibrated == nil || *m.LastCalibrated != 1700000 { t.Error("calibrated ts") }
+	if m.BaselineGain == nil || *m.BaselineGain != 0.95 {
+		t.Error("baseline gain")
+	}
+	if m.BaselineTauS == nil || *m.BaselineTauS != 2.0 {
+		t.Error("baseline τ")
+	}
+	if m.LastCalibrated == nil || *m.LastCalibrated != 1700000 {
+		t.Error("calibrated ts")
+	}
 }


### PR DESCRIPTION
## Summary

- Reject non-finite command, actual power, SoC, and `dtS` inputs before mutating the battery ARX/RLS model.
- Reject SoC outside `0..1` and non-positive `dtS`.
- Add regression coverage proving invalid observations leave model state unchanged.

## Root cause

`Model.Update` fed raw observations into saturation curves, RLS state, residual variance, and previous-sample fields before any finite/range validation. A NaN or Inf telemetry sample could therefore poison the trained model and cascade control behavior.

## Validation

- `cd go && go test ./internal/battery`
- `make test`