### PR TITLE
fix(control): use fractional SoC for PV-curtail battery headroom

### DIFF
--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -2069,14 +2069,14 @@ func ComputePVCurtail(state *State, store *telemetry.Store) []CurtailTarget {
 	return out
 }
 
-// pvCurtailBatterySoCMaxPct is the SoC ceiling above which a battery
+// pvCurtailBatterySoCMax is the fractional SoC ceiling above which a battery
 // is treated as having no curtail-absorption headroom. Below it, the
 // battery's MaxChargeW (or MaxCommandW default) is added to the live
 // curtail limit so PV stays uncapped while the battery can still take
 // the energy. Hard-coded conservatively — the goal is to err on the
 // side of preserving PV generation when there's anywhere meaningful
 // to put it.
-const pvCurtailBatterySoCMaxPct = 99.0
+const pvCurtailBatterySoCMax = 0.99
 
 // liveCurtailLimitW computes the cap PV may produce *right now* given
 // the planner's decision that curtail is economically warranted for
@@ -2089,7 +2089,7 @@ const pvCurtailBatterySoCMaxPct = 99.0
 //     stays the priority.
 //
 //  2. Battery absorption headroom — for every online battery with
-//     SoC below `pvCurtailBatterySoCMaxPct`, the per-driver MaxChargeW
+//     SoC below `pvCurtailBatterySoCMax`, the per-driver MaxChargeW
 //     (or MaxCommandW default) is added. PV can keep producing because
 //     the dispatch loop will route the surplus into the battery.
 //
@@ -2168,7 +2168,7 @@ func liveCurtailLimitW(state *State, store *telemetry.Store) (float64, bool) {
 		if h == nil || !h.IsOnline() {
 			continue
 		}
-		if r.SoC == nil || *r.SoC >= pvCurtailBatterySoCMaxPct {
+		if r.SoC == nil || *r.SoC >= pvCurtailBatterySoCMax {
 			continue
 		}
 		capW := float64(MaxCommandW)

--- a/go/internal/control/pv_curtail_test.go
+++ b/go/internal/control/pv_curtail_test.go
@@ -31,8 +31,8 @@ func emitPV(t *testing.T, s *telemetry.Store, driver string, w float64) {
 	s.Update(driver, telemetry.DerPV, w, nil, nil)
 }
 
-// emitBattery pushes a battery reading with an explicit SoC%. Used by
-// the live-curtail tests to vary absorption headroom.
+// emitBattery pushes a battery reading with an explicit fractional SoC.
+// Used by the live-curtail tests to vary absorption headroom.
 func emitBattery(t *testing.T, s *telemetry.Store, driver string, w, soc float64) {
 	t.Helper()
 	s.DriverHealthMut(driver).RecordSuccess()
@@ -330,7 +330,7 @@ func TestComputePVCurtail_BatteryHeadroomLiftsCap(t *testing.T) {
 	st.SupportsPVCurtail = map[string]bool{"solaredge": true}
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 60.0) // 60% SoC → 5 kW headroom available
+	emitBattery(t, store, "pixii", 0, 0.60) // 60% SoC → 5 kW headroom available
 	emitMeter(t, store, "meter", -2500)     // exporting 2.5 kW (load present but PV bigger)
 
 	got := findCurtail(ComputePVCurtail(st, store))
@@ -347,7 +347,7 @@ func TestComputePVCurtail_FullBatteryNoHeadroomCurtails(t *testing.T) {
 	st.SupportsPVCurtail = map[string]bool{"solaredge": true}
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 99.5) // above ceiling — no headroom
+	emitBattery(t, store, "pixii", 0, 0.995) // above ceiling — no headroom
 	emitMeter(t, store, "meter", -2500)     // exporting 2.5 kW → live load = 500 W
 
 	got := findCurtail(ComputePVCurtail(st, store))
@@ -364,7 +364,7 @@ func TestComputePVCurtail_RisingLoadLiftsCap(t *testing.T) {
 	st.SupportsPVCurtail = map[string]bool{"solaredge": true}
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 99.5) // full — no battery headroom
+	emitBattery(t, store, "pixii", 0, 0.995) // full — no battery headroom
 	// Live: load actually became 2500 W (heater turned on). Meter
 	// reports import = load - pv = 2500 - 3000 = -500 W (still
 	// exporting 500 W). live_load = -500 - (-3000) - 0 = 2500 W.
@@ -385,7 +385,7 @@ func TestComputePVCurtail_EVReserveLiftsCap(t *testing.T) {
 	st.EVSurplusOnlyReserveW = 3500 // wallbox wants 3.5 kW from PV
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 99.5)
+	emitBattery(t, store, "pixii", 0, 0.995)
 	emitMeter(t, store, "meter", -3000) // all PV currently exporting
 
 	got := findCurtail(ComputePVCurtail(st, store))
@@ -405,7 +405,7 @@ func TestComputePVCurtail_EVCurtailHeadroomLiftsCap(t *testing.T) {
 	st.EVCurtailHeadroomW = 11000   // but it COULD draw up to 11 kW if PV grew
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 99.5)
+	emitBattery(t, store, "pixii", 0, 0.995)
 	emitMeter(t, store, "meter", -3000)
 
 	got := findCurtail(ComputePVCurtail(st, store))


### PR DESCRIPTION
## Summary

- Change live PV-curtail battery-headroom gating from percent-style `99.0` to fractional `0.99` SoC.
- Update live curtail tests to emit runtime-style fractional battery SoC values.
- Preserve the existing behavior: batteries below 99% SoC can lift the live PV cap; essentially full batteries cannot.

## Root cause

The runtime driver/host contract reports battery SoC as a fraction `0..1`, but the live PV curtail logic compared that value against `99.0`. A full battery at `0.995` was therefore treated as having charge headroom, which could suppress planner-requested curtailment during negative-export slots.

## Validation

- `cd go && go test ./internal/control`

Note: a full `make test` run in this worktree was stopped after `cmd/sim-ferroamp` hung for several minutes before reaching the changed package.