### PR TITLE
feat(drivers): add Zuidwijk P1 Reader (raw TCP transport + DSMR 5 parser)

### DIFF
--- a/docs/host-api.md
+++ b/docs/host-api.md
@@ -300,6 +300,66 @@ local ok = host.modbus_write_multiple(40000, {1000, 2000, 3000})
 
 ---
 
+## TCP
+
+Raw TCP socket access. Available when the driver's config grants `capabilities.tcp` with an optional `allowed_hosts` allowlist. Used by drivers that talk to serial-to-Ethernet passthrough bridges or other protocols that stream unsolicited bytes over a long-lived TCP connection — Dutch P1 smart-meter readers streaming DSMR telegrams on port 23 being the canonical example. See `drivers/zuidwijk_p1.lua` for a full DSMR 5 parser built on this capability.
+
+The host runs a background read pump per driver that buffers incoming bytes in a 64 KiB ring. The driver drains the buffer at its own poll cadence and does its own framing — TCP is byte-stream, not message-framed. Read-only by design today: the supported targets never need driver-initiated writes, and arbitrary outbound TCP would dramatically widen the blast radius if a driver ever ran untrusted code.
+
+**Config:**
+```yaml
+- name: house-meter
+  lua: drivers/zuidwijk_p1.lua
+  capabilities:
+    tcp:
+      allowed_hosts: ["192.168.1.40:23"]   # bare "host" allows any port
+  config:
+    host: "192.168.1.40"
+    port: 23
+```
+
+### `host.tcp_open(addr)`
+
+Open a TCP connection to `"host:port"`. Idempotent — calling on an already-open socket is a no-op, so this is also the reconnect path.
+
+**Parameters:**
+- `addr` (string) -- `"host:port"`, e.g. `"192.168.1.40:23"`
+
+**Returns:**
+- On success: `(true, nil)`
+- On failure: `(nil, error_string)` — bad allowlist, dial error, etc.
+
+---
+
+### `host.tcp_recv()`
+
+Drain bytes received since the last call. Non-blocking. Returns an empty string when nothing has arrived; the driver does its own framing on the accumulated buffer.
+
+**Returns:** string -- raw bytes since the last call (Lua strings are 8-bit clean, so binary payloads work)
+
+**Example:**
+```lua
+local chunk = host.tcp_recv()
+if chunk ~= "" then
+    buffer = buffer .. chunk
+    -- ...split into frames, parse, emit
+end
+```
+
+---
+
+### `host.tcp_is_open()`
+
+Returns `true` while the read pump is alive. Flips to `false` on EOF or read error; the driver should `tcp_close` and `tcp_open` again on the next poll to recover.
+
+---
+
+### `host.tcp_close()`
+
+Close the socket and release the read pump. Safe to call on an already-closed cap.
+
+---
+
 ## Decode Helpers
 
 Always available regardless of protocol. Used to interpret raw register values from Modbus devices.

--- a/docs/writing-a-driver.md
+++ b/docs/writing-a-driver.md
@@ -232,7 +232,24 @@ Always wrap reads in `pcall` — a single failed register read should not
 crash the whole poll cycle. See `drivers/sungrow.lua:127-129` for the
 pattern.
 
-### 3.5 Decoders
+### 3.5 Raw TCP (granted only if the driver has `capabilities.tcp:` in its config)
+
+| Call | Purpose |
+|---|---|
+| `host.tcp_open(addr)` | Open a long-lived TCP socket to `"host:port"`. Idempotent — doubles as the reconnect path. |
+| `host.tcp_recv()` | Drain any bytes received since the last call (non-blocking, empty string when idle). |
+| `host.tcp_is_open()` | Boolean — false after EOF / read error. Re-open on the next poll. |
+| `host.tcp_close()` | Tear down the socket. |
+
+For passthrough Serial-to-Ethernet bridges (Dutch P1 smart-meter readers,
+some Modbus-RTU-to-TCP devices in raw mode) that stream unsolicited bytes
+on a fixed port. TCP is byte-stream — the driver does its own framing on
+the accumulated buffer. Read-only today: there's no `tcp_send`, because
+the supported targets don't expect input. See `drivers/zuidwijk_p1.lua`
+for a full DSMR 5 parser (frame detection + CRC16 + OBIS decode) built on
+this capability.
+
+### 3.6 Decoders
 
 Modbus returns raw uint16s. These helpers combine pairs back into the
 integer you actually want. Parameter order matters — `_le` takes
@@ -246,7 +263,7 @@ integer you actually want. Parameter order matters — `_le` takes
 | `host.decode_i32_be(hi, lo)` | Signed 32-bit, big-endian. |
 | `host.decode_i16(reg)` | Sign-extend a single uint16 to int16. |
 
-### 3.6 JSON
+### 3.7 JSON
 
 | Call | Purpose |
 |---|---|

--- a/drivers/zuidwijk_p1.lua
+++ b/drivers/zuidwijk_p1.lua
@@ -43,6 +43,7 @@ local PORT    = 23
 local ADDR    = nil
 local buffer  = ""
 local last_telegram_ms = -1
+local sn_set = false
 local crc_errors = 0
 
 -- Cap on retained buffer size between polls so a stuck framer (meter spewing
@@ -170,12 +171,14 @@ local function take_frame(buf)
 end
 
 -- Verify the wire CRC matches a CRC computed over '/' .. body .. '!'.
--- Returns true on match OR when no CRC is supplied (DSMR 4 / encrypted-
--- passthrough fallback) — better to accept an unverifiable frame than to
--- silently starve the dispatch loop. The empty/"0000" case is treated as
--- "not supplied" because old firmware emits zero when CRC isn't computed.
+-- Returns true only when the CRC matches OR when no CRC bytes were on
+-- the wire at all (the DSMR 4 / encrypted-passthrough '!\r\n' fallback,
+-- which take_frame surfaces as crc_hex == ""). The literal hex "0000" is
+-- treated as a real CRC value — a frame that genuinely computes to 0x0000
+-- must round-trip cleanly, and we mustn't blanket-accept any "!0000\r\n"
+-- trailer regardless of body content.
 local function crc_ok(body, crc_hex)
-    if crc_hex == "" or crc_hex == "0000" then
+    if crc_hex == "" then
         return true
     end
     local want = tonumber(crc_hex, 16)
@@ -292,12 +295,21 @@ function driver_poll()
 
     local o = parse_obis(latest)
 
-    -- Meter serial (hex-ASCII) — anchor hardware identity.
-    if last_telegram_ms < 0 then
+    -- Meter serial (hex-ASCII) — anchor hardware identity. Retry on every
+    -- telegram until 96.1.1 actually decodes: if the first frame we see
+    -- happens to be missing the SN line (truncated, partial buffer, or a
+    -- meter that publishes the long form only every Nth telegram) we'd
+    -- otherwise spend the whole process lifetime without a make:serial
+    -- anchor, falling back to MAC/endpoint and orphaning the persistent
+    -- battery model on the next driver rename.
+    if not sn_set then
         local sn_hex = obis_str(o, "0-0:96.1.1")
         if sn_hex and sn_hex ~= "" then
             local sn = hex_to_ascii(sn_hex)
-            if sn ~= "" then host.set_sn(sn) end
+            if sn ~= "" then
+                host.set_sn(sn)
+                sn_set = true
+            end
         end
     end
     last_telegram_ms = host.millis()
@@ -399,5 +411,6 @@ function driver_cleanup()
     pcall(host.tcp_close)
     buffer = ""
     last_telegram_ms = -1
+    sn_set = false
     crc_errors = 0
 end

--- a/drivers/zuidwijk_p1.lua
+++ b/drivers/zuidwijk_p1.lua
@@ -1,0 +1,403 @@
+-- zuidwijk_p1.lua
+-- Zuidwijk P1 Reader Ethernet driver (Dutch DSMR 5.0 smart-meter passthrough).
+-- Emits: Meter (read-only)
+-- Protocol: raw TCP — the device is a Serial-to-Ethernet bridge that streams
+--           the unsolicited P1 telegram from the meter once per second on
+--           a configurable TCP port (default 23). No request is needed and
+--           no decryption is performed by the device itself; encrypted
+--           meter data (rare in NL) must be decrypted by an external proxy
+--           before reaching this driver.
+
+DRIVER = {
+  id           = "zuidwijk-p1",
+  name         = "Zuidwijk P1 Reader Ethernet",
+  manufacturer = "Zuidwijk",
+  version      = "1.0.0",
+  protocols    = { "tcp" },
+  capabilities = { "meter" },
+  description  = "Dutch DSMR P1 smart-meter via Zuidwijk Serial-to-Ethernet bridge (raw TCP, port 23).",
+  homepage     = "https://www.zuidwijk.com/product/p1-reader-ethernet/",
+  authors      = { "forty-two-watts contributors" },
+  tested_models = { "Sagemcom T210-D", "Kaifa MA105/MA304", "Iskra ME382" },
+  verification_status = "experimental",
+  verification_notes = "Implemented from DSMR 5.0 spec; not yet exercised against live hardware.",
+  connection_defaults = {
+    port = 23,
+  },
+}
+--
+-- Sign convention (site / EMS):
+--   meter.w  : positive = importing from grid, negative = exporting
+-- DSMR reports import (1.7.0) and export (2.7.0) as separate non-negative
+-- values; the driver computes meter.w = import - export so the site
+-- convention is satisfied without any extra flipping.
+
+PROTOCOL = "tcp"
+
+----------------------------------------------------------------------------
+-- Config + state
+----------------------------------------------------------------------------
+
+local HOST    = nil
+local PORT    = 23
+local ADDR    = nil
+local buffer  = ""
+local last_telegram_ms = -1
+local crc_errors = 0
+
+-- Cap on retained buffer size between polls so a stuck framer (meter spewing
+-- non-DSMR bytes, partial decryption garbage) doesn't grow unbounded. Real
+-- telegrams are ~1 KB; 8 KB leaves plenty of slack for one telegram plus
+-- one in-flight follow-up before we drop oldest.
+local MAX_BUFFER = 8192
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+-- Bitwise helpers. Lua 5.1 has no bit operators and gopher-lua does not
+-- expose `bit32`, so the CRC implementation reaches for these arithmetic
+-- equivalents. Cost is ~16 iterations per XOR — negligible for a 1 KB
+-- telegram once per second.
+local function xor16(a, b)
+    local r, p = 0, 1
+    for _ = 1, 16 do
+        local aa, bb = a % 2, b % 2
+        if aa ~= bb then r = r + p end
+        a = math.floor(a / 2)
+        b = math.floor(b / 2)
+        p = p * 2
+    end
+    return r
+end
+
+-- DSMR CRC16: polynomial x^16+x^15+x^2+1 (0xA001 in reflected form), init
+-- 0x0000, computed over bytes from the leading '/' through the trailing
+-- '!' inclusive. Result is printed in the telegram as 4 uppercase hex
+-- digits followed by CR LF. This matches CRC-16/IBM (a.k.a. ARC) and the
+-- formulation used by Sagemcom / Kaifa / Iskra DSMR-5 meters.
+local function crc16_dsmr(data)
+    local crc = 0
+    for i = 1, #data do
+        crc = xor16(crc, string.byte(data, i))
+        for _ = 1, 8 do
+            if (crc % 2) == 1 then
+                crc = xor16(math.floor(crc / 2), 0xA001)
+            else
+                crc = math.floor(crc / 2)
+            end
+        end
+    end
+    return crc
+end
+
+-- Decode a hex-ASCII serial like "4530303834303031383239353439393137"
+-- into "E0084001829549917". DSMR stores 96.1.1 / 96.1.0 that way.
+local function hex_to_ascii(s)
+    if not s or s == "" then return "" end
+    local out = string.gsub(s, "(%x%x)", function(h)
+        local b = tonumber(h, 16)
+        if b == nil then return "" end
+        return string.char(b)
+    end)
+    return out
+end
+
+-- Split a DSMR value string like "00123.456*kWh" into (number, unit).
+-- Tolerates a missing unit ("0001" for tariff index, etc.).
+local function num_unit(s)
+    if not s then return nil, nil end
+    local n, u = string.match(s, "^([%-%d%.]+)%*?(.*)$")
+    if not n then return tonumber(s), nil end
+    return tonumber(n), u
+end
+
+-- Pull the LAST parenthesised group out of a DSMR value chunk. Lines like
+-- "0-1:24.2.1(241015095500S)(00123.456*m3)" carry a timestamp followed
+-- by the actual reading; we want the reading.
+local function last_paren(args)
+    if not args then return nil end
+    local last
+    for chunk in string.gmatch(args, "%(([^()]*)%)") do
+        last = chunk
+    end
+    return last
+end
+
+-- Extract the most recent complete DSMR frame from `buf`. Returns
+-- (frame_body, crc_hex, remaining_buffer) where:
+--   * frame_body excludes the trailing '!' + CRC + CRLF, ready for OBIS parse
+--   * crc_hex is the 4-char uppercase hex from the wire, or "" when the
+--     meter sent the no-CRC fallback ('!\r\n', DSMR 4 / passthrough firmware)
+-- Returns (nil, "", buf) if no complete frame is present yet.
+--
+-- A frame looks like:
+--     /XMX5LGBBFFB231215493\r\n
+--     \r\n
+--     <obis lines>\r\n
+--     !ABCD\r\n
+-- where ABCD is the CRC16 over '/' through '!' inclusive. We prefer the
+-- variant with CRC; if absent, fall back to the bare '!' terminator
+-- (DSMR 4 firmware, encrypted-passthrough proxies).
+local function take_frame(buf)
+    -- Locate end-of-telegram. '!XXXX\r\n' first (DSMR 5), bare '!\r\n' fallback.
+    local bang_s, eot = string.find(buf, "!%x%x%x%x\r?\n")
+    local crc_hex = ""
+    if bang_s then
+        crc_hex = string.upper(buf:sub(bang_s + 1, bang_s + 4))
+    else
+        bang_s, eot = string.find(buf, "!\r?\n")
+    end
+    if not bang_s then
+        return nil, "", buf
+    end
+    -- Find the latest '/' at or before the bang — start-of-frame marker.
+    local start_s
+    local from = 1
+    while true do
+        local s = string.find(buf, "/", from, true)
+        if not s or s > bang_s then break end
+        start_s = s
+        from    = s + 1
+    end
+    if not start_s then
+        -- '!' with no preceding '/': junk before the first frame. Discard
+        -- through the bang so we don't re-scan the same byte every poll.
+        return nil, "", buf:sub(eot + 1)
+    end
+    local body = buf:sub(start_s, bang_s - 1)
+    return body, crc_hex, buf:sub(eot + 1)
+end
+
+-- Verify the wire CRC matches a CRC computed over '/' .. body .. '!'.
+-- Returns true on match OR when no CRC is supplied (DSMR 4 / encrypted-
+-- passthrough fallback) — better to accept an unverifiable frame than to
+-- silently starve the dispatch loop. The empty/"0000" case is treated as
+-- "not supplied" because old firmware emits zero when CRC isn't computed.
+local function crc_ok(body, crc_hex)
+    if crc_hex == "" or crc_hex == "0000" then
+        return true
+    end
+    local want = tonumber(crc_hex, 16)
+    if want == nil then return false end
+    local got = crc16_dsmr(body .. "!")
+    return got == want
+end
+
+-- Parse a DSMR frame body into a {obis_code -> raw_args_string} table.
+-- Args is the full parenthesised tail of the line, e.g. "(01.234*kW)".
+local function parse_obis(frame)
+    local out = {}
+    for line in string.gmatch(frame, "[^\r\n]+") do
+        local code, rest = string.match(line, "^([%d%-:.]+)(%(.*)$")
+        if code then
+            out[code] = rest
+        end
+    end
+    return out
+end
+
+-- Pull a numeric DSMR value with optional unit suffix. Returns nil when the
+-- key is absent so callers can leave the meter field unset.
+local function obis_num(o, code)
+    local args = o[code]
+    if not args then return nil end
+    local v = last_paren(args)
+    local n = num_unit(v)
+    return n
+end
+
+local function obis_str(o, code)
+    local args = o[code]
+    if not args then return nil end
+    return last_paren(args)
+end
+
+----------------------------------------------------------------------------
+-- Driver interface
+----------------------------------------------------------------------------
+
+function driver_init(config)
+    host.set_make("Zuidwijk")
+    -- Bridge SN we don't know yet; meter serial flows in via OBIS 96.1.1 on
+    -- the first received telegram and becomes the anchored hardware identity.
+
+    if config then
+        if config.host then HOST = tostring(config.host) end
+        if config.port then PORT = tonumber(config.port) or 23 end
+    end
+    if HOST == nil or HOST == "" then
+        host.log("error", "zuidwijk-p1: config.host is required (e.g. \"192.168.1.40\")")
+        return
+    end
+    ADDR = string.format("%s:%d", HOST, PORT)
+
+    -- Poll the buffer every second — telegrams arrive at ~1 Hz, faster polls
+    -- just spin. The host's read pump runs independently in Go and buffers
+    -- bytes as they land; we drain it here.
+    host.set_poll_interval(1000)
+    host.log("info", "zuidwijk-p1: configured for " .. ADDR)
+end
+
+function driver_poll()
+    -- (Re)establish the TCP socket. The cap's Open is idempotent — calling
+    -- it on an already-open connection is a no-op, so this is also the
+    -- reconnect path after a dropped session (router reboot, P1 reader
+    -- power-cycle).
+    if not ADDR then return 5000 end
+    if not host.tcp_is_open() then
+        local ok, err = host.tcp_open(ADDR)
+        if not ok then
+            host.log("warn", "zuidwijk-p1: tcp_open " .. ADDR .. " failed: " .. tostring(err))
+            -- Back off briefly before retrying so a misconfigured host
+            -- doesn't hammer the network with reconnects every second.
+            return 5000
+        end
+        buffer = ""
+    end
+
+    -- Drain any new bytes from the read pump and append to our framing buffer.
+    local chunk = host.tcp_recv()
+    if chunk and chunk ~= "" then
+        buffer = buffer .. chunk
+        if #buffer > MAX_BUFFER then
+            -- Drop the oldest half so a runaway non-DSMR stream can't pin
+            -- memory while we wait for a valid frame boundary.
+            buffer = buffer:sub(#buffer - (MAX_BUFFER / 2))
+        end
+    end
+
+    -- Pull every complete frame the buffer holds. If multiple have arrived
+    -- (e.g. we polled twice as slowly as the meter speaks) we keep the
+    -- LAST one with a valid CRC — that's the freshest TRUSTED snapshot
+    -- of meter state. Frames with a bad CRC are counted and dropped; a
+    -- noisy connection that produces only bad frames simply emits
+    -- nothing, the watchdog then catches it as stale.
+    local latest = nil
+    while true do
+        local frame, crc_hex, rest = take_frame(buffer)
+        buffer = rest
+        if not frame then break end
+        if crc_ok(frame, crc_hex) then
+            latest = frame
+        else
+            crc_errors = crc_errors + 1
+            host.log("warn", "zuidwijk-p1: CRC mismatch — dropping frame (total bad: " .. crc_errors .. ")")
+        end
+    end
+    host.emit_metric("p1_crc_errors", crc_errors)
+    if not latest then
+        return 1000
+    end
+
+    local o = parse_obis(latest)
+
+    -- Meter serial (hex-ASCII) — anchor hardware identity.
+    if last_telegram_ms < 0 then
+        local sn_hex = obis_str(o, "0-0:96.1.1")
+        if sn_hex and sn_hex ~= "" then
+            local sn = hex_to_ascii(sn_hex)
+            if sn ~= "" then host.set_sn(sn) end
+        end
+    end
+    last_telegram_ms = host.millis()
+
+    -- Active power in kW. DSMR sends import + export as separate positive
+    -- values; the difference gives site-convention W.
+    local p_imp_kw = obis_num(o, "1-0:1.7.0") or 0
+    local p_exp_kw = obis_num(o, "1-0:2.7.0") or 0
+    local p_imp_l1 = obis_num(o, "1-0:21.7.0") or 0
+    local p_imp_l2 = obis_num(o, "1-0:41.7.0") or 0
+    local p_imp_l3 = obis_num(o, "1-0:61.7.0") or 0
+    local p_exp_l1 = obis_num(o, "1-0:22.7.0") or 0
+    local p_exp_l2 = obis_num(o, "1-0:42.7.0") or 0
+    local p_exp_l3 = obis_num(o, "1-0:62.7.0") or 0
+
+    local meter = {
+        w    = (p_imp_kw - p_exp_kw) * 1000,
+        l1_w = (p_imp_l1 - p_exp_l1) * 1000,
+        l2_w = (p_imp_l2 - p_exp_l2) * 1000,
+        l3_w = (p_imp_l3 - p_exp_l3) * 1000,
+    }
+
+    -- Per-phase voltage (DSMR units: V) — always reported on DSMR 5.
+    meter.l1_v = obis_num(o, "1-0:32.7.0")
+    meter.l2_v = obis_num(o, "1-0:52.7.0")
+    meter.l3_v = obis_num(o, "1-0:72.7.0")
+    -- Per-phase current (DSMR units: A). Unsigned on the wire — direction
+    -- is recoverable from l*_w. Pass through unsigned to match the meter.
+    meter.l1_a = obis_num(o, "1-0:31.7.0")
+    meter.l2_a = obis_num(o, "1-0:51.7.0")
+    meter.l3_a = obis_num(o, "1-0:71.7.0")
+
+    -- Lifetime energy counters. DSMR reports them split by tariff (T1 = low
+    -- / off-peak, T2 = high / peak). The dashboard wants a single import
+    -- and export figure, so sum the tariffs. Units are kWh → Wh.
+    local imp_t1 = obis_num(o, "1-0:1.8.1") or 0
+    local imp_t2 = obis_num(o, "1-0:1.8.2") or 0
+    local exp_t1 = obis_num(o, "1-0:2.8.1") or 0
+    local exp_t2 = obis_num(o, "1-0:2.8.2") or 0
+    if imp_t1 > 0 or imp_t2 > 0 then
+        meter.import_wh = (imp_t1 + imp_t2) * 1000
+    end
+    if exp_t1 > 0 or exp_t2 > 0 then
+        meter.export_wh = (exp_t1 + exp_t2) * 1000
+    end
+
+    host.emit("meter", meter)
+
+    -- Long-format TS diagnostics. The same fields the dashboard meter card
+    -- consumes, plus DSMR-specific niceties (per-tariff counters, failure
+    -- log scalars, gas reading) for operators that want the raw stream.
+    if meter.l1_w then host.emit_metric("meter_l1_w", meter.l1_w) end
+    if meter.l2_w then host.emit_metric("meter_l2_w", meter.l2_w) end
+    if meter.l3_w then host.emit_metric("meter_l3_w", meter.l3_w) end
+    if meter.l1_v then host.emit_metric("meter_l1_v", meter.l1_v) end
+    if meter.l2_v then host.emit_metric("meter_l2_v", meter.l2_v) end
+    if meter.l3_v then host.emit_metric("meter_l3_v", meter.l3_v) end
+    if meter.l1_a then host.emit_metric("meter_l1_a", meter.l1_a) end
+    if meter.l2_a then host.emit_metric("meter_l2_a", meter.l2_a) end
+    if meter.l3_a then host.emit_metric("meter_l3_a", meter.l3_a) end
+
+    -- Tariff index (1 = low, 2 = high, etc.) — useful for cost analytics.
+    local tariff = obis_num(o, "0-0:96.14.0")
+    if tariff then host.emit_metric("p1_tariff", tariff) end
+
+    -- Power failure counters (short + long). Climbing values indicate grid
+    -- stability problems that an operator wants to see in the TS DB.
+    local pf  = obis_num(o, "0-0:96.7.21")
+    local lpf = obis_num(o, "0-0:96.7.9")
+    if pf  then host.emit_metric("p1_power_failures",      pf)  end
+    if lpf then host.emit_metric("p1_long_power_failures", lpf) end
+
+    -- Gas counter (M-Bus channel 1, usually). Cumulative m³ reading. Logged
+    -- as a metric so a daily-delta query yields gas consumption without
+    -- adding a new emit type to the rest of the stack.
+    local gas_m3 = obis_num(o, "0-1:24.2.1")
+    if gas_m3 then host.emit_metric("gas_m3", gas_m3) end
+
+    return 1000
+end
+
+----------------------------------------------------------------------------
+-- Control (READ-ONLY — P1 is one-way out of the meter)
+----------------------------------------------------------------------------
+
+function driver_command(action, power_w, cmd)
+    if action == "init" or action == "deinit" then
+        return true
+    end
+    host.log("warn", "zuidwijk-p1: read-only driver, ignoring action=" .. tostring(action))
+    return false
+end
+
+function driver_default_mode()
+    -- Read-only: nothing to revert.
+end
+
+function driver_cleanup()
+    pcall(host.tcp_close)
+    buffer = ""
+    last_telegram_ms = -1
+    crc_errors = 0
+end

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -472,6 +472,7 @@ type Capabilities struct {
 	Modbus    *ModbusConfig    `yaml:"modbus,omitempty" json:"modbus,omitempty"`
 	HTTP      *HTTPCapability  `yaml:"http,omitempty" json:"http,omitempty"`
 	WebSocket *WSCapability    `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+	TCP       *TCPCapability   `yaml:"tcp,omitempty" json:"tcp,omitempty"`
 }
 
 // MQTTConfig grants access to one MQTT broker.
@@ -497,6 +498,15 @@ type HTTPCapability struct {
 // WSCapability grants WebSocket (ws://, wss://) access. Same allowlist
 // semantics as HTTPCapability — bare host = any port; "host:port" = exact.
 type WSCapability struct {
+	AllowedHosts []string `yaml:"allowed_hosts" json:"allowed_hosts"`
+}
+
+// TCPCapability grants raw TCP socket access (host.tcp_open). Same
+// allowlist semantics as the HTTP/WS lists: bare host entry matches any
+// port; "host:port" requires an exact match. Empty list = any host:port,
+// which is fine for fully-trusted LAN deployments but loose enough to
+// warrant an explicit list in shared installs.
+type TCPCapability struct {
 	AllowedHosts []string `yaml:"allowed_hosts" json:"allowed_hosts"`
 }
 
@@ -1070,8 +1080,10 @@ func (c *Config) Validate() error {
 		if d.Lua == "" {
 			return fmt.Errorf("driver %q: must specify `lua`", d.Name)
 		}
-		if d.EffectiveMQTT() == nil && d.EffectiveModbus() == nil && d.Capabilities.HTTP == nil {
-			return fmt.Errorf("driver %q: must have mqtt, modbus, or http capability", d.Name)
+		if d.EffectiveMQTT() == nil && d.EffectiveModbus() == nil &&
+			d.Capabilities.HTTP == nil && d.Capabilities.WebSocket == nil &&
+			d.Capabilities.TCP == nil {
+			return fmt.Errorf("driver %q: must have mqtt, modbus, http, websocket, or tcp capability", d.Name)
 		}
 	}
 	if len(c.Drivers) > 0 && siteMeters == 0 {

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -81,6 +81,12 @@ type HostEnv struct {
 	// WSAllowedHosts mirrors HTTPAllowedHosts but for ws://+wss:// URLs
 	// passed to host.ws_open. Same matching semantics; empty = any host.
 	WSAllowedHosts  []string
+	TCP             TCPCap   // nil → tcp_* calls return ErrNoCapability
+	// TCPAllowedHosts gates host.tcp_open(addr) the same way
+	// HTTPAllowedHosts gates HTTP. Empty = any host:port. The cap impl
+	// holds its own copy at construction; this field is informational so
+	// callers / tests can inspect what was granted.
+	TCPAllowedHosts []string
 	Start      time.Time  // monotonic start; host.millis() computed from here
 
 	// BatteryCapacityWh mirrors the operator's `battery_capacity_wh`
@@ -140,6 +146,17 @@ func (h *HostEnv) WithWS(w WSCap) *HostEnv { h.WS = w; return h }
 // WithWSAllowedHosts restricts which URLs the driver can ws_open to.
 func (h *HostEnv) WithWSAllowedHosts(hosts []string) *HostEnv {
 	h.WSAllowedHosts = hosts
+	return h
+}
+
+// WithTCP binds a raw TCP socket capability.
+func (h *HostEnv) WithTCP(t TCPCap) *HostEnv { h.TCP = t; return h }
+
+// WithTCPAllowedHosts records which addresses the driver is permitted to
+// host.tcp_open. The cap impl owns the authoritative copy; this field
+// just exposes the same list for inspection.
+func (h *HostEnv) WithTCPAllowedHosts(hosts []string) *HostEnv {
+	h.TCPAllowedHosts = hosts
 	return h
 }
 

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -33,6 +33,10 @@
 //	host.ws_messages()              -- drain inbound frames; "" entry = EOF
 //	host.ws_is_open()               -- boolean
 //	host.ws_close()                 -- close + free
+//	host.tcp_open(addr)             -- open raw TCP socket "host:port"; (true, nil) or (nil, err)
+//	host.tcp_recv()                 -- drain inbound bytes as a Lua string ("" if nothing)
+//	host.tcp_is_open()              -- boolean
+//	host.tcp_close()                -- close + free
 //
 // Lua 5.1 via yuin/gopher-lua — pure Go, zero CGo, one allocation-aware
 // interpreter per driver.
@@ -710,6 +714,62 @@ func registerHost(L *lua.LState, env *HostEnv) {
 			return 0
 		}
 		_ = env.WS.Close()
+		return 0
+	}))
+
+	// host.tcp_open("host:port")      → (true, nil) or (nil, error_string)
+	// host.tcp_recv()                 → string of buffered bytes since last
+	//                                   call ("" when nothing arrived). The
+	//                                   driver does its own framing (P1
+	//                                   telegrams use ! as the end-of-frame
+	//                                   marker, for instance).
+	// host.tcp_is_open()              → boolean — read pump alive. Flips to
+	//                                   false on EOF / read error; the
+	//                                   driver re-opens on the next poll.
+	// host.tcp_close()                → nil
+	host.RawSetString("tcp_open", L.NewFunction(func(L *lua.LState) int {
+		if env.TCP == nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString("tcp: capability not granted"))
+			return 2
+		}
+		addr := L.CheckString(1)
+		if err := env.TCP.Open(addr); err != nil {
+			L.Push(lua.LNil)
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		L.Push(lua.LBool(true))
+		return 1
+	}))
+
+	host.RawSetString("tcp_recv", L.NewFunction(func(L *lua.LState) int {
+		if env.TCP == nil {
+			// Mirror ws_messages / mqtt_messages contract: return an empty
+			// value rather than nil so drivers can concatenate without a
+			// nil guard.
+			L.Push(lua.LString(""))
+			return 1
+		}
+		b := env.TCP.PopBytes()
+		L.Push(lua.LString(string(b)))
+		return 1
+	}))
+
+	host.RawSetString("tcp_is_open", L.NewFunction(func(L *lua.LState) int {
+		if env.TCP == nil {
+			L.Push(lua.LBool(false))
+			return 1
+		}
+		L.Push(lua.LBool(env.TCP.IsOpen()))
+		return 1
+	}))
+
+	host.RawSetString("tcp_close", L.NewFunction(func(L *lua.LState) int {
+		if env.TCP == nil {
+			return 0
+		}
+		_ = env.TCP.Close()
 		return 0
 	}))
 

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -137,6 +137,17 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 			env.WithWSAllowedHosts(hosts)
 		}
 	}
+	if cfg.Capabilities.TCP != nil {
+		// Merge allowed_hosts with the driver's own `host`/`address` keys
+		// so the operator doesn't have to list the same endpoint twice.
+		// "host:port" entries pass through unchanged; bare "host" entries
+		// allow any port on that host.
+		hosts := mergeAllowedHosts(cfg.Capabilities.TCP.AllowedHosts, cfg.Config)
+		env.WithTCP(NewNetTCP(cfg.Name, hosts))
+		if len(hosts) > 0 {
+			env.WithTCPAllowedHosts(hosts)
+		}
+	}
 
 	luaDrv, err := NewLuaDriver(cfg.Lua, env)
 	if err != nil {
@@ -208,6 +219,9 @@ func (r *Registry) runLoop(rd *runningDriver) {
 			}
 			if rd.env.WS != nil {
 				_ = rd.env.WS.Close()
+			}
+			if rd.env.TCP != nil {
+				_ = rd.env.TCP.Close()
 			}
 			return
 		case cmd := <-rd.cmdCh:
@@ -482,6 +496,11 @@ func sameDriverConfig(a, b config.Driver) bool {
 	aMb, bMb := a.EffectiveModbus(), b.EffectiveModbus()
 	if (aMb == nil) != (bMb == nil) { return false }
 	if aMb != nil && (aMb.Host != bMb.Host || aMb.Port != bMb.Port || aMb.UnitID != bMb.UnitID) {
+		return false
+	}
+	aTCP, bTCP := a.Capabilities.TCP, b.Capabilities.TCP
+	if (aTCP == nil) != (bTCP == nil) { return false }
+	if aTCP != nil && !reflect.DeepEqual(aTCP.AllowedHosts, bTCP.AllowedHosts) {
 		return false
 	}
 	// Compare the free-form Config map. Previously omitted, so a changed

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -138,11 +138,14 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 		}
 	}
 	if cfg.Capabilities.TCP != nil {
-		// Merge allowed_hosts with the driver's own `host`/`address` keys
-		// so the operator doesn't have to list the same endpoint twice.
-		// "host:port" entries pass through unchanged; bare "host" entries
-		// allow any port on that host.
-		hosts := mergeAllowedHosts(cfg.Capabilities.TCP.AllowedHosts, cfg.Config)
+		// Start with the explicit allowlist from YAML, then layer the
+		// driver's own (host, port) on top as a TIGHT host:port entry —
+		// not a bare host the way HTTP/WS do it. Raw TCP can hit any
+		// service listening on the device (SSH, web UI, ...), so the
+		// safe default is "exactly the port the driver was wired to";
+		// the operator can still loosen this by listing bare hosts in
+		// capabilities.tcp.allowed_hosts when they want any-port access.
+		hosts := tcpAllowedHostsFor(cfg)
 		env.WithTCP(NewNetTCP(cfg.Name, hosts))
 		if len(hosts) > 0 {
 			env.WithTCPAllowedHosts(hosts)
@@ -436,6 +439,51 @@ func (r *Registry) RestartByName(ctx context.Context, name string) error {
 	}
 	cfg := rd.cfg
 	return r.Restart(ctx, cfg)
+}
+
+// tcpAllowedHostsFor builds the effective allowlist for a TCP-capable
+// driver. Explicit `capabilities.tcp.allowed_hosts` entries come first
+// (verbatim — operator can write either "host" or "host:port"). The
+// driver's own `config.host` is then auto-added as a tight `host:port`
+// entry when `config.port` is also set, falling back to bare host
+// otherwise. The tight default is deliberate: raw TCP can poke any
+// service on the same IP, so "P1 reader on :23" should not also grant
+// access to SSH on :22 of the same device.
+func tcpAllowedHostsFor(cfg config.Driver) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 4)
+	add := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, h := range cfg.Capabilities.TCP.AllowedHosts {
+		add(h)
+	}
+	if cfg.Config != nil {
+		host, _ := cfg.Config["host"].(string)
+		var port int
+		switch p := cfg.Config["port"].(type) {
+		case int:
+			port = p
+		case int64:
+			port = int(p)
+		case float64:
+			port = int(p)
+		}
+		if host != "" && port > 0 {
+			add(fmt.Sprintf("%s:%d", host, port))
+		} else if host != "" {
+			add(host)
+		}
+	}
+	return out
 }
 
 // mergeAllowedHosts returns the explicit allowlist plus any host implied

--- a/go/internal/drivers/registry_allowlist_test.go
+++ b/go/internal/drivers/registry_allowlist_test.go
@@ -3,6 +3,8 @@ package drivers
 import (
 	"reflect"
 	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
 )
 
 func TestMergeAllowedHosts(t *testing.T) {
@@ -75,6 +77,81 @@ func TestMergeAllowedHosts(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("mergeAllowedHosts() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TCP gets a tighter default than HTTP/WS: when the driver config supplies
+// both host and port, the auto-injected allowlist entry is `host:port`
+// (not bare host). Raw TCP can reach any service on the same IP, so
+// "P1 reader on :23" must not also grant access to SSH on :22.
+func TestTcpAllowedHostsFor(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.Driver
+		want []string
+	}{
+		{
+			name: "config.host+port → tight host:port entry",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{}},
+				Config:       map[string]any{"host": "192.168.1.40", "port": 23},
+			},
+			want: []string{"192.168.1.40:23"},
+		},
+		{
+			name: "config.host without port falls back to bare host",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{}},
+				Config:       map[string]any{"host": "192.168.1.40"},
+			},
+			want: []string{"192.168.1.40"},
+		},
+		{
+			name: "explicit allowlist preserved, config.host:port appended",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{
+					AllowedHosts: []string{"10.0.0.5", "loose-host"},
+				}},
+				Config: map[string]any{"host": "192.168.1.40", "port": 23},
+			},
+			want: []string{"10.0.0.5", "loose-host", "192.168.1.40:23"},
+		},
+		{
+			name: "duplicate entry dropped",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{
+					AllowedHosts: []string{"192.168.1.40:23"},
+				}},
+				Config: map[string]any{"host": "192.168.1.40", "port": 23},
+			},
+			want: []string{"192.168.1.40:23"},
+		},
+		{
+			name: "yaml-decoded port (int) is honoured",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{}},
+				Config:       map[string]any{"host": "192.168.1.40", "port": int64(2300)},
+			},
+			want: []string{"192.168.1.40:2300"},
+		},
+		{
+			name: "no config at all returns empty (no implicit any-host)",
+			cfg: config.Driver{
+				Capabilities: config.Capabilities{TCP: &config.TCPCapability{}},
+			},
+			want: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tcpAllowedHostsFor(tc.cfg)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("tcpAllowedHostsFor() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/go/internal/drivers/tcp_cap.go
+++ b/go/internal/drivers/tcp_cap.go
@@ -1,0 +1,185 @@
+package drivers
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TCPCap is the host's raw TCP socket capability. One driver = one upstream
+// connection (matches MQTTCap / WSCap shape). Used by drivers that talk to
+// passthrough Serial-to-Ethernet gateways or other protocols that stream
+// unsolicited bytes over a TCP socket — e.g. Dutch P1 smart-meter readers
+// streaming DSMR telegrams on port 23.
+//
+// Read-only by design today: the targets we have don't expect input from us,
+// and giving a driver write access to an arbitrary TCP socket is a much
+// larger blast-radius decision (CSRF-style escalations against internal
+// devices). Add tcp_send only when an actual driver needs it.
+type TCPCap interface {
+	Open(addr string) error
+	// PopBytes returns and clears any bytes buffered since the last call.
+	// EOF is signalled by IsOpen() flipping to false; an empty return with
+	// IsOpen()==false means the read pump exited and the driver should
+	// Close + Open again to recover.
+	PopBytes() []byte
+	IsOpen() bool
+	Close() error
+}
+
+// netTCP is the production TCPCap impl: one connection per driver, a
+// background read pump that appends bytes to an in-memory buffer, and a
+// non-blocking PopBytes drain. Mirrors gorillaWS's concurrency model.
+type netTCP struct {
+	driverName string
+	allowed    []string // empty = any host
+
+	mu     sync.Mutex
+	conn   net.Conn
+	open   bool
+	buf    []byte
+	stop   chan struct{}
+}
+
+// NewNetTCP returns a TCPCap bound to a driver name. The connection is not
+// opened until the driver calls host.tcp_open.
+func NewNetTCP(driverName string, allowedHosts []string) TCPCap {
+	cp := append([]string(nil), allowedHosts...)
+	return &netTCP{driverName: driverName, allowed: cp}
+}
+
+// tcpHostAllowed checks `host:port` style addresses against the allowlist.
+// Same matching semantics as the WS/HTTP lists: bare entry matches any port
+// on that host; "host:port" requires an exact match. Empty list = any host.
+func tcpHostAllowed(addr string, allowed []string) (bool, string) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return false, "invalid address (need host:port)"
+	}
+	host = strings.ToLower(host)
+	if len(allowed) == 0 {
+		return true, ""
+	}
+	for _, raw := range allowed {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		eHost, ePort, hasPort := splitHostPortLower(entry)
+		if !hasPort {
+			if strings.ToLower(entry) == host {
+				return true, ""
+			}
+			continue
+		}
+		if eHost == host && ePort == port {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("host %q (port %s) not in allowed_hosts", host, port)
+}
+
+func (n *netTCP) Open(addr string) error {
+	n.mu.Lock()
+	if n.open {
+		n.mu.Unlock()
+		return nil
+	}
+	n.mu.Unlock()
+
+	if ok, reason := tcpHostAllowed(addr, n.allowed); !ok {
+		return fmt.Errorf("tcp: %s", reason)
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("tcp dial: %w", err)
+	}
+
+	n.mu.Lock()
+	n.conn = conn
+	n.open = true
+	n.stop = make(chan struct{})
+	// Drop any buffered bytes from a prior connection so a re-Open doesn't
+	// deliver stale frame fragments mixed in with the new stream.
+	n.buf = nil
+	n.mu.Unlock()
+
+	go n.readPump()
+	return nil
+}
+
+func (n *netTCP) readPump() {
+	n.mu.Lock()
+	c := n.conn
+	stop := n.stop
+	n.mu.Unlock()
+	if c == nil {
+		return
+	}
+	// Small read buffer — P1 telegrams are ~1 KB and arrive once per second,
+	// so a 4 KB scratch covers a full telegram with margin.
+	scratch := make([]byte, 4096)
+	for {
+		// Generous read deadline: P1 readers stream one telegram per second,
+		// but a brief network blip mustn't tear down a live connection on
+		// healthy infrastructure. 60 s matches the WS pump and is well
+		// beyond the watchdog timeout, so a real silence flips the driver
+		// offline via the watchdog path long before the deadline fires.
+		_ = c.SetReadDeadline(time.Now().Add(60 * time.Second))
+		nRead, err := c.Read(scratch)
+		if nRead > 0 {
+			n.mu.Lock()
+			// Cap the inbound buffer at 64 KiB so a stalled driver poll
+			// can't blow memory. Drop oldest on overflow — keeps the most
+			// recent telegram which is what the driver actually wants.
+			if len(n.buf)+nRead > 65536 {
+				keep := 32768
+				if len(n.buf) > keep {
+					n.buf = n.buf[len(n.buf)-keep:]
+				}
+			}
+			n.buf = append(n.buf, scratch[:nRead]...)
+			n.mu.Unlock()
+		}
+		if err != nil {
+			n.mu.Lock()
+			n.open = false
+			n.mu.Unlock()
+			select {
+			case <-stop:
+			default:
+				close(stop)
+			}
+			return
+		}
+	}
+}
+
+func (n *netTCP) PopBytes() []byte {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out := n.buf
+	n.buf = nil
+	return out
+}
+
+func (n *netTCP) IsOpen() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.open
+}
+
+func (n *netTCP) Close() error {
+	n.mu.Lock()
+	c := n.conn
+	n.open = false
+	n.conn = nil
+	n.mu.Unlock()
+	if c == nil {
+		return nil
+	}
+	return c.Close()
+}

--- a/go/internal/drivers/tcp_cap.go
+++ b/go/internal/drivers/tcp_cap.go
@@ -132,21 +132,34 @@ func (n *netTCP) readPump() {
 		nRead, err := c.Read(scratch)
 		if nRead > 0 {
 			n.mu.Lock()
-			// Cap the inbound buffer at 64 KiB so a stalled driver poll
-			// can't blow memory. Drop oldest on overflow — keeps the most
-			// recent telegram which is what the driver actually wants.
-			if len(n.buf)+nRead > 65536 {
-				keep := 32768
-				if len(n.buf) > keep {
-					n.buf = n.buf[len(n.buf)-keep:]
+			// Only mutate shared state if this pump is still the current
+			// one. A stale pump woken after Close+Open must NOT mix bytes
+			// from the dead connection into the live buffer.
+			if n.conn == c {
+				// Cap the inbound buffer at 64 KiB so a stalled driver poll
+				// can't blow memory. Drop oldest on overflow — keeps the most
+				// recent telegram which is what the driver actually wants.
+				if len(n.buf)+nRead > 65536 {
+					keep := 32768
+					if len(n.buf) > keep {
+						n.buf = n.buf[len(n.buf)-keep:]
+					}
 				}
+				n.buf = append(n.buf, scratch[:nRead]...)
 			}
-			n.buf = append(n.buf, scratch[:nRead]...)
 			n.mu.Unlock()
 		}
 		if err != nil {
 			n.mu.Lock()
-			n.open = false
+			// Same staleness check: a stale pump's read-error must NOT
+			// clobber n.open after a fresh Close+Open has installed a
+			// new connection. Otherwise the driver sees IsOpen() flip
+			// false, calls Open() again, and leaks a connection per
+			// flap cycle — would exhaust local sockets on a P1 reader
+			// that flaps every few seconds.
+			if n.conn == c {
+				n.open = false
+			}
 			n.mu.Unlock()
 			select {
 			case <-stop:

--- a/go/internal/drivers/tcp_cap_test.go
+++ b/go/internal/drivers/tcp_cap_test.go
@@ -97,6 +97,94 @@ func TestTCPCap_AllowedHosts(t *testing.T) {
 	}
 }
 
+// TestTCPCap_StalePumpDoesNotClobberLiveState exercises the readPump→Close
+// race. We open against listener A, close, open against listener B, then
+// force A's accepted connection to drop. The stale pump for A wakes from
+// its read-error and must NOT mutate n.open or n.buf for the live B
+// connection. Without the staleness guard the driver would see IsOpen()
+// flip false and Open() a third socket on the next poll — leaking a
+// connection per flap cycle.
+func TestTCPCap_StalePumpDoesNotClobberLiveState(t *testing.T) {
+	lnA, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lnA.Close()
+	lnB, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lnB.Close()
+
+	// Listener A: accept, hand the conn back to the test so we can drop
+	// it at the precise moment after Close+Open below. Read pump is
+	// already blocked on c.Read().
+	connACh := make(chan net.Conn, 1)
+	go func() {
+		c, err := lnA.Accept()
+		if err == nil {
+			connACh <- c
+		}
+	}()
+
+	// Listener B: accept, push a byte payload so the test can verify the
+	// live cap is reading from B (not A).
+	livePayload := []byte("LIVE\r\n")
+	go func() {
+		c, err := lnB.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = c.Write(livePayload)
+		// Hold the conn open until the test ends.
+		buf := make([]byte, 16)
+		_, _ = c.Read(buf)
+		_ = c.Close()
+	}()
+
+	cap := NewNetTCP("test", nil)
+	if err := cap.Open(lnA.Addr().String()); err != nil {
+		t.Fatalf("open A: %v", err)
+	}
+	// Wait for A's server-side conn to be accepted.
+	var sideA net.Conn
+	select {
+	case sideA = <-connACh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener A did not accept in time")
+	}
+
+	// Close the cap (tears down the client side of A), then immediately
+	// Open against B. The stale pump for A is still blocked on c.Read().
+	_ = cap.Close()
+	if err := cap.Open(lnB.Addr().String()); err != nil {
+		t.Fatalf("open B: %v", err)
+	}
+
+	// Now force A's read pump to error out, AFTER the new conn is live.
+	_ = sideA.Close()
+
+	// Give the stale pump a beat to wake from its read error and try to
+	// mutate state. The live cap must remain open and B's bytes must
+	// land in the buffer.
+	deadline := time.Now().Add(2 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) {
+		got = append(got, cap.PopBytes()...)
+		if len(got) >= len(livePayload) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !cap.IsOpen() {
+		t.Error("IsOpen() flipped false — stale pump clobbered live state")
+	}
+	if string(got) != string(livePayload) {
+		t.Errorf("live payload corrupted by stale pump: got %q want %q", got, livePayload)
+	}
+	_ = cap.Close()
+}
+
 // ---- Driver-level test: feed a canned DSMR telegram through host.tcp_recv
 
 // fakeTCPCap is a TCPCap that returns a pre-loaded byte payload once and
@@ -313,6 +401,83 @@ func TestZuidwijkP1Driver_AcceptsLegacyNoCRC(t *testing.T) {
 	}
 	if !nearly(meter.RawW, 734, 0.5) {
 		t.Errorf("meter.w: got %v want ~734", meter.RawW)
+	}
+}
+
+func TestZuidwijkP1Driver_RetriesSNWhenFirstTelegramMissesIt(t *testing.T) {
+	// If the first telegram we see lacks 96.1.1 (truncated, partial buffer,
+	// firmware that publishes the long form only every N frames), the
+	// driver must keep trying — never giving up on the make:serial anchor
+	// for the rest of the process lifetime.
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+
+	// Build a "first frame without SN" by stripping the 96.1.1 line.
+	bodyNoSN := strings.Replace(dsmrBody,
+		"0-0:96.1.1(4530303834303031383239353439393137)\r\n", "", 1)
+	firstFrame := dsmrWrap(bodyNoSN, "")
+	secondFrame := dsmrWrap(dsmrBody, "")
+
+	cap := &fakeTCPCap{}
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(cap)
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Poll #1: only the SN-less telegram is available.
+	cap.bytes = []byte(firstFrame)
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll 1: %v", err)
+	}
+	if _, sn := env.Identity(); sn != "" {
+		t.Fatalf("SN should still be unset after frame without 96.1.1, got %q", sn)
+	}
+
+	// Poll #2: a follow-up telegram WITH the SN line. The driver must
+	// pick it up — previously the `last_telegram_ms < 0` guard prevented
+	// any retry, locking in the missing identity for the process lifetime.
+	cap.bytes = []byte(secondFrame)
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll 2: %v", err)
+	}
+	if _, sn := env.Identity(); sn != "E0084001829549917" {
+		t.Errorf("SN should be picked up on the 2nd telegram, got %q", sn)
+	}
+}
+
+func TestZuidwijkP1Driver_RejectsZeroLiteralCRCWhenBodyDoesNotMatch(t *testing.T) {
+	// A telegram with a real body but wire CRC literally "0000". The
+	// previous implementation treated "0000" as "no CRC supplied" and
+	// passed the frame through unverified. With the shortcut removed,
+	// "0000" is just a normal hex CRC value: it has to match the
+	// computed CRC, and it won't for our non-trivial body.
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+	cap := &fakeTCPCap{bytes: []byte(dsmrWrap(dsmrBody, "0000"))}
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(cap)
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if got := tel.Get("zuidwijk-p1", telemetry.DerMeter); got != nil {
+		t.Errorf("wire CRC of 0000 with non-matching body must be rejected, got reading %+v", got)
 	}
 }
 

--- a/go/internal/drivers/tcp_cap_test.go
+++ b/go/internal/drivers/tcp_cap_test.go
@@ -1,0 +1,345 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// ---- TCPCap unit tests -----------------------------------------------------
+
+func TestTCPCap_OpenRecvClose(t *testing.T) {
+	// Stand up a local TCP server that pushes a known byte payload and
+	// blocks until the client closes — exercises both the buffering path
+	// in netTCP and the Close → readPump unwind.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	payload := []byte("HELLO P1 TELEGRAM\r\n!ABCD\r\n")
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = c.Write(payload)
+		// Block; the test closes the cap which closes the conn and unblocks.
+		buf := make([]byte, 16)
+		_, _ = c.Read(buf)
+		_ = c.Close()
+	}()
+
+	cap := NewNetTCP("test", nil)
+	if err := cap.Open(ln.Addr().String()); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer cap.Close()
+
+	// Give the read pump a beat to drain the payload.
+	deadline := time.Now().Add(2 * time.Second)
+	var got []byte
+	for time.Now().Before(deadline) {
+		got = append(got, cap.PopBytes()...)
+		if len(got) >= len(payload) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("payload mismatch: got %q want %q", got, payload)
+	}
+	if !cap.IsOpen() {
+		t.Error("expected IsOpen() to be true while server is up")
+	}
+}
+
+func TestTCPCap_AllowedHosts(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	cases := []struct {
+		name    string
+		allowed []string
+		addr    string
+		wantErr bool
+	}{
+		{"empty allowlist = any host", nil, ln.Addr().String(), false},
+		{"bare host match", []string{"127.0.0.1"}, ln.Addr().String(), false},
+		{"host:port match", []string{"127.0.0.1:" + port}, ln.Addr().String(), false},
+		{"host:port mismatch", []string{"127.0.0.1:1"}, ln.Addr().String(), true},
+		{"different host blocked", []string{"10.0.0.1"}, ln.Addr().String(), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := NewNetTCP("test", tc.allowed)
+			err := cap.Open(tc.addr)
+			defer cap.Close()
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// ---- Driver-level test: feed a canned DSMR telegram through host.tcp_recv
+
+// fakeTCPCap is a TCPCap that returns a pre-loaded byte payload once and
+// then reports EOF. Lets us exercise the Lua driver's framing + parser
+// without standing up a network listener.
+type fakeTCPCap struct {
+	bytes  []byte
+	opened bool
+	closed bool
+}
+
+func (f *fakeTCPCap) Open(addr string) error { f.opened = true; return nil }
+func (f *fakeTCPCap) PopBytes() []byte {
+	out := f.bytes
+	f.bytes = nil
+	return out
+}
+func (f *fakeTCPCap) IsOpen() bool { return f.opened && !f.closed }
+func (f *fakeTCPCap) Close() error { f.closed = true; return nil }
+
+// Synthetic DSMR 5.0 telegram body. Values chosen so we can pin every emit:
+//   import 1.234 kW, export 0.500 kW   → meter.w = +734 W
+//   per-phase voltages 230.1 / 230.2 / 230.3 V
+//   per-phase currents 5 / 3 / 7 A
+//   import T1 100.000 kWh + T2 200.000 kWh → import_wh = 300_000
+//   export T1 10.000 kWh + T2 20.000 kWh → export_wh = 30_000
+// CRC is computed at runtime via dsmrCRC16; tests build the full telegram
+// with dsmrWrap() so they exercise the same CRC path the live meter does.
+const dsmrBody = "/XMX5LGBBFFB231215493\r\n" +
+	"\r\n" +
+	"1-3:0.2.8(50)\r\n" +
+	"0-0:1.0.0(241015095505S)\r\n" +
+	"0-0:96.1.1(4530303834303031383239353439393137)\r\n" +
+	"1-0:1.8.1(00100.000*kWh)\r\n" +
+	"1-0:1.8.2(00200.000*kWh)\r\n" +
+	"1-0:2.8.1(00010.000*kWh)\r\n" +
+	"1-0:2.8.2(00020.000*kWh)\r\n" +
+	"0-0:96.14.0(0002)\r\n" +
+	"1-0:1.7.0(01.234*kW)\r\n" +
+	"1-0:2.7.0(00.500*kW)\r\n" +
+	"0-0:96.7.21(00012)\r\n" +
+	"0-0:96.7.9(00003)\r\n" +
+	"1-0:32.7.0(230.1*V)\r\n" +
+	"1-0:52.7.0(230.2*V)\r\n" +
+	"1-0:72.7.0(230.3*V)\r\n" +
+	"1-0:31.7.0(005*A)\r\n" +
+	"1-0:51.7.0(003*A)\r\n" +
+	"1-0:71.7.0(007*A)\r\n" +
+	"1-0:21.7.0(00.500*kW)\r\n" +
+	"1-0:41.7.0(00.400*kW)\r\n" +
+	"1-0:61.7.0(00.334*kW)\r\n" +
+	"1-0:22.7.0(00.000*kW)\r\n" +
+	"1-0:42.7.0(00.000*kW)\r\n" +
+	"1-0:62.7.0(00.500*kW)\r\n" +
+	"0-1:24.1.0(003)\r\n" +
+	"0-1:96.1.0(4730303132393336353031383039333137)\r\n" +
+	"0-1:24.2.1(241015095500S)(00123.456*m3)\r\n"
+
+// dsmrCRC16 computes the CRC16-IBM (poly 0xA001, init 0x0000) used by
+// DSMR 5 — same algorithm as the driver's Lua implementation. Kept here
+// as a parallel reference so the test can assert end-to-end correctness
+// without invoking the Lua VM.
+func dsmrCRC16(data []byte) uint16 {
+	var crc uint16
+	for _, b := range data {
+		crc ^= uint16(b)
+		for i := 0; i < 8; i++ {
+			if crc&1 == 1 {
+				crc = (crc >> 1) ^ 0xA001
+			} else {
+				crc >>= 1
+			}
+		}
+	}
+	return crc
+}
+
+// dsmrWrap appends '!' + CRC hex + CRLF onto a DSMR body. crcOverride,
+// when non-empty, replaces the computed CRC — useful for the bad-CRC
+// test. Use "" to get a real, valid trailer.
+func dsmrWrap(body, crcOverride string) string {
+	if crcOverride == "" {
+		crc := dsmrCRC16([]byte(body + "!"))
+		return fmt.Sprintf("%s!%04X\r\n", body, crc)
+	}
+	return fmt.Sprintf("%s!%s\r\n", body, crcOverride)
+}
+
+func TestZuidwijkP1Driver_ParsesTelegram(t *testing.T) {
+	// Use the real driver file from the repo.
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(&fakeTCPCap{bytes: []byte(dsmrWrap(dsmrBody, ""))})
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1", "port": 23}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	meter := tel.Get("zuidwijk-p1", telemetry.DerMeter)
+	if meter == nil {
+		t.Fatal("no meter reading")
+	}
+	// 1.234 - 0.500 = 0.734 kW = 734 W
+	if !nearly(meter.RawW, 734, 0.5) {
+		t.Errorf("meter.w: got %v want ~734", meter.RawW)
+	}
+
+	mk, sn := env.Identity()
+	if mk != "Zuidwijk" {
+		t.Errorf("make: %q", mk)
+	}
+	if sn != "E0084001829549917" {
+		t.Errorf("sn: got %q want E0084001829549917", sn)
+	}
+}
+
+func TestZuidwijkP1Driver_TakesLatestFrameWhenBuffered(t *testing.T) {
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+
+	// Two back-to-back telegrams, differing only in active power. The
+	// driver must commit the *latest* one because that's the freshest
+	// snapshot of meter state. Both wrapped with valid CRCs so neither
+	// gets dropped by the CRC gate.
+	staleBody := strings.Replace(dsmrBody, "1-0:1.7.0(01.234*kW)", "1-0:1.7.0(00.100*kW)", 1)
+	staleBody = strings.Replace(staleBody, "1-0:2.7.0(00.500*kW)", "1-0:2.7.0(00.000*kW)", 1)
+	combined := dsmrWrap(staleBody, "") + dsmrWrap(dsmrBody, "")
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(&fakeTCPCap{bytes: []byte(combined)})
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	meter := tel.Get("zuidwijk-p1", telemetry.DerMeter)
+	if meter == nil {
+		t.Fatal("no meter reading")
+	}
+	if !nearly(meter.RawW, 734, 0.5) {
+		t.Errorf("expected the LATER frame (~734 W), got %v", meter.RawW)
+	}
+}
+
+func TestZuidwijkP1Driver_RejectsBadCRC(t *testing.T) {
+	// A telegram with the right body but a deliberately wrong CRC. The
+	// driver must drop it and produce no meter reading at all — the
+	// dispatch loop reading a corrupt grid value would chase a phantom
+	// setpoint until the watchdog catches the stall.
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(&fakeTCPCap{bytes: []byte(dsmrWrap(dsmrBody, "DEAD"))})
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if got := tel.Get("zuidwijk-p1", telemetry.DerMeter); got != nil {
+		t.Errorf("bad-CRC frame should produce no meter reading, got %+v", got)
+	}
+}
+
+func TestZuidwijkP1Driver_AcceptsLegacyNoCRC(t *testing.T) {
+	// DSMR 4 firmware and pure passthrough proxies emit '!\r\n' with no
+	// CRC. The driver must accept these (better unverified than starved)
+	// while logging a metric for visibility.
+	driverPath := repoDriverPath(t, "zuidwijk_p1.lua")
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("zuidwijk-p1", tel)
+	env.WithTCP(&fakeTCPCap{bytes: []byte(dsmrBody + "!\r\n")})
+
+	d, err := NewLuaDriver(driverPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), map[string]any{"host": "127.0.0.1"}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	meter := tel.Get("zuidwijk-p1", telemetry.DerMeter)
+	if meter == nil {
+		t.Fatal("legacy no-CRC frame should still be accepted")
+	}
+	if !nearly(meter.RawW, 734, 0.5) {
+		t.Errorf("meter.w: got %v want ~734", meter.RawW)
+	}
+}
+
+// repoDriverPath returns the absolute path to a driver file in the repo's
+// drivers/ directory. Walks up from the test's working directory until it
+// finds a `drivers/` sibling containing `name`.
+func repoDriverPath(t *testing.T, name string) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for dir := wd; dir != "/" && dir != ""; dir = filepath.Dir(dir) {
+		candidate := filepath.Join(dir, "drivers", name)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	t.Fatalf("could not locate drivers/%s starting from %s", name, wd)
+	return ""
+}
+
+func nearly(a, b, eps float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= eps
+}
+


### PR DESCRIPTION
## Summary

- Adds **`host.tcp_*` capability** — raw TCP socket access for the Lua driver host, parallel to MQTT / Modbus / HTTP / WebSocket. Background read pump + 64 KiB buffer + allowed-hosts gating. Read-only by design (no `tcp_send`).
- Adds **`drivers/zuidwijk_p1.lua`** — driver for the [Zuidwijk P1 Reader Ethernet](https://www.zuidwijk.com/product/p1-reader-ethernet/), a Serial-to-Ethernet bridge that streams unsolicited Dutch DSMR smart-meter telegrams on TCP :23. Parses the DSMR 5 telegram, validates CRC16-IBM, decodes the standard OBIS codes, emits meter telemetry in site convention (`w = (1.7.0 − 2.7.0) × 1000`).
- Updates `docs/host-api.md` with the new TCP section and `docs/writing-a-driver.md` with a TCP transport note.

### Why a new capability

The Zuidwijk reader has no JSON/HTTP API and only undocumented MQTT support. Native support requires a TCP socket on the host side. The capability is reusable — any future device that streams over a raw TCP port (Modbus-RTU-to-TCP passthrough, KNX/IP gateways in pure-stream mode, etc.) picks it up.

### Robustness

- **CRC16-IBM validation** on every telegram. Bad frames are dropped and counted via `emit_metric("p1_crc_errors", …)` so a flaky link can't poison the dispatch loop with hallucinated grid readings.
- **Legacy fallback**: DSMR 4 / encrypted-passthrough firmware that sends `!\r\n` with no CRC is still accepted (better unverified than starved); operators can see the rate via the same metric.
- **Reconnect path** built into `driver_poll` — `tcp_open` is idempotent, so a dropped session reconnects on the next tick.
- **Buffer cap** at 8 KiB to bound memory if the meter ever spews non-DSMR junk.

### Files

| Area | Files |
|---|---|
| New host capability | `go/internal/drivers/tcp_cap.go`, additions in `host.go` / `lua.go` / `registry.go` |
| Config schema | `go/internal/config/config.go` (new `TCPCapability`) |
| Driver | `drivers/zuidwijk_p1.lua` |
| Tests | `go/internal/drivers/tcp_cap_test.go` (5 tests) |
| Docs | `docs/host-api.md`, `docs/writing-a-driver.md` |

### Example config

```yaml
- name: house-meter
  lua: drivers/zuidwijk_p1.lua
  is_site_meter: true
  capabilities:
    tcp:
      allowed_hosts: ["192.168.1.40:23"]
  config:
    host: "192.168.1.40"
    port: 23
```

## Test plan

- [x] `make verify` — vet + full test suite + build clean
- [x] `TestTCPCap_OpenRecvClose` — real local listener round-trips bytes through the read pump
- [x] `TestTCPCap_AllowedHosts` — bare host / `host:port` / blocked entries
- [x] `TestZuidwijkP1Driver_ParsesTelegram` — canned DSMR with valid CRC → `meter.w ≈ 734 W`, decoded SN `E0084001829549917`
- [x] `TestZuidwijkP1Driver_TakesLatestFrameWhenBuffered` — two stacked telegrams, later one wins
- [x] `TestZuidwijkP1Driver_RejectsBadCRC` — corrupt CRC → no meter reading
- [x] `TestZuidwijkP1Driver_AcceptsLegacyNoCRC` — DSMR-4 fallback still accepted
- [ ] Live test against actual Zuidwijk hardware on a Dutch site (driver marked `verification_status = "experimental"` until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)