### PR TITLE
refactor(control): centralize dispatch post-processing + tighten host/store boundary validation

### DIFF
--- a/drivers/ctek.lua
+++ b/drivers/ctek.lua
@@ -150,15 +150,8 @@ local function decode_ascii(regs, n)
 end
 
 local function write_setpoint(amps)
-    -- host.modbus_write signals errors by RETURNING a string, not by
-    -- raising — pcall's `ok` is only false on a Lua runtime exception
-    -- (rare). On a Modbus / transport error the host pushes the error
-    -- string into pcall's second slot instead, so we have to inspect
-    -- both. Without this the driver would silently treat a failed
-    -- write as success and emit a stale `max_a` while the charger
-    -- never accepted the new setpoint.
-    local ok, err = pcall(host.modbus_write, REG_CHARGE_LIMIT, amps)
-    if not ok or (err ~= nil and err ~= "") then
+    local err = host.modbus_write(REG_CHARGE_LIMIT, amps)
+    if err ~= nil and err ~= "" then
         host.log("warn", "CTEK: write charging limit failed: " .. tostring(err))
         return false
     end

--- a/drivers/ctek_hybrid.lua
+++ b/drivers/ctek_hybrid.lua
@@ -171,8 +171,8 @@ local function decode_ascii(regs, n)
 end
 
 local function write_setpoint(amps)
-    local ok, err = pcall(host.modbus_write, REG_CHARGE_LIMIT, amps)
-    if not ok or (err ~= nil and err ~= "") then
+    local err = host.modbus_write(REG_CHARGE_LIMIT, amps)
+    if err ~= nil and err ~= "" then
         host.log("warn", "CTEK-hybrid: write charging limit failed: " .. tostring(err))
         return false
     end

--- a/drivers/ctek_v2.lua
+++ b/drivers/ctek_v2.lua
@@ -143,15 +143,8 @@ local function decode_ascii(regs, n)
 end
 
 local function write_setpoint(amps)
-    -- host.modbus_write signals errors by RETURNING a string, not by
-    -- raising — pcall's `ok` is only false on a Lua runtime exception
-    -- (rare). On a Modbus / transport error the host pushes the error
-    -- string into pcall's second slot instead, so we have to inspect
-    -- both. Without this the driver would silently treat a failed
-    -- write as success and emit a stale `max_a` while the charger
-    -- never accepted the new setpoint.
-    local ok, err = pcall(host.modbus_write, REG_CHARGE_LIMIT, amps)
-    if not ok or (err ~= nil and err ~= "") then
+    local err = host.modbus_write(REG_CHARGE_LIMIT, amps)
+    if err ~= nil and err ~= "" then
         host.log("warn", "CTEK: write charging limit failed: " .. tostring(err))
         return false
     end

--- a/drivers/deye.lua
+++ b/drivers/deye.lua
@@ -428,9 +428,9 @@ local CHARGE_CURRENT_DEFAULT_A = 31  -- matches Zap init profile
 local WRITE_DELAY_MS = 50
 
 local function write_reg(addr, val)
-    local ok, err = pcall(host.modbus_write, addr, val)
+    local err = host.modbus_write(addr, val)
     host.sleep(WRITE_DELAY_MS)
-    if not ok then
+    if err ~= nil and err ~= "" then
         host.log("warn", string.format("Deye: write %d=%d failed: %s",
             addr, val, tostring(err)))
         return false

--- a/drivers/ferroamp_modbus.lua
+++ b/drivers/ferroamp_modbus.lua
@@ -312,14 +312,22 @@ end
 
 -- Watchdog fallback: revert to autonomous self-consumption (mode 0).
 -- Matches drivers/ferroamp.lua's "auto" command for the MQTT variant.
--- Wrapped in pcall because the watchdog may fire precisely because
--- Modbus is unreachable — an unhandled write error here would crash the VM.
 function driver_default_mode()
     host.log("info", "Ferroamp Modbus: watchdog → auto / self-consumption")
-    pcall(host.modbus_write, 6000, 0)
+    local err = host.modbus_write(6000, 0)
+    if err ~= nil and err ~= "" then
+        host.log("warn", "Ferroamp Modbus: watchdog auto failed: " .. tostring(err))
+        return false
+    end
+    return true
 end
 
 function driver_cleanup()
     -- Return to auto on shutdown so the device doesn't stay in a forced mode.
-    pcall(host.modbus_write, 6000, 0)
+    local err = host.modbus_write(6000, 0)
+    if err ~= nil and err ~= "" then
+        host.log("warn", "Ferroamp Modbus: cleanup auto failed: " .. tostring(err))
+        return false
+    end
+    return true
 end

--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -115,7 +115,10 @@ function driver_poll()
     -- Keep the handshake counter moving so the Pixii never times out
     -- to idle. Pixii only requires that the value changes; 0..99 wrap.
     hb_tick = (hb_tick + 1) % 100
-    pcall(host.modbus_write, REG_HEARTBEAT, hb_tick)
+    local hb_err = host.modbus_write(REG_HEARTBEAT, hb_tick)
+    if hb_err ~= nil and hb_err ~= "" then
+        host.log("warn", "Pixii: heartbeat write failed: " .. tostring(hb_err))
+    end
 
     -- Read serial number once from SunSpec Common Model (offset 52 from
     -- the common block → absolute 40052, 16 regs ASCII).
@@ -399,7 +402,10 @@ local function write_setpoint_w(pixii_w)
     -- often faster than the poll tick, and we don't want the Pixii to
     -- edge into idle right after we told it to move.
     hb_tick = (hb_tick + 1) % 100
-    pcall(host.modbus_write, REG_HEARTBEAT, hb_tick)
+    local hb_err = host.modbus_write(REG_HEARTBEAT, hb_tick)
+    if hb_err ~= nil and hb_err ~= "" then
+        host.log("warn", "Pixii: heartbeat write failed: " .. tostring(hb_err))
+    end
     return true
 end
 

--- a/drivers/solaredge.lua
+++ b/drivers/solaredge.lua
@@ -404,9 +404,8 @@ end
 -- REG_APC_ENABLE is at 61440, REG_APC_LIMIT at 61441 → adjacent, so
 -- one multi-register write covers both.
 local function write_apc(enable, limit_pct)
-    local ok, err = pcall(host.modbus_write_multi, REG_APC_ENABLE,
-        { enable, limit_pct })
-    if (not ok) or type(err) == "string" then
+    local err = host.modbus_write_multi(REG_APC_ENABLE, { enable, limit_pct })
+    if err ~= nil and err ~= "" then
         return false, tostring(err)
     end
     return true, nil

--- a/drivers/solaredge_legacy.lua
+++ b/drivers/solaredge_legacy.lua
@@ -291,9 +291,8 @@ end
 
 -- See solaredge.lua write_apc for the FC 0x10 atomic-write rationale.
 local function write_apc(enable, limit_pct)
-    local ok, err = pcall(host.modbus_write_multi, REG_APC_ENABLE,
-        { enable, limit_pct })
-    if (not ok) or type(err) == "string" then
+    local err = host.modbus_write_multi(REG_APC_ENABLE, { enable, limit_pct })
+    if err ~= nil and err ~= "" then
         return false, tostring(err)
     end
     return true, nil

--- a/drivers/solaredge_pv.lua
+++ b/drivers/solaredge_pv.lua
@@ -224,9 +224,8 @@ end
 
 -- See solaredge.lua write_apc for the FC 0x10 atomic-write rationale.
 local function write_apc(enable, limit_pct)
-    local ok, err = pcall(host.modbus_write_multi, REG_APC_ENABLE,
-        { enable, limit_pct })
-    if (not ok) or type(err) == "string" then
+    local err = host.modbus_write_multi(REG_APC_ENABLE, { enable, limit_pct })
+    if err ~= nil and err ~= "" then
         return false, tostring(err)
     end
     return true, nil

--- a/drivers/solis.lua
+++ b/drivers/solis.lua
@@ -350,9 +350,9 @@ local WRITE_DELAY_MS = 100
 -- Write a single holding register and pace the bus so the next write
 -- doesn't land inside Solis's NACK window.
 local function write_reg(addr, val)
-    local ok, err = pcall(host.modbus_write, addr, val)
+    local err = host.modbus_write(addr, val)
     host.sleep(WRITE_DELAY_MS)
-    if not ok then
+    if err ~= nil and err ~= "" then
         host.log("warn", string.format("Solis: write %d=%d failed: %s",
             addr, val, tostring(err)))
         return false

--- a/drivers/sungrow.lua
+++ b/drivers/sungrow.lua
@@ -82,7 +82,10 @@ function configure_power_limits()
         host.log("info", "Max charge power: " .. string.format("%.2f", chg_kw) .. " kW")
         if chg[1] < 500 then
             host.log("info", "Setting max charge power to 5 kW")
-            pcall(host.modbus_write, 33046, 500)
+            local err = host.modbus_write(33046, 500)
+            if err ~= nil and err ~= "" then
+                host.log("warn", "Sungrow: max charge power write failed: " .. tostring(err))
+            end
         end
     end
 
@@ -93,7 +96,10 @@ function configure_power_limits()
         host.log("info", "Max discharge power: " .. string.format("%.2f", dis_kw) .. " kW")
         if dis[1] < 500 then
             host.log("info", "Setting max discharge power to 5 kW")
-            pcall(host.modbus_write, 33047, 500)
+            local err = host.modbus_write(33047, 500)
+            if err ~= nil and err ~= "" then
+                host.log("warn", "Sungrow: max discharge power write failed: " .. tostring(err))
+            end
         end
     end
 

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -931,15 +931,10 @@ func ComputeDispatch(
 	case ModeCharge:
 		state.resetSettlementAccounting()
 		targets := chargeAll(store, driverCapacities, state.DriverLimits)
-		targets = applyFuseGuard(targets, store, state, fuseMaxW)
-		targets = forceFuseDischarge(targets, store, state, driverCapacities, fuseMaxW)
-		now := time.Now()
-		state.LastDispatch = &now
-		for _, t := range targets {
-			state.PrevTargets[t.Driver] = t.TargetW
-		}
-		state.LastTargets = targets
-		return targets
+		return applyDispatchSafetyPipeline(targets, store, state, driverCapacities, fuseMaxW, dispatchSafetyOptions{
+			updatePrevTargets: true,
+			recordDispatch:    true,
+		})
 	}
 
 	// ---- Holdoff ----
@@ -1735,117 +1730,119 @@ func ComputeDispatch(
 	}
 
 	// ---- Fuse guard (bidirectional, #145) ----
-	raw = applyFuseGuard(raw, store, state, fuseMaxW)
+	return applyDispatchSafetyPipeline(raw, store, state, driverCapacities, fuseMaxW, dispatchSafetyOptions{
+		manualHoldActive:  manualHoldActive,
+		noSelfDischarge:   noSelfDischarge,
+		updatePrevTargets: true,
+		recordDispatch:    true,
+	})
+}
+
+type dispatchSafetyOptions struct {
+	manualHoldActive  bool
+	noSelfDischarge   bool
+	updatePrevTargets bool
+	recordDispatch    bool
+}
+
+func applyDispatchSafetyPipeline(
+	targets []DispatchTarget,
+	store *telemetry.Store,
+	state *State,
+	driverCapacities map[string]float64,
+	fuseMaxW float64,
+	opts dispatchSafetyOptions,
+) []DispatchTarget {
+	// ---- Fuse guard (bidirectional, #145) ----
+	targets = applyFuseGuard(targets, store, state, fuseMaxW)
 
 	// ---- Plan/exec sign-mismatch floor (energy planner modes only) ----
-	// Operator-report 2026-04-28 (08:00–08:15 CEST): planner_arbitrage
+	// Operator-report 2026-04-28 (08:00-08:15 CEST): planner_arbitrage
 	// peak slot wanted battery_w = -2400 W (discharge to export at peak),
-	// dispatch produced +1640..+1860 W (charged from PV surplus). PV
-	// got swallowed by the battery instead of sold at 334 öre/kWh.
+	// dispatch produced +1640..+1860 W (charged from PV surplus). PV got
+	// swallowed by the battery instead of sold at 334 ore/kWh.
 	//
-	// Root cause was a code-path divergence elsewhere; this is the
-	// rail that makes that whole class of bug a no-op:
+	// Root cause was a code-path divergence elsewhere; this is the rail that
+	// makes that whole class of bug a no-op:
 	//
-	//   plan says discharge, exec produces charge → idle this tick
-	//   plan says charge,    exec produces discharge → idle this tick
+	//   plan says discharge, exec produces charge -> idle this tick
+	//   plan says charge,    exec produces discharge -> idle this tick
 	//
-	// "Idle for this tick" is the right floor because:
-	//   - Discharging a charge slot would burn cycles against operator
-	//     intent. Idling and waiting for the next replan is harmless.
-	//   - Charging a discharge slot would buy energy at the exact slot
-	//     the planner intended to SELL it. Idling and letting PV export
-	//     naturally captures most of the lost revenue without any risk.
-	//
-	// Only applied in the energy planner modes. Manual modes have no plan
-	// to disagree with, and planner_self deliberately ignores plan sign:
-	// its plan contribution is idle-vs-participate; when it participates,
-	// the live self-consumption controller may charge or discharge to
-	// hold the grid near zero. forceFuseDischarge runs AFTER this
-	// so a fuse overflow can still drive discharge regardless of plan
-	// intent.
-	//
-	// Skipped when a manual hold is active: the operator is
-	// deliberately overriding the planner, so a sign mismatch with the
-	// plan is the intended behaviour, not a bug to clamp out.
-	if !manualHoldActive {
-		raw = applyPlanSignFloor(raw, state)
+	// Only applied in the energy planner modes. Manual modes have no plan to
+	// disagree with, and manual holds intentionally override planner intent.
+	if !opts.manualHoldActive {
+		targets = applyPlanSignFloor(targets, state)
 	}
-	if noSelfDischarge {
-		raw = floorNegativeTargets(raw)
+	if opts.noSelfDischarge {
+		targets = floorNegativeTargets(targets)
 	}
 
-	// forceFuseDischarge runs LAST, deliberately AFTER the slew loop
-	// at line 625. A fuse overflow can demand a battery target that's
-	// far beyond what slew would normally allow in a single 5 s tick
-	// (e.g. 0 W → −3 kW), and slew-limiting that would leave the
-	// fuse violated for multiple ticks. The fuse is the
-	// non-negotiable ceiling — it bypasses slew. Regression-guarded
-	// by TestFuseSaverBypassesSlew.
-	raw = forceFuseDischarge(raw, store, state, driverCapacities, fuseMaxW)
+	// forceFuseDischarge runs LAST. A fuse overflow can demand a battery
+	// target far beyond what slew would allow in one tick; slew-limiting that
+	// response would leave the fuse violated for multiple ticks.
+	targets = forceFuseDischarge(targets, store, state, driverCapacities, fuseMaxW)
+	republishFuseEVCapAfterFuseDischarge(targets, store, state, fuseMaxW)
+	recordDispatchTargets(targets, state, opts.updatePrevTargets, opts.recordDispatch)
+	return targets
+}
 
-	// ---- Republish FuseEVMaxW after forceFuseDischarge ----
-	// The joint allocator (line 625) computes FuseEVMaxW assuming the
-	// battery target it just produced is what gets dispatched. But
-	// forceFuseDischarge may have flipped that target from charge to
-	// discharge — freeing additional fuse headroom for the EV.
-	// Without this re-publish the loadpoint controller throttles the
-	// EV against a stale (too-conservative) cap for one tick. Run only
-	// when the joint allocator already engaged this tick — otherwise
-	// FuseEVMaxW is "no advice" and should stay 0.
-	// Skip the republish when the operator's tariff peak is the binding
-	// ceiling (peak < fuse). The republish's purpose is to free up EV
-	// headroom freed by forceFuseDischarge's transient battery bridge —
-	// that's the right thing for FUSE protection (hardware safety,
-	// battery is the last line of defense and there's no policy
-	// preference about how long to drain it). For TARIFF protection,
-	// the EV cap must reflect the steady state where the battery
-	// isn't covering, otherwise the bridge becomes a permanent
-	// shuttle and the operator pays the peak charge anyway. Let the
-	// joint allocator's pre-forceFuseDischarge FuseEVMaxW stand.
+func republishFuseEVCapAfterFuseDischarge(targets []DispatchTarget, store *telemetry.Store, state *State, fuseMaxW float64) {
+	// The joint allocator computes FuseEVMaxW assuming the battery target it
+	// produced is what gets dispatched. forceFuseDischarge may flip that target
+	// from charge to discharge, freeing additional fuse headroom for the EV.
+	if state == nil || !state.FuseSaturated || state.EVChargingW <= 0 || fuseMaxW <= 0 {
+		return
+	}
 	peakBindingW := fuseMaxW - state.fuseSafetyMarginW()
-	peakBinding := state != nil && state.PeakImportCeilingW > 0 && state.PeakImportCeilingW < peakBindingW
-	if !peakBinding && state.FuseSaturated && state.EVChargingW > 0 && fuseMaxW > 0 {
-		var postBat float64
-		seen := make(map[string]struct{}, len(raw))
-		for _, t := range raw {
-			if _, ok := seen[t.Driver]; ok {
-				continue
-			}
-			seen[t.Driver] = struct{}{}
-			postBat += t.TargetW
-		}
-		// H = rawGridW − currentTotal − E (unchanged from joint allocator)
-		// newGrid = H + postBat + E*scale ≤ ceiling
-		// → scale ≤ (ceiling − H − postBat) / E, capped to ≤1
-		// Use the effective import ceiling so peak-driven caps survive
-		// the post-forceFuseDischarge republish (otherwise the joint
-		// allocator's tariff-tightened cap gets overwritten with the
-		// fuse-only headroom).
-		ceilingW := state.effectiveImportCeilingW(fuseMaxW)
-		var rawGridW2 float64
-		if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
-			rawGridW2 = r.SmoothedW
-		}
-		H := rawGridW2 - currentTotal - state.EVChargingW
-		headroom := ceilingW - H - postBat
-		if headroom < 0 {
-			headroom = 0
-		}
-		newCap := headroom
-		if newCap > state.EVChargingW {
-			newCap = state.EVChargingW
-		}
-		state.FuseEVMaxW = newCap
+	peakBinding := state.PeakImportCeilingW > 0 && state.PeakImportCeilingW < peakBindingW
+	if peakBinding {
+		return
 	}
 
-	// Update state
-	now := time.Now()
-	state.LastDispatch = &now
-	for _, t := range raw {
-		state.PrevTargets[t.Driver] = t.TargetW
+	var currentBat, postBat float64
+	seen := make(map[string]struct{}, len(targets))
+	for _, t := range targets {
+		if _, ok := seen[t.Driver]; ok {
+			continue
+		}
+		seen[t.Driver] = struct{}{}
+		postBat += t.TargetW
+		if r := store.Get(t.Driver, telemetry.DerBattery); r != nil {
+			currentBat += r.SmoothedW
+		}
 	}
-	state.LastTargets = raw
-	return raw
+
+	ceilingW := state.effectiveImportCeilingW(fuseMaxW)
+	var rawGridW float64
+	if r := store.Get(state.SiteMeterDriver, telemetry.DerMeter); r != nil {
+		rawGridW = r.SmoothedW
+	}
+	H := rawGridW - currentBat - state.EVChargingW
+	headroom := ceilingW - H - postBat
+	if headroom < 0 {
+		headroom = 0
+	}
+	newCap := headroom
+	if newCap > state.EVChargingW {
+		newCap = state.EVChargingW
+	}
+	state.FuseEVMaxW = newCap
+}
+
+func recordDispatchTargets(targets []DispatchTarget, state *State, updatePrevTargets, recordDispatch bool) {
+	if state == nil {
+		return
+	}
+	if recordDispatch {
+		now := time.Now()
+		state.LastDispatch = &now
+	}
+	if updatePrevTargets {
+		for _, t := range targets {
+			state.PrevTargets[t.Driver] = t.TargetW
+		}
+	}
+	state.LastTargets = targets
 }
 
 // ComputePVCurtail returns one CurtailTarget per affected driver for

--- a/go/internal/control/pv_curtail_test.go
+++ b/go/internal/control/pv_curtail_test.go
@@ -348,7 +348,7 @@ func TestComputePVCurtail_FullBatteryNoHeadroomCurtails(t *testing.T) {
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
 	emitBattery(t, store, "pixii", 0, 0.995) // above ceiling — no headroom
-	emitMeter(t, store, "meter", -2500)     // exporting 2.5 kW → live load = 500 W
+	emitMeter(t, store, "meter", -2500)      // exporting 2.5 kW → live load = 500 W
 
 	got := findCurtail(ComputePVCurtail(st, store))
 	if abs(got["solaredge"]-500) > 1e-3 {
@@ -401,8 +401,8 @@ func TestComputePVCurtail_EVCurtailHeadroomLiftsCap(t *testing.T) {
 	st := NewState(0, 100, "meter")
 	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 500})
 	st.SupportsPVCurtail = map[string]bool{"solaredge": true}
-	st.EVSurplusOnlyReserveW = 0    // EV isn't drawing — dispatch reserve is 0
-	st.EVCurtailHeadroomW = 11000   // but it COULD draw up to 11 kW if PV grew
+	st.EVSurplusOnlyReserveW = 0  // EV isn't drawing — dispatch reserve is 0
+	st.EVCurtailHeadroomW = 11000 // but it COULD draw up to 11 kW if PV grew
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
 	emitBattery(t, store, "pixii", 0, 0.995)
@@ -422,7 +422,7 @@ func TestComputePVCurtail_ManualHoldBypassesLiveLimit(t *testing.T) {
 	st.SupportsPVCurtail = map[string]bool{"solaredge": true}
 	store := telemetry.NewStore()
 	emitPV(t, store, "solaredge", -3000)
-	emitBattery(t, store, "pixii", 0, 50.0)    // big headroom
+	emitBattery(t, store, "pixii", 0, 0.50) // big headroom
 	emitMeter(t, store, "meter", 0)
 	st.SetPVManualHold(PVManualHold{
 		Driver:    "solaredge",

--- a/go/internal/drivers/ferroamp_modbus_test.go
+++ b/go/internal/drivers/ferroamp_modbus_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 // TestFerroampModbusLoads exercises every lifecycle hook in the new
-// drivers/ferroamp_modbus.lua driver. No Modbus capability is attached,
-// so modbus_read / modbus_write calls inside the driver return an error
-// string — the driver's pcall guards must swallow those gracefully.
+// drivers/ferroamp_modbus.lua driver. A no-op Modbus capability is attached
+// so the default-mode write path can be exercised now that driver_default_mode
+// failures are surfaced.
 func TestFerroampModbusLoads(t *testing.T) {
 	tel := telemetry.NewStore()
-	env := NewHostEnv("ferroamp_modbus", tel)
+	env := NewHostEnv("ferroamp_modbus", tel).WithModbus(&mockModbus{})
 	d, err := NewLuaDriver("../../../drivers/ferroamp_modbus.lua", env)
 	if err != nil {
 		t.Fatalf("load: %v", err)

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -66,9 +67,9 @@ type HostEnv struct {
 	DriverName string
 	Logger     *slog.Logger
 	Telemetry  *telemetry.Store
-	MQTT       MQTTCap    // nil → mqtt_* calls return ErrNoCapability
-	Modbus     ModbusCap  // nil → modbus_* calls return ErrNoCapability
-	HTTP       bool       // false → http_* calls return ErrNoCapability
+	MQTT       MQTTCap   // nil → mqtt_* calls return ErrNoCapability
+	Modbus     ModbusCap // nil → modbus_* calls return ErrNoCapability
+	HTTP       bool      // false → http_* calls return ErrNoCapability
 	// HTTPAllowedHosts, when non-empty, restricts which hosts this
 	// driver can reach via host.http_get / host.http_post. Each entry
 	// is matched case-insensitively against the URL's host component
@@ -77,17 +78,17 @@ type HostEnv struct {
 	// backward compat with existing drivers that didn't declare a list.
 	// Populated from driver config `capabilities.http.allowed_hosts`.
 	HTTPAllowedHosts []string
-	WS              WSCap    // nil → ws_* calls return ErrNoCapability
+	WS               WSCap // nil → ws_* calls return ErrNoCapability
 	// WSAllowedHosts mirrors HTTPAllowedHosts but for ws://+wss:// URLs
 	// passed to host.ws_open. Same matching semantics; empty = any host.
-	WSAllowedHosts  []string
-	TCP             TCPCap   // nil → tcp_* calls return ErrNoCapability
+	WSAllowedHosts []string
+	TCP            TCPCap // nil → tcp_* calls return ErrNoCapability
 	// TCPAllowedHosts gates host.tcp_open(addr) the same way
 	// HTTPAllowedHosts gates HTTP. Empty = any host:port. The cap impl
 	// holds its own copy at construction; this field is informational so
 	// callers / tests can inspect what was granted.
 	TCPAllowedHosts []string
-	Start      time.Time  // monotonic start; host.millis() computed from here
+	Start           time.Time // monotonic start; host.millis() computed from here
 
 	// BatteryCapacityWh mirrors the operator's `battery_capacity_wh`
 	// declaration for this driver. Zero means "no physical battery
@@ -211,7 +212,7 @@ func (h *HostEnv) setPollInterval(ms int32) {
 func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 	var env struct {
 		Type string   `json:"type"`
-		W    float64  `json:"w"`
+		W    *float64 `json:"w"`
 		SoC  *float64 `json:"soc,omitempty"`
 	}
 	if err := json.Unmarshal(rawJSON, &env); err != nil {
@@ -220,6 +221,12 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 	t, err := telemetry.ParseDerType(env.Type)
 	if err != nil {
 		return err
+	}
+	rawW := 0.0
+	if env.W != nil {
+		rawW = *env.W
+	} else if t != telemetry.DerVehicle {
+		return fmt.Errorf("emit_telemetry: %s missing required w", t)
 	}
 	// Drop battery emits from drivers the operator declared as no-battery
 	// (battery_capacity_wh ≤ 0). Hybrid inverters used PV-only still expose
@@ -235,8 +242,11 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 		}
 		return nil
 	}
+	if err := telemetry.ValidateReading(t, rawW, env.SoC); err != nil {
+		return fmt.Errorf("emit_telemetry: %w", err)
+	}
 	if h.Telemetry != nil {
-		h.Telemetry.Update(h.DriverName, t, env.W, env.SoC, rawJSON)
+		h.Telemetry.Update(h.DriverName, t, rawW, env.SoC, rawJSON)
 	}
 	// Successful emit counts as a tick for health
 	if h.Telemetry != nil {
@@ -248,19 +258,29 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 // emitMetric buffers a scalar diagnostic metric for the long-format TS DB.
 // Driver authors call this for anything beyond the standard pv/battery/meter
 // shape — temperatures, voltages, frequencies, MPPT currents, etc.
-func (h *HostEnv) emitMetric(name string, value float64) {
-	if h.Telemetry == nil { return }
+func (h *HostEnv) emitMetric(name string, value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("emit_metric: %s is non-finite: %v", name, value)
+	}
+	if h.Telemetry == nil {
+		return nil
+	}
 	h.Telemetry.EmitMetric(h.DriverName, name, value)
+	return nil
 }
 
 // setSN records the device serial number.
 func (h *HostEnv) setSN(sn string) {
-	h.mu.Lock(); h.SN = sn; h.mu.Unlock()
+	h.mu.Lock()
+	h.SN = sn
+	h.mu.Unlock()
 }
 
 // setMake records the device manufacturer.
 func (h *HostEnv) setMake(m string) {
-	h.mu.Lock(); h.Make = m; h.mu.Unlock()
+	h.mu.Lock()
+	h.Make = m
+	h.mu.Unlock()
 }
 
 // PollInterval returns the driver's current requested poll cadence.
@@ -292,44 +312,60 @@ func (h *HostEnv) FullIdentity() (make, sn, mac, endpoint string) {
 // driver so it can participate in device_id resolution. Called by main
 // when wiring the MQTT/Modbus capability.
 func (h *HostEnv) SetEndpoint(ep string) {
-	h.mu.Lock(); h.Endpoint = ep; h.mu.Unlock()
+	h.mu.Lock()
+	h.Endpoint = ep
+	h.mu.Unlock()
 }
 
 // SetMAC records the L2 hardware address discovered via ARP.
 func (h *HostEnv) SetMAC(mac string) {
-	h.mu.Lock(); h.MAC = mac; h.mu.Unlock()
+	h.mu.Lock()
+	h.MAC = mac
+	h.mu.Unlock()
 }
 
 // ---- MQTT proxy ----
 
 func (h *HostEnv) mqttSubscribe(ctx context.Context, topic string) error {
-	if h.MQTT == nil { return ErrNoCapability }
+	if h.MQTT == nil {
+		return ErrNoCapability
+	}
 	return h.MQTT.Subscribe(topic)
 }
 
 func (h *HostEnv) mqttPublish(ctx context.Context, topic string, payload []byte) error {
-	if h.MQTT == nil { return ErrNoCapability }
+	if h.MQTT == nil {
+		return ErrNoCapability
+	}
 	return h.MQTT.Publish(topic, payload)
 }
 
 func (h *HostEnv) mqttPollMessages() ([]MQTTMessage, error) {
-	if h.MQTT == nil { return nil, ErrNoCapability }
+	if h.MQTT == nil {
+		return nil, ErrNoCapability
+	}
 	return h.MQTT.PopMessages(), nil
 }
 
 // ---- Modbus proxy ----
 
 func (h *HostEnv) modbusRead(addr, count uint16, kind int32) ([]uint16, error) {
-	if h.Modbus == nil { return nil, ErrNoCapability }
+	if h.Modbus == nil {
+		return nil, ErrNoCapability
+	}
 	return h.Modbus.Read(addr, count, kind)
 }
 
 func (h *HostEnv) modbusWriteSingle(addr, value uint16) error {
-	if h.Modbus == nil { return ErrNoCapability }
+	if h.Modbus == nil {
+		return ErrNoCapability
+	}
 	return h.Modbus.WriteSingle(addr, value)
 }
 
 func (h *HostEnv) modbusWriteMulti(addr uint16, values []uint16) error {
-	if h.Modbus == nil { return ErrNoCapability }
+	if h.Modbus == nil {
+		return ErrNoCapability
+	}
 	return h.Modbus.WriteMulti(addr, values)
 }

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -267,7 +267,10 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	host.RawSetString("emit_metric", L.NewFunction(func(L *lua.LState) int {
 		name := L.CheckString(1)
 		val := float64(L.CheckNumber(2))
-		env.emitMetric(name, val)
+		if err := env.emitMetric(name, val); err != nil {
+			L.Push(lua.LString(err.Error()))
+			return 1
+		}
 		return 0
 	}))
 

--- a/go/internal/drivers/lua_test.go
+++ b/go/internal/drivers/lua_test.go
@@ -250,6 +250,64 @@ end
 	}
 }
 
+func TestHostEmitRejectsInvalidTelemetry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lua")
+	src := `
+function driver_init(config) end
+function driver_poll()
+    local pv_err = host.emit("pv", { w = 500 })
+    assert(pv_err ~= nil, "positive pv should be rejected")
+    local bat_err = host.emit("battery", { w = 0, soc = 42 })
+    assert(bat_err ~= nil, "battery soc percent should be rejected")
+    local missing_w_err = host.emit("meter", { l1_w = 10 })
+    assert(missing_w_err ~= nil, "meter without w should be rejected")
+    local metric_err = host.emit_metric("bad_metric", 0/0)
+    assert(metric_err ~= nil, "non-finite metric should be rejected")
+    host.emit("vehicle", { soc = 55 })
+    host.emit("pv", { w = -500 })
+    return 1000
+end
+`
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tel := telemetry.NewStore()
+	env := NewHostEnv("boundary", tel)
+	env.BatteryCapacityWh = 9600
+
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if got := tel.Get("boundary", telemetry.DerBattery); got != nil {
+		t.Fatalf("invalid battery reading should be dropped, got %+v", got)
+	}
+	if got := tel.Get("boundary", telemetry.DerMeter); got != nil {
+		t.Fatalf("missing-w meter reading should be dropped, got %+v", got)
+	}
+	if got := tel.Get("boundary", telemetry.DerPV); got == nil || got.RawW != -500 {
+		t.Fatalf("valid negative pv reading should pass, got %+v", got)
+	}
+	if got := tel.Get("boundary", telemetry.DerVehicle); got == nil || got.SoC == nil || *got.SoC != 55 {
+		t.Fatalf("vehicle percent soc should pass, got %+v", got)
+	}
+	for _, sample := range tel.FlushSamples() {
+		if sample.Metric == "bad_metric" {
+			t.Fatalf("non-finite metric must not be buffered: %+v", sample)
+		}
+	}
+}
+
 func TestLuaDriverMissingFile(t *testing.T) {
 	env := NewHostEnv("test", telemetry.NewStore())
 	_, err := NewLuaDriver("/nonexistent/path.lua", env)

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -222,9 +222,42 @@ func key(driver string, t DerType) string {
 	return driver + ":" + t.String()
 }
 
+// ValidateReading enforces the site-convention invariants before telemetry
+// reaches smoothing, history buffering, control, or models.
+func ValidateReading(t DerType, rawW float64, soc *float64) error {
+	if !finite(rawW) {
+		return fmt.Errorf("%s power is non-finite: %v", t, rawW)
+	}
+	if soc != nil && !finite(*soc) {
+		return fmt.Errorf("%s soc is non-finite: %v", t, *soc)
+	}
+	switch t {
+	case DerPV:
+		if rawW > 0 {
+			return fmt.Errorf("pv power must be <= 0 in site convention, got %.3f W", rawW)
+		}
+	case DerEV:
+		if rawW < 0 {
+			return fmt.Errorf("ev power must be >= 0 in site convention, got %.3f W", rawW)
+		}
+	case DerBattery:
+		if soc != nil && (*soc < 0 || *soc > 1) {
+			return fmt.Errorf("battery soc must be a 0..1 fraction, got %.3f", *soc)
+		}
+	}
+	return nil
+}
+
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
 // Update feeds a new reading. Applies Kalman smoothing and stores both raw
 // and smoothed values.
 func (s *Store) Update(driver string, t DerType, rawW float64, soc *float64, data json.RawMessage) {
+	if err := ValidateReading(t, rawW, soc); err != nil {
+		return
+	}
 	k := key(driver, t)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -274,6 +307,9 @@ func (s *Store) Update(driver string, t DerType, rawW float64, soc *float64, dat
 // pv/battery/meter shape (temperatures, voltages, frequencies, etc.).
 // Drained by the control loop via FlushSamples.
 func (s *Store) EmitMetric(driver, name string, value float64) {
+	if !finite(value) {
+		return
+	}
 	now := time.Now()
 	s.pendingMu.Lock()
 	s.pending = append(s.pending, MetricSample{
@@ -332,7 +368,9 @@ func (s *Store) LatestMetric(driver, name string) (float64, time.Time, bool) {
 func (s *Store) FlushSamples() []MetricSample {
 	s.pendingMu.Lock()
 	defer s.pendingMu.Unlock()
-	if len(s.pending) == 0 { return nil }
+	if len(s.pending) == 0 {
+		return nil
+	}
 	out := s.pending
 	s.pending = nil
 	return out
@@ -340,7 +378,8 @@ func (s *Store) FlushSamples() []MetricSample {
 
 // Get returns the latest reading for a driver+type, or nil if absent.
 func (s *Store) Get(driver string, t DerType) *DerReading {
-	s.mu.RLock(); defer s.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if r, ok := s.readings[key(driver, t)]; ok {
 		return r
 	}
@@ -349,7 +388,8 @@ func (s *Store) Get(driver string, t DerType) *DerReading {
 
 // ReadingsByType returns all readings of a given type (e.g. all batteries).
 func (s *Store) ReadingsByType(t DerType) []*DerReading {
-	s.mu.RLock(); defer s.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	out := make([]*DerReading, 0)
 	for _, r := range s.readings {
 		if r.DerType == t {
@@ -400,7 +440,8 @@ func (s *Store) SumOnlineEVW() float64 {
 
 // ReadingsByDriver returns all readings from one driver.
 func (s *Store) ReadingsByDriver(driver string) []*DerReading {
-	s.mu.RLock(); defer s.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	out := make([]*DerReading, 0)
 	for _, r := range s.readings {
 		if r.Driver == driver {
@@ -423,9 +464,12 @@ func (s *Store) IsStale(driver string, t DerType, timeout time.Duration) bool {
 // (or nil if unknown). Mutations must go through Store methods or
 // DriverHealthMut in single-threaded test setup.
 func (s *Store) DriverHealth(name string) *DriverHealth {
-	s.mu.RLock(); defer s.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	h := s.health[name]
-	if h == nil { return nil }
+	if h == nil {
+		return nil
+	}
 	cp := *h
 	return &cp
 }
@@ -434,7 +478,8 @@ func (s *Store) DriverHealth(name string) *DriverHealth {
 // Holds no lock after return — callers must not share the pointer across
 // goroutines. Runtime code should use the Store RecordDriver* helpers.
 func (s *Store) DriverHealthMut(name string) *DriverHealth {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.driverHealthLocked(name)
 }
 
@@ -448,22 +493,26 @@ func (s *Store) driverHealthLocked(name string) *DriverHealth {
 }
 
 func (s *Store) EnsureDriverHealth(name string) {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.driverHealthLocked(name)
 }
 
 func (s *Store) RecordDriverSuccess(name string) {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.driverHealthLocked(name).RecordSuccess()
 }
 
 func (s *Store) RecordDriverTick(name string) {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.driverHealthLocked(name).RecordTick()
 }
 
 func (s *Store) RecordDriverError(name, err string) {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.driverHealthLocked(name).RecordError(err)
 }
 
@@ -485,7 +534,8 @@ func (s *Store) Remove(driver string) {
 
 // AllHealth returns a snapshot of all driver health entries.
 func (s *Store) AllHealth() map[string]DriverHealth {
-	s.mu.RLock(); defer s.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	out := make(map[string]DriverHealth, len(s.health))
 	for name, h := range s.health {
 		out[name] = *h
@@ -499,7 +549,8 @@ func (s *Store) AllHealth() map[string]DriverHealth {
 // cycle so the control loop can react (e.g. exclude offline drivers from
 // dispatch and ask them to revert to autonomous mode).
 func (s *Store) WatchdogScan(timeout time.Duration) []WatchdogTransition {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	now := time.Now()
 	var out []WatchdogTransition
 	for name, h := range s.health {
@@ -526,7 +577,8 @@ func (s *Store) WatchdogScan(timeout time.Duration) []WatchdogTransition {
 // DriverHealth entry — drivers can call this from driver_init before
 // any telemetry has flowed.
 func (s *Store) SetDriverWatchdogTimeout(name string, d time.Duration) {
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	h, ok := s.health[name]
 	if !ok {
 		h = &DriverHealth{Name: name}
@@ -552,6 +604,7 @@ func (s *Store) UpdateLoad(rawLoad float64) float64 {
 	if rawLoad < 0 {
 		rawLoad = 0
 	}
-	s.mu.Lock(); defer s.mu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.loadFilter.Update(rawLoad)
 }

--- a/go/internal/telemetry/telemetry_test.go
+++ b/go/internal/telemetry/telemetry_test.go
@@ -61,7 +61,7 @@ func TestStoreKeepsSeparateFiltersPerDriver(t *testing.T) {
 	soc := 0.5
 	s.Update("a", DerBattery, 100, &soc, nil)
 	s.Update("b", DerBattery, 200, &soc, nil)
-	s.Update("a", DerPV, 300, nil, nil)
+	s.Update("a", DerPV, -300, nil, nil)
 
 	if r := s.Get("a", DerBattery); r == nil || r.RawW != 100 {
 		t.Error("a:battery")
@@ -69,7 +69,7 @@ func TestStoreKeepsSeparateFiltersPerDriver(t *testing.T) {
 	if r := s.Get("b", DerBattery); r == nil || r.RawW != 200 {
 		t.Error("b:battery")
 	}
-	if r := s.Get("a", DerPV); r == nil || r.RawW != 300 {
+	if r := s.Get("a", DerPV); r == nil || r.RawW != -300 {
 		t.Error("a:pv")
 	}
 	if r := s.Get("b", DerPV); r != nil {
@@ -124,7 +124,9 @@ func TestHealthDegradesAfter3Errors(t *testing.T) {
 
 func TestHealthRecoversOnSuccess(t *testing.T) {
 	h := &DriverHealth{Name: "t"}
-	h.RecordError("e1"); h.RecordError("e2"); h.RecordError("e3")
+	h.RecordError("e1")
+	h.RecordError("e2")
+	h.RecordError("e3")
 	h.RecordSuccess()
 	if h.Status != StatusOk {
 		t.Errorf("success should reset to Ok: %v", h.Status)
@@ -155,6 +157,44 @@ func TestReadingPreservesData(t *testing.T) {
 	r := s.Get("a", DerMeter)
 	if string(r.Data) != string(raw) {
 		t.Errorf("data roundtrip: got %s", string(r.Data))
+	}
+}
+
+func TestStoreRejectsInvalidReadings(t *testing.T) {
+	s := NewStore()
+	s.Update("pv", DerPV, 500, nil, nil)
+	if r := s.Get("pv", DerPV); r != nil {
+		t.Fatalf("positive pv reading must be rejected, got %+v", r)
+	}
+
+	s.Update("pv", DerPV, -1200, nil, nil)
+	if r := s.Get("pv", DerPV); r == nil || r.RawW != -1200 {
+		t.Fatalf("valid pv reading should be stored, got %+v", r)
+	}
+
+	s.Update("pv", DerPV, math.NaN(), nil, nil)
+	if r := s.Get("pv", DerPV); r == nil || r.RawW != -1200 {
+		t.Fatalf("non-finite update should not overwrite last valid reading, got %+v", r)
+	}
+
+	badSoC := 42.0
+	s.Update("bat", DerBattery, 0, &badSoC, nil)
+	if r := s.Get("bat", DerBattery); r != nil {
+		t.Fatalf("battery percent soc must be rejected at telemetry boundary, got %+v", r)
+	}
+}
+
+func TestEmitMetricRejectsNonFinite(t *testing.T) {
+	s := NewStore()
+	s.EmitMetric("driver", "bad", math.Inf(1))
+	if samples := s.FlushSamples(); len(samples) != 0 {
+		t.Fatalf("non-finite metric should be dropped, got %+v", samples)
+	}
+
+	s.EmitMetric("driver", "ok", 42)
+	samples := s.FlushSamples()
+	if len(samples) != 1 || samples[0].Metric != "ok" || samples[0].Value != 42 {
+		t.Fatalf("valid metric not buffered as expected: %+v", samples)
 	}
 }
 


### PR DESCRIPTION
## Summary

This follows up on the bug-hunt refactor items after the earlier hardening PRs landed.

- Centralizes the control dispatch post-processing path so manual and charge paths share the same fuse guard, sign-floor, no-self-discharge, fuse-discharge, EV cap republish, and target bookkeeping logic.
- Adds finite/sign validation at the Lua host and telemetry-store boundaries so invalid PV, EV, battery SoC, missing required `w`, and non-finite metrics/readings are rejected before they mutate live state.
- Cleans up Lua Modbus write helpers that used `pcall` as if host write errors throw, and updates the Ferroamp Modbus smoke test for the now-surfaced default-mode failure behavior.

## Validation

- `go vet ./...`
- `go test ./internal/control ./internal/drivers ./internal/telemetry`
- `go test -count=1 -timeout 180s ./...`
