### PR TITLE
chore(release): manual trigger only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,12 @@
 name: release
 
-# Gated on the `test` workflow — triggering on `push:master` directly
-# would race: semantic-release pushes a changelog commit + tag before
-# `go test + vet` finishes, and master's branch protection rejects it
-# with GH006 ("Required status check ... is expected"). `workflow_run`
-# fires once test.yml completes; the `if:` on each job filters to
-# successful test runs so a broken master still blocks the release.
-# Manual dispatch stays available for emergency re-runs.
+# Manual-only trigger. We merge to master many times a day during
+# fast-iteration; auto-cutting a release per conventional commit spammed
+# Discord and burned ~30 min/release on the pi-gen image build.
+# Run `gh workflow run release.yml` (or click "Run workflow" in Actions)
+# when it's time to cut a real release — semantic-release will batch
+# every `fix:`/`feat:` since the last tag into one changelog + bump.
 on:
-  workflow_run:
-    workflows: [test]
-    types: [completed]
-    branches: [master]
   workflow_dispatch:
 
 # semantic-release needs to push a tag + the changelog commit.
@@ -26,10 +21,6 @@ jobs:
   release:
     name: semantic-release
     runs-on: ubuntu-latest
-    # Only proceed when tests succeeded (workflow_run path) or when
-    # manually re-triggered (workflow_dispatch has no workflow_run event
-    # attached — conclusion would be empty, so gate on the trigger too).
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version:   ${{ steps.semantic.outputs.new_release_version }}


### PR DESCRIPTION
## Summary

- Drop the `workflow_run` trigger that fired a release per successful test run on master.
- Keep `workflow_dispatch` so releases are cut on demand via `gh workflow run release.yml` (or the Actions "Run workflow" button).

## Why

We merge to master many times a day. Every `fix:` / `feat:` was producing a separate release with binaries, docker images, a ~30 min pi-gen image, and a Discord ping. Tonight's bug-hunt batch alone cut 6 releases for what should have been one.

## Behavior after this PR

- Push to master → only the `test` workflow runs (gates branch protection).
- When you decide it's time, trigger the release manually. semantic-release batches every conventional commit since the last tag into one bump + one changelog + one announcement.
- The downstream jobs (binaries, docker, rpi-image, discord) are already gated on `new_release_published`, so nothing else changes.

## Test plan

- [ ] Merge this PR. Confirm no release fires on the merge.
- [ ] Run `gh workflow run release.yml` once, confirm one batched release with all queued conventional commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)