### PR TITLE
feat(mpc): disable passive-arbitrage PV-charge bonus by default

### DIFF
--- a/.changeset/disable-pv-charge-bonus-default.md
+++ b/.changeset/disable-pv-charge-bonus-default.md
@@ -1,0 +1,22 @@
+---
+"forty-two-watts": minor
+---
+
+Disable the passive-arbitrage PV-charge bonus by default (was 30 öre/kWh).
+
+The bonus credited each kWh of battery charge fed from live PV surplus,
+intended to break ties when the DP saw "store PV now" and "export PV
+now, reimport later" as economically equivalent. In practice the import
+tariff + VAT asymmetry already makes storage strictly preferred under
+typical retail pricing, so the bonus was redundant.
+
+The redundancy is harmless on flat-price days, but on days with future
+negative-price hours the bonus pulled morning battery charging forward
+to the point where no SoC headroom remained when the negative-price
+window arrived — forcing PV export against negative prices instead of
+absorbing the (paid-to-consume) energy into the battery.
+
+Behavior change: operators who relied on the bonus can re-enable it
+explicitly via `planner.pv_charge_bonus_ore_kwh` in `config.yaml`.
+The previous fallback that silently reinstated 30 öre/kWh when the
+value was set to 0 has also been removed — 0 now means 0.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -2401,12 +2401,8 @@ func buildMPC(cfg *config.Config, st *state.Store, tel *telemetry.Store, capacit
 		safetyPenalty = 100
 	}
 	pvBonus := pl.PVChargeBonusOreKwh
-	if pvBonus <= 0 {
-		// 30 öre/kWh — beats typical PV-export spot prices and the
-		// round-trip efficiency cost (~20 öre/kWh against mean retail
-		// import), but small enough that genuine arbitrage spreads
-		// (>100 öre/kWh) still drive the DP.
-		pvBonus = 30
+	if pvBonus < 0 {
+		pvBonus = 0
 	}
 	chgEff := pl.ChargeEfficiency
 	if chgEff <= 0 {

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -273,12 +273,15 @@ type Planner struct {
 	SafetyFloorPenaltyOreKwhHour float64 `yaml:"safety_floor_penalty_ore_kwh_hour,omitempty" json:"safety_floor_penalty_ore_kwh_hour,omitempty"`
 
 	// PVChargeBonusOreKwh credits each kWh of battery charge fed from
-	// live PV surplus, in passive_arbitrage mode. Operator preference
-	// "always prefer PV first" — certain PV now beats forecast
-	// grid-charging later, even at economic parity. Default 30
-	// öre/kWh; set to 0 to disable the bias and let the DP optimise
-	// purely on price (which on flat-price days lets cheap PV export
-	// and refills from cheap grid later, losing efficiency).
+	// live PV surplus, in passive_arbitrage mode. Default 0 (disabled)
+	// — the import-tariff + VAT asymmetry already makes "store PV now"
+	// strictly preferred over "export PV now, reimport later" in the
+	// underlying DP economics, so the bonus is redundant under typical
+	// retail pricing. Setting it > 0 reinstates the bias and can pull
+	// battery charging forward; on days with future negative-price
+	// hours this leaves no headroom to absorb negative-priced PV and
+	// forces export at a loss. Use only if you have evidence that the
+	// DP is undervaluing storage in your specific configuration.
 	PVChargeBonusOreKwh float64 `yaml:"pv_charge_bonus_ore_kwh,omitempty" json:"pv_charge_bonus_ore_kwh,omitempty"`
 
 	ChargeEfficiency    float64 `yaml:"charge_efficiency,omitempty" json:"charge_efficiency,omitempty"`

--- a/go/test/e2e/pair_test.go
+++ b/go/test/e2e/pair_test.go
@@ -375,7 +375,19 @@ drivers: []
 
 func repoRoot(t *testing.T) string {
 	t.Helper()
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	// Strip GIT_* env vars so a parent pre-commit hook's GIT_DIR /
+	// GIT_WORK_TREE does not confuse --show-toplevel when `go test`
+	// is invoked transitively from `make verify` inside the hook.
+	env := os.Environ()
+	cleaned := env[:0]
+	for _, e := range env {
+		if !strings.HasPrefix(e, "GIT_") {
+			cleaned = append(cleaned, e)
+		}
+	}
+	cmd.Env = cleaned
+	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("repo root: %v", err)
 	}


### PR DESCRIPTION
## Summary

The `pv_charge_bonus_ore_kwh` planner credit (30 öre/kWh by default, applied only in `passive_arbitrage` mode) is now **disabled by default**. Operators who want the old behavior set it explicitly in `config.yaml`.

The YAML `0` semantics are also fixed: previously `<= 0` was silently rewritten to 30 in `main.go`, so the documented "set to 0 to disable" instruction did not actually work. The gate now rejects only negative values; `0` means `0`.

## Why

The bonus was introduced (`mpc.go:721–739` + `TestPassiveArbitragePVChargeBonusPrefersPVOverExport`) to tilt the DP toward "store PV now" when it saw "store PV now" and "export PV now, reimport later" as economically equivalent. In practice the **import-tariff + VAT asymmetry already makes storage strictly preferred** under typical retail pricing:

- Export revenue ≈ `spot`
- Import cost ≈ `(spot + tariff) × (1 + VAT)`
- With a 70 öre tariff and 25 % VAT, the round-trip "export then reimport" costs ~110 öre/kWh more than "store then self-consume"

So the bonus is redundant under normal pricing.

Where it actively hurts: on days with future **negative-price hours**, a 30 öre/kWh bonus on morning PV charging dominates the ~1–2 öre/kWh price signal that would otherwise encourage the DP to defer charging into the negative-price window. The battery ends up full before negative spot arrives, so the system either exports against negative prices (loses money) or curtails (zero revenue) instead of absorbing the (paid-to-consume) energy.

Reproduced today (2026-05-27) on a live SE4 site: morning PV filled batteries to 96 % / 100 % while next-24h spot ranged -0.17 → -1.31 öre/kWh.

## What changed

- `go/cmd/forty-two-watts/main.go`: removed the `pvBonus <= 0 → 30` fallback; gate is now `< 0 → 0`.
- `go/internal/config/config.go`: updated `PVChargeBonusOreKwh` field comment to document the new default and the failure mode it avoids.
- `.changeset/disable-pv-charge-bonus-default.md`: `minor` bump (behavior change).

### Bundled unrelated fix

- `go/test/e2e/pair_test.go::repoRoot` now strips `GIT_*` env vars before invoking `git rev-parse --show-toplevel`. Without this, the pre-commit hook's inherited `GIT_DIR` makes the rev-parse return the test's cwd, causing `TestPairFlow` / `TestPairFlowThroughRelay` to fail with `chdir .../go/test/e2e/go: no such file or directory` whenever `make verify` is invoked transitively from the hook. The failure was deterministic on the pre-commit path and never affected CI (which runs `make verify` directly).

## Test plan

- [x] `make verify` passes locally
- [x] Existing `TestPassiveArbitragePVChargeBonusPrefersPVOverExport` and `TestPassiveArbitragePVChargeBonusDoesNotMotivateGridCharge` still pass (they set the bonus explicitly, so they exercise the *mechanism*, not the default)
- [x] `TestPairFlow` + `TestPairFlowThroughRelay` now pass under the pre-commit hook
- [ ] Deploy to live SE4 site and observe that morning PV charging is deferred when negative spot is forecast later in the day

🤖 Generated with [Claude Code](https://claude.com/claude-code)