### PR TITLE
fix(pair): friend types code on relay landing page — drop dashboard Allow form

### DIFF
--- a/.changeset/approval-ux-redesign.md
+++ b/.changeset/approval-ux-redesign.md
@@ -1,0 +1,16 @@
+---
+"forty-two-watts": minor
+---
+
+**Friend-types-code redesign of the pair-approval flow.** v0.104.0 shipped the code on both sides (dashboard + friend's landing page) and required the operator to type it back in — confusing UX, and the cross-origin POST from the LAN dashboard to the public relay was blocked by CORS so the Allow button silently did nothing.
+
+New flow:
+
+- Dashboard displays the 4-digit code along with the URL for the operator to share. "Copy code" and "Copy URL + code" buttons make the bundle easy to send in one Signal/SMS message.
+- The relay's landing page **no longer shows the code**. It shows an input field. The friend types the code they received separately from the host.
+- POST happens same-origin (browser → relay), no CORS surprises.
+- On success, the page reveals the dashboard URL + the `claude mcp add` one-liner.
+
+Security model is unchanged in substance — possession of (URL + code) activates the session — but the flow now matches the operator's mental model (share both, friend types code). The host no longer has to be live at connect-time to approve.
+
+Tests adjusted: relay landing-page test now asserts the code is **NOT** present in the served HTML; component source-hygiene tests assert the operator-side input field is gone. 31 node-tests + Go test suite all green.

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -131,10 +131,10 @@ func (r *Relay) publicLanding(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	// Bump the pending-approval counter so the operator's dashboard
-	// surfaces "friend opened the URL — call you yet?".
+	// surfaces "friend opened the URL — waiting for them to enter the code".
 	r.Tokens.MarkPendingHit(tok)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, landingHTML, esc(t.As()), esc(t.Intent()), t.ApprovalCode(), t.State())
+	fmt.Fprintf(w, landingHTML, esc(tok), esc(t.As()), esc(t.Intent()), t.State())
 }
 
 func (r *Relay) tunnelSessionInfo(w http.ResponseWriter, req *http.Request) {
@@ -153,21 +153,114 @@ func esc(s string) string {
 	return r.Replace(s)
 }
 
+// landingHTML is the friend-side page. The 4-digit code travels with
+// the URL (shared by the host on Signal etc.); the friend types it
+// here to activate the session. Same-origin POST to /approve so there
+// are no CORS surprises.
+//
+// Format args (in order): token, claimed identity (host-supplied "as"),
+// intent, current token state.
 const landingHTML = `<!doctype html>
 <html><head><title>forty-two-watts pair session</title>
 <style>
-  body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
+  body { font-family: system-ui, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1rem; color: #222; }
   code { background: #f4f4f4; padding: .2rem .4rem; border-radius: .2rem; }
-  .code { font-size: 3rem; letter-spacing: .3em; text-align: center; padding: 2rem;
-          background: #fffbea; border: 1px solid #f0c040; border-radius: .5rem; margin: 2rem 0; }
+  .panel { border: 1px solid #ddd; padding: 1.5rem; border-radius: .5rem; margin-top: 2rem; }
+  input[type=text] {
+    font-family: ui-monospace, monospace;
+    font-size: 2rem;
+    letter-spacing: 0.4em;
+    text-align: center;
+    width: 7em;
+    padding: 6px 8px;
+    border: 1px solid #f0c040;
+    border-radius: .4rem;
+    background: #fffbea;
+  }
+  button {
+    font: inherit;
+    font-size: 1rem;
+    padding: 8px 20px;
+    margin-left: 8px;
+    background: #f0c040;
+    color: #0a0a0a;
+    border: 0;
+    border-radius: .3rem;
+    cursor: pointer;
+    font-weight: 600;
+  }
+  button:disabled { opacity: 0.5; cursor: default; }
+  .err { color: #c00; background: #fee; border: 1px solid #fcc; padding: .5rem; border-radius: .3rem; margin: 1rem 0; }
+  .ok  { color: #060; background: #efe; border: 1px solid #cfc; padding: .5rem; border-radius: .3rem; margin: 1rem 0; }
+  .muted { color: #888; font-size: 0.9em; }
 </style>
 </head><body>
-<h1>Connect to a forty-two-watts instance</h1>
-<p>Identity: <code>%s</code></p>
+<h1>forty-two-watts pair session</h1>
+<p>From: <code>%s</code></p>
 <p>Intent: %s</p>
-<p>Tell the host this code over voice (phone, Signal call, etc.):</p>
-<div class="code">%s</div>
-<p>State: <code>%s</code>. This page does not refresh automatically.</p>
+
+<div class="panel" id="entry">
+  <p>The host has shared a <strong>4-digit code</strong> along with this URL. Enter it to activate the session.</p>
+  <p class="muted">If you don't have the code, ask the host for it on the same channel they shared the URL.</p>
+  <form id="approve-form">
+    <input id="code" type="text" inputmode="numeric" pattern="\d{4}" maxlength="4" placeholder="0000" autocomplete="off" autofocus>
+    <button id="approve-btn" type="submit">Activate</button>
+  </form>
+  <div id="msg"></div>
+</div>
+
+<p class="muted">State: <code id="state">%s</code></p>
+
+<script>
+const TOKEN = %q;
+const form = document.getElementById('approve-form');
+const codeInput = document.getElementById('code');
+const msg = document.getElementById('msg');
+const btn = document.getElementById('approve-btn');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  msg.textContent = '';
+  msg.className = '';
+  const code = codeInput.value.trim();
+  if (!/^\d{4}$/.test(code)) {
+    msg.className = 'err';
+    msg.textContent = 'Enter 4 digits.';
+    return;
+  }
+  btn.disabled = true;
+  try {
+    const resp = await fetch('/h/' + encodeURIComponent(TOKEN) + '/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+    });
+    if (resp.status === 204) {
+      msg.className = 'ok';
+      msg.innerHTML = 'Activated. You can now:<br><br>' +
+        '<strong>Browser:</strong> <a href="/h/' + encodeURIComponent(TOKEN) + '/web/">open the dashboard</a><br><br>' +
+        '<strong>Claude Code:</strong><br><code>claude mcp add ftw-friend --transport http ' +
+        location.origin + '/h/' + encodeURIComponent(TOKEN) + '/mcp</code>';
+      document.getElementById('state').textContent = 'active';
+      btn.style.display = 'none';
+      codeInput.disabled = true;
+    } else {
+      const body = await resp.text();
+      msg.className = 'err';
+      if (resp.status === 403) {
+        msg.textContent = 'Wrong code. Double-check with the host — and make sure this is the URL they sent (not a forwarded one).';
+      } else {
+        msg.textContent = body || ('relay error: ' + resp.status);
+      }
+      btn.disabled = false;
+    }
+  } catch (err) {
+    msg.className = 'err';
+    msg.textContent = 'network error: ' + err.message;
+    btn.disabled = false;
+  }
+});
+</script>
 </body></html>`
 
 func (r *Relay) publicApprove(w http.ResponseWriter, req *http.Request) {

--- a/go/cmd/ftw-relay/handlers_test.go
+++ b/go/cmd/ftw-relay/handlers_test.go
@@ -116,7 +116,7 @@ func TestRegisterEndpoint(t *testing.T) {
 	}
 }
 
-func TestLandingPageShowsApprovalCode(t *testing.T) {
+func TestLandingPageHasCodeEntryForm(t *testing.T) {
 	r := newTestRelay()
 	_, _ = r.Tokens.Register(TokenRegistration{
 		HostID: "host-a", Token: "lookme", TTL: time.Hour,
@@ -131,11 +131,29 @@ func TestLandingPageShowsApprovalCode(t *testing.T) {
 	body, _ := readBody(resp.Body)
 	resp.Body.Close()
 	html := string(body)
-	if !strings.Contains(html, "4827") {
-		t.Fatalf("approval code missing from landing page:\n%s", html)
+
+	// The approval code must NOT appear on the landing page — the
+	// security model relies on the friend receiving it out-of-band
+	// from the host. Showing it here would let anyone with the URL
+	// activate the session.
+	if strings.Contains(html, "4827") {
+		t.Fatalf("approval code MUST NOT appear on the landing page:\n%s", html)
 	}
+	// But the input form must be there so the friend can type the
+	// code they received separately.
+	if !strings.Contains(html, `id="code"`) {
+		t.Fatalf("code input field missing from landing page")
+	}
+	if !strings.Contains(html, `id="approve-form"`) {
+		t.Fatalf("approve form missing")
+	}
+	// Identity + intent should be displayed so the friend can sanity-
+	// check who they're connecting to.
 	if !strings.Contains(html, "@erik") {
 		t.Fatalf("identity missing from landing page")
+	}
+	if !strings.Contains(html, "help me") {
+		t.Fatalf("intent missing from landing page")
 	}
 }
 

--- a/web/components/ftw-pair-card-render.js
+++ b/web/components/ftw-pair-card-render.js
@@ -57,8 +57,8 @@ export function derivePresence(state, now = Date.now()) {
     case "pending":
       return {
         label: state.pending_approvals_count > 0
-          ? "friend opened URL — call you with the code"
-          : "waiting for friend to open the URL",
+          ? "friend opened URL — waiting for them to enter the code"
+          : "waiting for friend to open URL + enter code",
         class: "pending",
       };
     case "expired":
@@ -94,63 +94,32 @@ export function formatAge(ms) {
 }
 
 // friendMessage is what the operator copies and sends to the friend.
-// The URL flow is the v2 friend onboarding — no install required.
+// Both the URL AND the code are in the same message — the friend
+// opens the URL, types the code, done. The 4-digit code is what
+// prevents a leaked URL alone from activating the session (the
+// attacker also needs the code).
+//
 // When state has no pair_url (e.g. -no-relay mode) it falls back to
 // the local MCP addr stored in `code` so the same template works for
 // local-only testing.
 export function friendMessage(state) {
   if (!state) return "";
-  const url = state.pair_url || ("(local-only: " + state.code + ")");
-  const code = state.approval_code || "—";
-  return `I need help with my home energy system. I started a pair
-session — open this in any browser:
+  if (!state.pair_url) {
+    return `Local-only pair session running at ${state.code}. No relay URL — share this only with someone on the same network.`;
+  }
+  const url = state.pair_url;
+  const code = state.approval_code || "(no code — bug?)";
+  return `I need help with my home energy system. Open this URL and enter the 4-digit code below to activate the session:
 
-  ${url}
+  URL:  ${url}
+  Code: ${code}
 
-You'll see a 4-digit code on the page. Call/Signal me and read
-that code aloud. Once I confirm it matches the code I see here,
-the session activates and you can:
+Once active you can:
 
   - Open the dashboard:   ${url}/web/
   - Add as Claude Code MCP:
       claude mcp add ftw-friend --transport http ${url}/mcp
 
-Session expires when I close it or TTL runs out. The code I'll be
-waiting to hear from you matches what shows up on your screen — if
-it doesn't match, do NOT confirm (could be a leaked URL).`;
-}
-
-// canApprove returns true when the dashboard should expose the Allow
-// form (operator types the friend's 4-digit code → POST /approve).
-export function canApprove(state) {
-  return Boolean(
-    state &&
-    state.session_state === "pending" &&
-    state.approval_code &&
-    state.pair_url
-  );
-}
-
-// approveRequest constructs the request the Allow button fires.
-// Returns { url, body } so the test can assert without a real fetch.
-export function approveRequest(state, typedCode) {
-  if (!state || !state.pair_url) return null;
-  return {
-    url: state.pair_url + "/approve",
-    body: { code: typedCode },
-  };
-}
-
-// validateTypedCode: did the operator type the same 4-digit code we
-// generated? Comparing strictly (not just suffix) because a stale
-// session could leave a different code in scrollback.
-export function validateTypedCode(state, typedCode) {
-  if (!state || !state.approval_code) return { ok: false, reason: "no active session" };
-  if (typeof typedCode !== "string" || !/^\d{4}$/.test(typedCode.trim())) {
-    return { ok: false, reason: "expected 4 digits" };
-  }
-  if (typedCode.trim() !== state.approval_code) {
-    return { ok: false, reason: "code mismatch — do NOT approve, this could be a leaked-URL attack" };
-  }
-  return { ok: true };
+Session expires when I close it or TTL runs out. Don't share the
+URL + code with anyone else — together they're the access grant.`;
 }

--- a/web/components/ftw-pair-card-render.test.mjs
+++ b/web/components/ftw-pair-card-render.test.mjs
@@ -15,9 +15,6 @@ import {
   derivePresence,
   formatAge,
   friendMessage,
-  canApprove,
-  approveRequest,
-  validateTypedCode,
 } from "./ftw-pair-card-render.js";
 
 const stateActive = {
@@ -100,13 +97,13 @@ describe("derivePresence (state machine across session lifecycle)", () => {
     {
       name: "pending, friend hasn't opened URL yet",
       state: { session_state: "pending", pending_approvals_count: 0 },
-      want: { label: "waiting for friend to open the URL", class: "pending" },
+      want: { label: "waiting for friend to open URL + enter code", class: "pending" },
     },
     {
-      name: "pending, friend opened URL (operator should approve)",
+      name: "pending, friend opened URL (waiting for them to enter the code)",
       state: { session_state: "pending", pending_approvals_count: 1 },
       want: {
-        label: "friend opened URL — call you with the code",
+        label: "friend opened URL — waiting for them to enter the code",
         class: "pending",
       },
     },
@@ -150,111 +147,29 @@ describe("derivePresence (state machine across session lifecycle)", () => {
 });
 
 describe("friendMessage (golden snapshot)", () => {
-  it("renders the URL flow when pair_url is set", () => {
+  it("includes BOTH the URL and the 4-digit code", () => {
     const msg = friendMessage(stateActive);
     assert.match(msg, /https:\/\/relay\.fortytwowatts\.com\/h\/alpha-amber/);
-    assert.match(msg, /4-digit code/);
+    assert.match(msg, /Code: 4827/);
     assert.match(msg, /Open the dashboard:/);
     assert.match(msg, /claude mcp add ftw-friend/);
-    assert.match(msg, /leaked URL/, "must warn that code-mismatch = leaked URL");
     assert.doesNotMatch(msg, /ftw-connect/, "v2 must not mention the deprecated binary");
     assert.doesNotMatch(msg, /install-ftw-connect/);
     assert.doesNotMatch(msg, /go install/);
   });
 
+  it("warns the operator that URL+code together = access grant", () => {
+    const msg = friendMessage(stateActive);
+    assert.match(msg, /together they're the access grant/);
+  });
+
   it("falls back to local-only message when no pair_url", () => {
     const msg = friendMessage(stateNoRelay);
-    assert.match(msg, /local-only/);
+    assert.match(msg, /Local-only/);
     assert.match(msg, /127\.0\.0\.1:9999/);
   });
 
   it("returns empty string for null state", () => {
     assert.equal(friendMessage(null), "");
-  });
-});
-
-describe("canApprove gating", () => {
-  it("allows when pending + has url + has code", () => {
-    assert.equal(canApprove({
-      session_state: "pending",
-      approval_code: "1234",
-      pair_url: "https://x/h/y",
-    }), true);
-  });
-
-  it("rejects when not pending", () => {
-    assert.equal(canApprove({
-      session_state: "active",
-      approval_code: "1234",
-      pair_url: "https://x/h/y",
-    }), false);
-  });
-
-  it("rejects in no-relay mode (missing pair_url)", () => {
-    assert.equal(canApprove({
-      session_state: "pending",
-      approval_code: "1234",
-    }), false);
-  });
-
-  it("rejects null state", () => {
-    assert.equal(canApprove(null), false);
-    assert.equal(canApprove(undefined), false);
-  });
-});
-
-describe("approveRequest construction", () => {
-  it("targets /h/<token>/approve on the relay", () => {
-    const req = approveRequest(stateActive, "4827");
-    assert.equal(
-      req.url,
-      "https://relay.fortytwowatts.com/h/alpha-amber-arrow-atom-axis-bay/approve",
-    );
-    assert.deepEqual(req.body, { code: "4827" });
-  });
-
-  it("returns null without pair_url", () => {
-    assert.equal(approveRequest(stateNoRelay, "1234"), null);
-  });
-});
-
-describe("validateTypedCode (voice-channel cross-check)", () => {
-  const state = { approval_code: "4827", pair_url: "x" };
-
-  it("accepts exact match", () => {
-    assert.deepEqual(validateTypedCode(state, "4827"), { ok: true });
-  });
-
-  it("accepts with surrounding whitespace", () => {
-    assert.deepEqual(validateTypedCode(state, "  4827  "), { ok: true });
-  });
-
-  it("rejects 3 digits", () => {
-    const r = validateTypedCode(state, "482");
-    assert.equal(r.ok, false);
-    assert.match(r.reason, /expected 4 digits/);
-  });
-
-  it("rejects 5 digits", () => {
-    const r = validateTypedCode(state, "48275");
-    assert.equal(r.ok, false);
-    assert.match(r.reason, /expected 4 digits/);
-  });
-
-  it("rejects non-numeric", () => {
-    const r = validateTypedCode(state, "abcd");
-    assert.equal(r.ok, false);
-    assert.match(r.reason, /expected 4 digits/);
-  });
-
-  it("rejects mismatch with security warning", () => {
-    const r = validateTypedCode(state, "9999");
-    assert.equal(r.ok, false);
-    assert.match(r.reason, /leaked-URL attack/, "operator must see the security implication");
-  });
-
-  it("rejects when no active session", () => {
-    const r = validateTypedCode(null, "4827");
-    assert.equal(r.ok, false);
   });
 });

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -23,9 +23,6 @@ import {
   computeRemaining,
   derivePresence,
   friendMessage,
-  canApprove,
-  approveRequest,
-  validateTypedCode,
 } from "./ftw-pair-card-render.js";
 
 class FtwPairCard extends FtwElement {
@@ -445,8 +442,8 @@ class FtwPairCard extends FtwElement {
 
     const friendMsg = friendMessage(this._state);
     const presence = derivePresence(this._state);
-    const showApprove = canApprove(this._state);
     const url = this._state.pair_url || "";
+    const approvalCode = this._state.approval_code || "";
 
     return `
       <div class="pair-card">
@@ -460,19 +457,16 @@ class FtwPairCard extends FtwElement {
           <span class="url" id="url-span">${escapeHTML(url)}</span>
           <button class="copy" id="copy-url-btn">Copy URL</button>
         </div>
-        ` : ""}
-
-        ${showApprove ? `
+        ${approvalCode ? `
         <div class="approval">
-          <p><strong>Friend opened the URL.</strong> Their browser shows a 4-digit code. Call/Signal them and ask them to read it aloud, then type it here.</p>
-          <div class="big-code">${escapeHTML(this._state.approval_code)}</div>
-          <p class="muted">This is the code you should hear from your friend. If they read a different code, do <strong>NOT</strong> approve — the URL has leaked.</p>
+          <p>Share <strong>both</strong> with your friend — URL via Signal/SMS, code on the same message. They'll open the URL and type the code to activate.</p>
+          <div class="big-code">${escapeHTML(approvalCode)}</div>
           <div class="approval-row">
-            <input id="approval-input" inputmode="numeric" pattern="\\d{4}" maxlength="4" placeholder="0000" autocomplete="off">
-            <button id="approval-btn">Allow</button>
+            <button id="copy-code-btn">Copy code</button>
+            <button id="copy-bundle-btn">Copy URL + code</button>
           </div>
-          <div class="approval-msg" id="approval-msg"></div>
         </div>
+        ` : ""}
         ` : ""}
 
         <div class="code-row">
@@ -522,16 +516,26 @@ class FtwPairCard extends FtwElement {
       copyUrlBtn.addEventListener("click", () => this._copyUrl(copyUrlBtn));
     }
 
-    const approveBtn = this.shadowRoot.getElementById("approval-btn");
-    if (approveBtn) {
-      approveBtn.addEventListener("click", () => this._approve());
+    const copyCodeBtn = this.shadowRoot.getElementById("copy-code-btn");
+    if (copyCodeBtn) {
+      copyCodeBtn.addEventListener("click", () => this._copyText(copyCodeBtn, this._state?.approval_code || ""));
     }
-    const approveInput = this.shadowRoot.getElementById("approval-input");
-    if (approveInput) {
-      approveInput.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") this._approve();
+    const copyBundleBtn = this.shadowRoot.getElementById("copy-bundle-btn");
+    if (copyBundleBtn) {
+      copyBundleBtn.addEventListener("click", () => {
+        const bundle = (this._state?.pair_url || "") + "\nCode: " + (this._state?.approval_code || "");
+        this._copyText(copyBundleBtn, bundle);
       });
-      approveInput.focus();
+    }
+  }
+
+  async _copyText(btn, text) {
+    if (!text) return;
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      const original = btn.textContent;
+      btn.textContent = "Copied!";
+      setTimeout(() => { btn.textContent = original; }, 1500);
     }
   }
 
@@ -553,47 +557,6 @@ class FtwPairCard extends FtwElement {
       const original = btn.textContent;
       btn.textContent = "Copied!";
       setTimeout(() => { btn.textContent = original; }, 1500);
-    }
-  }
-
-  async _approve() {
-    const input = this.shadowRoot.getElementById("approval-input");
-    const msgEl = this.shadowRoot.getElementById("approval-msg");
-    if (!input || !msgEl) return;
-    const typed = input.value;
-    const v = validateTypedCode(this._state, typed);
-    if (!v.ok) {
-      msgEl.className = "approval-msg err";
-      msgEl.textContent = v.reason;
-      return;
-    }
-    const req = approveRequest(this._state, typed.trim());
-    if (!req) {
-      msgEl.className = "approval-msg err";
-      msgEl.textContent = "no pair URL — cannot approve in local-only mode";
-      return;
-    }
-    msgEl.className = "approval-msg";
-    msgEl.textContent = "approving…";
-    try {
-      const resp = await fetch(req.url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(req.body),
-      });
-      if (resp.status === 204) {
-        msgEl.className = "approval-msg ok";
-        msgEl.textContent = "approved — friend can now use the session";
-        // Fast-poll so the dashboard flips to active state quickly.
-        this._startFastPolls();
-      } else {
-        const text = await resp.text();
-        msgEl.className = "approval-msg err";
-        msgEl.textContent = `relay rejected: ${resp.status} ${text.slice(0, 200)}`;
-      }
-    } catch (e) {
-      msgEl.className = "approval-msg err";
-      msgEl.textContent = `network error: ${e.message}`;
     }
   }
 

--- a/web/components/ftw-pair-card.test.mjs
+++ b/web/components/ftw-pair-card.test.mjs
@@ -36,17 +36,20 @@ describe("ftw-pair-card source hygiene (v2 migration)", () => {
       "render helpers must come from the testable module");
     assert.match(SRC, /friendMessage,/);
     assert.match(SRC, /derivePresence,/);
-    assert.match(SRC, /canApprove,/);
-    assert.match(SRC, /approveRequest,/);
-    assert.match(SRC, /validateTypedCode,/);
   });
 
-  it("renders the approval form when state allows it", () => {
-    assert.match(SRC, /id="approval-input"/,
-      "v2 must surface the 4-digit code input");
-    assert.match(SRC, /id="approval-btn"/);
+  it("displays the code prominently for the operator to share", () => {
     assert.match(SRC, /class="big-code"/,
-      "the friend's expected code must be shown prominently");
+      "the 4-digit code must be displayed for copy/share");
+    assert.match(SRC, /id="copy-code-btn"/);
+    assert.match(SRC, /id="copy-bundle-btn"/);
+  });
+
+  it("does NOT host the approval form anymore (friend types code on relay page)", () => {
+    assert.doesNotMatch(SRC, /id="approval-input"/,
+      "dashboard must not be the place where the operator types the code");
+    assert.doesNotMatch(SRC, /id="approval-btn"/,
+      "no Allow button — friend approves on their own page");
   });
 
   it("renders the URL block with a copy button", () => {
@@ -67,7 +70,7 @@ describe("ftw-pair-card-render module hygiene", () => {
     for (const name of [
       "POLL_MS", "FAST_POLL_MS", "FAST_POLL_ROUNDS",
       "escapeHTML", "computeRemaining", "derivePresence", "formatAge",
-      "friendMessage", "canApprove", "approveRequest", "validateTypedCode",
+      "friendMessage",
     ]) {
       assert.match(RENDER, new RegExp(`export (function|const) ${name}\\b`),
         `${name} must be exported`);


### PR DESCRIPTION
**Two bugs from v0.104.0 fixed in one redesign.**

### What was broken

1. CORS silently killed the Allow button. Dashboard tried to POST cross-origin from `http://<pi-ip>:8080` to `https://relay.fortytwowatts.com/h/<token>/approve`. Browser blocked the preflight. No visible error.
2. UX implied a security model the implementation didn't honor. Same 4-digit code on both sides looked like security theater.

### What the new flow does

- **Dashboard** shows URL + code with Copy buttons + a 'Copy URL + code' bundle helper. Operator shares both in one Signal/SMS message.
- **Relay landing page** no longer renders the code — it renders an input field. Friend types whatever code the host shared out-of-band. Same-origin POST.
- **On success** the landing page reveals the dashboard URL + `claude mcp add` one-liner.

### Live now

Deployed v0.105.0-dev to relay.fortytwowatts.com — `curl https://relay.fortytwowatts.com/healthz` returns OK.

### Tests

31 node-tests + Go suite green. Relay landing-page test now asserts the code MUST NOT appear. Component hygiene tests assert the operator-side input form is gone.