### PR TITLE
fix(curtail): no spurious release on |PV|=0 + Ferroamp NAK observability

### DIFF
--- a/.changeset/curtail-no-spurious-release-and-nak-metric.md
+++ b/.changeset/curtail-no-spurious-release-and-nak-metric.md
@@ -1,0 +1,33 @@
+---
+"forty-two-watts": patch
+---
+
+**Defense-in-depth against the 2026-05-27 Ferroamp brick.** Two
+independent changes that, combined with PR #367's driver-side hard
+fail on `pplim arg=0`, eliminate every known trigger path:
+
+- **Dispatcher**: `ComputePVCurtail` no longer emits a `curtail_disable`
+  release simply because a previously-curtailed driver dropped out of
+  the proportional allocation due to its own `|PV|` crashing to ~0
+  (often a direct consequence of OUR curtail throttling that driver
+  down). The release is now only sent when the curtail directive
+  truly clears, or the driver is removed from `SupportsPVCurtail`, or
+  the driver goes offline. Also: per-driver allocations rounding to
+  `≤ 1 W` are suppressed entirely — never publish a near-zero
+  `pplim` that some inverters treat as a hard "limit to 0 W" lock.
+
+- **Ferroamp driver**: subscribes to `extapi/control/response`
+  (was: `extapi/result` — wrong topic, never received anything),
+  parses `{"status":"ack|nak", ...}` responses, and exposes
+  cumulative `extapi_nak_count` + `extapi_ack_count` metrics. NAK
+  responses are also logged as warnings with `transId` + `msg`
+  fields. The 2026-05-27 brick was preceded by minutes of
+  `nak: no available ESOs detected in system` that we couldn't see
+  through ftw telemetry — now the operator can alert on any non-zero
+  NAK rate.
+
+Tests added:
+- Four new dispatcher regressions in `control/pv_curtail_test.go`
+  guarding the suppression / release semantics.
+- One driver test in `drivers/lua_ferroamp_curtail_test.go`
+  asserting NAK + ACK counter advancement.

--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -156,6 +156,13 @@ local MAX_DISPATCH_SCALE  = 2.0
 local last_eso_count             = 0
 local last_eso_discharge_capable = 0
 local last_eso_charge_capable    = 0
+-- Cumulative count of Ferroamp extapi `nak` responses since driver
+-- start. Surfaced as the `extapi_nak_count` metric so an operator can
+-- alert on any non-zero rate. NAKs are early signals of EMS-side
+-- trouble (e.g. "no available ESOs detected in system" preceded the
+-- 2026-05-27 brick by minutes).
+local extapi_nak_count           = 0
+local extapi_ack_count           = 0
 -- -1 = "no snapshot yet" sentinel. host.millis() can legitimately
 -- return 0 on the very first poll (sub-millisecond since startup), so
 -- we can't use 0 to mean "never set".
@@ -379,8 +386,15 @@ function driver_init(config)
     host.mqtt_subscribe("extapi/data/eso")
     host.mqtt_subscribe("extapi/data/sso")
 
-    -- Subscribe to control response topic to verify commands are received
-    host.mqtt_subscribe("extapi/result")
+    -- Subscribe to the EMS-side response channel for every command we
+    -- publish. We parse `{"status":"ack|nak", ...}` from each message
+    -- and count NAKs in a metric for operator alerting. The 2026-05-27
+    -- brick was preceded by minutes of `{"status":"nak","msg":"no
+    -- available ESOs detected in system"}` that we couldn't see at the
+    -- time because the driver subscribed to the wrong topic. Older
+    -- code used "extapi/result"; the actual response topic on the
+    -- firmwares we've tested is "extapi/control/response".
+    host.mqtt_subscribe("extapi/control/response")
 
     -- Query API version to verify connectivity and external API access
     local version_cmd = '{"transId":"init","cmd":{"name":"extapiversion"}}'
@@ -423,9 +437,28 @@ function driver_poll()
                 eso_ts_by_id[eid]   = now
             elseif msg.topic == "extapi/data/sso" then
                 sso_data = data; sso_ts = now
+            elseif msg.topic == "extapi/control/response" then
+                -- Track EMS-side ack/nak counters per published cmd.
+                -- A NAK is the canary for trouble (`"no available ESOs
+                -- detected in system"` preceded the 2026-05-27 brick by
+                -- minutes). Log every NAK so operators can correlate
+                -- with their command stream; surface the count as a
+                -- metric so ops dashboards can alert on rate.
+                local status = data["status"]
+                if status == "nak" then
+                    extapi_nak_count = extapi_nak_count + 1
+                    host.log("warn", string.format(
+                        "Ferroamp: extapi NAK (transId=%s msg=%s)",
+                        tostring(data["transId"] or "?"),
+                        tostring(data["msg"] or "?")))
+                elseif status == "ack" then
+                    extapi_ack_count = extapi_ack_count + 1
+                end
             end
         end
     end
+    host.emit_metric("extapi_nak_count", extapi_nak_count)
+    host.emit_metric("extapi_ack_count", extapi_ack_count)
 
     -- Drop stale caches so the rest of the poll falls through and
     -- the watchdog catches us when the EnergyHub stops publishing.

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -2079,28 +2079,102 @@ func ComputePVCurtail(state *State, store *telemetry.Store) []CurtailTarget {
 		}
 	}
 
+	// Release path. A previously-curtailed driver gets an explicit
+	// `curtail_disable` (LimitW: 0) only when one of the following is
+	// true:
+	//   - the curtail directive has cleared (no slot, no manual hold)
+	//   - the driver is no longer in `state.SupportsPVCurtail` (config
+	//     change removed the opt-in)
+	//   - the driver went offline (no harm — driver can't receive
+	//     anyway, but keeps `state.LastCurtailedDrivers` clean)
+	//
+	// We deliberately do NOT release a driver just because it dropped
+	// out of the live proportional allocation due to its own |PV|
+	// crashing to ~0. That very thing often happens as a direct
+	// consequence of our prior curtail (the inverter throttled PV down
+	// to the cap, telemetry reports 0 generation, allocator excludes
+	// it next tick). Emitting a release in that case publishes
+	// `pplim arg=0` on Ferroamp's extapi — same wire bytes as the
+	// release would have, opposite semantics — and locks the inverter
+	// at 0 W PV until the operator clears it from the Ferroamp portal
+	// (sticky-lock trap, 2026-05-27 incident; see #367 for the driver-
+	// side hard-fail that paired with this dispatcher fix).
+	//
+	// While the directive is active and the driver is still online +
+	// supported, the right behaviour is to leave the existing pplim
+	// in place; the driver will get a fresh non-zero target as soon as
+	// its live |PV| returns to a level the allocator can split.
 	var out []CurtailTarget
-	// Release any driver we curtailed last tick but not this one.
+	suppressedTrack := map[string]bool{}
 	for d := range state.LastCurtailedDrivers {
-		if _, ok := next[d]; !ok {
-			out = append(out, CurtailTarget{Driver: d, LimitW: 0})
+		if _, stillActive := next[d]; stillActive {
+			continue
 		}
+		if !wantCurtail {
+			out = append(out, CurtailTarget{Driver: d, LimitW: 0})
+			continue
+		}
+		if !state.SupportsPVCurtail[d] {
+			out = append(out, CurtailTarget{Driver: d, LimitW: 0})
+			continue
+		}
+		if store != nil {
+			if h := store.DriverHealth(d); h == nil || !h.IsOnline() {
+				out = append(out, CurtailTarget{Driver: d, LimitW: 0})
+				continue
+			}
+		}
+		// Online + supported + curtail still active + dropped from
+		// allocation. Don't release — the inverter is presumably at
+		// or near the previously-commanded cap and re-publishing 0
+		// would trip the sticky-pplim trap. Keep the driver in
+		// LastCurtailedDrivers so the next cycle's allocation decision
+		// is taken against an accurate baseline.
+		suppressedTrack[d] = true
 	}
 	for d, w := range next {
+		// Skip vanishingly-small per-driver shares. Proportional
+		// allocation can round a driver's share to ~0 when its live
+		// |PV| is small relative to the site total, and a curtail
+		// with power_w <= ~1 W lands at the driver as `pplim arg=0`
+		// on Ferroamp — the same sticky-lock trap. Better to leave
+		// the previous pplim in place for one cycle than risk it.
+		if w <= curtailMinPerDriverW {
+			continue
+		}
 		out = append(out, CurtailTarget{Driver: d, LimitW: w})
 	}
 
-	if len(next) == 0 {
+	// Update LastCurtailedDrivers to include every driver that either
+	// got a fresh non-zero target this tick OR was tracked through a
+	// suppressed-release decision above.
+	if len(out) == 0 && len(suppressedTrack) == 0 {
 		state.LastCurtailedDrivers = nil
 	} else {
-		updated := make(map[string]bool, len(next))
-		for d := range next {
+		updated := make(map[string]bool, len(out)+len(suppressedTrack))
+		for _, t := range out {
+			if t.LimitW > 0 {
+				updated[t.Driver] = true
+			}
+		}
+		for d := range suppressedTrack {
 			updated[d] = true
 		}
-		state.LastCurtailedDrivers = updated
+		if len(updated) == 0 {
+			state.LastCurtailedDrivers = nil
+		} else {
+			state.LastCurtailedDrivers = updated
+		}
 	}
 	return out
 }
+
+// curtailMinPerDriverW is the lower bound on a per-driver curtail
+// allocation. Anything at or below this is suppressed so we never
+// publish a near-zero pplim that some inverters (Ferroamp) treat as a
+// hard "limit to 0 W" sticky lock. Tuned conservatively — well below
+// any realistic curtail target operators actually want.
+const curtailMinPerDriverW = 1.0
 
 // pvCurtailBatterySoCMax is the fractional SoC ceiling above which a battery
 // is treated as having no curtail-absorption headroom. Below it, the

--- a/go/internal/control/pv_curtail_test.go
+++ b/go/internal/control/pv_curtail_test.go
@@ -442,3 +442,119 @@ func abs(x float64) float64 {
 	}
 	return x
 }
+
+// 2026-05-27 brick regression. A curtailed driver whose own |PV|
+// dropped to ~0 (often because OUR curtail throttled it) used to be
+// excluded from the proportional allocation, fall through the release
+// path, and receive a `CurtailTarget{LimitW: 0}` → main.go translated
+// to `curtail_disable` → Ferroamp Lua published `pplim arg=0` →
+// sticky-lock until portal reset. The dispatcher must NOT emit that
+// release while the curtail directive is still active and the driver
+// is online + supports curtail.
+func TestComputePVCurtail_DroppedDueToZeroPVDoesNotEmitRelease(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true, "sungrow": true}
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1000})
+	store := telemetry.NewStore()
+
+	// Tick 1: both drivers producing; both get curtailed.
+	emitPV(t, store, "ferroamp", -2000)
+	emitPV(t, store, "sungrow", -2000)
+	tick1 := findCurtail(ComputePVCurtail(st, store))
+	if !(tick1["ferroamp"] > 0 && tick1["sungrow"] > 0) {
+		t.Fatalf("tick1: expected both drivers curtailed, got %+v", tick1)
+	}
+
+	// Tick 2: ferroamp's PV crashed to 0 (the curtail throttled it
+	// down). Sungrow keeps generating. Directive still wants curtail.
+	emitPV(t, store, "ferroamp", 0)
+	emitPV(t, store, "sungrow", -2000)
+	tick2 := ComputePVCurtail(st, store)
+	for _, tg := range tick2 {
+		if tg.Driver == "ferroamp" {
+			t.Fatalf("ferroamp must NOT receive a release while curtail directive is still active and driver is online — got %+v (would publish pplim=0, sticky-lock trap)", tg)
+		}
+	}
+	// Sungrow should still get a fresh non-zero target.
+	gotSungrow := false
+	for _, tg := range tick2 {
+		if tg.Driver == "sungrow" && tg.LimitW > 0 {
+			gotSungrow = true
+		}
+	}
+	if !gotSungrow {
+		t.Errorf("tick2: sungrow should still be curtailed, got %+v", tick2)
+	}
+	// Ferroamp must remain in LastCurtailedDrivers (suppressed-track),
+	// so a future allocation knows its baseline.
+	if !st.LastCurtailedDrivers["ferroamp"] {
+		t.Errorf("ferroamp should remain tracked in LastCurtailedDrivers after suppression")
+	}
+}
+
+// A per-driver share that rounds to ~0 (≤ curtailMinPerDriverW) must
+// also be suppressed. Same trap as the above test, but the trigger is
+// proportional-allocation rounding rather than a |PV|==0 reading.
+func TestComputePVCurtail_TinyShareSuppressedNotPublishedAsZero(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true, "sungrow": true}
+	// Tiny PVLimitW vs huge sungrow PV → ferroamp's share is < 1 W.
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 100})
+	store := telemetry.NewStore()
+	emitPV(t, store, "ferroamp", -1) // 1 W abs
+	emitPV(t, store, "sungrow", -10000)
+
+	got := ComputePVCurtail(st, store)
+	for _, tg := range got {
+		if tg.LimitW > 0 && tg.LimitW <= 1.0 {
+			t.Fatalf("per-driver share <= curtailMinPerDriverW must be suppressed (sticky-pplim trap), got %+v", tg)
+		}
+		if tg.Driver == "ferroamp" && tg.LimitW == 0 {
+			t.Fatalf("ferroamp must not receive a zero release here (would publish pplim=0), got %+v", tg)
+		}
+	}
+}
+
+// Removing a driver from `SupportsPVCurtail` (operator opted out via
+// config) IS a legitimate release event — the dispatcher won't be
+// sending curtail to it anymore, so the driver-side pplim should be
+// released. This stays as the existing semantics; the brick fix only
+// changes the |PV|==0 suppression behaviour.
+func TestComputePVCurtail_RemovedFromSupportsStillEmitsRelease(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true}
+	st.LastCurtailedDrivers = map[string]bool{"ferroamp": true}
+	st.SlotDirective = stubSlotDirective(SlotDirective{PVLimitW: 1000})
+	store := telemetry.NewStore()
+	emitPV(t, store, "ferroamp", -2000)
+
+	// Operator removes ferroamp from supports map between ticks.
+	st.SupportsPVCurtail = map[string]bool{}
+
+	got := ComputePVCurtail(st, store)
+	if len(got) != 1 || got[0].Driver != "ferroamp" || got[0].LimitW != 0 {
+		t.Fatalf("removed-from-supports driver must get a release, got %+v", got)
+	}
+}
+
+// When the slot directive clears (curtail epoch ends), every previously
+// curtailed driver must receive an explicit release — even ones whose
+// |PV| has been 0 (which would otherwise be suppressed per the brick
+// fix). This is the normal end-of-slot path that the original code
+// was conflating with the |PV|==0 drop-out path.
+func TestComputePVCurtail_SlotClearReleasesEvenZeroPVDrivers(t *testing.T) {
+	st := NewState(0, 100, "meter")
+	st.SupportsPVCurtail = map[string]bool{"ferroamp": true}
+	st.LastCurtailedDrivers = map[string]bool{"ferroamp": true}
+	st.SlotDirective = stubSlotDirective(SlotDirective{}) // PVLimitW=0 → curtail cleared
+	store := telemetry.NewStore()
+	emitPV(t, store, "ferroamp", 0) // |PV|==0 path
+
+	got := ComputePVCurtail(st, store)
+	if len(got) != 1 || got[0].Driver != "ferroamp" || got[0].LimitW != 0 {
+		t.Fatalf("end-of-slot must release even zero-PV drivers, got %+v", got)
+	}
+	if len(st.LastCurtailedDrivers) != 0 {
+		t.Errorf("LastCurtailedDrivers should be cleared after the release tick, got %+v", st.LastCurtailedDrivers)
+	}
+}

--- a/go/internal/drivers/lua_ferroamp_curtail_test.go
+++ b/go/internal/drivers/lua_ferroamp_curtail_test.go
@@ -146,6 +146,64 @@ func TestFerroampCurtailDisableWithReleaseWattsPublishesRelease(t *testing.T) {
 	}
 }
 
+// 2026-05-27 observability gap. The driver subscribed to "extapi/result"
+// but Ferroamp's real response topic on the firmwares we've tested is
+// "extapi/control/response", so the EMS-side `{"status":"nak","msg":...}`
+// chatter was invisible. The brick that day was preceded by minutes of
+// `nak: no available ESOs detected in system` that we only discovered
+// via a mosquitto_sub session, not through ftw telemetry. The driver
+// now subscribes to the right topic and exposes an `extapi_nak_count`
+// metric so ops dashboards can alert on rate.
+func TestFerroampExtapiNakIncrementsCounterMetric(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d := newFerroampDriverWithConfig(t, tel, mqtt, nil)
+
+	// Drain any init-time emit_metric chatter so we measure only what
+	// our injected responses produce.
+	_ = tel.FlushSamples()
+
+	// First NAK.
+	mqtt.Push("extapi/control/response",
+		`{"status":"nak","transId":"ems-1","msg":"no available ESOs detected in system"}`)
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-1: %v", err)
+	}
+	checkMetric(t, tel.FlushSamples(), "extapi_nak_count", 1)
+
+	// Second NAK + an ACK in the same tick.
+	mqtt.Push("extapi/control/response",
+		`{"status":"nak","transId":"ems-2","msg":"some other reason"}`)
+	mqtt.Push("extapi/control/response",
+		`{"status":"ack","transId":"init","msg":"version: 1.2.1"}`)
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-2: %v", err)
+	}
+	samples := tel.FlushSamples()
+	checkMetric(t, samples, "extapi_nak_count", 2)
+	checkMetric(t, samples, "extapi_ack_count", 1)
+}
+
+// checkMetric asserts that `samples` contains at least one MetricSample
+// for `name` whose value equals `want` (most recent wins).
+func checkMetric(t *testing.T, samples []telemetry.MetricSample, name string, want float64) {
+	t.Helper()
+	var got float64
+	found := false
+	for _, s := range samples {
+		if s.Metric == name {
+			got = s.Value
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("metric %q not emitted in samples %+v", name, samples)
+	}
+	if got != want {
+		t.Errorf("metric %q = %v, want %v", name, got, want)
+	}
+}
+
 func TestFerroampCurtailNormalWattsPublishesPplim(t *testing.T) {
 	mqtt := &fakeMQTT{}
 	d := newFerroampDriverWithConfig(t, telemetry.NewStore(), mqtt, nil)


### PR DESCRIPTION
## Summary

Two independent defenses that close the remaining trigger paths to the 2026-05-27 Ferroamp brick. Combined with [#367](https://github.com/frahlg/forty-two-watts/pull/367)'s driver-side hard fail on `pplim arg=0`, this is the full belt-and-suspenders.

### 1. Dispatcher — don't release on |PV|=0 drop-out

Old `ComputePVCurtail` logic emitted a `curtail_disable` for any previously-curtailed driver that dropped from the active proportional allocation. That fired wrongly when a curtailed driver's own `|PV|` crashed to ~0 — often a direct consequence of OUR prior curtail throttling that inverter. The spurious release then published `pplim arg=0` to the driver. On Ferroamp's extapi: sticky-lock until portal reset.

New semantics — releases are emitted only when:
- The curtail directive truly clears (no slot directive + no manual hold), OR
- The driver was removed from `state.SupportsPVCurtail` (config change), OR
- The driver went offline

A driver that drops from the active allocation while curtail is still active is kept in `LastCurtailedDrivers` (suppressed-track) so the next cycle's allocation reasoning stays accurate. The existing `pplim` on the inverter is left in place — it'll get refreshed when the driver's `|PV|` returns to a level the allocator can split.

Plus: per-driver allocation rounding to `≤ 1 W` is suppressed — never publish a near-zero `pplim` that some inverters treat as a hard "limit to 0 W" lock.

### 2. Ferroamp driver — NAK observability

The driver subscribed to `extapi/result` (wrong topic — never received anything). It now subscribes to `extapi/control/response` and parses `{"status":"ack|nak", ...}` from each EMS response. Two new metrics:
- `extapi_nak_count` — cumulative NAK counter
- `extapi_ack_count` — cumulative ACK counter

NAK responses also log as warnings with `transId` + `msg` for correlation. The 2026-05-27 brick was preceded by **minutes** of `nak: no available ESOs detected in system` that we couldn't see through ftw telemetry — only `mosquitto_sub` revealed it. Operators can now alert on any non-zero NAK rate.

## Tests

- `go/internal/control/pv_curtail_test.go` — 4 new regressions:
  - `TestComputePVCurtail_DroppedDueToZeroPVDoesNotEmitRelease` (brick scenario)
  - `TestComputePVCurtail_TinyShareSuppressedNotPublishedAsZero` (rounding edge)
  - `TestComputePVCurtail_RemovedFromSupportsStillEmitsRelease` (config-change release)
  - `TestComputePVCurtail_SlotClearReleasesEvenZeroPVDrivers` (end-of-slot release)
- `go/internal/drivers/lua_ferroamp_curtail_test.go` — NAK/ACK counter metric test

## Out of scope (next PR)

Layer **E** from the brainstorming: self-healing watchdog that auto-publishes `pplim` release when the driver detects `sso_pv_v > 200V + ipv == 0` for >10 min during daylight (sunpos elevation > 5°). Indicates a stuck `pplim` state — automatic recovery without portal intervention.

## Test plan

- [x] `make verify` passes
- [x] All existing curtail + driver tests still pass
- [ ] After merge + release, re-enable `supports_pv_curtail: true` on Ferroamp on the live SE4 site. During the next negative-spot slot, observe in `/api/series`:
  - `extapi_ack_count` increments on each `pplim` command
  - `extapi_nak_count` stays at 0 (or reveals an unexpected EMS issue early)
  - When Ferroamp's PV throttles down to the cap, dispatcher does NOT emit a spurious release (verifiable by absence of "curtail_disable" payload in driver logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)