### PR TITLE
feat(ferroamp): self-healing watchdog for stuck-pplim trap (layer 3)

### DIFF
--- a/.changeset/ferroamp-stuck-pplim-watchdog.md
+++ b/.changeset/ferroamp-stuck-pplim-watchdog.md
@@ -1,0 +1,25 @@
+---
+"forty-two-watts": minor
+---
+
+**Ferroamp self-healing watchdog for the sticky-pplim trap.** When the
+SSO reports the post-incident signature — DC bus voltage > 200 V, zero
+PV current, no fault, relay closed — continuously for ten minutes, the
+driver now auto-publishes `pplim arg=<pplim_release_w>` to release
+the lock. Operator opts in by setting `config.pplim_release_w > 0`;
+without it, the watchdog logs a per-incident warning but does not
+publish (we have no safe release value to send).
+
+A five-minute cooldown between successive recoveries prevents command-
+spam if the release doesn't take. A new `stuck_pv_recovery_count`
+metric tracks lifetime recovery count so operators can alert on a
+chronic condition.
+
+Reuses the existing `pplim_release_w` field — same value, dual
+purpose (dispatcher `curtail_disable` release AND watchdog
+self-recovery).
+
+Layered with [#367](https://github.com/frahlg/forty-two-watts/pull/367)
+(driver hard-fail on `pplim arg=0`) and the dispatcher fix in the
+parallel PR (`fix(curtail): no spurious release ...`) this is the
+third and final layer of defense against the 2026-05-27 brick.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,6 +198,22 @@ The 2026-05-27 incident: dispatching `pplim arg=0` during a stale
 curtail-allocation cycle locked the SSO at 0 W PV for 30+ minutes
 and triggered a fault state on the EnergyHub.
 
+#### Ferroamp stuck-pplim self-healing watchdog
+
+The same `pplim_release_w` value (when set > 0) also arms a self-
+healing watchdog in the Ferroamp driver. If the SSO reports the
+sticky-pplim signature — DC bus voltage above 200 V, zero PV current,
+no fault, relay closed — continuously for ten minutes, the driver
+auto-publishes `pplim arg=<pplim_release_w>` to release the lock.
+A five-minute cooldown prevents command-spam if the recovery doesn't
+take. Operators who leave `pplim_release_w` unset see a per-incident
+warning log instead — no MQTT publish, because we don't have a safe
+release value to send.
+
+The `stuck_pv_recovery_count` metric tracks how many auto-recoveries
+the driver has issued since startup; alert on any non-zero rate to
+catch a chronic sticky-pplim condition that needs operator attention.
+
 ### `api` — REST + web UI
 
 ```yaml

--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -147,6 +147,21 @@ local CHARGE_CEIL_SOC     = 0.95
 -- the live SE4 site for 30+ minutes; recovery required a Ferroamp
 -- portal reset.
 local PPLIM_RELEASE_W     = 0
+
+-- Stuck-pplim self-healing watchdog. If the SSO reports DC bus voltage
+-- (paneler aktiva) AND zero PV current AND no fault for STUCK_PV_AFTER_MS
+-- continuous, we treat that as the sticky-pplim trap signature and
+-- auto-publish `pplim arg=PPLIM_RELEASE_W` to recover. Operator opts in
+-- by setting PPLIM_RELEASE_W > 0 — without that we just log a warning
+-- because we have no safe release value. The recovery has a cooldown
+-- (STUCK_PV_RECOVERY_COOLDOWN_MS) so a persistent issue can't loop us
+-- into command-spam. 2026-05-27 incident background: PR #367 + #372.
+local STUCK_PV_AFTER_MS              = 10 * 60 * 1000  -- 10 minutes
+local STUCK_PV_RECOVERY_COOLDOWN_MS  = 5 * 60 * 1000   -- 5 minutes
+local STUCK_PV_DC_V_THRESHOLD        = 200             -- volts on the DC bus
+local stuck_pv_since_ms              = -1              -- -1 = not stuck
+local stuck_pv_last_recovery_ms      = -1              -- -1 = never recovered
+local stuck_pv_recovery_count        = 0
 -- Cap on the N_total/N_capable multiplier so a transient "only 1 of 4
 -- capable" snapshot can't quadruple the on-wire setpoint past inverter
 -- rating before the next poll corrects it. 2.0 covers the common
@@ -742,13 +757,62 @@ function driver_poll()
         local sso_udc = extract_val(sso_data, "udc")
         if sso_udc then host.emit_metric("sso_dc_link_v", tonumber(sso_udc) or 0) end
         local sso_upv = extract_val(sso_data, "upv")
-        if sso_upv then host.emit_metric("sso_pv_v", tonumber(sso_upv) or 0) end
+        local upv_n = tonumber(sso_upv) or 0
+        if sso_upv then host.emit_metric("sso_pv_v", upv_n) end
         local sso_ipv = extract_val(sso_data, "ipv")
-        if sso_ipv then host.emit_metric("sso_pv_a", tonumber(sso_ipv) or 0) end
+        local ipv_n = tonumber(sso_ipv) or 0
+        if sso_ipv then host.emit_metric("sso_pv_a", ipv_n) end
         local sso_relay = extract_val(sso_data, "relaystatus")
-        if sso_relay then host.emit_metric("sso_relaystatus", tonumber(sso_relay) or 0) end
+        local relay_n = tonumber(sso_relay) or 0
+        if sso_relay then host.emit_metric("sso_relaystatus", relay_n) end
         local sso_fault = extract_val(sso_data, "faultcode")
-        if sso_fault then host.emit_metric("sso_faultcode", tonumber(sso_fault) or 0) end
+        local fault_n = tonumber(sso_fault) or 0
+        if sso_fault then host.emit_metric("sso_faultcode", fault_n) end
+
+        -- Stuck-pplim self-healing watchdog. The 2026-05-27 incident
+        -- left the SSO at upv≈500V + ipv=0 + faultcode=0 + relay=1
+        -- (paneler aktiva, ingen MPPT, ingen hårdvarufel) — the
+        -- signature of a sticky `pplim arg=0` lock. Recovery via portal
+        -- took 30+ minutes. If the operator has opted in by setting
+        -- `pplim_release_w`, the driver now detects the signature and
+        -- auto-publishes a release (`pplim arg=PPLIM_RELEASE_W`) after
+        -- STUCK_PV_AFTER_MS continuous, throttled by a cooldown so a
+        -- persistent issue can't loop us into command-spam.
+        local stuck = (upv_n > STUCK_PV_DC_V_THRESHOLD)
+                  and (ipv_n == 0)
+                  and (fault_n == 0)
+                  and (relay_n == 1)
+        if stuck then
+            if stuck_pv_since_ms < 0 then
+                stuck_pv_since_ms = now
+            elseif (now - stuck_pv_since_ms) > STUCK_PV_AFTER_MS then
+                local cool_ok = stuck_pv_last_recovery_ms < 0
+                            or (now - stuck_pv_last_recovery_ms) > STUCK_PV_RECOVERY_COOLDOWN_MS
+                if PPLIM_RELEASE_W > 0 and cool_ok then
+                    local payload = string.format(
+                        '{"transId":"stuck-pv-recover","cmd":{"name":"pplim","arg":%d}}',
+                        PPLIM_RELEASE_W)
+                    local err = host.mqtt_publish("extapi/control/request", payload)
+                    if not err then
+                        stuck_pv_last_recovery_ms = now
+                        stuck_pv_recovery_count   = stuck_pv_recovery_count + 1
+                        host.log("warn", string.format(
+                            "Ferroamp: stuck-pplim detected (upv=%.1fV, ipv=0A for %d min) — auto-published pplim arg=%d to recover",
+                            upv_n, math.floor((now - stuck_pv_since_ms) / 60000), PPLIM_RELEASE_W))
+                    end
+                elseif PPLIM_RELEASE_W <= 0 and cool_ok then
+                    -- Log-only path: operator hasn't opted in. Reuse the
+                    -- cooldown so we don't spam every poll.
+                    stuck_pv_last_recovery_ms = now
+                    host.log("warn", string.format(
+                        "Ferroamp: stuck-pplim signature for %d min (upv=%.1fV, ipv=0A) — set config.pplim_release_w to enable auto-recovery",
+                        math.floor((now - stuck_pv_since_ms) / 60000), upv_n))
+                end
+            end
+        else
+            stuck_pv_since_ms = -1
+        end
+        host.emit_metric("stuck_pv_recovery_count", stuck_pv_recovery_count)
     end
 
     return 1000

--- a/go/internal/drivers/lua_ferroamp_stuck_pv_test.go
+++ b/go/internal/drivers/lua_ferroamp_stuck_pv_test.go
@@ -1,0 +1,284 @@
+package drivers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// newFerroampDriverWithConfigAndEnv mirrors newFerroampDriverWithConfig
+// from lua_ferroamp_curtail_test.go but also returns the HostEnv so the
+// caller can rewind millis() via env.Start for time-based tests.
+func newFerroampDriverWithConfigAndEnv(t *testing.T, tel *telemetry.Store, mqtt *fakeMQTT, config map[string]any) (*LuaDriver, *HostEnv) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	luaPath := filepath.Join(wd, "..", "..", "..", "drivers", "ferroamp.lua")
+	if _, err := os.Stat(luaPath); err != nil {
+		t.Fatalf("ferroamp.lua not found at %s: %v", luaPath, err)
+	}
+	env := NewHostEnv("ferroamp", tel).WithMQTT(mqtt)
+	env.BatteryCapacityWh = 15200
+	d, err := NewLuaDriver(luaPath, env)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := d.Init(context.Background(), config); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	t.Cleanup(d.Cleanup)
+	return d, env
+}
+
+// 2026-05-27 recovery automation. After the sticky-pplim brick we want
+// the driver to self-heal: if the SSO reports DC bus voltage (paneler
+// aktiva), zero PV current, no fault, and the relay closed for a long
+// continuous stretch, auto-publish a pplim release. Operator opts in
+// by setting `pplim_release_w`; without it, the watchdog only logs.
+//
+// The test pushes a stuck-signature SSO payload, rewinds the host's
+// monotonic clock past STUCK_PV_AFTER_MS (10 min) so we don't burn
+// wall-clock, polls, and asserts:
+//   1. pplim arg=<release_w> is published exactly once
+//   2. stuck_pv_recovery_count metric advances to 1
+//   3. Cooldown: a subsequent poll does NOT re-publish (counter stays 1)
+//   4. A poll AFTER the cooldown CAN re-publish (counter advances to 2)
+//   5. Once stuck signature clears (ipv > 0), counter stops advancing
+func TestFerroampStuckPVWatchdogAutoPublishesRelease(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, env := newFerroampDriverWithConfigAndEnv(t, tel, mqtt, map[string]any{
+		"pplim_release_w": 15000,
+	})
+
+	 // see helper at the bottom of this file
+
+	// Helper: push one stuck-signature SSO payload and one trivial ehub
+	// so the poll has something fresh to consume each tick. (Ehub kept
+	// minimal — we only care about the SSO branch here.)
+	pushStuckSSO := func() {
+		mqtt.Push("extapi/data/sso",
+			`{"id":{"val":"PS00990-A04-S23091622"},`+
+				`"upv":{"val":"500.0"},`+
+				`"ipv":{"val":"0.0"},`+
+				`"relaystatus":{"val":"1"},`+
+				`"faultcode":{"val":"0"},`+
+				`"udc":{"val":"499.0"}}`)
+		mqtt.Push("extapi/data/ehub",
+			`{"pext":{"L1":-100,"L2":-100,"L3":-100},"ppv":{"val":300},`+
+				`"pbat":{"val":0},"gridfreq":{"val":50.0},`+
+				`"ul":{"L1":230,"L2":230,"L3":230},`+
+				`"iext":{"L1":-0.4,"L2":-0.4,"L3":-0.4}}`)
+	}
+
+	// Tick 1: stuck signature seen for the first time. Should NOT
+	// trigger recovery yet (under STUCK_PV_AFTER_MS).
+	pushStuckSSO()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-1: %v", err)
+	}
+	mark1 := len(mqtt.Published())
+	for _, p := range mqtt.Published() {
+		if strings.Contains(p.Payload, `"name":"pplim"`) {
+			t.Fatalf("tick 1: must not publish pplim immediately on first stuck-signature poll, got %q", p.Payload)
+		}
+	}
+
+	// Rewind host millis() by 11 min so the next tick sees a stretch
+	// of stuck-signature longer than STUCK_PV_AFTER_MS (10 min).
+	env.Start = env.Start.Add(-11 * time.Minute)
+
+	// Tick 2: stuck for > 10 min → auto-publish pplim release.
+	pushStuckSSO()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-2: %v", err)
+	}
+	want := `"name":"pplim","arg":15000`
+	found := false
+	for _, p := range mqtt.Published()[mark1:] {
+		if strings.Contains(p.Payload, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("tick 2: expected a pplim arg=15000 release publish, got %v",
+			payloadsAfter(mqtt, mark1))
+	}
+	checkMetricStuckPV(t, tel.FlushSamples(), "stuck_pv_recovery_count", 1)
+
+	// Tick 3: still stuck, but cooldown < STUCK_PV_RECOVERY_COOLDOWN_MS
+	// since the recovery. Must NOT re-publish.
+	mark3 := len(mqtt.Published())
+	pushStuckSSO()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-3: %v", err)
+	}
+	for _, p := range mqtt.Published()[mark3:] {
+		if strings.Contains(p.Payload, `"name":"pplim"`) {
+			t.Fatalf("tick 3: cooldown should prevent re-publish, got %q", p.Payload)
+		}
+	}
+
+	// Rewind another 6 min so we're past the cooldown (5 min) AND
+	// still well past STUCK_PV_AFTER_MS.
+	env.Start = env.Start.Add(-6 * time.Minute)
+	mark4 := len(mqtt.Published())
+	pushStuckSSO()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-4: %v", err)
+	}
+	found = false
+	for _, p := range mqtt.Published()[mark4:] {
+		if strings.Contains(p.Payload, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("tick 4: cooldown expired, expected a second pplim release publish")
+	}
+	checkMetricStuckPV(t, tel.FlushSamples(), "stuck_pv_recovery_count", 2)
+}
+
+// Without operator opt-in (`pplim_release_w` == 0) the watchdog must
+// only LOG the stuck condition, never publish a recovery payload —
+// because we have no safe value to send. (Per PR #367: `pplim arg=0`
+// is the very trap we're trying to recover from.)
+func TestFerroampStuckPVWatchdogNoPublishWithoutPplimReleaseW(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, env := newFerroampDriverWithConfigAndEnv(t, tel, mqtt, nil)
+
+	
+
+	push := func() {
+		mqtt.Push("extapi/data/sso",
+			`{"id":{"val":"PS00990-A04-S23091622"},`+
+				`"upv":{"val":"500.0"},"ipv":{"val":"0.0"},`+
+				`"relaystatus":{"val":"1"},"faultcode":{"val":"0"},`+
+				`"udc":{"val":"499.0"}}`)
+		mqtt.Push("extapi/data/ehub",
+			`{"pext":{"L1":-100,"L2":-100,"L3":-100},"ppv":{"val":300},`+
+				`"pbat":{"val":0},"gridfreq":{"val":50.0},`+
+				`"ul":{"L1":230,"L2":230,"L3":230},`+
+				`"iext":{"L1":-0.4,"L2":-0.4,"L3":-0.4}}`)
+	}
+
+	push()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-1: %v", err)
+	}
+	env.Start = env.Start.Add(-11 * time.Minute)
+	mark := len(mqtt.Published())
+	push()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-2: %v", err)
+	}
+	for _, p := range mqtt.Published()[mark:] {
+		if strings.Contains(p.Payload, `"name":"pplim"`) {
+			t.Fatalf("must not auto-publish pplim without operator pplim_release_w opt-in, got %q", p.Payload)
+		}
+	}
+	// Counter metric should still be emitted (at 0) so dashboards can
+	// distinguish "feature inactive" from "feature missing".
+	checkMetricStuckPV(t, tel.FlushSamples(), "stuck_pv_recovery_count", 0)
+}
+
+// When the stuck signature clears (ipv goes non-zero), the counter
+// stops advancing on subsequent polls — i.e. the detection logic
+// actually checks the live signal, not just elapsed time.
+func TestFerroampStuckPVWatchdogResetsWhenSignatureClears(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, env := newFerroampDriverWithConfigAndEnv(t, tel, mqtt, map[string]any{
+		"pplim_release_w": 15000,
+	})
+	
+
+	pushStuck := func() {
+		mqtt.Push("extapi/data/sso",
+			`{"id":{"val":"PS00990-A04-S23091622"},"upv":{"val":"500.0"},`+
+				`"ipv":{"val":"0.0"},"relaystatus":{"val":"1"},`+
+				`"faultcode":{"val":"0"},"udc":{"val":"499.0"}}`)
+		mqtt.Push("extapi/data/ehub",
+			`{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},`+
+				`"pbat":{"val":0},"gridfreq":{"val":50.0},`+
+				`"ul":{"L1":230,"L2":230,"L3":230},`+
+				`"iext":{"L1":0,"L2":0,"L3":0}}`)
+	}
+	pushHealthy := func() {
+		mqtt.Push("extapi/data/sso",
+			`{"id":{"val":"PS00990-A04-S23091622"},"upv":{"val":"480.0"},`+
+				`"ipv":{"val":"5.0"},"relaystatus":{"val":"1"},`+
+				`"faultcode":{"val":"0"},"udc":{"val":"478.0"}}`)
+		mqtt.Push("extapi/data/ehub",
+			`{"pext":{"L1":-100,"L2":-100,"L3":-100},"ppv":{"val":2400},`+
+				`"pbat":{"val":0},"gridfreq":{"val":50.0},`+
+				`"ul":{"L1":230,"L2":230,"L3":230},`+
+				`"iext":{"L1":-0.4,"L2":-0.4,"L3":-0.4}}`)
+	}
+
+	// Establish "stuck" + trigger one recovery so counter is at 1.
+	pushStuck()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-1: %v", err)
+	}
+	env.Start = env.Start.Add(-11 * time.Minute)
+	pushStuck()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-2: %v", err)
+	}
+	checkMetricStuckPV(t, tel.FlushSamples(), "stuck_pv_recovery_count", 1)
+
+	// Signature clears (PV recovered). Counter must NOT advance even
+	// after another long stretch — because stuck_pv_since_ms is reset.
+	env.Start = env.Start.Add(-20 * time.Minute)
+	pushHealthy()
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll-3: %v", err)
+	}
+	checkMetricStuckPV(t, tel.FlushSamples(), "stuck_pv_recovery_count", 1)
+}
+
+// payloadsAfter returns the publish payloads at indices >= mark in
+// the mqtt fake's Published log. Mirrors the helper in
+// lua_ferroamp_curtail_test.go (publishedSinceMark) but in a
+// MQTTMessage shape for easier diff-printing.
+func payloadsAfter(mqtt *fakeMQTT, mark int) []MQTTMessage {
+	pubs := mqtt.Published()
+	if mark >= len(pubs) {
+		return nil
+	}
+	out := make([]MQTTMessage, len(pubs)-mark)
+	copy(out, pubs[mark:])
+	return out
+}
+
+// checkMetricStuckPV asserts that `samples` contains at least one
+// MetricSample for `name` whose value equals `want` (most recent
+// wins). Local copy so this test file is independent of PR #372,
+// which lands the shared `checkMetric` helper in
+// lua_ferroamp_curtail_test.go.
+func checkMetricStuckPV(t *testing.T, samples []telemetry.MetricSample, name string, want float64) {
+	t.Helper()
+	var got float64
+	found := false
+	for _, s := range samples {
+		if s.Metric == name {
+			got = s.Value
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("metric %q not emitted in samples %+v", name, samples)
+	}
+	if got != want {
+		t.Errorf("metric %q = %v, want %v", name, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Third and final layer of defense against the 2026-05-27 Ferroamp brick. When the SSO reports the post-incident signature continuously for ten minutes, the driver auto-publishes `pplim arg=<pplim_release_w>` to release the lock.

| Layer | PR | Status |
|---|---|---|
| 1. Driver hard-fail on `pplim arg=0` | [#367](https://github.com/frahlg/forty-two-watts/pull/367) | ✅ Merged |
| 2. Dispatcher: no spurious release on \|PV\|=0 + NAK observability | [#372](https://github.com/frahlg/forty-two-watts/pull/372) | 🟡 Open |
| **3. Self-healing watchdog (this PR)** | **#373 (this)** | — |

Together: the brick scenario is both un-triggerable (1, 2) AND self-recoverable (3).

## Detection signature

All four must be true continuously for ≥ 10 minutes:
- `sso_pv_v > 200 V` (DC bus voltage = panels active = daylight)
- `sso_pv_a == 0 A` (no MPPT current)
- `sso_faultcode == 0` (no hardware fault)
- `sso_relaystatus == 1` (relay closed)

That's exactly the live signature from the 2026-05-27 incident: `upv=489.176 V, ipv=0.0 A, faultcode=0, relaystatus=1` while the inverter was bricked at pplim=0.

## State machine

```
not stuck → stuck (timer starts) → stuck for ≥ 10 min → recover (cooldown starts) → cooldown (5 min) → recover again if still stuck
                ↓ signature breaks at any point → not stuck (timer resets)
```

- `stuck_pv_since_ms`: latches on first stuck poll; cleared the moment the signature breaks (e.g. `ipv > 0`).
- `STUCK_PV_AFTER_MS = 10 min`: threshold before any recovery is eligible.
- `STUCK_PV_RECOVERY_COOLDOWN_MS = 5 min`: between successive recoveries — prevents command-spam if the release doesn't take.
- `stuck_pv_recovery_count`: cumulative counter emitted every poll. Ops dashboards alert on any non-zero rate.

## Operator opt-in

Reuses the existing `config.pplim_release_w` field — same value, dual purpose:
- Dispatcher's `curtail_disable` action publishes `pplim arg=<release_w>` when the slot ends.
- Watchdog publishes the same payload on stuck-signature detection.

Without `pplim_release_w` (default `0`), the watchdog only logs a per-incident warning — no MQTT publish, because we don't have a safe release value to send.

## Tests (`lua_ferroamp_stuck_pv_test.go`)

- `TestFerroampStuckPVWatchdogAutoPublishesRelease` — full cycle: detect → wait → recover → cooldown blocks → cooldown expires → recover again
- `TestFerroampStuckPVWatchdogNoPublishWithoutPplimReleaseW` — log-only path, no MQTT publish
- `TestFerroampStuckPVWatchdogResetsWhenSignatureClears` — `ipv > 0` cancels the stuck timer

Uses `env.Start.Add(-N * time.Minute)` to advance `host.millis()` without burning wall-clock — same pattern as `TestFerroampDriverStopsEmittingWhenMQTTStalls`.

## Out of scope

- Multi-SSO sites (per-SSO state tracking) — single-SSO cache is the current limitation; multi-SSO needs a separate refactor.
- Auto-recovery from non-sticky brick states (e.g. `faultcode != 0`). Those need operator attention regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)