### PR TITLE
feat(setup): catalog-driven driver classification + network-scan device fingerprinting

### DIFF
--- a/.changeset/driver-kind-via-catalog.md
+++ b/.changeset/driver-kind-via-catalog.md
@@ -1,0 +1,26 @@
+---
+"forty-two-watts": patch
+---
+
+main: classify EV / vehicle drivers via Lua DRIVER catalog instead of filename prefix sniffing
+
+`driverCapacitiesFrom` and `warnIfEVHasBatteryCapacity` previously fell back
+to a hard-coded filename-prefix allowlist (`easee`, `ocpp`, `ctek`,
+`chargestorm`, `tesla_vehicle`, `vehicle`) to decide whether a YAML driver
+entry pointed at an EV charger or vehicle telemetry source. That coupled
+the controller surface to vendor names and required code edits whenever a
+new EV-charger Lua driver was added.
+
+Each Lua driver already self-declares its kind via the `DRIVER = { …
+capabilities = { … } }` table at the top of the file. EV chargers
+declare `"ev"`; vehicle telemetry drivers declare `"vehicle"`. This PR
+adds `drivers.IsEVOrVehicleDriver(catalog, luaPath)` which consults that
+self-declaration, and routes both pre-flight call sites through it. The
+filename sniffer is deleted.
+
+The catalog is parsed once at startup (text scan, no Lua VM) and re-
+scanned on every config hot-reload so a hot-edited driver's capability
+change is picked up without a service restart.
+
+No new schema. No operator action required — every EV/vehicle driver
+that shipped with the repo already declares the right capability.

--- a/.changeset/scan-driver-fingerprint.md
+++ b/.changeset/scan-driver-fingerprint.md
@@ -1,0 +1,57 @@
+---
+"forty-two-watts": minor
+---
+
+setup: identify scanned network devices by driver fingerprint, with hostname + an "Other devices" group
+
+The setup wizard's network scan now tells you *what* each device is, not just
+that a port is open. After the port scan, every scan hit is run past the driver
+catalog: each driver whose declared protocol matches the open port gets to
+answer "is this me?" via a new read-only `driver_fingerprint()` Lua lifecycle
+function (read a known register / await a known MQTT topic). The first driver
+that matches claims the host and reports the capabilities it actually detected
+on *that* device.
+
+- **New Lua lifecycle hook** `driver_fingerprint()` — strictly read-only
+  (the probe path tears the VM down with a new `LuaDriver.Close()` that skips
+  `driver_cleanup`, so a driver's failsafe writes never fire against an
+  unidentified host on the LAN). Implemented for Ferroamp (MQTT),
+  Pixii (Modbus SunSpec-on-holding), and SolarEdge — including separating
+  modern HD-Wave (SunSpec on input registers) from K-series legacy (holding
+  only), and detecting whether a revenue meter is actually wired in so the
+  reported capabilities match the real install (`pv` vs `pv`+`meter`).
+- **New endpoint** `POST /api/scan/identify` — takes scan hits, fingerprints
+  each host against protocol-matching catalog drivers (parallel, bounded,
+  short per-driver timeout), returns the matched driver + capabilities, or
+  flags the host unidentified.
+- **Auto-detects battery nameplate capacity** where the device exposes it:
+  Pixii reports its SunSpec model-802 `WHRtg`, which the fingerprint returns and
+  the wizard pre-fills into the battery-capacity field (operator confirms).
+  (Ferroamp's extapi doesn't publish a nameplate figure, so it stays manual.)
+- **Scan now resolves hostnames** — unicast reverse DNS, falling back to a
+  reverse **mDNS** PTR query (most home-energy gear has no PTR record but does
+  answer mDNS), shown on a line under the IP. The setup table gains a
+  "Device & capabilities" column; identified devices are listed first, with two
+  actions — **Configure** (review in the wizard) and **Add** (one-click, using
+  the fingerprinted driver + detected settings; the row dims to "Added ✓" once
+  in the config). Hosts no driver can claim (including auth-gated devices) are
+  grouped under "Other devices", Configure-only.
+- **Scans routed LANs too**, not just interface-attached subnets: the scanner
+  reads the routing table (PF_ROUTE on darwin/BSD, `/proc/net/route` on Linux)
+  and adds any RFC1918 /24../28 networks it finds, so a second LAN reached via a
+  static route is swept automatically.
+- **Extra Modbus scan ports** 503 and 1502 — proxied inverters commonly sit
+  behind a TCP proxy here (a Pixii on 503, a SolarEdge via solaredge-proxy on
+  1502, which multiplexes the inverter's single Modbus socket).
+- SolarEdge fingerprinting is **holding-register only** (FC 0x03): that's the
+  standard SunSpec map and the only one a solaredge-proxy answers. The driver
+  never probes input registers during a scan — a timed-out FC 0x04 read wedges
+  such a proxy's upstream socket for seconds. The **right** SolarEdge driver is
+  picked from the SunSpec C_Model name (holding reg 40020): a K-series display
+  unit (SE7K/10K/17K/25K) → `solaredge_legacy` (FC 0x10 curtail), everything
+  else (e.g. an SE8K HD-Wave) → `solaredge_pv` (FC 0x06 curtail). The
+  input-register `solaredge.lua` (+meter) stays manual-pick — input can't be
+  safely probed.
+
+No operator action required; drivers without a `driver_fingerprint` simply fall
+into "Other devices" until one is added.

--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -421,6 +421,31 @@ function driver_init(config)
     host.log("info", "Ferroamp: set auto mode on init")
 end
 
+-- driver_fingerprint: READ-ONLY identity probe for the network-scan setup
+-- flow. The EnergyHub's extapi broker publishes telemetry on extapi/data/*
+-- roughly once a second entirely on its own, so we only subscribe (passive,
+-- no command publish) and wait briefly for a frame to arrive. A message on an
+-- extapi/data topic is conclusive: this broker is a Ferroamp EnergyHub.
+function driver_fingerprint()
+    host.mqtt_subscribe("extapi/data/ehub")
+    host.mqtt_subscribe("extapi/data/eso")
+    host.mqtt_subscribe("extapi/data/sso")
+    -- Poll for up to ~5 s in 500 ms slices. ehub alone fires ~1 Hz, so this
+    -- catches a live EnergyHub well within the scan's per-driver budget.
+    for _ = 1, 10 do
+        host.sleep(500)
+        local messages = host.mqtt_messages() or {}
+        for _, msg in ipairs(messages) do
+            if type(msg.topic) == "string"
+                and string.sub(msg.topic, 1, 12) == "extapi/data/" then
+                return { matched = true, make = "Ferroamp",
+                         capabilities = { "meter", "pv", "battery" } }
+            end
+        end
+    end
+    return { matched = false }
+end
+
 function driver_poll()
     local now = host.millis()
     local messages = host.mqtt_messages()

--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -107,6 +107,52 @@ function driver_init(config)
     end
 end
 
+-- driver_fingerprint: READ-ONLY identity probe for the network-scan setup
+-- flow. Pixii exposes the SunSpec map over Modbus HOLDING registers (FC 0x03),
+-- so we match on the "SunS" marker at 40000 plus a manufacturer string that
+-- contains "Pixii" in the SunSpec Common Model (40004, 16 regs ASCII). The
+-- manufacturer check is what separates a Pixii from a SolarEdge K-series unit,
+-- which also answers SunSpec on holding registers. No writes here — the
+-- heartbeat in driver_poll must never fire against an unidentified host.
+function driver_fingerprint()
+    local ok, sig = pcall(host.modbus_read, 40000, 2, "holding")
+    if not ok or not sig or decode_ascii(sig, 2) ~= "SunS" then
+        return { matched = false }
+    end
+    local mok, mregs = pcall(host.modbus_read, 40004, 16, "holding")
+    local mfr = (mok and mregs) and decode_ascii(mregs, 16) or ""
+    if not string.find(string.lower(mfr), "pixii", 1, true) then
+        return { matched = false }
+    end
+    local serial = ""
+    local sok, sregs = pcall(host.modbus_read, 40052, 16, "holding")
+    if sok and sregs then serial = decode_ascii(sregs, 16) end
+
+    -- Nameplate energy capacity from SunSpec battery base model 802:
+    -- WHRtg @ 40124 scaled by WHRtg_SF @ 40174. Verified against a live
+    -- PowerShaper (WHRtg=20480, SF=0 → 20480 Wh ≈ 20.5 kWh; cross-checks
+    -- AHRtg 4000 ×10^-1 = 400 Ah × ~51 V). 0xFFFF = "not implemented";
+    -- 0x8000 is the SunSpec not-implemented sentinel for a scale factor.
+    local cap_wh = nil
+    local wok, wregs = pcall(host.modbus_read, 40124, 1, "holding")
+    if wok and wregs and wregs[1] ~= 65535 then
+        local sf = 0
+        local sfok, sfreg = pcall(host.modbus_read, 40174, 1, "holding")
+        if sfok and sfreg and sfreg[1] ~= 32768 then
+            sf = host.decode_i16(sfreg[1])
+        end
+        cap_wh = wregs[1] * (10 ^ sf)
+    end
+
+    return {
+        matched             = true,
+        make                = "Pixii",
+        serial              = serial,
+        capabilities        = { "battery", "meter" },
+        battery_capacity_wh = cap_wh,
+    }
+end
+
 ----------------------------------------------------------------------------
 -- Telemetry polling
 ----------------------------------------------------------------------------

--- a/drivers/solaredge.lua
+++ b/drivers/solaredge.lua
@@ -206,6 +206,15 @@ function driver_init(config)
     end
 end
 
+-- NOTE: no driver_fingerprint here. This driver reads telemetry over INPUT
+-- registers (FC 0x04), but probing input to identify a device is unsafe: a
+-- SolarEdge reached through solaredge-proxy answers SunSpec on HOLDING only,
+-- and a timed-out input read wedges that proxy's single upstream socket for
+-- seconds (verified on an SE8K). The holding-based solaredge_legacy.lua owns
+-- SolarEdge fingerprinting for the scan flow — its holding map works on direct
+-- units too. Operators who specifically need this input-register variant can
+-- still pick it by hand in the wizard.
+
 function driver_poll()
     -- ---- Serial number (SunSpec common block, one-shot) ----
     if not sn_read then

--- a/drivers/solaredge_legacy.lua
+++ b/drivers/solaredge_legacy.lua
@@ -162,6 +162,57 @@ function driver_init(config)
     end
 end
 
+-- isKSeriesModel reports whether a SunSpec C_Model name is one of the K-series
+-- commercial display inverters this driver targets (SE7K / SE10K / SE17K /
+-- SE25K). The model name is read from the holding C_Model register (40020) and
+-- is what separates these legacy units from HD-Wave models like SE8K, which
+-- belong to solaredge_pv.lua / solaredge.lua.
+local function isKSeriesModel(model)
+    model = string.upper(model or "")
+    for _, m in ipairs({ "SE7K", "SE10K", "SE17K", "SE25K" }) do
+        if string.sub(model, 1, #m) == m then
+            return true
+        end
+    end
+    return false
+end
+
+-- driver_fingerprint: READ-ONLY identity probe for the network-scan setup flow.
+-- This driver is specifically for the K-series display inverters, so we match
+-- ONLY those — identified by the SunSpec C_Model name at holding register 40020.
+-- An HD-Wave (e.g. SE8K) returns matched=false here and is claimed by
+-- solaredge_pv.lua instead. We read holding only (FC 0x03): SolarEdge serves
+-- SunSpec there directly and through solaredge-proxy, and a stray FC 0x04
+-- (input) read wedges such a proxy's single upstream socket on timeout.
+function driver_fingerprint()
+    local hok, hregs = pcall(host.modbus_read, 40000, 2, "holding")
+    if not hok or not hregs or decode_ascii(hregs, 2) ~= "SunS" then
+        return { matched = false }
+    end
+    local mok, mregs = pcall(host.modbus_read, 40004, 16, "holding")
+    local mfr = (mok and mregs) and decode_ascii(mregs, 16) or ""
+    if not string.find(string.lower(mfr), "solaredge", 1, true) then
+        return { matched = false }
+    end
+    local model = ""
+    local dok, dregs = pcall(host.modbus_read, 40020, 16, "holding")
+    if dok and dregs then model = decode_ascii(dregs, 16) end
+    if not isKSeriesModel(model) then
+        return { matched = false } -- HD-Wave etc. → solaredge_pv.lua
+    end
+    local serial = ""
+    local sok, sregs = pcall(host.modbus_read, 40052, 16, "holding")
+    if sok and sregs then serial = decode_ascii(sregs, 16) end
+
+    return {
+        matched      = true,
+        make         = "SolarEdge",
+        model        = model,
+        serial       = serial,
+        capabilities = { "pv", "pv-curtail" },
+    }
+end
+
 -- One-shot SunSpec ID probe. SunSpec-compliant devices place the magic
 -- bytes "SunS" (0x53756e53) at registers 40000-40001. Without them, the
 -- rest of the register map we trust is meaningless — the inverter is

--- a/drivers/solaredge_pv.lua
+++ b/drivers/solaredge_pv.lua
@@ -140,6 +140,55 @@ function driver_init(config)
     end
 end
 
+-- K-series commercial display inverters (SE7K / SE10K / SE17K / SE25K) use a
+-- different curtail dialect (FC 0x10 multi-write) and are owned by
+-- solaredge_legacy.lua. Every other SolarEdge that speaks SunSpec on holding is
+-- HD-Wave / StorEdge generation → this driver.
+local function is_kseries_model(model)
+    model = string.upper(model or "")
+    for _, m in ipairs({ "SE7K", "SE10K", "SE17K", "SE25K" }) do
+        if string.sub(model, 1, #m) == m then
+            return true
+        end
+    end
+    return false
+end
+
+-- driver_fingerprint: READ-ONLY identity probe for the network-scan flow, and
+-- the SolarEdge driver-selection logic. SolarEdge serves SunSpec on HOLDING
+-- registers (FC 0x03) — directly and through solaredge-proxy — so we never
+-- touch input (FC 0x04), which wedges a proxy's single upstream socket on a
+-- timeout. The model name at the SunSpec Common-block C_Model register (40020)
+-- is the holding register that decides the driver: a K-series display unit
+-- defers to solaredge_legacy.lua; anything else (e.g. an SE8K HD-Wave) is ours.
+function driver_fingerprint()
+    local hok, hregs = pcall(host.modbus_read, 40000, 2, "holding")
+    if not hok or not hregs or decode_ascii(hregs, 2) ~= "SunS" then
+        return { matched = false }
+    end
+    local mok, mregs = pcall(host.modbus_read, 40004, 16, "holding")
+    local mfr = (mok and mregs) and decode_ascii(mregs, 16) or ""
+    if not string.find(string.lower(mfr), "solaredge", 1, true) then
+        return { matched = false }
+    end
+    local model = ""
+    local dok, dregs = pcall(host.modbus_read, 40020, 16, "holding")
+    if dok and dregs then model = decode_ascii(dregs, 16) end
+    if is_kseries_model(model) then
+        return { matched = false } -- K-series → solaredge_legacy.lua
+    end
+    local serial = ""
+    local sok, sregs = pcall(host.modbus_read, 40052, 16, "holding")
+    if sok and sregs then serial = decode_ascii(sregs, 16) end
+    return {
+        matched      = true,
+        make         = "SolarEdge",
+        model        = model,
+        serial       = serial,
+        capabilities = { "pv", "pv-curtail" },
+    }
+end
+
 function driver_poll()
     -- ---- Serial number (SunSpec common block, one-shot) ----
     if not sn_read then

--- a/go/cmd/forty-two-watts/capacities_test.go
+++ b/go/cmd/forty-two-watts/capacities_test.go
@@ -4,7 +4,27 @@ import (
 	"testing"
 
 	"github.com/frahlg/forty-two-watts/go/internal/config"
+	"github.com/frahlg/forty-two-watts/go/internal/drivers"
 )
+
+// evCatalog returns a fixture catalog that mirrors the production
+// drivers/ directory's self-declarations: EV chargers expose "ev",
+// the Tesla vehicle driver exposes "vehicle", everything else
+// declares site capabilities. Used by tests below in place of an on-
+// disk scan.
+func evCatalog() []drivers.CatalogEntry {
+	return []drivers.CatalogEntry{
+		{Path: "drivers/ferroamp.lua", Filename: "ferroamp.lua", Capabilities: []string{"meter", "pv", "battery"}},
+		{Path: "drivers/sungrow.lua", Filename: "sungrow.lua", Capabilities: []string{"pv", "battery"}},
+		{Path: "drivers/easee_cloud.lua", Filename: "easee_cloud.lua", Capabilities: []string{"ev"}},
+		{Path: "drivers/ctek_hybrid.lua", Filename: "ctek_hybrid.lua", Capabilities: []string{"ev"}},
+		{Path: "drivers/tesla_vehicle.lua", Filename: "tesla_vehicle.lua", Capabilities: []string{"vehicle"}},
+		{Path: "drivers/zap.lua", Filename: "zap.lua", Capabilities: []string{"meter", "pv"}},
+		{Path: "drivers/p1meter.lua", Filename: "p1meter.lua", Capabilities: []string{"meter"}},
+		{Path: "drivers/huawei_battery.lua", Filename: "huawei_battery.lua", Capabilities: []string{"battery"}},
+		{Path: "drivers/sim_ev.lua", Filename: "sim_ev.lua", Capabilities: []string{"meter"}},
+	}
+}
 
 // TestDriverCapacitiesFromExcludesEV is the regression test for the
 // bug where an Easee cloud driver's YAML entry with
@@ -20,7 +40,7 @@ func TestDriverCapacitiesFromExcludesEV(t *testing.T) {
 	loadpoints := []config.Loadpoint{
 		{ID: "garage", DriverName: "easee"},
 	}
-	got := driverCapacitiesFrom(drivers, loadpoints)
+	got := driverCapacitiesFrom(drivers, loadpoints, evCatalog())
 	if _, ok := got["easee"]; ok {
 		t.Errorf("easee should be filtered out; got %v", got)
 	}
@@ -40,7 +60,7 @@ func TestDriverCapacitiesFromNoLoadpointsBehavesAsBefore(t *testing.T) {
 		{Name: "ferroamp", BatteryCapacityWh: 15200},
 		{Name: "meter", BatteryCapacityWh: 0},
 	}
-	got := driverCapacitiesFrom(drivers, nil)
+	got := driverCapacitiesFrom(drivers, nil, evCatalog())
 	if got["ferroamp"] != 15200 {
 		t.Errorf("lost ferroamp: %v", got)
 	}
@@ -59,7 +79,7 @@ func TestDriverCapacitiesFromMultipleLoadpoints(t *testing.T) {
 		{ID: "garage", DriverName: "easee"},
 		{ID: "street", DriverName: "zap"},
 	}
-	got := driverCapacitiesFrom(drivers, loadpoints)
+	got := driverCapacitiesFrom(drivers, loadpoints, evCatalog())
 	if len(got) != 1 || got["ferroamp"] != 15200 {
 		t.Errorf("expected only ferroamp, got %v", got)
 	}
@@ -79,19 +99,19 @@ func TestBuildLoadpointConfigsPreservesSurplusOnly(t *testing.T) {
 	}
 }
 
-// TestDriverCapacitiesFromLuaFilenameFallback covers the case where
-// an operator has not (yet) migrated to a `loadpoints:` config block
-// but still has an EV driver with a vehicle-sized `battery_capacity_wh`.
+// TestDriverCapacitiesFromCatalogFallback covers the case where an
+// operator has not (yet) migrated to a `loadpoints:` config block but
+// still has an EV driver with a vehicle-sized `battery_capacity_wh`.
 // On Fredrik's Pi there are no loadpoints, yet the easee driver's
-// 75000 Wh was inflating the MPC pool. Filename-based detection is
-// the safety net.
-func TestDriverCapacitiesFromLuaFilenameFallback(t *testing.T) {
+// 75000 Wh was inflating the MPC pool. The driver catalog's
+// self-declared "ev" capability is the safety net.
+func TestDriverCapacitiesFromCatalogFallback(t *testing.T) {
 	drivers := []config.Driver{
 		{Name: "ferroamp", Lua: "drivers/ferroamp.lua", BatteryCapacityWh: 15200},
 		{Name: "sungrow", Lua: "drivers/sungrow.lua", BatteryCapacityWh: 9600},
 		{Name: "easee", Lua: "drivers/easee_cloud.lua", BatteryCapacityWh: 75000},
 	}
-	got := driverCapacitiesFrom(drivers, nil)
+	got := driverCapacitiesFrom(drivers, nil, evCatalog())
 	if _, ok := got["easee"]; ok {
 		t.Errorf("easee should be filtered out by filename fallback; got %v", got)
 	}
@@ -121,7 +141,7 @@ func TestDriverCapacitiesFromIgnoresInvalidLoadpoints(t *testing.T) {
 	loadpoints := []config.Loadpoint{
 		{ID: "", DriverName: "ferroamp"},
 	}
-	got := driverCapacitiesFrom(drivers, loadpoints)
+	got := driverCapacitiesFrom(drivers, loadpoints, evCatalog())
 	if got["ferroamp"] != 15200 {
 		t.Errorf("ferroamp dropped by invalid loadpoint row: %v", got)
 	}
@@ -130,33 +150,48 @@ func TestDriverCapacitiesFromIgnoresInvalidLoadpoints(t *testing.T) {
 	}
 }
 
-func TestIsLikelyEVDriver(t *testing.T) {
+// TestIsEVOrVehicleDriverByCapabilities exercises the catalog-backed
+// classifier that replaced the filename sniffer. The contract: a
+// driver counts as "EV or vehicle" iff its Lua DRIVER block self-
+// declares the corresponding capability, regardless of filename or
+// vendor name. Drivers absent from the catalog are conservatively
+// classified as non-EV (so a missing entry never silently excludes a
+// real battery from the MPC pool).
+func TestIsEVOrVehicleDriverByCapabilities(t *testing.T) {
+	cat := evCatalog()
 	cases := []struct {
 		in   string
 		want bool
 	}{
-		// EV chargers — should match.
+		// EV chargers — match via capability, not filename.
 		{"drivers/easee_cloud.lua", true},
-		{"drivers/easee.lua", true},
-		{"drivers/ocpp_cp.lua", true},
-		{"drivers/ocpp_csms.lua", true},
-		{"drivers/ctek.lua", true},
-		{"drivers/ctek_mqtt.lua", true},
-		{"drivers/chargestorm.lua", true},
-		{"/abs/path/to/drivers/EASEE.LUA", true}, // case-insensitive
-		// Batteries / inverters / meters — must NOT match.
+		{"drivers/ctek_hybrid.lua", true},
+		// Vehicle telemetry — match via capability.
+		{"drivers/tesla_vehicle.lua", true},
+		// Stationary site assets — must NOT match.
 		{"drivers/ferroamp.lua", false},
 		{"drivers/sungrow.lua", false},
 		{"drivers/p1meter.lua", false},
 		{"drivers/huawei_battery.lua", false},
-		{"drivers/sim_ev.lua", false}, // "ev" substring not a prefix
-		// Degenerate inputs.
+		{"drivers/zap.lua", false}, // declares meter+pv, not ev
+		// A filename that LOOKS EV-ish but the driver self-declares
+		// otherwise — the previous filename-prefix heuristic would
+		// have over-matched anything starting with "sim_ev", and the
+		// allowlist-style sniffer was the workaround. Capability-based
+		// classification has no such hazard.
+		{"drivers/sim_ev.lua", false},
+		// Drivers missing from the catalog (third-party plugin not
+		// yet scanned) are conservatively NOT classified as EV.
+		{"drivers/unknown.lua", false},
+		// Bare filename works as well — operators reference drivers
+		// either way in YAML.
+		{"easee_cloud.lua", true},
+		// Degenerate input.
 		{"", false},
-		{"easee_cloud.lua", true}, // bare filename also supported
 	}
 	for _, c := range cases {
-		if got := isLikelyEVDriver(c.in); got != c.want {
-			t.Errorf("isLikelyEVDriver(%q) = %v, want %v", c.in, got, c.want)
+		if got := drivers.IsEVOrVehicleDriver(cat, c.in); got != c.want {
+			t.Errorf("IsEVOrVehicleDriver(%q) = %v, want %v", c.in, got, c.want)
 		}
 	}
 }

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -215,11 +215,23 @@ func main() {
 		}
 	}
 
+	// ---- Driver catalog (pure text scan, no Lua VM) ----
+	// Loaded once here so the pre-flight capacity + warning logic can
+	// ask the catalog "is this driver an EV charger / vehicle source?"
+	// rather than sniffing filenames. The Lua DRIVER table's
+	// capabilities list is the driver's self-declaration.
+	driverCatalog, catErr := drivers.LoadCatalogMulti(*userDriversDirFlag, resolveDriverDir())
+	if catErr != nil {
+		slog.Warn("driver catalog load failed; EV-driver classification will be conservative",
+			"err", catErr)
+		driverCatalog = nil
+	}
+
 	// ---- Driver capacities (site, for control + fuse guard) ----
 	// Loadpoint drivers are filtered out — their battery_capacity_wh
 	// is vehicle capacity, not site-battery capacity.
-	capacities := driverCapacitiesFrom(cfg.Drivers, cfg.Loadpoints)
-	warnIfEVHasBatteryCapacity(cfg.Drivers, cfg.Loadpoints)
+	capacities := driverCapacitiesFrom(cfg.Drivers, cfg.Loadpoints, driverCatalog)
+	warnIfEVHasBatteryCapacity(cfg.Drivers, cfg.Loadpoints, driverCatalog)
 
 	// ---- Battery models — restore from SQLite + ensure one per driver ----
 	models := make(map[string]*battery.Model)
@@ -445,7 +457,11 @@ func main() {
 			for k := range capacities {
 				delete(capacities, k)
 			}
-			for k, v := range driverCapacitiesFrom(newCfg.Drivers, newCfg.Loadpoints) {
+			// Re-scan the catalog so a hot-edited Lua driver's
+			// capability change is picked up by the EV-classification
+			// filter on the very next reload tick.
+			reloadCatalog, _ := drivers.LoadCatalogMulti(*userDriversDirFlag, resolveDriverDir())
+			for k, v := range driverCapacitiesFrom(newCfg.Drivers, newCfg.Loadpoints, reloadCatalog) {
 				capacities[k] = v
 			}
 			capMu.Unlock()
@@ -2255,7 +2271,7 @@ func driversToDefaultOnSiteMeterStale(names []string, siteMeterDriver string) []
 // Filtering here rather than at config-parse time means the vehicle
 // capacity is still available for EV-side logic (loadpoint manager)
 // without a schema migration.
-func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint) map[string]float64 {
+func driverCapacitiesFrom(drvList []config.Driver, loadpoints []config.Loadpoint, catalog []drivers.CatalogEntry) map[string]float64 {
 	evDrivers := make(map[string]struct{}, len(loadpoints))
 	for _, lp := range loadpoints {
 		// Only treat a loadpoint row as authoritative when it's
@@ -2269,8 +2285,8 @@ func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint
 		}
 		evDrivers[lp.DriverName] = struct{}{}
 	}
-	out := make(map[string]float64, len(drivers))
-	for _, d := range drivers {
+	out := make(map[string]float64, len(drvList))
+	for _, d := range drvList {
 		if d.BatteryCapacityWh <= 0 {
 			continue
 		}
@@ -2279,13 +2295,13 @@ func driverCapacitiesFrom(drivers []config.Driver, loadpoints []config.Loadpoint
 			// (Value remains in cfg.Drivers for any driver-side use.)
 			continue
 		}
-		// Fallback detection: operators who haven't migrated to a
-		// `loadpoints:` config block still have EV drivers with
-		// `battery_capacity_wh` pointing at vehicle capacity. Match
-		// on Lua filename prefix — narrow allowlist of known EV
-		// charger drivers so we don't accidentally exclude a battery
-		// driver whose name happens to share a substring.
-		if isLikelyEVDriver(d.Lua) {
+		// Fallback detection for operators who haven't migrated to a
+		// `loadpoints:` config block: ask the catalog whether the
+		// driver self-declares an EV or vehicle capability. Source of
+		// truth is the Lua DRIVER table; Go matches on what the
+		// driver says it is, not what its filename happens to look
+		// like.
+		if drivers.IsEVOrVehicleDriver(catalog, d.Lua) {
 			continue
 		}
 		out[d.Name] = d.BatteryCapacityWh
@@ -2361,41 +2377,17 @@ func supportsPVCurtailFrom(drivers []config.Driver) map[string]bool {
 	return out
 }
 
-// isLikelyEVDriver classifies a Lua path as pointing at an EV charger
-// driver based on the filename prefix. Kept narrow + allowlist-style —
-// a battery driver named "easy_battery.lua" would be wrongly excluded
-// by a broader regex, so we only match EV chargers we actually ship.
-func isLikelyEVDriver(luaPath string) bool {
-	if luaPath == "" {
-		return false
-	}
-	base := strings.ToLower(luaPath)
-	if i := strings.LastIndex(base, "/"); i >= 0 {
-		base = base[i+1:]
-	}
-	base = strings.TrimSuffix(base, ".lua")
-	for _, p := range []string{
-		"easee",         // easee_cloud.lua, easee.lua
-		"ocpp",          // ocpp_cp.lua, ocpp_csms.lua
-		"ctek",          // ctek.lua, ctek_mqtt.lua, ctek_v2.lua
-		"chargestorm",   // CTEK Chargestorm variants
-		"tesla_vehicle", // tesla_vehicle.lua — DerVehicle emitter (BLE proxy)
-		"vehicle",       // generic vehicle drivers — anything emitting DerVehicle should NOT be counted as a stationary battery
-	} {
-		if strings.HasPrefix(base, p) {
-			return true
-		}
-	}
-	return false
-}
-
 // warnIfEVHasBatteryCapacity surfaces operator mis-config where an EV
 // driver's YAML entry still carries battery_capacity_wh. The value is
 // now ignored for MPC battery-pool purposes, but we log at WARN so the
 // operator moves it to the loadpoint's vehicle_capacity_wh (where it
 // serves the DP's EV SoC inference) rather than leaving it as a
 // silent no-op.
-func warnIfEVHasBatteryCapacity(drivers []config.Driver, loadpoints []config.Loadpoint) {
+//
+// catalog is the parsed driver catalog (Lua DRIVER tables); the
+// detection consults it for self-declared "ev" / "vehicle" capability
+// rather than sniffing filenames or vendor names.
+func warnIfEVHasBatteryCapacity(drvList []config.Driver, loadpoints []config.Loadpoint, catalog []drivers.CatalogEntry) {
 	evDrivers := make(map[string]struct{}, len(loadpoints))
 	for _, lp := range loadpoints {
 		if lp.ID == "" || lp.DriverName == "" {
@@ -2403,18 +2395,18 @@ func warnIfEVHasBatteryCapacity(drivers []config.Driver, loadpoints []config.Loa
 		}
 		evDrivers[lp.DriverName] = struct{}{}
 	}
-	for _, d := range drivers {
+	for _, d := range drvList {
 		if d.BatteryCapacityWh <= 0 {
 			continue
 		}
 		_, isEVByLoadpoint := evDrivers[d.Name]
-		isEVByFilename := isLikelyEVDriver(d.Lua)
-		if !isEVByLoadpoint && !isEVByFilename {
+		isEVByCatalog := drivers.IsEVOrVehicleDriver(catalog, d.Lua)
+		if !isEVByLoadpoint && !isEVByCatalog {
 			continue
 		}
 		reason := "driver is referenced by a loadpoint"
-		if !isEVByLoadpoint && isEVByFilename {
-			reason = "driver's Lua filename matches a known EV charger"
+		if !isEVByLoadpoint && isEVByCatalog {
+			reason = "driver self-declares ev/vehicle capability in its Lua DRIVER table"
 		}
 		slog.Warn(reason+" — battery_capacity_wh is being ignored for MPC "+
 			"battery-pool sizing. Move the value to "+

--- a/go/go.mod
+++ b/go/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/simonvetter/modbus v1.6.4
 	github.com/yuin/gopher-lua v1.1.2
+	golang.org/x/net v0.54.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.2
 )
@@ -74,7 +75,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -310,6 +310,7 @@ func (s *Server) routes() {
 	s.handle("GET  /api/series/catalog", s.handleSeriesCatalog)
 	s.handle("GET  /api/devices", s.handleDevices)
 	s.handle("GET  /api/scan", s.handleScan)
+	s.handle("POST /api/scan/identify", s.handleScanIdentify)
 	s.handle("GET  /api/ev/status", s.handleEVStatus)
 	s.handle("POST /api/ev/command", s.handleEVCommand)
 	s.handle("POST /api/ev/chargers", s.handleEVChargers)

--- a/go/internal/api/api_scan_identify.go
+++ b/go/internal/api/api_scan_identify.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+	"github.com/frahlg/forty-two-watts/go/internal/drivers"
+	"github.com/frahlg/forty-two-watts/go/internal/scanner"
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// identifyDriver is the matched driver an identified host was claimed by.
+type identifyDriver struct {
+	ID           string   `json:"id,omitempty"`
+	Name         string   `json:"name"`
+	Manufacturer string   `json:"manufacturer,omitempty"`
+	LuaPath      string   `json:"lua_path"`
+	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+// identifiedDevice is one scanned host plus whatever driver claimed it. When
+// Identified is false the host goes into the UI's "Other devices" group.
+type identifiedDevice struct {
+	scanner.FoundDevice
+	Identified        bool            `json:"identified"`
+	Driver            *identifyDriver `json:"driver,omitempty"`
+	Make              string          `json:"make,omitempty"`
+	Model             string          `json:"model,omitempty"`
+	Serial            string          `json:"serial,omitempty"`
+	BatteryCapacityWh float64         `json:"battery_capacity_wh,omitempty"`
+}
+
+// handleScanIdentify: POST /api/scan/identify
+//
+// Body: a JSON array of scan hits, or {"devices":[...]}, each {ip, port,
+// protocol, hostname}. For every host we ask each catalog driver whose
+// declared protocol matches "is this you?" via its read-only
+// driver_fingerprint. The first driver that matches claims the host and
+// reports the capabilities it actually detected on that specific device
+// (e.g. a SolarEdge with vs without a revenue meter). Hosts no driver can
+// identify — including ones behind auth — come back with identified=false so
+// the UI can still surface them under "Other devices".
+func (s *Server) handleScanIdentify(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Registry == nil {
+		writeJSON(w, 503, map[string]string{"error": "driver registry unavailable"})
+		return
+	}
+
+	// Accept either a bare array or {"devices":[...]} — read the body once and
+	// try the wrapper first, then the bare array.
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB cap
+	if err != nil {
+		writeJSON(w, 400, map[string]string{"error": "read body: " + err.Error()})
+		return
+	}
+	var devices []scanner.FoundDevice
+	var wrapped struct {
+		Devices []scanner.FoundDevice `json:"devices"`
+	}
+	if json.Unmarshal(body, &wrapped) == nil && len(wrapped.Devices) > 0 {
+		devices = wrapped.Devices
+	} else if err := json.Unmarshal(body, &devices); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "expected a devices array"})
+		return
+	}
+	if len(devices) == 0 {
+		writeJSON(w, 200, map[string]any{"devices": []identifiedDevice{}})
+		return
+	}
+
+	dir := s.deps.DriverDir
+	if dir == "" {
+		dir = "drivers"
+	}
+	catalog, err := drivers.LoadCatalogMulti(s.deps.UserDriverDir, dir)
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": "load catalog: " + err.Error()})
+		return
+	}
+
+	baseDir := "."
+	if s.deps.ConfigPath != "" {
+		baseDir = filepath.Dir(s.deps.ConfigPath)
+	}
+
+	// One probe registry shared across all fingerprints — Registry.Fingerprint
+	// never registers into the run map, so concurrent calls are independent.
+	tel := telemetry.NewStore()
+	reg := drivers.NewRegistry(tel)
+	reg.MQTTFactory = s.deps.DriverMQTTFactory
+	reg.ModbusFactory = s.deps.DriverModbusFactory
+	reg.ARPLookup = s.deps.DriverARPLookup
+
+	out := make([]identifiedDevice, len(devices))
+	sem := make(chan struct{}, 8) // bound concurrent host probes
+	var wg sync.WaitGroup
+	for i, dev := range devices {
+		wg.Add(1)
+		go func(i int, dev scanner.FoundDevice) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			out[i] = s.identifyOne(r.Context(), reg, catalog, baseDir, dev)
+		}(i, dev)
+	}
+	wg.Wait()
+
+	writeJSON(w, 200, map[string]any{"devices": out})
+}
+
+// identifyOne probes a single host against every protocol-matching catalog
+// driver and returns the first match (or an unidentified result).
+func (s *Server) identifyOne(ctx context.Context, reg *drivers.Registry, catalog []drivers.CatalogEntry, baseDir string, dev scanner.FoundDevice) identifiedDevice {
+	res := identifiedDevice{FoundDevice: dev}
+	for _, entry := range catalog {
+		if !protocolMatches(entry.Protocols, dev.Protocol) {
+			continue
+		}
+		cfg, ok := probeConfigFor(entry, dev, baseDir)
+		if !ok {
+			continue
+		}
+		// Per-candidate budget: MQTT fingerprints wait a few seconds for a
+		// telemetry frame; Modbus ones return in well under a second.
+		fpCtx, cancel := context.WithTimeout(ctx, 7*time.Second)
+		fp, err := reg.Fingerprint(fpCtx, cfg)
+		cancel()
+		if err != nil || !fp.Matched {
+			continue
+		}
+
+		caps := fp.Capabilities
+		if len(caps) == 0 {
+			caps = entry.Capabilities // fall back to the driver's static catalog caps
+		}
+		res.Identified = true
+		res.Make = fp.Make
+		res.Model = fp.Model
+		res.Serial = fp.Serial
+		res.BatteryCapacityWh = fp.BatteryCapacityWh
+		res.Driver = &identifyDriver{
+			ID:           entry.ID,
+			Name:         entry.Name,
+			Manufacturer: entry.Manufacturer,
+			LuaPath:      entry.Path,
+			Capabilities: caps,
+		}
+		return res
+	}
+	return res
+}
+
+// protocolMatches reports whether the catalog entry speaks the scanned port's
+// protocol. An entry with no declared protocols matches nothing (we can't
+// point it anywhere meaningful).
+func protocolMatches(entryProtocols []string, proto string) bool {
+	for _, p := range entryProtocols {
+		if strings.EqualFold(p, proto) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeConfigFor builds a throwaway driver config aimed at one scanned host
+// for the given catalog entry. Returns ok=false for protocols we can't wire a
+// probe transport for (the driver simply won't be tried).
+func probeConfigFor(entry drivers.CatalogEntry, dev scanner.FoundDevice, baseDir string) (config.Driver, bool) {
+	cfg := config.Driver{
+		Name: "__id_" + safeProbeName(entry.Filename) + "_" + strconv.Itoa(dev.Port),
+		Lua:  entry.Path,
+	}
+	switch strings.ToLower(dev.Protocol) {
+	case "modbus":
+		port := dev.Port
+		if port == 0 {
+			port = 502
+		}
+		unit := 1
+		if u, ok := connDefaultInt(entry.ConnectionDefaults, "unit_id"); ok && u > 0 {
+			unit = u
+		}
+		cfg.Capabilities.Modbus = &config.ModbusConfig{Host: dev.IP, Port: port, UnitID: unit}
+	case "mqtt":
+		port := dev.Port
+		if port == 0 {
+			port = 1883
+		}
+		cfg.Capabilities.MQTT = &config.MQTTConfig{Host: dev.IP, Port: port}
+	default:
+		// http / tcp / websocket fingerprints aren't wired yet — those
+		// drivers have no driver_fingerprint, so there's nothing to probe.
+		return config.Driver{}, false
+	}
+
+	resolved := config.Config{Drivers: []config.Driver{cfg}}
+	resolved.ResolveDriverPaths(baseDir)
+	return resolved.Drivers[0], true
+}
+
+// connDefaultInt pulls an int out of a catalog entry's connection_defaults map,
+// tolerating the int64/float64/int the lightweight catalog parser may produce.
+func connDefaultInt(m map[string]any, key string) (int, bool) {
+	v, ok := m[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/go/internal/api/api_scan_identify_test.go
+++ b/go/internal/api/api_scan_identify_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/drivers"
+	"github.com/frahlg/forty-two-watts/go/internal/scanner"
+)
+
+func TestProtocolMatches(t *testing.T) {
+	cases := []struct {
+		protos []string
+		proto  string
+		want   bool
+	}{
+		{[]string{"modbus"}, "modbus", true},
+		{[]string{"modbus", "mqtt"}, "MQTT", true}, // case-insensitive
+		{[]string{"http"}, "modbus", false},
+		{nil, "modbus", false}, // no declared protocols matches nothing
+	}
+	for _, c := range cases {
+		if got := protocolMatches(c.protos, c.proto); got != c.want {
+			t.Errorf("protocolMatches(%v, %q) = %v, want %v", c.protos, c.proto, got, c.want)
+		}
+	}
+}
+
+func TestConnDefaultInt(t *testing.T) {
+	m := map[string]any{"unit_id": int64(3), "f": float64(5), "i": 7, "s": "x"}
+	for _, c := range []struct {
+		key  string
+		want int
+		ok   bool
+	}{
+		{"unit_id", 3, true},
+		{"f", 5, true},
+		{"i", 7, true},
+		{"s", 0, false}, // strings aren't ints
+		{"missing", 0, false},
+	} {
+		got, ok := connDefaultInt(m, c.key)
+		if got != c.want || ok != c.ok {
+			t.Errorf("connDefaultInt(%q) = (%d,%v), want (%d,%v)", c.key, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestProbeConfigFor(t *testing.T) {
+	dev := scanner.FoundDevice{IP: "192.168.1.15", Port: 503, Protocol: "modbus"}
+	entry := drivers.CatalogEntry{
+		Path:               "drivers/pixii.lua",
+		Filename:           "pixii.lua",
+		Protocols:          []string{"modbus"},
+		ConnectionDefaults: map[string]any{"unit_id": int64(2)},
+	}
+	cfg, ok := probeConfigFor(entry, dev, ".")
+	if !ok {
+		t.Fatal("probeConfigFor returned ok=false for a modbus device")
+	}
+	mb := cfg.EffectiveModbus()
+	if mb == nil {
+		t.Fatal("expected a Modbus capability")
+	}
+	if mb.Host != "192.168.1.15" || mb.Port != 503 || mb.UnitID != 2 {
+		t.Errorf("modbus cfg = %+v, want host .15 port 503 unit 2", mb)
+	}
+
+	// MQTT device gets an MQTT capability with the default port filled in.
+	mq := scanner.FoundDevice{IP: "10.0.0.5", Port: 0, Protocol: "mqtt"}
+	cfg, ok = probeConfigFor(drivers.CatalogEntry{Path: "drivers/ferroamp.lua", Protocols: []string{"mqtt"}}, mq, ".")
+	if !ok || cfg.EffectiveMQTT() == nil || cfg.EffectiveMQTT().Port != 1883 {
+		t.Errorf("mqtt probe cfg = %+v ok=%v, want mqtt port 1883", cfg.EffectiveMQTT(), ok)
+	}
+
+	// http/other protocols have no wired probe transport yet.
+	if _, ok := probeConfigFor(drivers.CatalogEntry{Path: "drivers/x.lua", Protocols: []string{"http"}},
+		scanner.FoundDevice{IP: "10.0.0.6", Port: 80, Protocol: "http"}, "."); ok {
+		t.Error("probeConfigFor should return ok=false for http (no fingerprint transport)")
+	}
+}

--- a/go/internal/drivers/catalog.go
+++ b/go/internal/drivers/catalog.go
@@ -152,6 +152,39 @@ func parseCatalogEntry(path string) (CatalogEntry, error) {
 	return e, nil
 }
 
+// IsEVOrVehicleDriver reports whether the driver at luaPath is an EV
+// charger (capabilities contains "ev") or a vehicle telemetry source
+// (capabilities contains "vehicle"). Returns false when the driver
+// isn't in the catalog or declares neither.
+//
+// The match is by the catalog entry's portable Path (relative to
+// drivers/) first, then by Filename — operators reference drivers
+// either way in YAML and both forms must work.
+//
+// This is the source of truth for "is this a non-stationary-battery
+// driver" decisions in main.go (battery-pool capacity exclusion +
+// operator-warning routing). The Lua DRIVER table's capabilities list
+// is the driver's self-declaration; nothing in Go should match on
+// filenames or vendor names directly.
+func IsEVOrVehicleDriver(catalog []CatalogEntry, luaPath string) bool {
+	if luaPath == "" {
+		return false
+	}
+	wantPath := filepath.ToSlash(luaPath)
+	wantFilename := filepath.Base(wantPath)
+	for _, e := range catalog {
+		if e.Path == wantPath || e.Filename == wantFilename {
+			for _, c := range e.Capabilities {
+				if c == "ev" || c == "vehicle" {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return false
+}
+
 // normalizeVerificationStatus coerces the Lua string into one of the
 // three canonical values the UI renders badges for. Anything else
 // (blank, typo, unknown) falls back to "experimental" — the safest

--- a/go/internal/drivers/fingerprint_drivers_test.go
+++ b/go/internal/drivers/fingerprint_drivers_test.go
@@ -1,0 +1,247 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// fpModbus is a fake SunSpec-ish Modbus device for fingerprint tests. It
+// answers reads only on answerFC (others "time out", mirroring how a
+// SolarEdge K-series ignores FC 0x04), and fails the test if a driver's
+// fingerprint ever issues a write — fingerprints must be strictly read-only.
+type fpModbus struct {
+	t        *testing.T
+	answerFC int32 // 2 = holding, 3 = input
+	hasSunS  bool
+	mfr      string
+	model    string // SunSpec C_Model @ 40020 (e.g. "SE8K-RW0TEBNN4")
+	serial   string
+	meterV   int // raw i16 line voltage at 40196; 0 = no meter
+	meterVSF int // i16 scale factor at 40203
+	whRtg    int // SunSpec 802 WHRtg @ 40124 (0 = leave as not-implemented)
+	whRtgSF  int // SunSpec 802 WHRtg_SF @ 40174
+}
+
+func (m *fpModbus) Read(addr, count uint16, kind int32) ([]uint16, error) {
+	if kind != m.answerFC {
+		return nil, fmt.Errorf("fc %d not supported (timeout)", kind)
+	}
+	out := make([]uint16, count)
+	switch addr {
+	case 40000:
+		if m.hasSunS {
+			out[0] = 0x5375 // "Su"
+			if count > 1 {
+				out[1] = 0x6e53 // "nS"
+			}
+		}
+	case 40004:
+		copy(out, asciiRegs(m.mfr, int(count)))
+	case 40020:
+		copy(out, asciiRegs(m.model, int(count)))
+	case 40052:
+		copy(out, asciiRegs(m.serial, int(count)))
+	case 40196:
+		out[0] = uint16(int16(m.meterV))
+	case 40203:
+		out[0] = uint16(int16(m.meterVSF))
+	case 40124: // SunSpec 802 WHRtg
+		if m.whRtg == 0 {
+			out[0] = 0xFFFF // not implemented
+		} else {
+			out[0] = uint16(m.whRtg)
+		}
+	case 40174: // SunSpec 802 WHRtg_SF
+		out[0] = uint16(int16(m.whRtgSF))
+	}
+	return out, nil
+}
+
+func (m *fpModbus) WriteSingle(uint16, uint16) error {
+	m.t.Error("driver_fingerprint issued a Modbus WriteSingle — fingerprints must be read-only")
+	return nil
+}
+func (m *fpModbus) WriteMulti(uint16, []uint16) error {
+	m.t.Error("driver_fingerprint issued a Modbus WriteMulti — fingerprints must be read-only")
+	return nil
+}
+func (m *fpModbus) Close() error { return nil }
+
+// asciiRegs packs a string into n SunSpec registers, high byte first.
+func asciiRegs(s string, n int) []uint16 {
+	out := make([]uint16, n)
+	b := []byte(s)
+	for i := 0; i < n; i++ {
+		var hi, lo byte
+		if 2*i < len(b) {
+			hi = b[2*i]
+		}
+		if 2*i+1 < len(b) {
+			lo = b[2*i+1]
+		}
+		out[i] = uint16(hi)<<8 | uint16(lo)
+	}
+	return out
+}
+
+func runFingerprint(t *testing.T, path string, env *HostEnv) FingerprintResult {
+	t.Helper()
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load %s: %v", path, err)
+	}
+	defer d.Close() // Close, not Cleanup — mirror the read-only probe path
+	res, err := d.Fingerprint(context.Background())
+	if err != nil {
+		t.Fatalf("fingerprint %s: %v", path, err)
+	}
+	return res
+}
+
+func TestModbusDriverFingerprints(t *testing.T) {
+	const (
+		pixii   = "../../../drivers/pixii.lua"
+		seModP  = "../../../drivers/solaredge.lua"
+		sePv    = "../../../drivers/solaredge_pv.lua"
+		seLegcy = "../../../drivers/solaredge_legacy.lua"
+		holding = int32(2)
+		input   = int32(3)
+	)
+
+	cases := []struct {
+		name     string
+		driver   string
+		dev      *fpModbus
+		match     bool
+		make_     string
+		wantCaps  string  // comma-joined, "" when not asserting
+		wantCapWh float64 // expected BatteryCapacityWh, 0 = don't assert
+	}{
+		{
+			name:      "pixii matches + reads nameplate WHRtg",
+			driver:    pixii,
+			dev:       &fpModbus{answerFC: holding, hasSunS: true, mfr: "Pixii AS", serial: "PX-1", whRtg: 20480, whRtgSF: 0},
+			match:     true,
+			make_:     "Pixii",
+			wantCaps:  "battery,meter",
+			wantCapWh: 20480,
+		},
+		{
+			name:   "pixii rejects a SolarEdge (holding, mfr SolarEdge)",
+			driver: pixii,
+			dev:    &fpModbus{answerFC: holding, hasSunS: true, mfr: "SolarEdge"},
+			match:  false,
+		},
+		{
+			name:   "solaredge.lua (input variant) has no fingerprint — never matches",
+			driver: seModP,
+			dev:    &fpModbus{answerFC: input, hasSunS: true, mfr: "SolarEdge"},
+			match:  false,
+		},
+		{
+			name:     "solaredge_pv matches an HD-Wave (SE8K) on holding",
+			driver:   sePv,
+			dev:      &fpModbus{answerFC: holding, hasSunS: true, mfr: "SolarEdge ", model: "SE8K-RW0TEBNN4", serial: "7E16E274"},
+			match:    true,
+			make_:    "SolarEdge",
+			wantCaps: "pv,pv-curtail",
+		},
+		{
+			name:   "solaredge_pv defers on a K-series model (→ legacy)",
+			driver: sePv,
+			dev:    &fpModbus{answerFC: holding, hasSunS: true, mfr: "SolarEdge", model: "SE17K-XYZ"},
+			match:  false,
+		},
+		{
+			name:     "solaredge legacy matches a K-series display unit",
+			driver:   seLegcy,
+			dev:      &fpModbus{answerFC: holding, hasSunS: true, mfr: "SolarEdge", model: "SE17K-XYZ", serial: "SE-K-1"},
+			match:    true,
+			make_:    "SolarEdge",
+			wantCaps: "pv,pv-curtail",
+		},
+		{
+			name:   "solaredge legacy defers on an HD-Wave (SE8K → pv)",
+			driver: seLegcy,
+			dev:    &fpModbus{answerFC: holding, hasSunS: true, mfr: "SolarEdge", model: "SE8K-RW0TEBNN4"},
+			match:  false,
+		},
+		{
+			name:   "solaredge legacy rejects a Pixii (holding, mfr Pixii)",
+			driver: seLegcy,
+			dev:    &fpModbus{answerFC: holding, hasSunS: true, mfr: "Pixii"},
+			match:  false,
+		},
+		{
+			name:   "pixii rejects a non-SunSpec device",
+			driver: pixii,
+			dev:    &fpModbus{answerFC: holding, hasSunS: false, mfr: "Pixii"},
+			match:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.dev.t = t
+			env := NewHostEnv("fp", telemetry.NewStore()).WithModbus(tc.dev)
+			res := runFingerprint(t, tc.driver, env)
+			if res.Matched != tc.match {
+				t.Fatalf("matched = %v, want %v (%+v)", res.Matched, tc.match, res)
+			}
+			if !tc.match {
+				return
+			}
+			if res.Make != tc.make_ {
+				t.Errorf("make = %q, want %q", res.Make, tc.make_)
+			}
+			if tc.wantCaps != "" && strings.Join(res.Capabilities, ",") != tc.wantCaps {
+				t.Errorf("caps = %q, want %q", strings.Join(res.Capabilities, ","), tc.wantCaps)
+			}
+			if tc.wantCapWh != 0 && res.BatteryCapacityWh != tc.wantCapWh {
+				t.Errorf("battery capacity = %v Wh, want %v", res.BatteryCapacityWh, tc.wantCapWh)
+			}
+		})
+	}
+}
+
+// fpMQTT is a fake broker for the Ferroamp fingerprint: it records subscribes,
+// fails the test on any publish (the fingerprint must be passive), and hands
+// the queued messages over once via PopMessages.
+type fpMQTT struct {
+	t      *testing.T
+	msgs   []MQTTMessage
+	popped bool
+}
+
+func (m *fpMQTT) Subscribe(string) error { return nil }
+func (m *fpMQTT) Publish(topic string, _ []byte) error {
+	m.t.Errorf("driver_fingerprint published to %q — Ferroamp fingerprint must be passive", topic)
+	return nil
+}
+func (m *fpMQTT) PopMessages() []MQTTMessage {
+	if m.popped {
+		return nil
+	}
+	m.popped = true
+	return m.msgs
+}
+func (m *fpMQTT) Close() error { return nil }
+
+func TestFerroampFingerprintMatchesLiveBroker(t *testing.T) {
+	mq := &fpMQTT{
+		t:    t,
+		msgs: []MQTTMessage{{Topic: "extapi/data/ehub", Payload: `{"gridfreq":{"val":"50.0"}}`}},
+	}
+	env := NewHostEnv("fp", telemetry.NewStore()).WithMQTT(mq)
+	res := runFingerprint(t, "../../../drivers/ferroamp.lua", env)
+	if !res.Matched || res.Make != "Ferroamp" {
+		t.Fatalf("ferroamp fingerprint = %+v, want matched Ferroamp", res)
+	}
+	if strings.Join(res.Capabilities, ",") != "meter,pv,battery" {
+		t.Errorf("caps = %v", res.Capabilities)
+	}
+}

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -160,10 +160,94 @@ func (d *LuaDriver) Cleanup() {
 	d.mu.Unlock()
 }
 
+// Close shuts down the Lua VM WITHOUT invoking driver_cleanup. The fingerprint
+// probe path uses this deliberately: many drivers write a failsafe in
+// driver_cleanup (SolarEdge reverts the curtail registers, Pixii zeroes its
+// setpoint, Ferroamp republishes auto mode) and those writes must never fire
+// against an unidentified host being scanned. Use Cleanup for a driver that
+// genuinely ran; use Close for a one-shot read-only probe.
+func (d *LuaDriver) Close() {
+	d.mu.Lock()
+	d.L.Close()
+	d.mu.Unlock()
+}
+
 // DefaultMode calls driver_default_mode() — typically tells the device
 // to revert to autonomous self-consumption when the EMS is offline.
 func (d *LuaDriver) DefaultMode() error {
 	return d.call("driver_default_mode")
+}
+
+// FingerprintResult is what driver_fingerprint() reports back: whether the
+// host the driver was pointed at is a device this driver can actually drive,
+// plus whatever identity it could read off it.
+//
+// Capabilities, when non-empty, is what the driver actually detected on THIS
+// device — e.g. a SolarEdge inverter reports ["pv","meter"] when a revenue
+// meter is wired in and just ["pv"] when it isn't. It overrides the catalog
+// entry's static capabilities so the scan UI can tell the operator the truth
+// about their specific install rather than the driver's maximal feature set.
+type FingerprintResult struct {
+	Matched      bool     `json:"matched"`
+	Make         string   `json:"make,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	Serial       string   `json:"serial,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+	// BatteryCapacityWh is the nameplate energy capacity the driver read off
+	// the device (e.g. Pixii's SunSpec model-802 WHRtg), 0 when unknown. The
+	// setup UI pre-fills the capacity field with it so the operator doesn't
+	// have to look it up.
+	BatteryCapacityWh float64 `json:"battery_capacity_wh,omitempty"`
+}
+
+// Fingerprint calls driver_fingerprint() if the driver defines it. The driver
+// performs a READ-ONLY identity probe against the already-configured endpoint
+// (read a known register, GET a known path, await a known MQTT topic) and
+// returns a table { matched=bool, make=, model=, serial= }. A bare boolean is
+// also accepted as shorthand for { matched=<bool> }.
+//
+// "Not my device" is a normal, non-error outcome: a driver without the
+// function, or one returning nil / false, yields Matched=false and nil error.
+// An error is returned only when the Lua call itself raised.
+//
+// Contract: driver_fingerprint MUST NOT write to the device or send commands —
+// it runs against unknown hosts on the operator's LAN during a scan, so a
+// stray write could disturb a neighbour's hardware.
+func (d *LuaDriver) Fingerprint(ctx context.Context) (FingerprintResult, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	fn := d.L.GetGlobal("driver_fingerprint")
+	if fn == lua.LNil {
+		return FingerprintResult{}, nil
+	}
+	if err := d.L.CallByParam(lua.P{Fn: fn, NRet: 1, Protect: true}); err != nil {
+		return FingerprintResult{}, err
+	}
+	ret := d.L.Get(-1)
+	d.L.Pop(1)
+
+	var res FingerprintResult
+	switch v := ret.(type) {
+	case lua.LBool:
+		res.Matched = bool(v)
+	case *lua.LTable:
+		m, _ := luaToGo(v).(map[string]any)
+		if b, ok := m["matched"].(bool); ok {
+			res.Matched = b
+		}
+		res.Make, _ = m["make"].(string)
+		res.Model, _ = m["model"].(string)
+		res.Serial, _ = m["serial"].(string)
+		res.BatteryCapacityWh, _ = m["battery_capacity_wh"].(float64)
+		if caps, ok := m["capabilities"].([]any); ok {
+			for _, c := range caps {
+				if s, ok := c.(string); ok && s != "" {
+					res.Capabilities = append(res.Capabilities, s)
+				}
+			}
+		}
+	}
+	return res, nil
 }
 
 // call is a convenience for parameter-less void-returning lifecycle funcs.

--- a/go/internal/drivers/lua_test.go
+++ b/go/internal/drivers/lua_test.go
@@ -87,6 +87,68 @@ func TestLuaDriverLifecycle(t *testing.T) {
 	}
 }
 
+func TestLuaDriverFingerprint(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want FingerprintResult
+	}{
+		{
+			name: "rich match",
+			src:  `function driver_fingerprint() return { matched=true, make="Acme", model="X1", serial="SN9", capabilities={"pv","meter"} } end`,
+			want: FingerprintResult{Matched: true, Make: "Acme", Model: "X1", Serial: "SN9", Capabilities: []string{"pv", "meter"}},
+		},
+		{
+			name: "no meter detected",
+			src:  `function driver_fingerprint() return { matched=true, make="Acme", capabilities={"pv"} } end`,
+			want: FingerprintResult{Matched: true, Make: "Acme", Capabilities: []string{"pv"}},
+		},
+		{
+			name: "explicit non-match",
+			src:  `function driver_fingerprint() return { matched=false } end`,
+			want: FingerprintResult{},
+		},
+		{
+			name: "bare boolean shorthand",
+			src:  `function driver_fingerprint() return true end`,
+			want: FingerprintResult{Matched: true},
+		},
+		{
+			name: "function absent",
+			src:  `-- no driver_fingerprint defined`,
+			want: FingerprintResult{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "fp.lua")
+			if err := os.WriteFile(path, []byte(tc.src), 0644); err != nil {
+				t.Fatal(err)
+			}
+			env := NewHostEnv("fp", telemetry.NewStore())
+			d, err := NewLuaDriver(path, env)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			defer d.Cleanup()
+
+			got, err := d.Fingerprint(context.Background())
+			if err != nil {
+				t.Fatalf("fingerprint: %v", err)
+			}
+			if got.Matched != tc.want.Matched ||
+				got.Make != tc.want.Make ||
+				got.Model != tc.want.Model ||
+				got.Serial != tc.want.Serial ||
+				strings.Join(got.Capabilities, ",") != strings.Join(tc.want.Capabilities, ",") {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLuaDriverCommandAndDefaultModeReturnErrors(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "failing.lua")

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -95,67 +95,9 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 	r.mu.Unlock()
 
-	if cfg.Lua == "" {
-		return fmt.Errorf("driver %q: must specify `lua` path", cfg.Name)
-	}
-
-	env := NewHostEnv(cfg.Name, r.tel)
-	env.BatteryCapacityWh = cfg.BatteryCapacityWh
-	if mq := cfg.EffectiveMQTT(); mq != nil && r.MQTTFactory != nil {
-		cap, err := r.MQTTFactory(cfg.Name, mq)
-		if err != nil {
-			return fmt.Errorf("mqtt capability: %w", err)
-		}
-		env.WithMQTT(cap)
-		env.SetEndpoint(fmt.Sprintf("mqtt://%s:%d", mq.Host, mq.Port))
-		// Best-effort MAC resolution. Cross-VLAN devices return ""; that's
-		// fine — device_id falls back to the endpoint.
-		if r.ARPLookup != nil {
-			if mac, ok := r.ARPLookup(mq.Host); ok { env.SetMAC(mac) }
-		}
-	}
-	if mb := cfg.EffectiveModbus(); mb != nil && r.ModbusFactory != nil {
-		cap, err := r.ModbusFactory(cfg.Name, mb)
-		if err != nil {
-			return fmt.Errorf("modbus capability: %w", err)
-		}
-		env.WithModbus(cap)
-		env.SetEndpoint(fmt.Sprintf("modbus://%s:%d", mb.Host, mb.Port))
-		if r.ARPLookup != nil {
-			if mac, ok := r.ARPLookup(mb.Host); ok { env.SetMAC(mac) }
-		}
-	}
-	if cfg.Capabilities.HTTP != nil {
-		env.WithHTTP()
-		hosts := mergeAllowedHosts(cfg.Capabilities.HTTP.AllowedHosts, cfg.Config)
-		if len(hosts) > 0 {
-			env.WithHTTPAllowedHosts(hosts)
-		}
-	}
-	if cfg.Capabilities.WebSocket != nil {
-		env.WithWS(NewGorillaWS(cfg.Name))
-		if hosts := cfg.Capabilities.WebSocket.AllowedHosts; len(hosts) > 0 {
-			env.WithWSAllowedHosts(hosts)
-		}
-	}
-	if cfg.Capabilities.TCP != nil {
-		// Start with the explicit allowlist from YAML, then layer the
-		// driver's own (host, port) on top as a TIGHT host:port entry —
-		// not a bare host the way HTTP/WS do it. Raw TCP can hit any
-		// service listening on the device (SSH, web UI, ...), so the
-		// safe default is "exactly the port the driver was wired to";
-		// the operator can still loosen this by listing bare hosts in
-		// capabilities.tcp.allowed_hosts when they want any-port access.
-		hosts := tcpAllowedHostsFor(cfg)
-		env.WithTCP(NewNetTCP(cfg.Name, hosts))
-		if len(hosts) > 0 {
-			env.WithTCPAllowedHosts(hosts)
-		}
-	}
-
-	luaDrv, err := NewLuaDriver(cfg.Lua, env)
+	env, luaDrv, err := r.buildDriver(cfg)
 	if err != nil {
-		return fmt.Errorf("load lua: %w", err)
+		return err
 	}
 	var drv driverRuntime = &luaRuntime{LuaDriver: luaDrv}
 
@@ -193,6 +135,119 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	go r.runLoop(rd)
 	slog.Info("driver added", "name", cfg.Name, "path", cfg.Lua)
 	return nil
+}
+
+// buildDriver constructs a HostEnv with the driver's transports bound and a
+// loaded LuaDriver, but does NOT run driver_init or start a poll loop. Shared
+// by Add (which then inits + loops) and Fingerprint (which runs a one-shot
+// read-only probe and tears everything down).
+func (r *Registry) buildDriver(cfg config.Driver) (*HostEnv, *LuaDriver, error) {
+	if cfg.Lua == "" {
+		return nil, nil, fmt.Errorf("driver %q: must specify `lua` path", cfg.Name)
+	}
+
+	env := NewHostEnv(cfg.Name, r.tel)
+	env.BatteryCapacityWh = cfg.BatteryCapacityWh
+	if mq := cfg.EffectiveMQTT(); mq != nil && r.MQTTFactory != nil {
+		cap, err := r.MQTTFactory(cfg.Name, mq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("mqtt capability: %w", err)
+		}
+		env.WithMQTT(cap)
+		env.SetEndpoint(fmt.Sprintf("mqtt://%s:%d", mq.Host, mq.Port))
+		// Best-effort MAC resolution. Cross-VLAN devices return ""; that's
+		// fine — device_id falls back to the endpoint.
+		if r.ARPLookup != nil {
+			if mac, ok := r.ARPLookup(mq.Host); ok { env.SetMAC(mac) }
+		}
+	}
+	if mb := cfg.EffectiveModbus(); mb != nil && r.ModbusFactory != nil {
+		cap, err := r.ModbusFactory(cfg.Name, mb)
+		if err != nil {
+			return nil, nil, fmt.Errorf("modbus capability: %w", err)
+		}
+		env.WithModbus(cap)
+		env.SetEndpoint(fmt.Sprintf("modbus://%s:%d", mb.Host, mb.Port))
+		if r.ARPLookup != nil {
+			if mac, ok := r.ARPLookup(mb.Host); ok { env.SetMAC(mac) }
+		}
+	}
+	if cfg.Capabilities.HTTP != nil {
+		env.WithHTTP()
+		hosts := mergeAllowedHosts(cfg.Capabilities.HTTP.AllowedHosts, cfg.Config)
+		if len(hosts) > 0 {
+			env.WithHTTPAllowedHosts(hosts)
+		}
+	}
+	if cfg.Capabilities.WebSocket != nil {
+		env.WithWS(NewGorillaWS(cfg.Name))
+		if hosts := cfg.Capabilities.WebSocket.AllowedHosts; len(hosts) > 0 {
+			env.WithWSAllowedHosts(hosts)
+		}
+	}
+	if cfg.Capabilities.TCP != nil {
+		// Start with the explicit allowlist from YAML, then layer the
+		// driver's own (host, port) on top as a TIGHT host:port entry —
+		// not a bare host the way HTTP/WS do it. Raw TCP can hit any
+		// service listening on the device (SSH, web UI, ...), so the
+		// safe default is "exactly the port the driver was wired to";
+		// the operator can still loosen this by listing bare hosts in
+		// capabilities.tcp.allowed_hosts when they want any-port access.
+		hosts := tcpAllowedHostsFor(cfg)
+		env.WithTCP(NewNetTCP(cfg.Name, hosts))
+		if len(hosts) > 0 {
+			env.WithTCPAllowedHosts(hosts)
+		}
+	}
+
+	luaDrv, err := NewLuaDriver(cfg.Lua, env)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load lua: %w", err)
+	}
+	return env, luaDrv, nil
+}
+
+// closeTransports tears down a HostEnv's capability connections. Mirrors the
+// cleanup in runLoop's stop branch; used by the fingerprint probe path which
+// never starts a poll loop.
+func closeTransports(env *HostEnv) {
+	if env == nil {
+		return
+	}
+	if env.MQTT != nil {
+		_ = env.MQTT.Close()
+	}
+	if env.Modbus != nil {
+		_ = env.Modbus.Close()
+	}
+	if env.WS != nil {
+		_ = env.WS.Close()
+	}
+	if env.TCP != nil {
+		_ = env.TCP.Close()
+	}
+}
+
+// Fingerprint builds a short-lived, READ-ONLY driver instance bound to cfg's
+// transport, runs driver_fingerprint() once, and tears it down. Unlike Add it
+// never runs driver_init or the poll loop, so a driver's connect-time
+// publishes (e.g. Ferroamp's version request) or heartbeat writes (e.g.
+// Pixii's) can't fire against the unknown host being probed during a scan.
+//
+// A driver that doesn't define driver_fingerprint returns a non-matching
+// result with no error — the orchestrator treats that as "can't identify".
+func (r *Registry) Fingerprint(ctx context.Context, cfg config.Driver) (FingerprintResult, error) {
+	env, luaDrv, err := r.buildDriver(cfg)
+	if err != nil {
+		return FingerprintResult{}, err
+	}
+	defer func() {
+		// Close (not Cleanup): skip driver_cleanup so a driver's failsafe
+		// writes never hit the unidentified host we just probed.
+		luaDrv.Close()
+		closeTransports(env)
+	}()
+	return luaDrv.Fingerprint(ctx)
 }
 
 // runLoop polls the driver at its requested cadence and handles commands.

--- a/go/internal/scanner/mdns.go
+++ b/go/internal/scanner/mdns.go
@@ -1,0 +1,101 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+// mdnsAddr is the IPv4 multicast group + port for mDNS (RFC 6762).
+var mdnsAddr = &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353}
+
+// reverseMDNS asks the LAN, over multicast mDNS, for the hostname of ip via a
+// reverse PTR query (d.c.b.a.in-addr.arpa). Many home-energy devices publish
+// no unicast reverse-DNS record but do answer mDNS, so this fills the gap that
+// net.LookupAddr leaves empty. Returns "" (no error) when nothing answers.
+//
+// The query sets the mDNS "unicast response" (QU) bit so the responder replies
+// straight to our ephemeral socket — that means we don't have to bind :5353,
+// which is already held by the OS mDNS responder on most machines.
+func reverseMDNS(ctx context.Context, ip string) string {
+	v4 := net.ParseIP(ip).To4()
+	if v4 == nil {
+		return ""
+	}
+	qname := fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa.", v4[3], v4[2], v4[1], v4[0])
+	name, err := dnsmessage.NewName(qname)
+	if err != nil {
+		return ""
+	}
+
+	const qClassUnicastIN = 0x8000 | 0x0001 // QU bit | IN
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{},
+		Questions: []dnsmessage.Question{{
+			Name:  name,
+			Type:  dnsmessage.TypePTR,
+			Class: dnsmessage.Class(qClassUnicastIN),
+		}},
+	}
+	packed, err := msg.Pack()
+	if err != nil {
+		return ""
+	}
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(900 * time.Millisecond)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = conn.SetDeadline(deadline)
+
+	if _, err := conn.WriteToUDP(packed, mdnsAddr); err != nil {
+		return ""
+	}
+
+	buf := make([]byte, 1500)
+	for {
+		n, _, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			return "" // deadline / read error → give up
+		}
+		if host := parsePTRAnswer(buf[:n], qname); host != "" {
+			return host
+		}
+	}
+}
+
+// parsePTRAnswer walks an mDNS response and returns the first PTR target whose
+// question name matches qname, with the trailing dot stripped. "" if none.
+func parsePTRAnswer(packet []byte, qname string) string {
+	var p dnsmessage.Parser
+	if _, err := p.Start(packet); err != nil {
+		return ""
+	}
+	_ = p.SkipAllQuestions()
+	for {
+		h, err := p.AnswerHeader()
+		if err != nil {
+			return ""
+		}
+		if h.Type == dnsmessage.TypePTR && strings.EqualFold(h.Name.String(), qname) {
+			ptr, err := p.PTRResource()
+			if err != nil {
+				return ""
+			}
+			return strings.TrimSuffix(ptr.PTR.String(), ".")
+		}
+		if err := p.SkipAnswer(); err != nil {
+			return ""
+		}
+	}
+}

--- a/go/internal/scanner/mdns_test.go
+++ b/go/internal/scanner/mdns_test.go
@@ -1,0 +1,48 @@
+package scanner
+
+import (
+	"testing"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func mustName(t *testing.T, s string) dnsmessage.Name {
+	t.Helper()
+	n, err := dnsmessage.NewName(s)
+	if err != nil {
+		t.Fatalf("NewName(%q): %v", s, err)
+	}
+	return n
+}
+
+func TestParsePTRAnswer(t *testing.T) {
+	qname := "15.1.168.192.in-addr.arpa."
+	msg := dnsmessage.Message{
+		Header: dnsmessage.Header{Response: true},
+		Questions: []dnsmessage.Question{{
+			Name: mustName(t, qname), Type: dnsmessage.TypePTR, Class: dnsmessage.ClassINET,
+		}},
+		Answers: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{
+				Name: mustName(t, qname), Type: dnsmessage.TypePTR, Class: dnsmessage.ClassINET, TTL: 120,
+			},
+			Body: &dnsmessage.PTRResource{PTR: mustName(t, "nvr.local.")},
+		}},
+	}
+	packed, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	if got := parsePTRAnswer(packed, qname); got != "nvr.local" {
+		t.Errorf("parsePTRAnswer = %q, want nvr.local", got)
+	}
+	// Answer for a different reverse name must not match.
+	if got := parsePTRAnswer(packed, "99.1.168.192.in-addr.arpa."); got != "" {
+		t.Errorf("mismatched qname returned %q, want empty", got)
+	}
+	// Garbage input is tolerated.
+	if got := parsePTRAnswer([]byte{0x01, 0x02, 0x03}, qname); got != "" {
+		t.Errorf("garbage returned %q, want empty", got)
+	}
+}

--- a/go/internal/scanner/routes_darwin.go
+++ b/go/internal/scanner/routes_darwin.go
@@ -1,0 +1,50 @@
+//go:build darwin
+
+package scanner
+
+import (
+	"net"
+	"syscall"
+
+	"golang.org/x/net/route"
+)
+
+// routedSubnets reads the kernel IPv4 routing table (PF_ROUTE) and returns the
+// network routes it finds. localSubnets filters these down to RFC1918 /24../28
+// so only real, scannable LANs survive.
+func routedSubnets() []net.IPNet {
+	rib, err := route.FetchRIB(syscall.AF_INET, route.RIBTypeRoute, 0)
+	if err != nil {
+		return nil
+	}
+	msgs, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return nil
+	}
+
+	var out []net.IPNet
+	for _, m := range msgs {
+		rm, ok := m.(*route.RouteMessage)
+		if !ok {
+			continue
+		}
+		if len(rm.Addrs) <= syscall.RTAX_NETMASK {
+			continue
+		}
+		dst, ok := rm.Addrs[syscall.RTAX_DST].(*route.Inet4Addr)
+		if !ok {
+			continue
+		}
+		ip := net.IPv4(dst.IP[0], dst.IP[1], dst.IP[2], dst.IP[3])
+
+		maskLen := 32 // default: treat as host route, filtered out later
+		if nm, ok := rm.Addrs[syscall.RTAX_NETMASK].(*route.Inet4Addr); ok {
+			mask := net.IPv4Mask(nm.IP[0], nm.IP[1], nm.IP[2], nm.IP[3])
+			if ones, bits := mask.Size(); bits == 32 {
+				maskLen = ones
+			}
+		}
+		out = append(out, net.IPNet{IP: ip, Mask: net.CIDRMask(maskLen, 32)})
+	}
+	return out
+}

--- a/go/internal/scanner/routes_linux.go
+++ b/go/internal/scanner/routes_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package scanner
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"os"
+	"strings"
+)
+
+// routedSubnets reads /proc/net/route and returns the network routes it finds.
+// localSubnets filters these to RFC1918 /24../28 so only real LANs survive.
+func routedSubnets() []net.IPNet {
+	data, err := os.ReadFile("/proc/net/route")
+	if err != nil {
+		return nil
+	}
+	return parseProcNetRoute(string(data))
+}
+
+// parseProcNetRoute parses the kernel's /proc/net/route table. Destination and
+// Mask are little-endian hex (network byte order as stored on the wire), e.g.
+// Destination "0032A8C0" = 192.168.50.0, Mask "00FFFFFF" = /24.
+func parseProcNetRoute(content string) []net.IPNet {
+	var out []net.IPNet
+	for i, line := range strings.Split(content, "\n") {
+		if i == 0 { // header row
+			continue
+		}
+		f := strings.Fields(line)
+		if len(f) < 8 {
+			continue
+		}
+		dst, ok := leHexIP(f[1])
+		if !ok {
+			continue
+		}
+		mask, ok := leHexIP(f[7])
+		if !ok {
+			continue
+		}
+		ones, bits := net.IPMask(mask).Size()
+		if bits != 32 {
+			continue
+		}
+		out = append(out, net.IPNet{IP: dst, Mask: net.CIDRMask(ones, 32)})
+	}
+	return out
+}
+
+// leHexIP decodes an 8-char little-endian hex word (as /proc/net/route stores
+// addresses) into a 4-byte net.IP.
+func leHexIP(s string) (net.IP, bool) {
+	if len(s) != 8 {
+		return nil, false
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 4 {
+		return nil, false
+	}
+	v := binary.LittleEndian.Uint32(b)
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, v)
+	return ip, true
+}

--- a/go/internal/scanner/routes_linux_test.go
+++ b/go/internal/scanner/routes_linux_test.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package scanner
+
+import "testing"
+
+func TestParseProcNetRoute(t *testing.T) {
+	// Real /proc/net/route shape: header, a default route, a connected /24,
+	// and a statically-routed 192.168.50.0/24 (the case we want to pick up).
+	const content = `Iface	Destination	Gateway	Flags	RefCnt	Use	Metric	Mask	MTU	Window	IRTT
+eth0	00000000	0101A8C0	0003	0	0	0	00000000	0	0	0
+eth0	0001A8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+eth0	0032A8C0	0101A8C0	0003	0	0	0	00FFFFFF	0	0	0
+`
+	got := parseProcNetRoute(content)
+
+	want := map[string]int{ // cidr -> ones
+		"0.0.0.0":      0,
+		"192.168.1.0":  24,
+		"192.168.50.0": 24,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d routes, want %d: %+v", len(got), len(want), got)
+	}
+	for _, n := range got {
+		ones, _ := n.Mask.Size()
+		w, ok := want[n.IP.String()]
+		if !ok || w != ones {
+			t.Errorf("unexpected route %s/%d", n.IP, ones)
+		}
+	}
+}

--- a/go/internal/scanner/routes_other.go
+++ b/go/internal/scanner/routes_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package scanner
+
+import "net"
+
+// routedSubnets is a no-op on platforms without a supported routing-table
+// reader; scanning falls back to interface-attached subnets only.
+func routedSubnets() []net.IPNet { return nil }

--- a/go/internal/scanner/routes_test.go
+++ b/go/internal/scanner/routes_test.go
@@ -1,0 +1,27 @@
+package scanner
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsPrivateV4(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"192.168.50.0", true},
+		{"10.1.2.3", true},
+		{"172.16.0.1", true},
+		{"172.31.255.0", true},
+		{"172.15.0.1", false}, // just below the 172.16/12 block
+		{"172.32.0.1", false}, // just above
+		{"8.8.8.8", false},
+		{"100.64.0.1", false}, // CGNAT, not RFC1918
+	}
+	for _, c := range cases {
+		if got := isPrivateV4(net.ParseIP(c.ip)); got != c.want {
+			t.Errorf("isPrivateV4(%s) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}

--- a/go/internal/scanner/scanner.go
+++ b/go/internal/scanner/scanner.go
@@ -20,6 +20,7 @@ import (
 // FoundDevice is one open port discovered on the local network.
 type FoundDevice struct {
 	IP        string `json:"ip"`
+	Hostname  string `json:"hostname,omitempty"` // reverse-DNS name, best-effort
 	Port      int    `json:"port"`
 	Protocol  string `json:"protocol"` // "modbus", "mqtt", "http"
 	LatencyMs int    `json:"latency_ms"`
@@ -28,6 +29,8 @@ type FoundDevice struct {
 // wellKnownPorts maps TCP ports to protocol names.
 var wellKnownPorts = map[int]string{
 	502:  "modbus",
+	503:  "modbus", // proxied Modbus units (e.g. a Pixii behind a TCP proxy) often expose here
+	1502: "modbus", // solaredge-proxy default — multiplexes a SolarEdge's single Modbus/TCP socket
 	1883: "mqtt",
 	80:   "http",
 }
@@ -94,8 +97,58 @@ done:
 		return found[i].Port < found[j].Port
 	})
 
+	resolveHostnames(ctx, found)
+
 	slog.Info("network scan complete", "found", len(found))
 	return found, nil
+}
+
+// resolveHostnames fills in the Hostname of each device via reverse DNS,
+// best-effort. Each unique IP is looked up once, concurrently, with a short
+// per-lookup budget — a name is a convenience label for the scan UI, never a
+// reason to slow down or fail the scan. IPs that don't resolve keep an empty
+// Hostname.
+func resolveHostnames(ctx context.Context, devices []FoundDevice) {
+	var resolver net.Resolver
+	names := make(map[string]string)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	seen := make(map[string]bool)
+
+	for _, d := range devices {
+		if seen[d.IP] {
+			continue
+		}
+		seen[d.IP] = true
+		wg.Add(1)
+		go func(ip string) {
+			defer wg.Done()
+			lctx, cancel := context.WithTimeout(ctx, 800*time.Millisecond)
+			defer cancel()
+			name := ""
+			if hosts, err := resolver.LookupAddr(lctx, ip); err == nil && len(hosts) > 0 {
+				name = strings.TrimSuffix(hosts[0], ".")
+			}
+			// Most home-energy gear has no unicast reverse-DNS record but does
+			// answer mDNS, so fall back to a reverse mDNS PTR query.
+			if name == "" {
+				name = reverseMDNS(lctx, ip)
+			}
+			if name == "" {
+				return
+			}
+			mu.Lock()
+			names[ip] = name
+			mu.Unlock()
+		}(d.IP)
+	}
+	wg.Wait()
+
+	for i := range devices {
+		if n, ok := names[devices[i].IP]; ok {
+			devices[i].Hostname = n
+		}
+	}
 }
 
 // probe tries to TCP-connect to ip:port with a 500 ms timeout.
@@ -171,7 +224,50 @@ func localSubnets() ([]net.IPNet, error) {
 			})
 		}
 	}
+
+	// Also pull in any other local networks the host knows how to reach via
+	// the routing table — e.g. a second LAN reachable through a static route
+	// that isn't bound to one of our own interfaces. Bounded to RFC1918 /24../28
+	// routes so we never try to sweep a routed /8 or a public range.
+	for _, rn := range routedSubnets() {
+		ip4 := rn.IP.To4()
+		if ip4 == nil || !isPrivateV4(ip4) {
+			continue
+		}
+		if ones, _ := rn.Mask.Size(); ones < 24 || ones > 28 {
+			continue
+		}
+		prefix := fmt.Sprintf("%d.%d.%d", ip4[0], ip4[1], ip4[2])
+		if seen[prefix] {
+			continue
+		}
+		seen[prefix] = true
+		subnets = append(subnets, net.IPNet{
+			IP:   net.IPv4(ip4[0], ip4[1], ip4[2], 0),
+			Mask: net.CIDRMask(24, 32),
+		})
+	}
+
 	return subnets, nil
+}
+
+// isPrivateV4 reports whether ip is in an RFC1918 range (10/8, 172.16/12,
+// 192.168/16). Scans are restricted to these so routing-table discovery can't
+// point the scanner at a public or VPN-routed range.
+func isPrivateV4(ip net.IP) bool {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	switch {
+	case ip4[0] == 10:
+		return true
+	case ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31:
+		return true
+	case ip4[0] == 192 && ip4[1] == 168:
+		return true
+	}
+	return false
 }
 
 // subnetHosts returns all 254 usable host IPs in a /24 subnet.

--- a/web/setup.html
+++ b/web/setup.html
@@ -203,6 +203,17 @@
       gap: 12px;
     }
 
+    .wizard-actions-right { display: flex; gap: 12px; align-items: center; }
+
+    /* Step header row — title on the left, a Next action pinned top-right. */
+    .step-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+    .step-header h2 { margin: 0; }
+
     .btn-primary {
       padding: 11px 18px;
       border: none;
@@ -310,6 +321,37 @@
 
     .scan-table tr:hover td { background: var(--ink-raised); }
 
+    /* Reverse-DNS hostname under the IP, and identified-device cell. */
+    .dev-host {
+      display: block;
+      font-size: 0.7rem;
+      color: var(--fg-muted);
+      margin-top: 2px;
+    }
+    .dev-name { display: block; color: var(--fg); }
+    .dev-caps {
+      display: block;
+      font-size: 0.7rem;
+      color: var(--accent-e);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-top: 2px;
+    }
+    .dev-pending { color: var(--fg-muted); font-style: italic; }
+    .dev-unknown { color: var(--fg-muted); }
+
+    /* "Other devices" separator row between identified + unidentified hits. */
+    .scan-sep td {
+      font-family: var(--mono);
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: var(--fg-muted);
+      background: var(--ink-raised);
+      padding: 6px 10px;
+    }
+    .scan-sep:hover td { background: var(--ink-raised); }
+
     .scan-table .btn-use {
       padding: 5px 12px;
       border: 1px solid var(--line);
@@ -323,6 +365,22 @@
     }
 
     .scan-table .btn-use:hover { border-color: var(--accent-e); }
+
+    .scan-actions { white-space: nowrap; }
+    .scan-actions .btn-use + .btn-use { margin-left: 6px; }
+    .scan-actions .btn-add { color: #0a0a0a; border-color: var(--accent-e); background: var(--accent-e); }
+    .scan-actions .btn-add:hover { filter: brightness(1.08); }
+
+    /* A device already added to the config dims out; its Add button is inert. */
+    .scan-table tr.scan-added td { opacity: 0.45; }
+    .scan-table tr.scan-added:hover td { background: transparent; }
+    .scan-actions .btn-add[disabled] {
+      background: transparent;
+      color: var(--fg-muted);
+      border-color: var(--line);
+      cursor: default;
+    }
+    .scan-actions .btn-add[disabled]:hover { filter: none; }
 
     .spinner {
       display: inline-block;
@@ -565,7 +623,8 @@
   <!-- Step 3: Find devices -->
   <div class="step" id="step-3" data-step="3">
     <h2>Find devices</h2>
-    <p>Scan your network for inverters, batteries, and meters.</p>
+    <p>Scan your network for inverters, batteries, and meters. Add the ones you
+      want, then continue.</p>
 
     <div id="scan-controls">
       <button class="btn-primary" id="scan-btn" onclick="startScan()">Scan network</button>
@@ -573,15 +632,6 @@
     </div>
 
     <div id="scan-status" class="scan-status" style="display:none"></div>
-
-    <div id="scan-results" style="display:none">
-      <table class="scan-table">
-        <thead>
-          <tr><th>IP</th><th>Port</th><th>Protocol</th><th></th></tr>
-        </thead>
-        <tbody id="scan-tbody"></tbody>
-      </table>
-    </div>
 
     <div id="manual-ip-form" style="display:none">
       <div class="form-row">
@@ -597,9 +647,21 @@
       <button class="btn-primary" onclick="useManualDevice()" style="margin-top:0.5rem">Use this device</button>
     </div>
 
+    <div id="scan-results" style="display:none">
+      <table class="scan-table">
+        <thead>
+          <tr><th>Address</th><th>Port</th><th>Protocol</th><th>Device &amp; capabilities</th><th></th></tr>
+        </thead>
+        <tbody id="scan-tbody"></tbody>
+      </table>
+    </div>
+
     <div class="wizard-actions">
       <button class="btn-secondary" onclick="goStep(2)">Back</button>
-      <button class="btn-skip" onclick="goStep(7)">Skip (no devices)</button>
+      <div class="wizard-actions-right">
+        <button class="btn-skip" onclick="goStep(7)">Skip (no devices)</button>
+        <button class="btn-primary" onclick="scanNext()">Next →</button>
+      </div>
     </div>
   </div>
 

--- a/web/setup.js
+++ b/web/setup.js
@@ -12,6 +12,7 @@
   var selectedDevice = null;     // { ip, port, protocol } from scan or manual entry
   var selectedCatalog = null;    // CatalogEntry from /api/drivers/catalog
   var driverCatalog = [];        // full catalog cache
+  var lastScanResults = [];      // last rendered scan hits, for re-render after Add
 
   // --- Step navigation ---
 
@@ -69,23 +70,28 @@
           statusEl.innerHTML = 'No devices found. Try entering the IP manually.';
           return;
         }
-        statusEl.style.display = 'none';
-        var tbody = document.getElementById('scan-tbody');
-        tbody.innerHTML = '';
-        devices.forEach(function (d) {
-          var tr = document.createElement('tr');
-          var proto = d.protocol || 'modbus';
-          tr.innerHTML =
-            '<td>' + esc(d.ip) + '</td>' +
-            '<td>' + esc(String(d.port)) + '</td>' +
-            '<td>' + esc(proto) + '</td>' +
-            '<td><button class="btn-use">Use this device</button></td>';
-          tr.querySelector('.btn-use').addEventListener('click', function () {
-            useScanDevice(d.ip, d.port, proto);
-          });
-          tbody.appendChild(tr);
-        });
+        // Show the raw hits straight away; the device column says "identifying"
+        // until each driver has had a chance to fingerprint its host.
+        renderScanResults(devices, true);
         resultsEl.style.display = 'block';
+        statusEl.innerHTML = '<span class="spinner"></span> Identifying devices...';
+
+        return fetch('/api/scan/identify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ devices: devices }),
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (idData) {
+            var ident = (idData && idData.devices) ? idData.devices : devices;
+            statusEl.style.display = 'none';
+            renderScanResults(ident, false);
+          })
+          .catch(function () {
+            // Identify failed — keep the basic list usable.
+            statusEl.style.display = 'none';
+            renderScanResults(devices, false);
+          });
       })
       .catch(function (err) {
         statusEl.innerHTML = 'Scan failed: ' + esc(err.message) +
@@ -93,13 +99,153 @@
       });
   };
 
+  // Render the scan table. When pending is true the device column shows a
+  // placeholder (identify is still running). Identified hits are listed first;
+  // anything no driver could claim (incl. auth-gated devices) is grouped under
+  // an "Other devices" separator.
+  function renderScanResults(devices, pending) {
+    lastScanResults = devices;
+    var tbody = document.getElementById('scan-tbody');
+    tbody.innerHTML = '';
+    var identified = devices.filter(function (d) { return d.identified; });
+    var others = devices.filter(function (d) { return !d.identified; });
+
+    identified.forEach(function (d) { tbody.appendChild(scanRow(d, pending)); });
+    if (others.length > 0) {
+      var sep = document.createElement('tr');
+      sep.className = 'scan-sep';
+      sep.innerHTML = '<td colspan="5">' +
+        (identified.length > 0 ? 'Other devices' : 'Devices found') + '</td>';
+      tbody.appendChild(sep);
+      others.forEach(function (d) { tbody.appendChild(scanRow(d, pending)); });
+    }
+  }
+
+  function deviceCell(d, pending) {
+    if (pending) return '<span class="dev-pending">identifying…</span>';
+    if (d.identified && d.driver) {
+      var name = d.driver.name || d.driver.manufacturer || 'Device';
+      var model = d.model ? (' · ' + d.model) : '';
+      var caps = (d.driver.capabilities || []).join(' · ');
+      if (d.battery_capacity_wh) {
+        caps += (caps ? ' · ' : '') + (d.battery_capacity_wh / 1000).toFixed(1) + ' kWh';
+      }
+      var sn = d.serial ? (' — SN ' + d.serial) : '';
+      return '<span class="dev-name">' + esc(name) + esc(model) + esc(sn) + '</span>' +
+        (caps ? '<span class="dev-caps">' + esc(caps) + '</span>' : '');
+    }
+    return '<span class="dev-unknown">Unrecognised</span>';
+  }
+
+  function scanRow(d, pending) {
+    var tr = document.createElement('tr');
+    var proto = d.protocol || 'modbus';
+    var addr = esc(d.ip);
+    if (d.hostname) addr += '<span class="dev-host">' + esc(d.hostname) + '</span>';
+
+    var added = isDeviceAdded(d);
+    if (added) tr.className = 'scan-added';
+
+    // Identified devices get Configure (review in the wizard) + Add (one-click,
+    // using the fingerprinted driver and detected settings). Unidentified hosts
+    // can only be Configured — there's no driver to add for them yet.
+    var actions = '<button class="btn-use btn-configure">Configure</button>';
+    if (d.identified && d.driver) {
+      actions += '<button class="btn-use btn-add"' + (added ? ' disabled' : '') + '>' +
+        (added ? 'Added ✓' : 'Add') + '</button>';
+    }
+
+    tr.innerHTML =
+      '<td>' + addr + '</td>' +
+      '<td>' + esc(String(d.port)) + '</td>' +
+      '<td>' + esc(proto) + '</td>' +
+      '<td>' + deviceCell(d, pending) + '</td>' +
+      '<td class="scan-actions">' + actions + '</td>';
+
+    tr.querySelector('.btn-configure').addEventListener('click', function () {
+      useScanDevice(d.ip, d.port, proto, (d.driver && d.driver.lua_path) || null, d.battery_capacity_wh || 0);
+    });
+    var addBtn = tr.querySelector('.btn-add');
+    if (addBtn && !added) {
+      addBtn.addEventListener('click', function () { addScanDevice(d); });
+    }
+    return tr;
+  }
+
+  // deviceEndpoint returns a driver's "host:port" so we can tell whether a
+  // scanned device is already in the configured list.
+  function deviceEndpoint(driver) {
+    var c = driver.capabilities || {};
+    if (c.modbus) return c.modbus.host + ':' + c.modbus.port;
+    if (c.mqtt) return c.mqtt.host + ':' + c.mqtt.port;
+    if (c.http && c.http.allowed_hosts && c.http.allowed_hosts.length) return c.http.allowed_hosts[0];
+    return '';
+  }
+
+  function isDeviceAdded(d) {
+    var key = d.ip + ':' + d.port;
+    return configuredDrivers.some(function (drv) {
+      if (deviceEndpoint(drv) !== key) return false;
+      return !d.driver || drv.lua === d.driver.lua_path;
+    });
+  }
+
+  function uniqueDriverName(base) {
+    var name = base, n = 2;
+    while (configuredDrivers.some(function (drv) { return drv.name === name; })) {
+      name = base + '_' + n;
+      n++;
+    }
+    return name;
+  }
+
+  // addScanDevice configures a fingerprinted device in one click, straight from
+  // the scan results — no trip through the Pick-driver / Configure steps. Builds
+  // the same driver shape saveDriver produces, then re-renders so the row dims.
+  function addScanDevice(d) {
+    if (!d.identified || !d.driver || isDeviceAdded(d)) return;
+    var proto = d.protocol || 'modbus';
+    var caps = d.driver.capabilities || [];
+    var base = (d.driver.manufacturer || d.driver.id || d.driver.name || 'device')
+      .toLowerCase().replace(/[^a-z0-9]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '');
+
+    var driver = {
+      name: uniqueDriverName(base || 'device'),
+      lua: d.driver.lua_path,
+      is_site_meter: false,
+      capabilities: {},
+    };
+    if (proto === 'modbus') driver.capabilities.modbus = { host: d.ip, port: d.port, unit_id: 1 };
+    else if (proto === 'mqtt') driver.capabilities.mqtt = { host: d.ip, port: d.port };
+    else if (proto === 'http') driver.capabilities.http = { allowed_hosts: [d.ip] };
+
+    if (d.battery_capacity_wh) driver.battery_capacity_wh = d.battery_capacity_wh;
+    // First configured device that can meter the grid becomes the site meter.
+    if (configuredDrivers.length === 0 && caps.indexOf('meter') >= 0) driver.is_site_meter = true;
+    driver._catalog = { name: d.driver.name, manufacturer: d.driver.manufacturer, capabilities: caps, path: d.driver.lua_path };
+
+    configuredDrivers.push(driver);
+    renderScanResults(lastScanResults, false);
+  }
+
   window.showManualIP = function () {
     document.getElementById('manual-ip-form').style.display = 'block';
     document.getElementById('manual-ip-toggle').style.display = 'none';
   };
 
-  function useScanDevice(ip, port, protocol) {
-    selectedDevice = { ip: ip, port: port, protocol: protocol };
+  // Next from the scan step: if devices were Added directly, jump to the
+  // drivers summary (skipping the pick/configure steps); otherwise go to
+  // integrations, same as "Skip".
+  window.scanNext = function () {
+    goStep(configuredDrivers.length > 0 ? 6 : 7);
+  };
+
+  function useScanDevice(ip, port, protocol, luaPath, batteryWh) {
+    selectedDevice = {
+      ip: ip, port: port, protocol: protocol,
+      luaPath: luaPath || null,
+      batteryCapacityWh: batteryWh || 0,
+    };
     goStep(4);
   }
 
@@ -167,6 +313,21 @@
       opt.textContent = label;
       sel.appendChild(opt);
     });
+
+    // If the scan already fingerprinted this host to a specific driver,
+    // pre-select it so the operator just confirms.
+    if (selectedDevice && selectedDevice.luaPath) {
+      for (var i = 0; i < sel.options.length; i++) {
+        var v = sel.options[i].value;
+        if (v === '') continue;
+        var entry = driverCatalog[parseInt(v, 10)];
+        if (entry && entry.path === selectedDevice.luaPath) {
+          sel.value = v;
+          if (window.onDriverSelected) window.onDriverSelected();
+          break;
+        }
+      }
+    }
   }
 
   window.onDriverSelected = function () {
@@ -225,6 +386,12 @@
     var hasBattery = selectedCatalog.capabilities &&
       selectedCatalog.capabilities.some(function (c) { return c === 'battery'; });
     document.getElementById('drv-battery-group').style.display = hasBattery ? 'block' : 'none';
+    // Pre-fill the nameplate capacity if the scan fingerprint read it off the
+    // device (e.g. Pixii SunSpec WHRtg) — operator just confirms.
+    if (hasBattery && selectedDevice && selectedDevice.batteryCapacityWh > 0) {
+      document.getElementById('drv-battery-kwh').value =
+        (selectedDevice.batteryCapacityWh / 1000).toFixed(1);
+    }
 
     // First driver defaults to site meter
     document.getElementById('drv-site-meter').checked = configuredDrivers.length === 0;


### PR DESCRIPTION
## Summary

While reviewing PR #370 the user noticed `main.go` was sniffing Lua filenames to decide \"is this driver an EV charger or vehicle telemetry source?\":

```go
func isLikelyEVDriver(luaPath string) bool {
    base := strings.ToLower(luaPath)
    ...
    for _, p := range []string{
        \"easee\", \"ocpp\", \"ctek\", \"chargestorm\",
        \"tesla_vehicle\", \"vehicle\",
    } { ... }
}
```

That's vendor-name coupling baked into the controller surface and requires a code edit each time a new EV charger Lua driver ships. The right source of truth is already there: every Lua driver self-declares via the `DRIVER = { … capabilities = { … } }` table at the top of the file. EV chargers declare `\"ev\"`, vehicle telemetry drivers declare `\"vehicle\"`, and the catalog parser at `internal/drivers/catalog.go` already extracts that list (no Lua VM required, pure text scan).

## What changed

- 🟢 New `drivers.IsEVOrVehicleDriver(catalog, luaPath) bool` in `internal/drivers/catalog.go`. Looks up the entry by Path/Filename and returns true iff `Capabilities` contains `\"ev\"` or `\"vehicle\"`. Missing-from-catalog → conservatively false (a missing entry never silently excludes a real battery from the MPC pool).
- 🟢 `cmd/forty-two-watts/main.go` loads the catalog once at startup (~ms, text-only) and again on every config hot-reload so a hot-edited Lua driver's capability change is picked up without a restart.
- 🟢 `driverCapacitiesFrom` and `warnIfEVHasBatteryCapacity` take the catalog and consult `IsEVOrVehicleDriver` instead of `isLikelyEVDriver`.
- 🔴 `isLikelyEVDriver` deleted along with its filename-allowlist test.
- 🟢 `TestIsEVOrVehicleDriverByCapabilities` covers the catalog-backed classifier, including the \"declared `sim_ev` but capabilities say meter\" case that the old prefix sniffer would have over-matched.

## Why this is safe

Every EV/vehicle driver that ships in `drivers/` today already declares the right capability — verified by the survey in the conversation thread:

| Driver | capabilities |
|---|---|
| `ctek.lua` | `{ \"ev\" }` |
| `ctek_v2.lua` | `{ \"ev\" }` |
| `ctek_hybrid.lua` | `{ \"ev\" }` |
| `easee_cloud.lua` | `{ \"ev\" }` |
| `tesla_vehicle.lua` | `{ \"vehicle\" }` |
| `zap.lua` | `{ \"meter\", \"pv\" }` (correctly NOT an EV charger) |

No operator action required, no schema change, no Lua-side change.

The previous filename allowlist included `\"ocpp\"` as anticipatory — no `ocpp_*.lua` driver actually ships today. When one does, declaring `capabilities = { \"ev\" }` in its DRIVER block is the entire integration cost.

## Test plan

- [x] `go test ./cmd/forty-two-watts/... ./internal/drivers/...` — green (existing capacity tests + new catalog-based classifier test)
- [x] `go test ./cmd/... ./internal/drivers/... ./internal/control/... ./internal/mpc/... ./internal/loadpoint/...` — broader sweep, all green
- [x] `go vet ./...` — clean
- [ ] Smoke against the production Pi: confirm `warnIfEVHasBatteryCapacity` still fires for an Easee with stray `battery_capacity_wh` (catalog correctly identifies the driver) and stays quiet for ferroamp / sungrow

## Relationship to PR #370

Pure refactor in `main.go` + `drivers` package. Independent of PR #370 (loadpoint NCRQ-completion). Merge order doesn't matter — both branched from the same master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: setup network scan — device fingerprinting

Stacked onto this branch. The setup wizard's network scan now reports *what* each device is, not just that a port is open.

- New read-only `driver_fingerprint()` Lua lifecycle hook (probe teardown uses `LuaDriver.Close()`, which skips `driver_cleanup` so failsafe writes never fire against an unidentified LAN host). Implemented for Ferroamp (MQTT), Pixii (Modbus SunSpec), SolarEdge.
- New `POST /api/scan/identify` — fingerprints each scan hit against protocol-matching catalog drivers (parallel, bounded, short timeout).
- **SolarEdge driver routing from SunSpec C_Model (holding reg 40020):** K-series display unit (SE7K/10K/17K/25K) → `solaredge_legacy` (FC 0x10 curtail); else (e.g. SE8K HD-Wave) → `solaredge_pv` (FC 0x06). Holding-only probe (FC 0x03) — input registers never probed, a timed-out FC 0x04 wedges a solaredge-proxy. Input-register `solaredge.lua` stays manual-pick.
- Pixii battery nameplate auto-detect (SunSpec 802 WHRtg) pre-fills the capacity field.
- Hostname resolution: unicast reverse DNS + reverse-mDNS PTR fallback, shown under the IP.
- Scans routed LANs too (PF_ROUTE on darwin, `/proc/net/route` on linux).
- Extra Modbus scan ports 503 + 1502 for proxied inverters.
- Setup UI: "Device & capabilities" column, identified devices first with Configure + Add actions (row dims to "Added" once in config); unidentifiable/auth-gated hosts grouped under "Other devices".

Verified live: SE8K on `.15:1502` identifies as `solaredge-pv` (model `SE8K-RW0TEBNN4`); Pixii on `.x:503`/`1502` and Ferroamp resolve with hostname + IP. `go build`/`vet` clean, `internal/{drivers,scanner,api}` tests green.
