### PR TITLE
fix(control): passive_arbitrage idle slot — don't absorb live PV surplus

### DIFF
--- a/.changeset/passive-arbitrage-idle-live-export-gate.md
+++ b/.changeset/passive-arbitrage-idle-live-export-gate.md
@@ -1,0 +1,31 @@
+---
+"forty-two-watts": patch
+---
+
+**Fix: `planner_passive_arbitrage` no longer absorbs live PV surplus into the
+battery on a plan-idle slot.** When the DP picked idle for a slot
+(`battery_w = 0`) and live conditions turn out to have more PV (or less
+load) than the forecast assumed, the dispatcher now holds the battery at
+0 and lets the surplus export — rather than collapsing to
+self-consumption and chasing `grid = 0` by ramping the charge up.
+
+The DP picks idle slots deliberately, often to preserve export revenue
+at the current spot when future PV is plentiful and future prices are
+lower. The old behaviour reactively swallowed that surplus because the
+fallback path was symmetric with self-consumption ("balance to zero"),
+which discards the DP's intent. The gate is the mirror of
+`plannerSelfExportSurplusGate`, but triggered on the **live** baseline
+grid (`grid_meter − Σ battery_w`) rather than the plan's forecasted
+grid — for the slot we're already in, live measurements override the
+(possibly-stale) forecast.
+
+Reactive discharge on live import is unchanged: a passive-arbitrage
+idle slot with the meter importing still allows the battery to cover
+the load. The change is one-sided — block reactive charging when the
+meter shows export potential the forecast missed.
+
+Found 2026-05-28 on a sunny May afternoon with a wildly over-estimated
+load forecast: planner expected ~2.8 kW load vs. actual ~0.5 kW, picked
+idle on net-≈0 forecast, and the dispatcher charged 2.6 kW into the
+battery despite high current spot (160 öre), low future spot (95 öre),
+and abundant forecast PV in upcoming slots.

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2078,6 +2078,54 @@ func TestPlannerSelfPlannedPVExportDoesNotAbsorbLiveSurplus(t *testing.T) {
 	}
 }
 
+// passive_arbitrage idle slot under live PV surplus: the EMS must not absorb
+// the surplus into the battery, even when the plan's own forecast for this
+// slot was near-balanced (idle, no planned export). For the slot we're
+// already in, live measurements override the forecast — the DP picked idle
+// deliberately, so sustaining "do not charge" under a bigger-than-forecast
+// surplus is the correct generalisation.
+//
+// Production trigger (v0.87.x, 2026-05-28, site .40): load forecast was
+// 2782 W vs actual 504 W on a high-PV slot. Plan said grid≈+28 W with
+// battery_w=0. Dispatch fell through to self_consumption + grid_target=0
+// and charged 2.6 kW into batteries despite high current spot + low future
+// spot + abundant future PV — the exact case the DP picked idle to avoid.
+func TestPlannerPassiveArbitrageIdleDoesNotAbsorbLiveSurplus(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 0, // DP picked idle (load≈PV per forecast)
+		Strategy:        "passive_arbitrage",
+		PlannedGridW:    30, // forecast: grid near zero, not export
+		HasPlannedGridW: true,
+	}
+	// Live mirrors the production report: PV surplus pushing the meter
+	// negative, battery already pulling 1600 W. Without a live-export gate
+	// the PI ramps charge UP to chase grid=0 and swallows the surplus.
+	// Correct behaviour: ramp battery back to 0, let the surplus export.
+	store := seedStore(-100, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 1600, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if math.Abs(targets[0].TargetW) > 1 {
+		t.Errorf("TargetW = %f W — passive_arbitrage idle slot with live PV surplus must NOT absorb (DP picked idle; for the current slot, live grid sign overrides stale forecast)", targets[0].TargetW)
+	}
+}
+
 func TestPlannerSelfPlannedPVExportStopsChargingWithoutSlew(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -825,6 +825,14 @@ func ComputeDispatch(
 	plannerSelfIdleGate := false
 	plannerSelfExportSurplusGate := false
 	plannerSelfNoChargeStalePlan := false
+	// passiveArbitrageIdleSlot tracks "we're in planner_passive_arbitrage on an
+	// idle plan-slot (BatteryEnergyWh ≈ 0)". For these slots the DP picked
+	// idle deliberately; the live-export gate below uses this to suppress
+	// reactive absorption when actual conditions show PV surplus the
+	// forecast missed (mirror of plannerSelfExportSurplusGate, but
+	// triggered by LIVE grid sign rather than planned grid — since
+	// passive_arbitrage idle slots can be set with planned grid near zero).
+	passiveArbitrageIdleSlot := false
 	var currentDirective SlotDirective
 
 	// ---- Manual hold: highest-priority override ----
@@ -872,9 +880,9 @@ func ComputeDispatch(
 				// Charge slots (BatteryEnergyWh > idleWh) still use the energy
 				// path so the DP's deliberate grid-charge intent is honoured.
 				const idleWhGate = 50.0
-				isPassiveArbitrageIdleSlot := state.Mode == ModePlannerPassiveArbitrage &&
+				passiveArbitrageIdleSlot = state.Mode == ModePlannerPassiveArbitrage &&
 					dir.BatteryEnergyWh <= idleWhGate
-				if !isPassiveArbitrageIdleSlot {
+				if !passiveArbitrageIdleSlot {
 					useEnergyPath = true
 				}
 				// Distribution mode is decoupled from planner strategy in
@@ -1037,10 +1045,6 @@ func ComputeDispatch(
 	// modes' non-discharge intent (planner_cheap / planner_arbitrage
 	// during charging slots) remains in scope.
 	noSelfDischarge := planNonDischargeIntent
-	// CHARGE-direction safeties for planner_self. exportSurplusGate +
-	// stale-plan block charge fully; idleGate applies a soft ceiling
-	// computed from live PV surplus (handled below, not via this flag).
-	noSelfCharge := !manualHoldActive && (plannerSelfExportSurplusGate || plannerSelfNoChargeStalePlan)
 
 	// ---- Sum of battery current power (site-signed) ----
 	// Used by both paths: legacy distributors take (currentTotal + correction);
@@ -1050,6 +1054,29 @@ func ComputeDispatch(
 		currentTotal += b.currentW
 	}
 	surplus := newSurplusAccounting(rawGridW, gridW, currentTotal, state)
+
+	// passive_arbitrage idle slot + live PV surplus: don't absorb. Forecasts
+	// guide FUTURE slots; for the slot we're already in, the live meter is
+	// authoritative. The DP picked idle here on purpose — when actual
+	// conditions diverge upward in PV (or downward in load) such that the
+	// baseline-grid-with-battery-at-zero shows export, sustain the DP's
+	// "don't charge" choice rather than letting reactive PI swallow it.
+	// baselineGridW removes the batteries' current contribution from the
+	// live meter — same shape as planner_self's planned-baseline gate, but
+	// computed from telemetry instead of the (possibly-stale) plan.
+	passiveArbitrageIdleLiveExportGate := false
+	if passiveArbitrageIdleSlot {
+		baselineGridW := gridW - currentTotal
+		if baselineGridW < -mpc.IdleGateThresholdW {
+			passiveArbitrageIdleLiveExportGate = true
+		}
+	}
+	// CHARGE-direction safeties for planner_self. exportSurplusGate +
+	// stale-plan block charge fully; idleGate applies a soft ceiling
+	// computed from live PV surplus (handled below, not via this flag).
+	// passiveArbitrageIdleLiveExportGate is the live-grid mirror that
+	// extends the same charge-block to planner_passive_arbitrage idle slots.
+	noSelfCharge := !manualHoldActive && (plannerSelfExportSurplusGate || plannerSelfNoChargeStalePlan || passiveArbitrageIdleLiveExportGate)
 
 	// ---- Compute totalCorrection — paths diverge here ----
 	var totalCorrection float64


### PR DESCRIPTION
## Summary

- `planner_passive_arbitrage` idle slots (DP picked `battery_w ≈ 0`) no longer absorb live PV surplus into the battery
- New gate triggers on **live** baseline grid (`grid_meter − Σ battery_w`), not planned grid — for the slot we're already in, mätaren slår forecast
- Reactive discharge on live import is unchanged; the gate is one-sided

## Background

Found 2026-05-28 on site .40: load forecast was 2782 W vs actual 504 W on a sunny afternoon (phantom heating term in the load model — separate fix follows). The planner picked idle on the forecast's net-≈0 balance, then the dispatcher fell through to `self_consumption + grid_target=0` and charged 2.6 kW into batteries despite high current spot (160 öre), low future spot (95 öre), and abundant forecast PV in upcoming slots.

The DP was *right* to pick idle (the math says hold off — future PV will refill cheap), but the EMS overrode the DP's intent. The gate makes the EMS respect "don't charge here" decisions even when live surplus diverges upward from forecast.

Same shape as `plannerSelfExportSurplusGate`, but triggered on the live meter instead of the plan — passive_arbitrage's idle slots can quantize to "battery=0" with planned grid near zero (not export), so a plan-gated trigger would miss this case.

## Test plan

- [x] `TestPlannerPassiveArbitrageIdleDoesNotAbsorbLiveSurplus` (new failing test, now passes)
- [x] Full `go test ./...` green (unit + e2e)
- [x] `make verify-all` (cross-compile arm64/amd64/windows clean)
- [ ] Watch site .40 once deployed — surplus should export rather than charge

🤖 Generated with [Claude Code](https://claude.com/claude-code)