### PR TITLE
feat(loadmodel): adaptive heating coefficient — learn from measurements

### DIFF
--- a/.changeset/loadmodel-adaptive-heating-coef.md
+++ b/.changeset/loadmodel-adaptive-heating-coef.md
@@ -1,0 +1,33 @@
+---
+"forty-two-watts": minor
+---
+
+**Load model now adapts the heating coefficient online from measurements.**
+Previously `HeatingW_per_degC` was operator-set and never moved — if the
+value drifted from reality (or the house turned out not to track outdoor
+temperature at all), forecasts silently inflated cold-day load and the
+MPC made decisions on phantom heating draw.
+
+The fit runs as one-parameter SGD on the prediction residual:
+`coef ← coef + α · err / deltaT`. Gated on `bucket.Samples ≥
+MinTrustSamples` (residual derives the slope from the bucket baseline)
+and on `deltaT ≥ 3 °C` (warm samples and near-reference samples have no
+heating signal to extract). Clamped to `[0, 1500] W/°C`.
+
+The fit runs **before** the outlier filter so a wildly stale coefficient
+can recover — without that ordering, every cold sample under a wrong
+coef looks like an outlier vs the warm-day MAE and nothing could ever
+pull the value down.
+
+Operator config (`Planner.HeatingWPerDegC` / `SetHeatingCoef`) still
+seeds the initial estimate and is re-applied on
+`POST /api/loadmodel/reset`. From there observation drives the value.
+Households whose load is temperature-independent (district heating,
+solar-gain-dominated shoulder seasons, well-insulated homes) converge
+toward 0 W/°C.
+
+Found 2026-05-28 on site .40: planner predicted 2782 W load for a sunny
+May afternoon (actual 504 W). Root cause was the un-adapted heating
+term — `300 W/°C × (18 − 11.4 °C) = 1980 W` of phantom load applied
+without seasonal / solar-gain awareness. The dispatcher fix in #375
+prevents the *symptom*; this change addresses the *cause*.

--- a/go/internal/loadmodel/CLAUDE.md
+++ b/go/internal/loadmodel/CLAUDE.md
@@ -65,9 +65,16 @@ Persistence: `state.Store.SaveConfig("loadmodel/state_utc", …)` — constant a
 Reset: `POST /api/loadmodel/reset` preserves the configured heating
 coefficient.
 
-`HeatingW_per_degC` is operator-set via `Service.SetHeatingCoef` (called
-from config reload). Not fit online — too noisy and entangled with bucket
-baseline (`model.go:179-184`).
+`HeatingW_per_degC` is adapted online from prediction residuals
+(`model.go` — SGD step `coef ← coef + HeatingAlpha · err / deltaT`,
+gated on `bucket.Samples ≥ MinTrustSamples` and `deltaT ≥
+HeatingMinDeltaT`). The fit runs **before** the outlier filter so a
+stale coefficient can recover even when its own predictions look like
+outliers vs warm-day MAE. Operator-set via `Service.SetHeatingCoef` /
+config reload seeds the initial estimate; observation drives adaptation
+from there. A household whose load is unaffected by outdoor temperature
+(district heating, well-insulated home dominated by solar gain in
+shoulder season) converges to 0 W/°C.
 
 ## Public API surface
 
@@ -98,11 +105,12 @@ Service (`service.go`):
 
 ## What NOT to do
 
-- Do not use this to learn heating sensitivity — leave
-  `HeatingW_per_degC` as an operator input. Online fit co-varies with the
-  bucket baseline and gives noise.
 - Never train on `loadW < 0`; transient flows during PI steps can appear
   negative. `sample()` already skips, keep it that way (`service.go:145`).
+- Do not gate the heating fit on the outlier filter. The whole point of
+  the pre-filter placement is that a stale coefficient can recover —
+  every cold-day sample under a wrong coef looks like an outlier, and
+  gating the fit would lock the model into the wrong estimate forever.
 - Do not remove the "subtract heating before EMA" step — a bucket should
   learn base load, not "base + this week's weather".
 - Do not change `Buckets` without migrating stored state.

--- a/go/internal/loadmodel/model.go
+++ b/go/internal/loadmodel/model.go
@@ -18,9 +18,13 @@
 //     yields ~60 samples per bucket per week), we trust observations.
 //
 //  4. Optional temperature correction. Outdoor temperature below 18°C
-//     tracks strongly with heating load. We maintain a global scalar
-//     `HeatingW_per_degC`, fit online via a simple EMA of residuals
-//     vs. (18 − temp_c). Adds 0 W when temp is unknown or ≥ 18°C.
+//     tracks heating load in homes with electric/heat-pump heating. We
+//     maintain a global scalar `HeatingW_per_degC` and fit it online
+//     via SGD on the prediction residual against (18 − temp_c), gated
+//     on bucket trust. Houses unaffected by outdoor temperature (district
+//     heating, all-electric pure-resistive baseboards on thermostats,
+//     etc.) converge toward 0 W/°C. Adds 0 W when temp is unknown or
+//     ≥ 18°C.
 //
 // The fallback-on-empty behavior makes this model safe on cold boot —
 // the MPC always gets a plausible load estimate, never zero or wild.
@@ -42,6 +46,22 @@ const MinTrustSamples = 8
 // HeatingReferenceC is the indoor setpoint the heating curve is
 // relative to. Load proportional to max(setpoint − outdoor, 0).
 const HeatingReferenceC = 18.0
+
+// HeatingAlpha is the EMA weight applied to per-sample heating-slope
+// estimates. ~0.01 picks up systematic bias within a few hundred cold
+// samples (~1–2 weeks of every-15-min telemetry) while staying robust
+// to noise and to the bucket↔coef joint-fit underdetermination.
+const HeatingAlpha = 0.01
+
+// HeatingMinDeltaT gates the online fit: a sample whose deltaT is too
+// small (warm day, near reference) contributes too much noise via the
+// 1/deltaT divisor in the SGD step. Skip it. Bucket EMA still updates.
+const HeatingMinDeltaT = 3.0
+
+// HeatingCoefMaxW is the physical upper bound for the learned slope.
+// District-heating-replacement territory; well above any single-family
+// home. Clamp prevents one anomalous sample from blowing up the fit.
+const HeatingCoefMaxW = 1500.0
 
 // Profile selects which learned occupancy profile is used for training
 // and prediction.
@@ -222,9 +242,38 @@ func (m *Model) Update(t time.Time, actualLoadW, tempC float64) (updated bool) {
 	}
 	idx := HourOfWeek(t)
 	b := &m.Bucket[idx]
-	// Outlier filter: once we have some history, reject 10× MAE residuals.
 	predicted := m.Predict(t, tempC)
 	err := actualLoadW - predicted
+
+	// ---- Online heating fit ----
+	// Adapt HeatingW_per_degC from observed residuals before the outlier
+	// filter so a wildly stale coefficient can recover: every cold sample
+	// would otherwise look like an outlier vs the warm-day MAE, and no
+	// data could ever pull the coefficient down. Bucket-trust gates the
+	// fit because the residual derives the slope from the bucket
+	// baseline; an untrusted bucket would feed prior error into the
+	// heating estimate.
+	//
+	// SGD step on the squared-error loss: d/d(coef) ∝ −err · deltaT,
+	// so coef ← coef + α · err / deltaT (the 1/deltaT cancels the
+	// gradient's deltaT factor, giving a per-sample slope estimate).
+	// HeatingMinDeltaT gates near-reference samples where 1/deltaT
+	// amplifies noise. Clamp to [0, HeatingCoefMaxW]: floor at zero
+	// (heating doesn't go negative physically); a household whose load
+	// is unaffected by outdoor temperature gracefully settles at the
+	// floor.
+	if tempC < HeatingReferenceC-HeatingMinDeltaT && b.Samples >= MinTrustSamples {
+		deltaT := HeatingReferenceC - tempC
+		m.HeatingW_per_degC += HeatingAlpha * err / deltaT
+		if m.HeatingW_per_degC < 0 {
+			m.HeatingW_per_degC = 0
+		}
+		if m.HeatingW_per_degC > HeatingCoefMaxW {
+			m.HeatingW_per_degC = HeatingCoefMaxW
+		}
+	}
+
+	// Outlier filter: once we have some history, reject 10× MAE residuals.
 	if m.Samples > 50 {
 		band := math.Max(m.MAE*10, 200)
 		if math.Abs(err) > band {
@@ -257,12 +306,12 @@ func (m *Model) Update(t time.Time, actualLoadW, tempC float64) (updated bool) {
 		}
 		b.Samples++
 	}
-	// Heating coefficient is operator-configured (Planner.HeatingWPerDegC
-	// in config). We don't try to identify it from data here because
-	// online fit is noisy + entangled with the bucket baseline. The
-	// simple path is: user enters "my house needs ~300 W/°C" once,
-	// the MPC uses it for forward-looking cold-day planning. Room for
-	// a dedicated offline OLS fit in a future iteration.
+	// Heating coefficient is adapted online above. The operator value
+	// (Planner.HeatingWPerDegC) seeds the initial estimate and is also
+	// applied on /api/loadmodel/reset; from there observation drives the
+	// fit. For a household whose load doesn't track temperature, the
+	// coefficient converges toward zero — which matches the user-visible
+	// guarantee "the model uses what it sees".
 
 	m.Samples++
 	m.LastMs = t.UnixMilli()

--- a/go/internal/loadmodel/model_test.go
+++ b/go/internal/loadmodel/model_test.go
@@ -242,3 +242,90 @@ func TestRepairPoisonedBuckets(t *testing.T) {
 		t.Errorf("healthy bucket should be untouched: got %.0f W, want 2200 W", m.Bucket[eveningIdx].Mean)
 	}
 }
+
+// TestHeatingCoefLearnsFromMeasurements — a household whose load grows with
+// the heating-degrees signal should converge to roughly the true sensitivity
+// from measurements alone. The old behaviour was operator-only: coef stayed
+// at whatever the human typed in (or 0 if untyped). With online adaptation,
+// the model uses what it observes — including across mixed warm/cold days
+// where the warm days anchor the bucket baseline.
+func TestHeatingCoefLearnsFromMeasurements(t *testing.T) {
+	const trueBase = 800.0
+	const trueCoef = 250.0 // W per °C below 18°C
+	m := NewModel(8000)
+	rng := rand.New(rand.NewSource(7))
+	t0 := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	// 80 weeks of hourly samples (~13.5k) — every bucket gets ~80 samples,
+	// alternating warm (no heating signal) and cold (heating signal) days.
+	for i := 0; i < 80*7*24; i++ {
+		ts := t0.Add(time.Duration(i) * time.Hour)
+		// Day index alternates warm vs cold so each bucket trains under
+		// both regimes; bucket Mean anchors on warm samples, heating
+		// coefficient learns from the cold-day excess.
+		day := i / 24
+		var tempC float64
+		if day%2 == 0 {
+			tempC = 19.0 // warm — no heating contribution
+		} else {
+			tempC = 6.0 // cold — deltaT = 12 → +3000 W heating contribution
+		}
+		deltaT := math.Max(0, HeatingReferenceC-tempC)
+		actual := trueBase + trueCoef*deltaT + (rng.Float64()*2-1)*40
+		m.Update(ts, actual, tempC)
+	}
+	if math.Abs(m.HeatingW_per_degC-trueCoef) > 80 {
+		t.Errorf("heating coef should learn ~%.0f W/°C, got %.0f W/°C",
+			trueCoef, m.HeatingW_per_degC)
+	}
+}
+
+// TestHeatingCoefLearnsDownForUnheatedHome — operator may have configured a
+// non-zero heating coefficient, but if the actual load shows no temperature
+// dependence (district heating, all-electric with no thermostat coupling, or
+// even an over-shaded house dominated by solar gain in shoulder season),
+// the learned coefficient must adapt downward toward 0. Without this, a
+// stale operator value silently inflates forecast load on every cold-day
+// slot — which is exactly the failure mode that bit site .40 in May 2026
+// (300 W/°C × 6.6°C cold → 1980 W of phantom load while the sun was out).
+func TestHeatingCoefLearnsDownForUnheatedHome(t *testing.T) {
+	const trueBase = 800.0
+	m := NewModel(8000)
+	m.HeatingW_per_degC = 500 // operator-set; actual home is unheated
+	rng := rand.New(rand.NewSource(11))
+	t0 := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 80*7*24; i++ {
+		ts := t0.Add(time.Duration(i) * time.Hour)
+		day := i / 24
+		var tempC float64
+		if day%2 == 0 {
+			tempC = 19.0
+		} else {
+			tempC = 6.0
+		}
+		// Actual load is temperature-independent — pure noise around base.
+		actual := trueBase + (rng.Float64()*2-1)*40
+		m.Update(ts, actual, tempC)
+	}
+	if m.HeatingW_per_degC > 80 {
+		t.Errorf("unheated home: heating coef should drift toward 0, got %.0f W/°C",
+			m.HeatingW_per_degC)
+	}
+}
+
+// TestHeatingFitWaitsForBucketTrust — the heating regression piggybacks on
+// the bucket-baseline estimate; if buckets haven't accumulated enough
+// samples, the residual `(actual − bucket.Mean)` is dominated by prior
+// error, not by the heating term. Fitting heating off untrustworthy buckets
+// produces wild swings — gate the fit on bucket trust the same way Predict
+// gates the bucket EMA blend.
+func TestHeatingFitWaitsForBucketTrust(t *testing.T) {
+	m := NewModel(8000)
+	// Feed exactly one cold sample at a single bucket. Bucket samples count
+	// will be 1 — far below MinTrustSamples. The heating coef must not
+	// jump from this single under-trusted observation.
+	t0 := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+	m.Update(t0, 5000, 5.0) // arbitrary big load, cold day
+	if m.HeatingW_per_degC != 0 {
+		t.Errorf("untrusted bucket must not drive heating fit, coef = %.0f", m.HeatingW_per_degC)
+	}
+}


### PR DESCRIPTION
## Summary

- `HeatingW_per_degC` is no longer a frozen operator value — it's fit online from observed residuals
- One-parameter SGD: `coef ← coef + α · err / deltaT`, gated on bucket trust and `deltaT ≥ 3 °C`, clamped to `[0, 1500] W/°C`
- Fit runs **before** the outlier filter so a stale coefficient can recover (otherwise cold-day samples under a wrong coef look like outliers and lock the model into the wrong value forever)
- Operator config still seeds the initial estimate and re-applies on `/api/loadmodel/reset`
- Households where load doesn't track temperature (district heating, solar-gain-dominated, well-insulated) converge toward 0 W/°C

## Background

Found 2026-05-28 on site .40: planner predicted 2782 W load on a sunny May afternoon (actual 504 W). Root cause: stale operator heating coef × ambient `(18 − 11.4 °C) × 300 W/°C = 1980 W` of phantom load applied without seasonal or solar-gain awareness. Dispatcher fix (#375) prevents the symptom; this PR addresses the cause.

User direction was explicit: "Vår load modell bör ju vara lärande av vad som faktiskt händer. … Kanske har man ett hushåll som inte alls påverkas av utomhustemp? då ska den faktorn ner till noll." The implementation honours that — uses measurements as truth, converges toward zero for temperature-independent homes.

## Test plan

- [x] `TestHeatingCoefLearnsFromMeasurements` — heated home converges to true 250 W/°C
- [x] `TestHeatingCoefLearnsDownForUnheatedHome` — stale operator value 500 drifts to ~0 after enough samples
- [x] `TestHeatingFitWaitsForBucketTrust` — under-trusted bucket doesn't drive fit
- [x] All existing loadmodel/mpc/control tests still green
- [x] Full `make verify-all` clean
- [ ] After deploy on site .40: call `POST /api/loadmodel/reset` to clear the contaminated state, watch coef converge from telemetry over the coming days

🤖 Generated with [Claude Code](https://claude.com/claude-code)