### PR TITLE
fix(arbitrage): cover-load discharge slots chase live grid=0

### DIFF
--- a/.changeset/arbitrage-cover-load-reactive.md
+++ b/.changeset/arbitrage-cover-load-reactive.md
@@ -1,0 +1,27 @@
+---
+"forty-two-watts": minor
+---
+
+**Fix: `planner_arbitrage` cover-load discharge slots now chase the live
+zero-grid line instead of rigidly running the planned discharge power.**
+When the DP picks a discharge slot to *offset expensive import* (rather
+than to *export at peak price*), the energy-allocation path used to lock
+the battery at `remainingWh × 3600 / remainingS` regardless of live
+conditions — exporting at spot price any forecast-load undershoot and
+under-covering any forecast-load overshoot. The EMS now routes these
+slots through reactive PI on grid=0, the same path
+`planner_passive_arbitrage` non-charge slots and `planner_self`
+participant slots already use.
+
+Detection: `PlannedGridW > -100 W` (no significant planned export) AND
+`BatteryEnergyWh < -50 Wh` (discharge planned). Peak-export slots
+(`PlannedGridW < -100 W`) stay on the energy path — extra export there is
+bonus revenue at the price the DP picked the slot for. Charge slots
+stay on the energy path so deliberate grid-charge intent is honoured.
+
+Found 2026-05-28: plan estimated baseload 1.7 kW for a slot that scheduled
+the battery to be empty by 23:30. Real load was 0.9 kW; battery sat at
+-1.7 kW exporting 800 W at spot. Then load surged to 3.2 kW and the
+battery stayed at -1.7 kW, forcing 0.5 kW import. Both directions are
+now reactive — the slot's Wh budget guides where the battery is
+generally headed, the meter decides the instantaneous power.

--- a/docs/plan-ems-contract.md
+++ b/docs/plan-ems-contract.md
@@ -142,6 +142,42 @@ The plan becomes a **participation schedule** for this mode, not a
 power trajectory. The three principles still hold for the other planner
 modes where they make sense.
 
+## Exception: planner_arbitrage cover-load discharge
+
+`planner_arbitrage` discharge slots are not all alike. The DP picks a
+slot for one of two reasons:
+
+- **Peak-export intent** (`PlannedGridW < 0`): the export price at this
+  slot is high enough to make sending energy across the meter net
+  positive. Extra export from a load undershoot is bonus revenue.
+- **Cover-load intent** (`PlannedGridW ≈ 0` or import): the import price
+  at this slot is high enough to make discharging worthwhile against
+  *local load*. No export was anticipated; any export at this slot's
+  export price is energy the operator buys back later at consumer price.
+
+Until 2026-05-28 the EMS treated both identically on the
+energy-allocation path — `targetTotalW = remainingWh × 3600 / remainingS`
+runs whether the slot exports or not. An operator reported the symptom:
+plan baseload 1.7 kW, real load 0.9 kW, battery sat at -1.7 kW exporting
+800 W at spot, then bought it back later at the consumer rate.
+
+`planner_arbitrage` cover-load discharge slots therefore execute as
+**reactive PI-on-grid=0**, identical to `planner_self` participant slots
+and the existing `planner_passive_arbitrage` non-charge carve-out. Live
+load undershoot backs the battery off toward 0; live load overshoot
+ramps the battery further within driver limits.
+
+Detection (`go/internal/control/dispatch.go`): `state.Mode == planner_arbitrage`,
+`HasPlannedGridW`, `BatteryEnergyWh < -idleWhGate`, and
+`PlannedGridW > -coverLoadExportToleranceW` (default -100 W). Peak-export
+slots stay on the energy path; charge slots stay on the energy path.
+
+The Wh budget for the slot is *not* enforced as a hard cap on the
+reactive path. A 15-min slot × MaxDischargeW caps over-delivery at
+~1.25 kWh, and the next reactive replan (load-error integral >400 Wh)
+picks up the actual SoC for re-allocation. Symmetric to `planner_self`,
+which has run without a per-slot Wh cap since #130.
+
 ## Mode taxonomy
 
 Today's `Mode` is a soup of strategies, dispatch rules, and execution

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2126,6 +2126,249 @@ func TestPlannerPassiveArbitrageIdleDoesNotAbsorbLiveSurplus(t *testing.T) {
 	}
 }
 
+// Operator-report 2026-05-28: planner_arbitrage discharge slot, plan estimated
+// baseload ~1.7 kW (BatteryEnergyWh ≈ -425 over 15 min), plan grid target ~0.
+// Live load was 0.9 kW; battery sat at -1.7 kW per the energy-allocation
+// formula, exporting 800 W at the spot price the operator would later have to
+// buy back at consumer price. The DP picked this slot to *cover load* during
+// an expensive window, not to export — the existing "bonus revenue" carve-out
+// on the energy path applies only to slots where PlannedGridW < 0 (export
+// intent). The fix routes cover-load discharge slots (BatteryEnergyWh < 0 AND
+// PlannedGridW ~> 0) through reactive PI-on-grid=0, same path passive_arb
+// idle slots already use.
+func TestPlannerArbitrageCoverLoadBacksOffOnLoadUndershoot(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425, // DP planned -1.7 kW × 15 min discharge
+		Strategy:        "arbitrage",
+		PlannedGridW:    1700, // plan: cover ~1.7 kW load, no export
+		HasPlannedGridW: true,
+	}
+	// Battery already running at the planned -1.7 kW; live grid is -800 W
+	// because actual load is only 900 W (load = grid - battery = -800 + 1700).
+	store := seedStore(-800, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Energy path would hold target at -1700. Reactive PI must back off
+	// toward -900 W (the actual load). First-cycle PI is between -1700 and
+	// -900 W; assert "less negative than planned" with margin.
+	if got <= -1500 {
+		t.Errorf("TargetW = %.0f W — cover-load arbitrage slot must back off from planned -1700 W when live grid shows export; want target > -1500 W", got)
+	}
+	// Sign should still be discharge (still positive load to cover).
+	if got >= 0 {
+		t.Errorf("TargetW = %.0f W — cover-load slot with positive live load must still discharge", got)
+	}
+}
+
+// Mirror of the undershoot case for a load *spike*: planned -1.7 kW but real
+// load is 3.2 kW. Energy path holds at -1.7 kW and lets 1.5 kW import. Reactive
+// PI ramps the battery down further to keep grid near 0.
+func TestPlannerArbitrageCoverLoadRampsOnLoadOvershoot(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+		Strategy:        "arbitrage",
+		PlannedGridW:    1700,
+		HasPlannedGridW: true,
+	}
+	// Battery at planned -1700; load surged to 3200 → grid = 3200 - 1700 = 1500.
+	store := seedStore(1500, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Energy path would hold at -1700. Reactive PI must push more discharge.
+	if got >= -2000 {
+		t.Errorf("TargetW = %.0f W — cover-load slot with 1500 W live import must discharge more than the planned -1700 W; want target ≤ -2000 W", got)
+	}
+}
+
+// Peak-export discharge slot (PlannedGridW < 0): the DP deliberately chose
+// to export at this slot's high price. Reactive carve-out must NOT trigger;
+// energy path holds the planned rate even when live PV varies. This is the
+// behaviour the existing dispatch.go:87-91 comment justifies.
+func TestPlannerArbitragePeakExportSlotStaysOnEnergyPath(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -500, // -2 kW × 15 min
+		Strategy:        "arbitrage",
+		PlannedGridW:    -2000, // plan: export 2 kW to grid
+		HasPlannedGridW: true,
+	}
+	// Live grid already exporting (-500 W). Reactive PI on grid=0 would
+	// charge (+500 W). Energy path must discharge ≈ -2000 W per plan.
+	store := seedStore(-500, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.8},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	if got >= -1000 {
+		t.Errorf("TargetW = %.0f W — peak-export arbitrage slot (PlannedGridW=-2000) must stay on energy path and discharge ≈ -2000 W; cover-load carve-out incorrectly fired", got)
+	}
+}
+
+// Cover-load slot with live PV surplus (unexpected). Energy path would blindly
+// discharge -1.7 kW *into* the export, doubling the loss. Reactive carve-out
+// must absorb the live surplus (or at least not discharge further).
+func TestPlannerArbitrageCoverLoadDoesNotDischargeIntoLiveExport(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+		Strategy:        "arbitrage",
+		PlannedGridW:    500, // plan: small net import (cover load)
+		HasPlannedGridW: true,
+	}
+	// Unexpected PV surplus: grid exporting 800 W with battery idle.
+	store := seedStore(-800, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Must not discharge into the live export. Either idle (≈0) or charge to absorb.
+	if got < -50 {
+		t.Errorf("TargetW = %.0f W — cover-load slot with live PV surplus must not discharge into export; want target ≥ -50 W", got)
+	}
+}
+
+// Backcompat: legacy callers without HasPlannedGridW (the simpler slotDirective
+// test helper) must still use the energy path — intent is unknown. Locks in
+// behaviour-preservation for tests written before this change.
+func TestPlannerArbitrageDischargeSlotWithoutPlannedGridWUsesEnergyPath(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+		Strategy:        "arbitrage",
+		HasPlannedGridW: false, // unknown intent
+	}
+	// Same live conditions as the undershoot test, but unknown plan intent.
+	store := seedStore(-800, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	// Energy path must hold ≈ -1700 W.
+	if got > -1500 {
+		t.Errorf("TargetW = %.0f W — HasPlannedGridW=false means unknown intent; must fall through to energy path and hold ≈ -1700 W", got)
+	}
+}
+
+// The carve-out also applies to passive_arbitrage — same cover-load math,
+// just under the passive-arbitrage contract (no grid-charge ever). Mirror of
+// the load-undershoot test for the passive mode.
+func TestPlannerPassiveArbitrageCoverLoadBacksOffOnLoadUndershoot(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+		Strategy:        "passive_arbitrage",
+		PlannedGridW:    1700,
+		HasPlannedGridW: true,
+	}
+	store := seedStore(-800, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	got := targets[0].TargetW
+	if got <= -1500 {
+		t.Errorf("TargetW = %.0f W — passive_arbitrage cover-load slot must back off when live grid shows export; want target > -1500 W", got)
+	}
+	if got >= 0 {
+		t.Errorf("TargetW = %.0f W — cover-load slot with positive live load must still discharge", got)
+	}
+}
+
 func TestPlannerSelfPlannedPVExportStopsChargingWithoutSlew(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -84,11 +84,17 @@ type SlotDirective struct {
 	// live gridW match plan", preventing the energy budget from blindly
 	// driving extra grid import.
 	//
-	// Discharge slots are intentionally NOT clamped: extra export during
-	// a discharge slot is bonus revenue (the Wh budget is still delivered
-	// — the extra comes from load undershooting forecast), and backing
-	// off would undermine a DP choice the planner already evaluated. See
+	// Discharge slots are intentionally NOT clamped on the energy-allocation
+	// path: extra export during an EXPORT-INTENT slot (PlannedGridW < 0,
+	// e.g. peak-shave discharge picked by the DP for its export price) is
+	// bonus revenue and backing off would undermine the DP choice. See
 	// docs/safety.md §8 for the full rationale.
+	//
+	// Cover-load discharge slots (PlannedGridW ≈ 0 or import) are a
+	// DIFFERENT story: the DP picked discharge to offset an expensive
+	// import, not to export. There the energy path is rerouted to reactive
+	// PI on grid=0 — see the cover-load carve-out a few hundred lines
+	// below where useEnergyPath is decided.
 	//
 	// HasPlannedGridW gates whether the cap should consult PlannedGridW
 	// at all. Stored as a separate bool (rather than a *float64) so the
@@ -882,7 +888,25 @@ func ComputeDispatch(
 				const idleWhGate = 50.0
 				passiveArbitrageIdleSlot = state.Mode == ModePlannerPassiveArbitrage &&
 					dir.BatteryEnergyWh <= idleWhGate
-				if !passiveArbitrageIdleSlot {
+				// planner_arbitrage cover-load discharge slots: same fallthrough.
+				// The energy path's "extra export is bonus revenue" carve-out
+				// (see SlotDirective.PlannedGridW doc) is correct for peak-export
+				// slots where the DP picked the slot for its export price. But
+				// when PlannedGridW ≈ 0 (or import), the DP picked discharge
+				// to *cover load* — no export was anticipated. Locking discharge
+				// at the planned rate then exports any forecast-load undershoot
+				// at the spot price the operator later buys back at consumer
+				// price. Reactive PI on grid=0 fixes both directions: load
+				// undershoot backs off; load overshoot ramps further. The
+				// passive_arbitrage variant of this carve-out already covers
+				// passive cover-load discharge (BatteryEnergyWh <= idleWh
+				// captures non-charge slots). Operator-report 2026-05-28.
+				const coverLoadExportToleranceW = 100.0
+				coverLoadDischargeSlot := state.Mode == ModePlannerArbitrage &&
+					dir.HasPlannedGridW &&
+					dir.BatteryEnergyWh < -idleWhGate &&
+					dir.PlannedGridW > -coverLoadExportToleranceW
+				if !passiveArbitrageIdleSlot && !coverLoadDischargeSlot {
 					useEnergyPath = true
 				}
 				// Distribution mode is decoupled from planner strategy in


### PR DESCRIPTION
## Summary

- `planner_arbitrage` discharge slots now distinguish **peak-export intent** (`PlannedGridW < 0` — extra export is bonus revenue, keep energy path) from **cover-load intent** (`PlannedGridW ≈ 0` or import — DP picked discharge to offset expensive import, not to export). The latter now routes through reactive PI-on-grid=0, identical to the `planner_self` participant path and the existing `planner_passive_arbitrage` non-charge carve-out.
- The energy-allocation formula `targetTotalW = remainingWh × 3600 / remainingS` is otherwise unchanged for charge slots and peak-export slots.

## Motivating incident

Operator-report 2026-05-28:
- Plan estimated baseload 1.7 kW for a slot scheduled to drain the battery by 23:30.
- Real load was 0.9 kW. Battery sat at -1.7 kW exporting 800 W at spot price — energy that's bought back later at the higher consumer price. Negative trade.
- Then real load surged to 3.2 kW. Battery stayed at -1.7 kW and 0.5 kW was imported through the expensive window.

Both directions are now reactive — slot Wh budget guides where the battery is generally headed, the live meter decides instantaneous power.

## Detection

In `go/internal/control/dispatch.go`, next to the existing `passiveArbitrageIdleSlot` carve-out:

```go
const coverLoadExportToleranceW = 100.0
coverLoadDischargeSlot := state.Mode == ModePlannerArbitrage &&
    dir.HasPlannedGridW &&
    dir.BatteryEnergyWh < -idleWhGate &&
    dir.PlannedGridW > -coverLoadExportToleranceW
if !passiveArbitrageIdleSlot && !coverLoadDischargeSlot {
    useEnergyPath = true
}
```

## What does NOT change

- Peak-export discharge slots (`PlannedGridW < -100 W`) — energy path holds the planned rate; covered by `TestPlannerArbitragePeakExportSlotStaysOnEnergyPath`.
- Charge slots (`BatteryEnergyWh > 0`) — deliberate grid-charge intent honoured.
- `HasPlannedGridW = false` (older test fixtures, legacy code paths) — falls through to energy path; covered by `TestPlannerArbitrageDischargeSlotWithoutPlannedGridWUsesEnergyPath`.
- `planner_passive_arbitrage` cover-load — already handled by the existing `BatteryEnergyWh <= idleWhGate` non-charge carve-out; regression-locked by `TestPlannerPassiveArbitrageCoverLoadBacksOffOnLoadUndershoot`.

## Wh budget on the reactive path

Not enforced as a hard cap (matches `planner_self`). A 15-min slot × `MaxDischargeW` caps over-delivery at ~1.25 kWh; the reactive replan trigger (load-error integral > 400 Wh) picks up the actual SoC for re-allocation. If field reports show SoC-utarmning on envis last-överskridelse, can promote to a hard cap by reusing the existing `slotDelivered` bookkeeping.

## Test plan

- [x] `TestPlannerArbitrageCoverLoadBacksOffOnLoadUndershoot` — undershoot reproduces operator scenario, target backs off from -1700 W.
- [x] `TestPlannerArbitrageCoverLoadRampsOnLoadOvershoot` — overshoot ramps battery beyond planned rate.
- [x] `TestPlannerArbitragePeakExportSlotStaysOnEnergyPath` — peak-export regression.
- [x] `TestPlannerArbitrageCoverLoadDoesNotDischargeIntoLiveExport` — live PV surplus does not get blindly exported via battery.
- [x] `TestPlannerArbitrageDischargeSlotWithoutPlannedGridWUsesEnergyPath` — backcompat for `HasPlannedGridW=false`.
- [x] `TestPlannerPassiveArbitrageCoverLoadBacksOffOnLoadUndershoot` — passive cover-load regression.
- [x] `make verify` clean (vet + full test + build).
- [x] `make verify-all` clean (cross-compile for arm64 / amd64 / windows).
- [ ] Manual smoke on a Pi running planner_arbitrage during an expensive evening slot — watch for cover-load behaviour matching the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)