### PR TITLE
feat(diagnostics): per-slot Wh delivery tracking for reactive dispatch paths

### DIFF
--- a/.changeset/slot-delivery-observability.md
+++ b/.changeset/slot-delivery-observability.md
@@ -1,0 +1,19 @@
+---
+"forty-two-watts": minor
+---
+
+feat(diagnostics): per-slot Wh delivery tracking for reactive dispatch paths
+
+Adds an independent per-slot Wh accumulator that runs on every dispatch
+tick regardless of which execution path was taken (planner_self, planner
+passive_arbitrage idle slots, the planner_arbitrage cover-load carve-out
+from PR #378, manual modes, plain self_consumption). At slot rollover
+the actual fleet delivery is compared against the plan's
+`BatteryEnergyWh`; ratios outside [0.5, 1.5] are logged and bump
+`SlotDeliveryStats.OverDeliveryCount` / `UnderDeliveryCount`, surfaced
+on `/api/status`. Idle slots (|planned| ≤ 50 Wh) are skipped — ratio
+against ~0 is meaningless.
+
+Pure observability — no dispatch decision reads the counters and no
+hard Wh cap is applied to reactive paths. The point is to measure
+first, decide on enforcement later.

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -748,6 +748,11 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"phase_powers": siteMeterPhasePowers(s.deps.Tel, ctrl.SiteMeterDriver),
 		"drivers":      drivers,
 		"dispatch":     dispatch,
+		// Observability counters for the per-slot Wh tracker. Pure
+		// diagnostic — incremented when actual fleet delivery diverges
+		// from the plan's BatteryEnergyWh by > 50 % (over) or < 50 %
+		// (under). Idle slots (|planned| ≤ 50 Wh) are ignored.
+		"slot_delivery_stats": ctrl.SlotDeliveryStats,
 	}
 	if energyToday != nil || energyCurrentSlot != nil {
 		energy := map[string]any{}

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -4838,3 +4838,283 @@ func TestPlannerPassiveArbitrageChargeSlotPreservedAgainstReactiveDischarge(t *t
 		t.Errorf("TargetW = %.0f W — passive_arbitrage charge slot must NOT discharge reactively; the grid-charge plan must remain authoritative", got)
 	}
 }
+
+// ---- Slot delivery observability ----
+//
+// These tests cover the path-agnostic per-slot Wh accumulator that
+// runs on EVERY dispatch tick (planner_self, planner_passive_arbitrage,
+// the planner_arbitrage cover-load carve-out from PR #378, etc.).
+// The accumulator measures actual fleet delivery and compares it
+// against the plan's BatteryEnergyWh at slot rollover. Pure
+// observability — no dispatch decision reads the counters.
+
+// makeSlotMetricsState configures the minimum State needed to exercise
+// the slot-delivery accumulator. Mode is planner_arbitrage so that
+// SlotDirective is consulted, but useEnergyPath is irrelevant to the
+// accumulator (it runs above all mode logic).
+func makeSlotMetricsState(siteMeter string, dirFn SlotDirectiveFunc) *State {
+	st := NewState(0, 0, siteMeter)
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = dirFn
+	return st
+}
+
+// 1. The accumulator integrates current battery total × dt across
+//    multiple ticks within the same slot.
+func TestSlotMetricsAccumulatesActualWhAcrossTicks(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:       now.Add(-1 * time.Minute),
+		SlotEnd:         now.Add(14 * time.Minute),
+		BatteryEnergyWh: -300,
+		Strategy:        "arbitrage",
+	}
+	// Battery at -1000 W (site-signed: discharging) throughout.
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1000, 0.5},
+	})
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return dir, true })
+
+	// Tick 1 — initialise accumulator (no integration yet, anchor only).
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.slotActualWh != 0 {
+		t.Fatalf("first tick should only anchor, got slotActualWh=%f", st.slotActualWh)
+	}
+	if !st.slotActualSlotStart.Equal(dir.SlotStart) {
+		t.Fatalf("anchor SlotStart = %v, want %v", st.slotActualSlotStart, dir.SlotStart)
+	}
+
+	// Simulate 60 s elapsed since the anchor tick by rewinding the
+	// last-tick timestamp. -1000 W × 60 s ≈ -16.67 Wh.
+	st.slotActualLastTs = st.slotActualLastTs.Add(-60 * time.Second)
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	wantWh := -1000.0 * 60.0 / 3600.0 // ≈ -16.667
+	if math.Abs(st.slotActualWh-wantWh) > 1.0 {
+		t.Errorf("after ~60 s @ -1000 W: slotActualWh = %.3f Wh, want ≈ %.3f Wh", st.slotActualWh, wantWh)
+	}
+
+	// Another 60 s — total should be ~ -33.3 Wh.
+	st.slotActualLastTs = st.slotActualLastTs.Add(-60 * time.Second)
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	wantWh2 := -1000.0 * 120.0 / 3600.0
+	if math.Abs(st.slotActualWh-wantWh2) > 1.0 {
+		t.Errorf("after ~120 s @ -1000 W: slotActualWh = %.3f Wh, want ≈ %.3f Wh", st.slotActualWh, wantWh2)
+	}
+}
+
+// 2. When the SlotDirective's SlotStart advances, the accumulator
+//    resets — the in-progress slot accumulator must not leak into
+//    the next slot's measurement.
+func TestSlotMetricsResetsOnSlotRollover(t *testing.T) {
+	now := time.Now()
+	slot1Start := now.Add(-30 * time.Second)
+	slot1 := SlotDirective{
+		SlotStart:       slot1Start,
+		SlotEnd:         slot1Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -300,
+	}
+	slot2Start := slot1Start.Add(15 * time.Minute)
+	slot2 := SlotDirective{
+		SlotStart:       slot2Start,
+		SlotEnd:         slot2Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -300,
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1000, 0.5},
+	})
+
+	active := slot1
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return active, true })
+
+	// Tick 1 — anchor slot 1, then integrate 60 s.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	st.slotActualLastTs = st.slotActualLastTs.Add(-60 * time.Second)
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if math.Abs(st.slotActualWh) < 10 {
+		t.Fatalf("setup: slot 1 should have ~ -16.7 Wh accumulated, got %f", st.slotActualWh)
+	}
+
+	// Swap to slot 2 — rollover should reset slotActualWh and re-anchor.
+	active = slot2
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.slotActualWh != 0 {
+		t.Errorf("after slot rollover, slotActualWh should reset to 0, got %f", st.slotActualWh)
+	}
+	if !st.slotActualSlotStart.Equal(slot2Start) {
+		t.Errorf("after rollover, anchor = %v, want %v", st.slotActualSlotStart, slot2Start)
+	}
+}
+
+// 3. Over-delivery: planned -425 Wh, actual ~ -850 Wh → ratio 2.0,
+//    well above 1.5. Counter should increment by 1 on slot rollover.
+func TestSlotMetricsLogsOverDeliveryAtSlotEnd(t *testing.T) {
+	now := time.Now()
+	slot1Start := now.Add(-1 * time.Minute)
+	slot1 := SlotDirective{
+		SlotStart:       slot1Start,
+		SlotEnd:         slot1Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+	}
+	slot2Start := slot1Start.Add(15 * time.Minute)
+	slot2 := SlotDirective{
+		SlotStart:       slot2Start,
+		SlotEnd:         slot2Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+	}
+	// Battery discharging hard: -1700 W average × 30 min = -850 Wh
+	// (using fewer ticks here — we drive the accumulator directly).
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.5},
+	})
+
+	active := slot1
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return active, true })
+
+	// Anchor slot 1.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	// Force accumulator to -850 Wh (2 × planned magnitude → ratio 2.0).
+	st.slotActualWh = -850
+
+	// Rollover into slot 2 — should log + increment OverDeliveryCount.
+	active = slot2
+	beforeOver := st.SlotDeliveryStats.OverDeliveryCount
+	beforeUnder := st.SlotDeliveryStats.UnderDeliveryCount
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.SlotDeliveryStats.OverDeliveryCount != beforeOver+1 {
+		t.Errorf("OverDeliveryCount = %d, want %d (incremented by 1 at rollover)",
+			st.SlotDeliveryStats.OverDeliveryCount, beforeOver+1)
+	}
+	if st.SlotDeliveryStats.UnderDeliveryCount != beforeUnder {
+		t.Errorf("UnderDeliveryCount = %d, want unchanged %d", st.SlotDeliveryStats.UnderDeliveryCount, beforeUnder)
+	}
+}
+
+// 4. Under-delivery: planned -425 Wh, actual -100 Wh → ratio 0.235,
+//    well below 0.5. Counter should increment by 1.
+func TestSlotMetricsLogsUnderDelivery(t *testing.T) {
+	now := time.Now()
+	slot1Start := now.Add(-1 * time.Minute)
+	slot1 := SlotDirective{
+		SlotStart:       slot1Start,
+		SlotEnd:         slot1Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+	}
+	slot2Start := slot1Start.Add(15 * time.Minute)
+	slot2 := SlotDirective{
+		SlotStart:       slot2Start,
+		SlotEnd:         slot2Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -400, 0.5},
+	})
+
+	active := slot1
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return active, true })
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	st.slotActualWh = -100 // ratio = 100/425 ≈ 0.235 < 0.5
+
+	active = slot2
+	before := st.SlotDeliveryStats.UnderDeliveryCount
+	beforeOver := st.SlotDeliveryStats.OverDeliveryCount
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.SlotDeliveryStats.UnderDeliveryCount != before+1 {
+		t.Errorf("UnderDeliveryCount = %d, want %d", st.SlotDeliveryStats.UnderDeliveryCount, before+1)
+	}
+	if st.SlotDeliveryStats.OverDeliveryCount != beforeOver {
+		t.Errorf("OverDeliveryCount = %d, want unchanged %d", st.SlotDeliveryStats.OverDeliveryCount, beforeOver)
+	}
+}
+
+// 5. Idle slots — |planned| ≤ 50 Wh — must not trigger logs or
+//    counters regardless of actual delivery. Ratio against ~0 is
+//    meaningless.
+func TestSlotMetricsIgnoresIdleSlots(t *testing.T) {
+	now := time.Now()
+	slot1Start := now.Add(-1 * time.Minute)
+	slot1 := SlotDirective{
+		SlotStart:       slot1Start,
+		SlotEnd:         slot1Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -30, // below 50 Wh threshold
+	}
+	slot2Start := slot1Start.Add(15 * time.Minute)
+	slot2 := SlotDirective{
+		SlotStart:       slot2Start,
+		SlotEnd:         slot2Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -30,
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -2000, 0.5},
+	})
+
+	active := slot1
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return active, true })
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	st.slotActualWh = -500 // any value — should be ignored at rollover
+
+	active = slot2
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if st.SlotDeliveryStats.OverDeliveryCount != 0 || st.SlotDeliveryStats.UnderDeliveryCount != 0 {
+		t.Errorf("idle slot (|planned|=30 Wh) must not bump counters, got over=%d under=%d",
+			st.SlotDeliveryStats.OverDeliveryCount, st.SlotDeliveryStats.UnderDeliveryCount)
+	}
+}
+
+// 6. Counter accumulates monotonically across multiple over-delivery
+//    rollovers — three slots in sequence → counter = 3.
+func TestSlotMetricsCounterSurvivesMultipleSlots(t *testing.T) {
+	now := time.Now()
+	base := now.Add(-1 * time.Hour) // well in the past so all slots are "real"
+
+	slots := []SlotDirective{
+		{SlotStart: base, SlotEnd: base.Add(15 * time.Minute), BatteryEnergyWh: -400},
+		{SlotStart: base.Add(15 * time.Minute), SlotEnd: base.Add(30 * time.Minute), BatteryEnergyWh: -400},
+		{SlotStart: base.Add(30 * time.Minute), SlotEnd: base.Add(45 * time.Minute), BatteryEnergyWh: -400},
+		{SlotStart: base.Add(45 * time.Minute), SlotEnd: base.Add(60 * time.Minute), BatteryEnergyWh: -400},
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -2000, 0.5},
+	})
+
+	idx := 0
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) {
+		return slots[idx], true
+	})
+
+	// Anchor slot 0.
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	// For each of slots 0,1,2: force over-delivery on the in-flight slot,
+	// then advance idx → next tick triggers rollover evaluation.
+	for i := 0; i < 3; i++ {
+		st.slotActualWh = -1000 // ratio = 1000/400 = 2.5 → over
+		idx++
+		_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	}
+	if st.SlotDeliveryStats.OverDeliveryCount != 3 {
+		t.Errorf("after 3 over-delivery rollovers, OverDeliveryCount = %d, want 3",
+			st.SlotDeliveryStats.OverDeliveryCount)
+	}
+}

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -330,6 +330,37 @@ type State struct {
 	slotDelivered    float64   // Wh delivered to batteries since slot start
 	lastTickTs       time.Time // for ∫ battery_w dt
 
+	// slotActualWh + slotActualLastTs + slotActualSlotStart are the
+	// path-agnostic per-slot delivery accumulator. Updated on EVERY
+	// dispatch tick (every mode, every path) from the live battery
+	// aggregate — independent of the energy-allocation bookkeeping
+	// above (which only updates inside useEnergyPath).
+	//
+	// The point is observability: when reactive paths (cover-load
+	// discharge, planner_self, planner_passive_arbitrage idle slots,
+	// the planner_arbitrage cover-load carve-out from PR #378) execute,
+	// the existing slotDelivered does not track them. Without an
+	// independent accumulator there's no way to measure whether those
+	// paths over- or under-deliver vs the plan's BatteryEnergyWh.
+	//
+	// At slot rollover (SlotStart change) the just-ended slot is
+	// evaluated and over/under-delivery is logged + counted. The
+	// resulting counters surface on /api/status so operators can spot
+	// systemic forecast vs reality drift. Site-signed: negative = the
+	// fleet discharged Wh during the slot.
+	slotActualWh         float64
+	slotActualLastTs     time.Time
+	slotActualSlotStart  time.Time
+	slotActualPlannedWh  float64 // planned BatteryEnergyWh cached for the slot in flight
+
+	// SlotDeliveryStats counts how many slots ended with the actual
+	// fleet delivery falling outside ±50 % of the planned magnitude.
+	// Idle/charge slots with |planned| ≤ 50 Wh are ignored — the
+	// ratio is meaningless when the denominator is ~0. Read-only from
+	// the API; mutated only inside ComputeDispatch under the caller's
+	// outer ctrlMu.
+	SlotDeliveryStats SlotDeliveryStats
+
 	// PlanStale tracks whether the last cycle fell back to self_consumption
 	// because the plan was missing. Surfaced via the API for the UI.
 	PlanStale bool
@@ -541,6 +572,106 @@ func resetEnergyDispatchBookkeeping(state *State) {
 	state.currentDirective = SlotDirective{}
 	state.slotDelivered = 0
 	state.lastTickTs = time.Time{}
+}
+
+// SlotDeliveryStats tracks observed gaps between the plan's per-slot
+// BatteryEnergyWh and the live fleet's actual delivered Wh. Updated at
+// slot rollover by updateSlotDeliveryMetrics. Pure observability — no
+// dispatch decision reads these.
+type SlotDeliveryStats struct {
+	OverDeliveryCount  uint64 `json:"over_delivery_count"`
+	UnderDeliveryCount uint64 `json:"under_delivery_count"`
+}
+
+// slotDeliveryOverThreshold + slotDeliveryUnderThreshold define the
+// magnitude band that counts as "delivered within plan". The plan-vs-
+// actual ratio is computed as |actual| / max(|planned|, 1); ratios
+// outside [0.5, 1.5] increment the corresponding counter (when the
+// slot wasn't an idle one — see slotDeliveryIdleWhCutoff).
+const (
+	slotDeliveryOverThreshold  = 1.5
+	slotDeliveryUnderThreshold = 0.5
+	slotDeliveryIdleWhCutoff   = 50.0
+	slotDeliveryMaxTickDtS     = 300.0
+)
+
+// updateSlotDeliveryMetrics is the path-agnostic per-slot Wh tracker.
+// It runs on EVERY dispatch tick (every mode, every path) so reactive
+// paths that bypass the energy-allocation bookkeeping still feed an
+// independent record of "what did the fleet actually deliver this
+// slot, and how does that compare to the plan?". See State.slotActualWh
+// for the rationale and the cover-load carve-out (PR #378) context.
+//
+// When SlotDirective is unset or returns ok=false the accumulator is
+// paused for this tick: there's no slot context to attribute Wh to.
+//
+// When the directive's SlotStart advances the just-ended slot is
+// scored: |actual| / max(|planned|, 1). Ratios > 1.5 log an
+// over-delivery and bump OverDeliveryCount; ratios < 0.5 log
+// under-delivery and bump UnderDeliveryCount. Idle/charge slots
+// where |planned| ≤ slotDeliveryIdleWhCutoff are skipped — measuring
+// a ratio against ~0 is meaningless.
+//
+// The first-ever tick (zero-value slotActualSlotStart) initialises
+// the accumulator without emitting anything.
+func updateSlotDeliveryMetrics(state *State, currentTotalW float64, now time.Time) {
+	if state == nil || state.SlotDirective == nil {
+		return
+	}
+	dir, ok := state.SlotDirective(now)
+	if !ok {
+		return
+	}
+
+	if state.slotActualSlotStart.IsZero() {
+		state.slotActualSlotStart = dir.SlotStart
+		state.slotActualLastTs = now
+		state.slotActualWh = 0
+		state.slotActualPlannedWh = dir.BatteryEnergyWh
+		return
+	}
+
+	if !dir.SlotStart.Equal(state.slotActualSlotStart) {
+		// Slot rollover: evaluate the just-ended slot using the
+		// planned Wh cached from prior ticks. Reactive paths don't
+		// touch state.currentDirective (that's energy-path bookkeeping),
+		// so this accumulator keeps its own slotActualPlannedWh.
+		plannedWh := state.slotActualPlannedWh
+		if math.Abs(plannedWh) > slotDeliveryIdleWhCutoff {
+			ratio := math.Abs(state.slotActualWh) / math.Max(math.Abs(plannedWh), 1)
+			switch {
+			case ratio > slotDeliveryOverThreshold:
+				slog.Info("dispatch slot over-delivery",
+					"mode", state.Mode,
+					"planned_wh", plannedWh,
+					"actual_wh", state.slotActualWh,
+					"ratio", ratio,
+					"slot_start", state.slotActualSlotStart)
+				state.SlotDeliveryStats.OverDeliveryCount++
+			case ratio < slotDeliveryUnderThreshold:
+				slog.Info("dispatch slot under-delivery",
+					"mode", state.Mode,
+					"planned_wh", plannedWh,
+					"actual_wh", state.slotActualWh,
+					"ratio", ratio,
+					"slot_start", state.slotActualSlotStart)
+				state.SlotDeliveryStats.UnderDeliveryCount++
+			}
+		}
+		state.slotActualSlotStart = dir.SlotStart
+		state.slotActualLastTs = now
+		state.slotActualWh = 0
+		state.slotActualPlannedWh = dir.BatteryEnergyWh
+		return
+	}
+
+	dt := now.Sub(state.slotActualLastTs).Seconds()
+	if dt > 0 && dt < slotDeliveryMaxTickDtS {
+		state.slotActualWh += currentTotalW * dt / 3600.0
+	}
+	state.slotActualLastTs = now
+	// Keep the planned value fresh in case a mid-slot replan changed it.
+	state.slotActualPlannedWh = dir.BatteryEnergyWh
 }
 
 const (
@@ -780,6 +911,33 @@ func ComputeDispatch(
 	driverCapacities map[string]float64,
 	fuseMaxW float64,
 ) []DispatchTarget {
+	// ---- Per-slot Wh delivery observability (path-agnostic) ----
+	// Runs on EVERY tick before any mode/short-circuit decision so the
+	// idle / charge / holdoff / reactive-fallback paths all contribute
+	// to the actual-delivered accumulator. Independent of the
+	// energy-allocation bookkeeping (slotDelivered) which only updates
+	// inside useEnergyPath — that's why reactive cover-load discharge
+	// (PR #378) and planner_passive_arbitrage idle slots are invisible
+	// to that accumulator. This one isn't.
+	//
+	// Pure observability — log + counter only. No dispatch decision
+	// reads SlotDeliveryStats; no Wh cap is applied to reactive paths
+	// from this data. The point is to measure first, decide whether a
+	// cap is warranted later.
+	{
+		now := time.Now()
+		var liveBatTotal float64
+		for name := range driverCapacities {
+			if r := store.Get(name, telemetry.DerBattery); r != nil {
+				h := store.DriverHealth(name)
+				if h != nil && h.IsOnline() {
+					liveBatTotal += r.SmoothedW
+				}
+			}
+		}
+		updateSlotDeliveryMetrics(state, liveBatTotal, now)
+	}
+
 	// ---- Planner modes: the plan is a scheduler, not a regulator ----
 	// The plan decides WHEN each strategy applies (self-consumption now,
 	// charge at 02:00, export at 17:00). The EMS decides HOW batteries


### PR DESCRIPTION
## Summary

- Adds a path-agnostic per-slot Wh accumulator that runs on **every** dispatch tick, regardless of execution path.
- At slot rollover the accumulator scores actual fleet delivery against the plan's `BatteryEnergyWh`: ratio > 1.5 → `SlotDeliveryStats.OverDeliveryCount++` + `slog.Info` log line; ratio < 0.5 → `UnderDeliveryCount++` + log line.
- Counters surface on `GET /api/status` under `"slot_delivery_stats"` so operators can spot systemic forecast-vs-reality drift.

## Why now

PR #378 (commit `adf3f86`) added a cover-load carve-out: `planner_arbitrage` discharge slots with `PlannedGridW > -100 W` AND `BatteryEnergyWh < -50 Wh` fall through from the energy-allocation path to reactive PI-on-grid=0. There are now multiple execution paths where the plan's per-slot Wh budget is not strictly tracked by the existing `slotDelivered` accumulator:

- the cover-load reactive path (PR #378)
- the existing `planner_passive_arbitrage` idle / non-charge carve-out
- the `planner_self` path (always reactive)
- manual modes and plain `self_consumption`

Without an independent accumulator we have no data on whether those paths over- or under-deliver vs the DP's plan. This PR adds that data-gathering layer so we can decide later whether a hard Wh cap is warranted.

## What is NOT changing

- **No Wh cap is added.** Pure observability. No dispatch decision reads `SlotDeliveryStats`; reactive paths still chase grid=0 unconstrained by plan magnitude.
- Idle slots (`|planned| ≤ 50 Wh`) are intentionally skipped — over/under against ~0 is meaningless.
- The energy-allocation bookkeeping (`slotDelivered` / `lastTickTs` / `currentDirective`) is untouched. The new accumulator runs alongside it on its own fields (`slotActualWh`, `slotActualLastTs`, `slotActualSlotStart`, `slotActualPlannedWh`).

## Implementation notes

- New helper `updateSlotDeliveryMetrics(state, currentTotalW, now)` invoked at the very top of `ComputeDispatch`, before the manual-hold / idle / charge / holdoff short-circuits so the tick is counted even when those paths return early.
- `dt` capped at 300 s to handle long pauses (mirrors the existing energy-path guard at `dispatch.go:1133`).
- Slot rollover detected by `dir.SlotStart != state.slotActualSlotStart`; the just-ended slot is evaluated using `state.slotActualPlannedWh` (cached on every tick so reactive paths that never populate `state.currentDirective` still have a planned magnitude to compare against).
- First-ever tick (zero-value `slotActualSlotStart`) only anchors — no log emission.

## Test plan

- [x] `TestSlotMetricsAccumulatesActualWhAcrossTicks` — Wh integrates across ticks at -1000 W battery.
- [x] `TestSlotMetricsResetsOnSlotRollover` — accumulator resets to 0 when `SlotStart` advances.
- [x] `TestSlotMetricsLogsOverDeliveryAtSlotEnd` — planned -425, actual -850 (ratio 2.0) bumps `OverDeliveryCount`.
- [x] `TestSlotMetricsLogsUnderDelivery` — planned -425, actual -100 (ratio 0.24) bumps `UnderDeliveryCount`.
- [x] `TestSlotMetricsIgnoresIdleSlots` — planned -30 Wh (below 50 Wh cutoff) never bumps counters.
- [x] `TestSlotMetricsCounterSurvivesMultipleSlots` — 3 sequential over-delivery rollovers → counter = 3.
- [x] `make verify` passes locally (vet + full test suite + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)