### PR TITLE
feat(mpc): tighter replan triggers + twin-driven replan signal

### DIFF
--- a/.changeset/replanner-more-responsive.md
+++ b/.changeset/replanner-more-responsive.md
@@ -1,0 +1,17 @@
+---
+"forty-two-watts": minor
+---
+
+feat(mpc): tighter replan triggers + twin-driven replan signal
+
+Tightens the reactive replan thresholds (PV 500→250 Wh, load 400→200 Wh,
+half-life 15→8 min, cooldown 60→30 s) and adds a third trigger that fires
+when the PV or load twin's CURRENT prediction has shifted materially (RMSE
+> 250 W PV / 200 W load over the next 16 slots) from the prediction the
+active plan was built on.
+
+The twin already self-corrects every cycle through RLS; the planner only
+consumed its output every 15 min. The new signal closes that gap without
+waiting for the integral-of-error to accumulate. Replanning is ~100 ms on
+a Pi 4 (51 × 21 × 193 DP cells, sub-1 % CPU) — being stingy was the wrong
+default.

--- a/go/internal/mpc/reactive_test.go
+++ b/go/internal/mpc/reactive_test.go
@@ -164,6 +164,238 @@ func TestReactiveLoadDivergenceSkipsOfflineSiteMeter(t *testing.T) {
 	}
 }
 
+// buildDefaultTestService spins up a Service with the production
+// defaults (PV=250Wh, Load=200Wh, MinReplanGap=30s, 8-min half-life
+// inside checkDivergence) so the tighter-trigger tests exercise what
+// real deployments see.
+func buildDefaultTestService(t *testing.T, planPV, planLoad float64) (*Service, *telemetry.Store) {
+	t.Helper()
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	tel := telemetry.NewStore()
+	tel.DriverHealthMut("site").RecordSuccess()
+	tel.DriverHealthMut("inverter").RecordSuccess()
+
+	// Mirror New()'s defaults so this test exercises the production
+	// reactive-trigger numbers.
+	s := New(st, tel, "SE3", Params{})
+	s.SiteMeter = "site"
+	s.ReactiveInterval = 10 * time.Millisecond
+	now := time.Now()
+	s.last = &Plan{
+		GeneratedAtMs: now.Add(-time.Minute).UnixMilli(),
+		Actions: []Action{{
+			SlotStartMs: now.Add(-5 * time.Minute).UnixMilli(),
+			SlotLenMin:  15,
+			PVW:         planPV,
+			LoadW:       planLoad,
+		}},
+	}
+	s.lastReplanAt = time.Now().Add(-time.Hour)
+	return s, tel
+}
+
+// TestReactiveReplanFiresAtTighterLoadThreshold proves the lowered
+// 200 Wh load threshold + 8-min half-life trip a replan after a few
+// minutes of sustained drift, while the old 400 Wh + 15-min combo
+// would still be coasting.
+func TestReactiveReplanFiresAtTighterLoadThreshold(t *testing.T) {
+	s, tel := buildDefaultTestService(t, 0, 500)
+	// Sustained +1500 W house load drift. Steady-state of the leaky
+	// integral with the new 480 s half-life is roughly
+	// 1500 W × 480 s / ln(2) / 3600 ≈ 290 Wh — well past 200 Wh.
+	tel.Update("site", telemetry.DerMeter, 2000, nil, nil) // pv=0, bat=0 → load=2000, plan=500, gap=1500
+	driveTicks(s, 30, 10)
+	if s.lastReason != "reactive-load" {
+		t.Fatalf("expected reactive-load with new 200 Wh threshold, got %q (loadInt=%.0fWh)",
+			s.lastReason, s.loadErrIntWh)
+	}
+}
+
+// TestReactiveReplanFiresAtTighterPVThreshold mirrors the load case
+// for PV — same magnitudes scaled to the 250 Wh threshold.
+func TestReactiveReplanFiresAtTighterPVThreshold(t *testing.T) {
+	s, tel := buildDefaultTestService(t, 0, 500)
+	// Sustained PV undershoot: plan expected 0, actual −2000 W generation.
+	// Same steady-state arithmetic — ~390 Wh > 250 Wh.
+	tel.Update("inverter", telemetry.DerPV, -2000, nil, nil)
+	tel.Update("site", telemetry.DerMeter, -1500, nil, nil) // load 500 + pv -2000
+	driveTicks(s, 30, 10)
+	if s.lastReason != "reactive-pv" {
+		t.Fatalf("expected reactive-pv with new 250 Wh threshold, got %q (pvInt=%.0fWh)",
+			s.lastReason, s.pvErrIntWh)
+	}
+}
+
+// TestReactiveReplanRespectsShorterCooldown — the 30 s MinReplanGap
+// still suppresses back-to-back replans even when the integral is hot.
+func TestReactiveReplanRespectsShorterCooldown(t *testing.T) {
+	s, tel := buildDefaultTestService(t, 0, 500)
+	s.lastReplanAt = time.Now().Add(-5 * time.Second)
+	s.lastReason = "scheduled"
+	tel.Update("site", telemetry.DerMeter, 5000, nil, nil)
+	driveTicks(s, 60, 10)
+	if s.lastReason != "scheduled" {
+		t.Fatalf("30 s cooldown should still suppress replan 5 s after the last; got %q", s.lastReason)
+	}
+}
+
+// ---- Twin-drift trigger ----
+
+// twinDriftService wires PV/Load predictors and a cached plan + planned
+// predictions snapshot. The snapshot lives at fixed slot timestamps so
+// the comparison is deterministic regardless of wall-clock drift.
+func twinDriftService(t *testing.T) *Service {
+	t.Helper()
+	st, err := state.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	tel := telemetry.NewStore()
+	s := New(st, tel, "SE3", Params{})
+	s.ReactiveInterval = 10 * time.Millisecond
+	// Make sure cooldown doesn't suppress the first trigger.
+	s.lastReplanAt = time.Now().Add(-time.Hour)
+	return s
+}
+
+func TestTwinDriftReplanFiresOnLargePVShift(t *testing.T) {
+	s := twinDriftService(t)
+
+	// Snapshot the plan's PV predictions: 16 slots of 1000 W each.
+	now := time.Now().Truncate(time.Minute)
+	pp := &plannedPredictions{
+		pv:        make([]float64, 16),
+		load:      make([]float64, 16),
+		slotStart: make([]time.Time, 16),
+		builtAt:   now,
+	}
+	for i := 0; i < 16; i++ {
+		pp.pv[i] = 1000
+		pp.slotStart[i] = now.Add(time.Duration(i) * 15 * time.Minute)
+	}
+	s.plannedPredictions = pp
+	// A live PV predictor that now returns 1500 W per slot — RMSE = 500 W,
+	// well past the 250 W threshold.
+	s.PV = func(time.Time, float64) float64 { return 1500 }
+	// Stub a minimal plan so replan() (called on trigger) doesn't panic —
+	// it'll bail with "no prices available yet" but lastReason has been
+	// set on the service before that call, which is what we assert.
+	s.last = &Plan{GeneratedAtMs: now.UnixMilli()}
+
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "twin-drift-pv" {
+		t.Fatalf("expected twin-drift-pv after 500 W RMSE shift, got %q", s.lastReason)
+	}
+}
+
+func TestTwinDriftReplanFiresOnLargeLoadShift(t *testing.T) {
+	s := twinDriftService(t)
+
+	now := time.Now().Truncate(time.Minute)
+	pp := &plannedPredictions{
+		pv:        make([]float64, 16),
+		load:      make([]float64, 16),
+		slotStart: make([]time.Time, 16),
+		builtAt:   now,
+	}
+	for i := 0; i < 16; i++ {
+		pp.load[i] = 800
+		pp.slotStart[i] = now.Add(time.Duration(i) * 15 * time.Minute)
+	}
+	s.plannedPredictions = pp
+	s.Load = func(time.Time) float64 { return 1100 } // RMSE = 300 W > 200 W
+	s.last = &Plan{GeneratedAtMs: now.UnixMilli()}
+
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "twin-drift-load" {
+		t.Fatalf("expected twin-drift-load after 300 W RMSE shift, got %q", s.lastReason)
+	}
+}
+
+func TestTwinDriftReplanIgnoresTinyShift(t *testing.T) {
+	s := twinDriftService(t)
+	now := time.Now().Truncate(time.Minute)
+	pp := &plannedPredictions{
+		pv:        make([]float64, 16),
+		load:      make([]float64, 16),
+		slotStart: make([]time.Time, 16),
+		builtAt:   now,
+	}
+	for i := 0; i < 16; i++ {
+		pp.pv[i] = 1000
+		pp.load[i] = 800
+		pp.slotStart[i] = now.Add(time.Duration(i) * 15 * time.Minute)
+	}
+	s.plannedPredictions = pp
+	// PV drifted only 100 W — under 250 W threshold. Load held.
+	s.PV = func(time.Time, float64) float64 { return 1100 }
+	s.Load = func(time.Time) float64 { return 800 }
+	s.last = &Plan{GeneratedAtMs: now.UnixMilli()}
+	s.lastReason = "scheduled"
+
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "scheduled" {
+		t.Fatalf("100 W RMSE must not trigger replan, got %q", s.lastReason)
+	}
+}
+
+func TestTwinDriftReplanRespectsCooldown(t *testing.T) {
+	s := twinDriftService(t)
+	s.MinReplanGap = 30 * time.Second
+	s.lastReplanAt = time.Now().Add(-5 * time.Second) // inside cooldown
+
+	now := time.Now().Truncate(time.Minute)
+	pp := &plannedPredictions{
+		pv:        make([]float64, 16),
+		load:      make([]float64, 16),
+		slotStart: make([]time.Time, 16),
+		builtAt:   now,
+	}
+	for i := 0; i < 16; i++ {
+		pp.pv[i] = 1000
+		pp.slotStart[i] = now.Add(time.Duration(i) * 15 * time.Minute)
+	}
+	s.plannedPredictions = pp
+	s.PV = func(time.Time, float64) float64 { return 2000 } // huge drift
+	s.last = &Plan{GeneratedAtMs: now.UnixMilli()}
+	s.lastReason = "scheduled"
+
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "scheduled" {
+		t.Fatalf("cooldown should suppress twin-drift replan, got %q", s.lastReason)
+	}
+}
+
+func TestTwinDriftReplanSkipsWhenPredictorIsNil(t *testing.T) {
+	s := twinDriftService(t)
+	// No predictors wired (s.PV == nil && s.Load == nil) and no snapshot.
+	// Must not panic; lastReason untouched.
+	s.lastReason = "scheduled"
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "scheduled" {
+		t.Fatalf("nil predictors must not trigger replan, got %q", s.lastReason)
+	}
+
+	// Even with a snapshot present but predictors nil, no trigger.
+	now := time.Now()
+	pp := &plannedPredictions{
+		pv:        []float64{1000, 1000, 1000},
+		load:      []float64{500, 500, 500},
+		slotStart: []time.Time{now, now.Add(15 * time.Minute), now.Add(30 * time.Minute)},
+		builtAt:   now,
+	}
+	s.plannedPredictions = pp
+	s.checkTwinDrift(context.Background())
+	if s.lastReason != "scheduled" {
+		t.Fatalf("nil predictors with snapshot must still not trigger, got %q", s.lastReason)
+	}
+}
+
 func TestLastReplanInfoReturnsPair(t *testing.T) {
 	s, _ := buildTestService(t, 0, 0)
 	s.lastReplanAt = time.Unix(1700000000, 0)

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -100,15 +100,33 @@ type Service struct {
 	// kWh-scale drift, not W-scale noise. Integrating over a window
 	// filters the transients and keeps us honest.
 	ReactiveInterval time.Duration // how often to check (default 10s)
-	MinReplanGap     time.Duration // cooldown between reactive replans (default 60s)
-	PVDivergenceWh   float64       // |integrated gap|; 0 disables (default 500 Wh)
-	LoadDivergenceWh float64       // |integrated gap|; 0 disables (default 400 Wh)
+	MinReplanGap     time.Duration // cooldown between reactive replans (default 30s)
+	PVDivergenceWh   float64       // |integrated gap|; 0 disables (default 250 Wh)
+	LoadDivergenceWh float64       // |integrated gap|; 0 disables (default 200 Wh)
+
+	// TwinDriftPVW and TwinDriftLoadW trigger a replan when the PV /
+	// load twin's CURRENT prediction over the next TwinDriftHorizonSlots
+	// slots diverges (RMSE, W) from the prediction snapshot baked into
+	// the active plan. Complements the integral-of-error path: the
+	// integrators only see the current slot, but the twins self-correct
+	// continuously (RLS) — so when their next-few-hours forecast shifts
+	// materially, the plan goes stale even while the current slot looks
+	// fine. 0 disables.
+	TwinDriftPVW          float64 // RMSE threshold (W), default 250
+	TwinDriftLoadW        float64 // RMSE threshold (W), default 200
+	TwinDriftHorizonSlots int     // how many forward slots to compare (default 16 ≈ 4 h @15-min)
 
 	// Leaky integrals (Wh) of (actual − predicted) over the last
 	// ~WindowMin minutes. Decayed each tick so old divergence fades.
 	pvErrIntWh   float64
 	loadErrIntWh float64
 	lastTickMs   int64
+
+	// plannedPredictions snapshots the per-slot PV + load predictions
+	// the most recent successful replan was built on, so the twin-drift
+	// detector can compare today's prediction against the one the active
+	// plan committed to. Updated under s.mu in replan().
+	plannedPredictions *plannedPredictions
 
 	// SiteMeter is the driver name whose meter reading represents the
 	// site's grid connection. Used by the reactive-replan check to
@@ -156,6 +174,18 @@ type Service struct {
 	done chan struct{}
 }
 
+// plannedPredictions captures the PV + load twin predictions the most
+// recent replan was built on, plus the slot grid they were sampled at.
+// The twin-drift check polls the predictors again at the same slot
+// timestamps and computes RMSE — any material shift means the plan is
+// running on a forecast the twins have since corrected away from.
+type plannedPredictions struct {
+	pv        []float64   // per-slot W (magnitude, ≥ 0)
+	load      []float64   // per-slot W (≥ 0)
+	slotStart []time.Time // slot-start timestamps for re-sampling
+	builtAt   time.Time
+}
+
 func (s *Service) driverOnline(name string) bool {
 	if s == nil || s.Tele == nil {
 		return false
@@ -174,11 +204,20 @@ func New(st *state.Store, tl *telemetry.Store, zone string, p Params) *Service {
 		Horizon:          48 * time.Hour, // always plan 48h — forecaster fills beyond day-ahead
 		Interval:         15 * time.Minute,
 		ReactiveInterval: 10 * time.Second,
-		MinReplanGap:     60 * time.Second,
-		PVDivergenceWh:   500, // 500 Wh sustained gap over ~15 min
-		LoadDivergenceWh: 400,
-		stop:             make(chan struct{}),
-		done:             make(chan struct{}),
+		// Tightened 2026-05: lower thresholds + shorter half-life + shorter
+		// cooldown so reactive paths replan well before the integrated gap
+		// has shifted real arbitrage value. Each replan is ~100 ms on a
+		// Pi 4 (51 SoC × 21 action × 193 slots DP, sub-1 % CPU) — being
+		// stingy was leaving stale plans in place every time the cover-
+		// load reactive carve-out fired (PR #378).
+		MinReplanGap:          30 * time.Second,
+		PVDivergenceWh:        250, // 250 Wh sustained gap over ~8 min
+		LoadDivergenceWh:      200,
+		TwinDriftPVW:          250,
+		TwinDriftLoadW:        200,
+		TwinDriftHorizonSlots: 16, // ~4 h at 15-min slots — short enough to keep RMSE meaningful
+		stop:                  make(chan struct{}),
+		done:                  make(chan struct{}),
 	}
 }
 
@@ -460,6 +499,7 @@ func (s *Service) loop(ctx context.Context) {
 			s.replan(ctx)
 		case <-reactiveTick:
 			s.checkDivergence(ctx)
+			s.checkTwinDrift(ctx)
 		}
 	}
 }
@@ -528,10 +568,13 @@ func (s *Service) checkDivergence(ctx context.Context) {
 		}
 	}
 
-	// Leaky integral of energy error (Wh). Decay with a 15-minute
+	// Leaky integral of energy error (Wh). Decay with an 8-minute
 	// half-life so transients fade but a sustained offset accumulates.
-	// decay = 0.5^(dt/halflife), halflife = 900s.
-	const halflifeS = 900.0
+	// decay = 0.5^(dt/halflife), halflife = 480s. Shortened from 15 min
+	// to react ~2× faster — replanning is cheap (~100 ms DP) and the old
+	// half-life left stale plans in flight every time the integral was
+	// dominated by minutes-old residuals.
+	const halflifeS = 480.0
 	tickMs := time.Now().UnixMilli()
 	dtS := 0.0
 	if s.lastTickMs > 0 {
@@ -576,6 +619,145 @@ func (s *Service) checkDivergence(ctx context.Context) {
 	s.mu.Lock()
 	s.pvErrIntWh = 0
 	s.loadErrIntWh = 0
+	s.mu.Unlock()
+	s.replan(ctx)
+}
+
+// snapshotPredictions samples the PV + load twins at the build-time slot
+// grid so the twin-drift detector can later re-sample at the same
+// timestamps and compute RMSE. Returns nil when neither predictor is
+// wired — twin-drift is a no-op in that case.
+func (s *Service) snapshotPredictions(slots []Slot, forecasts []state.ForecastPoint) *plannedPredictions {
+	if s == nil || (s.PV == nil && s.Load == nil) {
+		return nil
+	}
+	horizon := s.TwinDriftHorizonSlots
+	if horizon <= 0 {
+		horizon = 16
+	}
+	n := len(slots)
+	if n > horizon {
+		n = horizon
+	}
+	if n == 0 {
+		return nil
+	}
+	pp := &plannedPredictions{
+		pv:        make([]float64, n),
+		load:      make([]float64, n),
+		slotStart: make([]time.Time, n),
+		builtAt:   time.Now(),
+	}
+	for i := 0; i < n; i++ {
+		ts := time.UnixMilli(slots[i].StartMs).UTC()
+		pp.slotStart[i] = ts
+		if s.PV != nil {
+			cloud := lookupCloud(forecasts, slots[i].StartMs)
+			pv := s.PV(ts, cloud)
+			if math.IsNaN(pv) || math.IsInf(pv, 0) || pv < 0 {
+				pv = 0
+			}
+			pp.pv[i] = pv
+		}
+		if s.Load != nil {
+			ld := s.Load(ts)
+			if math.IsNaN(ld) || math.IsInf(ld, 0) || ld < 0 {
+				ld = 0
+			}
+			pp.load[i] = ld
+		}
+	}
+	return pp
+}
+
+// checkTwinDrift compares the PV + load twin's CURRENT predictions over
+// the next horizon slots to the snapshot the active plan was built on.
+// RMSE per signal; trigger replan when either exceeds its threshold.
+// Subject to MinReplanGap cooldown. No-op when no snapshot exists (e.g.
+// before the first replan) or predictors aren't wired.
+func (s *Service) checkTwinDrift(ctx context.Context) {
+	if s == nil {
+		return
+	}
+	s.mu.RLock()
+	pp := s.plannedPredictions
+	last := s.lastReplanAt
+	pvThresh := s.TwinDriftPVW
+	loadThresh := s.TwinDriftLoadW
+	pvFn := s.PV
+	loadFn := s.Load
+	s.mu.RUnlock()
+	if pp == nil || len(pp.slotStart) == 0 {
+		return
+	}
+	if pvFn == nil && loadFn == nil {
+		return
+	}
+	if pvThresh <= 0 && loadThresh <= 0 {
+		return
+	}
+	if time.Since(last) < s.MinReplanGap {
+		return
+	}
+
+	// Re-sample at the same slot timestamps. Need forecasts again for
+	// cloud lookup (PV predictor signature). Read from store; on error
+	// we fall back to a 50% cloud prior — the comparison is still valid
+	// because the original snapshot would have used the same fallback.
+	var forecasts []state.ForecastPoint
+	if s.Store != nil && pvFn != nil {
+		untilMs := pp.slotStart[len(pp.slotStart)-1].UnixMilli() + 24*3600*1000
+		sinceMs := pp.slotStart[0].UnixMilli() - 15*60*1000
+		if fs, err := s.Store.LoadForecasts(sinceMs, untilMs); err == nil {
+			forecasts = fs
+		}
+	}
+
+	var pvSumSq, loadSumSq float64
+	pvCount, loadCount := 0, 0
+	for i, ts := range pp.slotStart {
+		if pvFn != nil && pvThresh > 0 {
+			cloud := lookupCloud(forecasts, ts.UnixMilli())
+			pv := pvFn(ts, cloud)
+			if math.IsNaN(pv) || math.IsInf(pv, 0) || pv < 0 {
+				pv = 0
+			}
+			d := pv - pp.pv[i]
+			pvSumSq += d * d
+			pvCount++
+		}
+		if loadFn != nil && loadThresh > 0 {
+			ld := loadFn(ts)
+			if math.IsNaN(ld) || math.IsInf(ld, 0) || ld < 0 {
+				ld = 0
+			}
+			d := ld - pp.load[i]
+			loadSumSq += d * d
+			loadCount++
+		}
+	}
+	var pvRMSE, loadRMSE float64
+	if pvCount > 0 {
+		pvRMSE = math.Sqrt(pvSumSq / float64(pvCount))
+	}
+	if loadCount > 0 {
+		loadRMSE = math.Sqrt(loadSumSq / float64(loadCount))
+	}
+
+	reason := ""
+	switch {
+	case pvThresh > 0 && pvRMSE > pvThresh:
+		reason = "twin-drift-pv"
+		slog.Info("mpc: reactive replan", "trigger", "twin-drift-pv", "rmse", pvRMSE)
+	case loadThresh > 0 && loadRMSE > loadThresh:
+		reason = "twin-drift-load"
+		slog.Info("mpc: reactive replan", "trigger", "twin-drift-load", "rmse", loadRMSE)
+	}
+	if reason == "" {
+		return
+	}
+	s.mu.Lock()
+	s.lastReason = reason
 	s.mu.Unlock()
 	s.replan(ctx)
 }
@@ -780,12 +962,21 @@ func (s *Service) replan(_ context.Context) *Plan {
 		plan.Baselines = &bl
 	}
 
+	// Snapshot the twin predictions that went into this plan so the
+	// twin-drift detector can compare today's predictor output against
+	// the prediction the plan committed to. Sampled at the same slot
+	// timestamps buildSlots used. forecasts cloud lookup mirrors the
+	// path buildSlots takes for the PV predictor so the snapshot is
+	// apples-to-apples with what's re-sampled later.
+	pp := s.snapshotPredictions(slots, forecasts)
+
 	s.mu.Lock()
 	s.last = &plan
 	s.lastSlots = slots
 	s.lastParams = p
 	s.lastLoadpointID = loadpointID
 	s.lastReplanAt = time.Now()
+	s.plannedPredictions = pp
 	reason := s.lastReason
 	if reason == "" {
 		reason = "manual"


### PR DESCRIPTION
## Summary

- Tighten reactive replan thresholds: PV 500 → 250 Wh, load 400 → 200 Wh,
  half-life 15 → 8 min, cooldown 60 → 30 s.
- Add a third trigger — `checkTwinDrift` — that fires when the PV or
  load twin's CURRENT prediction has RMSE'd past 250 W (PV) / 200 W
  (load) from the prediction the active plan was built on, across the
  next 16 slots (~4 h @ 15-min).
- `replan()` now snapshots the planned PV + load predictions per slot
  so the twin-drift detector has a stable comparison baseline. The
  snapshot is built under the same `s.mu` lock as `s.last`.

## Motivation

PR #378 added a cover-load reactive carve-out in the dispatch layer. That
moved more decisions out of the plan and into the reactive paths, which
exposed how lazily the plan itself was refreshing — the integral-of-error
path can sit just under the threshold while the twins (RLS, self-correcting
every cycle) have already moved their forecast meaningfully.

The new twin-drift signal closes that gap: it's a direct read on "the
inputs we built the plan from have changed", not a derived signal that
fades back toward zero when reality swings symmetrically.

Why being aggressive about replanning is safe: a full DP solve on a Pi 4
is ~100 ms (51 SoC × 21 action × 193 slots, sub-1 % CPU). Sitting on a
stale plan for kWh-scale arbitrage value to recover the ~100 ms is the
wrong trade.

## What does NOT change

- DP grid resolution (51 × 21 × 193) — same compute envelope.
- Terminal-credit math (`upperHalfMeanPrice`, `selfConsumptionTerminalPrice`).
- Plan stability protections: `MaxPlanAge` gate, `SlotStart` anchoring,
  cooldown between reactive replans (still enforced, just shorter).
- Predictor signatures (`PVPredictor`, `LoadPredictor`) — unchanged.

## Test plan

- [x] `TestReactiveReplanFiresAtTighterLoadThreshold` — exercises 1.5 kW
      sustained load drift hitting the new 200 Wh threshold within minutes.
- [x] `TestReactiveReplanFiresAtTighterPVThreshold` — symmetric PV case
      against the new 250 Wh threshold.
- [x] `TestReactiveReplanRespectsShorterCooldown` — 30 s cooldown still
      suppresses back-to-back replans.
- [x] `TestTwinDriftReplanFiresOnLargePVShift` — RMSE 500 W → twin-drift-pv.
- [x] `TestTwinDriftReplanFiresOnLargeLoadShift` — RMSE 300 W → twin-drift-load.
- [x] `TestTwinDriftReplanIgnoresTinyShift` — RMSE 100 W stays quiet.
- [x] `TestTwinDriftReplanRespectsCooldown` — large shift inside 30 s gap
      does not trigger.
- [x] `TestTwinDriftReplanSkipsWhenPredictorIsNil` — no panic, no replan
      when predictors aren't wired (initial boot, unit tests).
- [x] `make verify` green (vet + unit + e2e + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)