### PR TITLE
feat(pvmodel): rolling residual correction for short-horizon prediction

### DIFF
--- a/.changeset/pvmodel-residual-correction.md
+++ b/.changeset/pvmodel-residual-correction.md
@@ -1,0 +1,41 @@
+---
+"forty-two-watts": minor
+---
+
+**PV twin now applies a short-horizon residual correction on top of the
+structural RLS prediction.** The RLS model's forgetting factor (~3h
+half-life @ 60s cadence) is tuned to learn site orientation, shading
+and slow soiling drift; it does not respond fast enough to "today's
+persistent NWP bias" — e.g. when measured cloud cover is heavier than
+the forecast assumed for the last 90 minutes, structural predictions
+stay biased high while RLS chews through the samples needed to adapt.
+
+The new layer keeps a 2-hour rolling buffer of (predicted_at_t,
+actual_at_t) pairs, computes the mean residual, and applies it as an
+additive bias to MPC slot predictions, fading linearly over a 2 h
+horizon (full correction ≤ 30 min, zero by 120 min). Beyond 2 h the
+structural model is again the best estimate — weather fronts roll in,
+time-of-day shifts, and the residual is no longer relevant.
+
+Gates (`go/internal/pvmodel/residual.go`):
+- ≥ 20 samples in the 2 h window before any correction applies.
+- `|mean residual|` ≥ 25 W → otherwise treated as "no bias detected".
+- `std / |mean|` ≤ 1.0 → variance-dominated streams are skipped.
+- `dt ≤ 0` (past slot) → factor = 0.
+
+Wiring: `pvmodel.Service.ResidualCorrect` is plumbed into
+`mpc.Service.PVResidualCorrect` (new optional hook). The planner calls
+the corrector on the slot midpoint inside `buildSlots`, after the twin
+prediction and before `selectPlannerPVW` blends with the NWP forecast.
+A nil hook is a hard no-op, so existing wiring without the corrector
+is unchanged.
+
+**PV only**: load is multimodal (appliances cycling) and a rolling-mean
+correction can chase the noise. Variance gate would catch it most of
+the time, but risk/reward is poor without dedicated diagnostics.
+Revisit when load observability lands.
+
+Diagnostics exposed via `GET /api/pvmodel`:
+`pv_residual_correction_w` (the value the planner would apply 15 min
+out), `pv_residual_sample_count`, `pv_residual_mean_w`,
+`pv_residual_std_w`, `pv_residual_window_minutes`.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -712,6 +712,7 @@ func main() {
 		mpcSvc.FuseMaxW = cfg.Fuse.MaxPowerW()
 		if pvSvc != nil {
 			mpcSvc.PV = pvSvc.Predict
+			mpcSvc.PVResidualCorrect = pvSvc.ResidualCorrect
 		}
 		mpcSvc.Load = loadSvc.Predict
 		mpcSvc.Price = priceFc.Predict

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -2016,15 +2016,27 @@ func (s *Server) handlePVModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	m := s.deps.PVModel.Model()
+	rd := s.deps.PVModel.ResidualDiagSnapshot()
+	// Single-number "what is the planner doing right now" view: the
+	// correction the MPC would apply to a slot 15 min out, after the
+	// ramp-off + gates. Saves operators from interpreting mean × ramp
+	// themselves.
+	now := time.Now()
+	currentCorrW := s.deps.PVModel.ResidualCorrect(now, now.Add(15*time.Minute), 0)
 	writeJSON(w, 200, map[string]any{
-		"enabled":    true,
-		"samples":    m.Samples,
-		"mae_w":      m.MAE,
-		"rated_w":    m.RatedW,
-		"quality":    m.Quality(),
-		"last_ms":    m.LastMs,
-		"forgetting": m.Forgetting,
-		"beta":       m.Beta,
+		"enabled":                    true,
+		"samples":                    m.Samples,
+		"mae_w":                      m.MAE,
+		"rated_w":                    m.RatedW,
+		"quality":                    m.Quality(),
+		"last_ms":                    m.LastMs,
+		"forgetting":                 m.Forgetting,
+		"beta":                       m.Beta,
+		"pv_residual_correction_w":   currentCorrW,
+		"pv_residual_sample_count":   rd.SampleCount,
+		"pv_residual_mean_w":         rd.MeanW,
+		"pv_residual_std_w":          rd.StdW,
+		"pv_residual_window_minutes": rd.WindowMinutes,
 	})
 }
 

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -18,6 +18,20 @@ import (
 // in the DB.
 type PVPredictor func(t time.Time, cloudPct float64) float64
 
+// PVResidualCorrector is an optional additive bias the planner applies
+// on top of a base PV prediction for short-horizon slots. Implemented
+// by *pvmodel.Service.ResidualCorrect. Returns 0 when no correction is
+// available; sign + magnitude come from a recent rolling residual of
+// predicted-vs-actual PV (generation-positive W). Leave nil to disable.
+//
+// Why a separate hook rather than baking it into PVPredictor: the
+// correction is purely a planner-side adjustment — UI overlays and
+// dispatch's "is the twin's *now* prediction close to *now* reading"
+// gate want the structural twin, not a slot-target-dependent additive.
+// Keeping it a separate hook also makes the wiring trivially testable
+// without a full pvmodel.Service.
+type PVResidualCorrector func(now, tTarget time.Time, basePrediction float64) float64
+
 // LoadPredictor plugs in a learned load predictor. Implemented by
 // *loadmodel.Service.Predict. Leave nil to fall back to Service.BaseLoad.
 type LoadPredictor func(t time.Time) float64
@@ -60,10 +74,11 @@ type Service struct {
 	BaseLoad  float64 // baseline household load (W). 0 disables load assumption.
 	Horizon   time.Duration
 	Interval  time.Duration
-	PV        PVPredictor    // optional — overrides stored pv_w_estimated
-	Load      LoadPredictor  // optional — overrides flat BaseLoad
-	Price     PricePredictor // optional — fills in future slots when day-ahead isn't published yet
-	Loadpoint LoadpointProbe // optional — when non-nil, the DP extends its state with EV dimensions
+	PV                PVPredictor         // optional — overrides stored pv_w_estimated
+	PVResidualCorrect PVResidualCorrector // optional — additive short-horizon bias on top of PV
+	Load              LoadPredictor       // optional — overrides flat BaseLoad
+	Price             PricePredictor      // optional — fills in future slots when day-ahead isn't published yet
+	Loadpoint         LoadpointProbe      // optional — when non-nil, the DP extends its state with EV dimensions
 
 	// SaveDiag is called synchronously after every successful replan
 	// with the same Diagnostic the /api/mpc/diagnose endpoint would
@@ -615,7 +630,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 		// continue without PV forecast
 	}
 
-	slots := buildSlots(prices, forecasts, s.BaseLoad, now.UnixMilli(), s.PV, s.Load)
+	slots := buildSlots(prices, forecasts, s.BaseLoad, now.UnixMilli(), s.PV, s.PVResidualCorrect, s.Load)
 	if len(slots) == 0 {
 		return nil
 	}
@@ -900,8 +915,9 @@ func extendPricesWithForecast(prices []state.PricePoint, zone string, pricer Pri
 // that the forecast service stored at fetch time. This lets the model
 // learn system-specific orientation/shading/soiling and drive planning
 // off the better signal without re-fetching weather.
-func buildSlots(prices []state.PricePoint, forecasts []state.ForecastPoint, baseLoad float64, nowMs int64, pv PVPredictor, load LoadPredictor) []Slot {
+func buildSlots(prices []state.PricePoint, forecasts []state.ForecastPoint, baseLoad float64, nowMs int64, pv PVPredictor, pvCorrect PVResidualCorrector, load LoadPredictor) []Slot {
 	out := make([]Slot, 0, len(prices))
+	now := time.UnixMilli(nowMs).UTC()
 	for _, pr := range prices {
 		slotLen := pr.SlotLenMin
 		if slotLen <= 0 {
@@ -912,12 +928,30 @@ func buildSlots(prices []state.PricePoint, forecasts []state.ForecastPoint, base
 			continue // past slot
 		}
 		slotT := time.UnixMilli(pr.SlotTsMs).UTC()
+		// Slot midpoint feeds the residual ramp-off: dt measured from
+		// the middle of the slot is a better proxy for the average
+		// correction applied across the slot than dt-from-start (which
+		// under-counts the slot's slice of the 30-min full-on plateau).
+		slotMidMs := pr.SlotTsMs + int64(slotLen)*30*1000 // start + half-slot in ms
+		slotMidT := time.UnixMilli(slotMidMs).UTC()
 		var pvW float64
 		forecastPVW := lookupPV(forecasts, pr.SlotTsMs)
 		if pv != nil {
 			cloud := lookupCloud(forecasts, pr.SlotTsMs)
 			radiationBacked := lookupHasRadiation(forecasts, pr.SlotTsMs)
-			pvW = selectPlannerPVW(forecastPVW, pv(slotT, cloud), radiationBacked)
+			base := pv(slotT, cloud)
+			if pvCorrect != nil {
+				// Correction returns generation-positive W (same as `base`).
+				// Floor the corrected base at 0 — a residual large enough
+				// to push it negative is a sign-flip, not a plausible PV
+				// prediction.
+				corrected := base + pvCorrect(now, slotMidT, base)
+				if corrected < 0 {
+					corrected = 0
+				}
+				base = corrected
+			}
+			pvW = selectPlannerPVW(forecastPVW, base, radiationBacked)
 		} else {
 			pvW = forecastPVW
 		}

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -30,6 +30,7 @@ func TestBuildSlotsFallsBackToForecastWhenTwinCollapses(t *testing.T) {
 		ts,
 		func(time.Time, float64) float64 { return 0 },
 		nil,
+		nil,
 	)
 	if len(slots) != 1 {
 		t.Fatalf("got %d slots, want 1", len(slots))
@@ -61,12 +62,61 @@ func TestBuildSlotsKeepsTwinWhenPredictionIsSane(t *testing.T) {
 		ts,
 		func(time.Time, float64) float64 { return twinPV },
 		nil,
+		nil,
 	)
 	if len(slots) != 1 {
 		t.Fatalf("got %d slots, want 1", len(slots))
 	}
 	if got := slots[0].PVW; math.Abs(got+twinPV) > 1e-6 {
 		t.Fatalf("slot PVW = %f, want %f", got, -twinPV)
+	}
+}
+
+// TestBuildSlots_AppliesPVResidualCorrection: a non-nil
+// PVResidualCorrector adds an additive bias to the twin's per-slot
+// prediction BEFORE selectPlannerPVW blends with the forecast. We mock
+// the corrector to apply -200 W to the first slot only and verify the
+// final slot 0 PVW reflects the correction while slot 1 does not.
+func TestBuildSlots_AppliesPVResidualCorrection(t *testing.T) {
+	ts0 := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC).UnixMilli()
+	ts1 := ts0 + 15*60*1000
+	cloud := 30.0
+	forecastPV := 0.0 // disable forecast blending so we see the pure twin path
+	twinPV := 1500.0
+	// Correction of -200 W means PV generation is being under-predicted
+	// by 200 W on the rolling residual; final base should be 1300 W on
+	// slot 0 only.
+	correctedSlot := time.UnixMilli(ts0 + 15*30*1000).UTC() // slot 0 midpoint
+	pvCorrect := func(now, tTarget time.Time, base float64) float64 {
+		if tTarget.Equal(correctedSlot) {
+			return -200
+		}
+		return 0
+	}
+	slots := buildSlots(
+		[]state.PricePoint{
+			{SlotTsMs: ts0, SlotLenMin: 15, SpotOreKwh: 120, TotalOreKwh: 180},
+			{SlotTsMs: ts1, SlotLenMin: 15, SpotOreKwh: 120, TotalOreKwh: 180},
+		},
+		[]state.ForecastPoint{
+			{SlotTsMs: ts0, SlotLenMin: 60, CloudCoverPct: &cloud, PVWEstimated: &forecastPV},
+		},
+		2500,
+		ts0,
+		func(time.Time, float64) float64 { return twinPV },
+		pvCorrect,
+		nil,
+	)
+	if len(slots) != 2 {
+		t.Fatalf("got %d slots, want 2", len(slots))
+	}
+	// Slot 0: base 1500 + (-200) = 1300 → PVW = -1300 (site-sign).
+	if got, want := slots[0].PVW, -1300.0; math.Abs(got-want) > 1e-6 {
+		t.Fatalf("slot 0 PVW = %f, want %f (correction applied)", got, want)
+	}
+	// Slot 1: no correction → PVW = -1500.
+	if got, want := slots[1].PVW, -1500.0; math.Abs(got-want) > 1e-6 {
+		t.Fatalf("slot 1 PVW = %f, want %f (no correction)", got, want)
 	}
 }
 
@@ -261,6 +311,7 @@ func TestBuildSlotsEmptyForecast(t *testing.T) {
 		nil, // empty forecasts
 		1500,
 		ts,
+		nil,
 		nil,
 		nil,
 	)

--- a/go/internal/pvmodel/residual.go
+++ b/go/internal/pvmodel/residual.go
@@ -1,0 +1,263 @@
+package pvmodel
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// Rolling residual correction — short-horizon additive bias on top of
+// the structural RLS twin.
+//
+// Motivation: the RLS model's forgetting factor (~200-sample window @
+// 60s cadence → ~3h half-life) is tuned to capture orientation,
+// shading and slow soiling drift. It does NOT respond fast enough to
+// "today's persistent NWP bias" — e.g. when measured cloud cover is
+// heavier than the forecast assumed for the last 90 minutes, the
+// twin's structural prediction stays biased high until RLS has chewed
+// through enough samples.
+//
+// The residual buffer fits a very cheap signal (rolling mean of
+// recent prediction-vs-actual residuals) and applies it as an
+// additive bias to near-future predictions, fading linearly to zero
+// over a 2h horizon. Beyond 2h the structural model is again the
+// best estimate — weather fronts have rolled in, time-of-day is
+// different, etc.
+//
+// This is intentionally NOT applied to load (other PRs in flight on
+// load observability): load is multimodal — appliances kicking on
+// and off can produce a high-mean / high-variance residual stream
+// that a rolling-mean correction would chase as noise. The variance
+// gate below would catch it most of the time but the risk/reward is
+// poor without dedicated diagnostics. Revisit when load observability
+// data is in.
+
+// Tunables. Constants rather than fields on the buffer so they stay
+// inspectable in `/api/pvmodel` diagnostics and so callers can't
+// silently disable the gates by setting them to extreme values.
+const (
+	// ResidualBufferWindow is how far back the rolling residual reaches.
+	// Matches NowAnchorHorizon (2h) on purpose: both mechanisms fade out
+	// over the same window, so dispatch decisions see one consistent
+	// "short-horizon" semantic.
+	ResidualBufferWindow = 2 * time.Hour
+	// residualBufferMaxSamples bounds memory regardless of sample
+	// cadence. 240 = 1 sample every 30s for 2h, which is roughly twice
+	// the live sampling rate of pvmodel.Service (60s cadence). Drops
+	// oldest first.
+	residualBufferMaxSamples = 240
+	// residualMinSamples gates Correct() — below this we have too few
+	// data points to estimate either mean or std reliably.
+	residualMinSamples = 20
+	// residualEpsilonW is the "no bias detected" floor on |mean|. The
+	// twin's MAE on a converged 5 kW system is typically 100-300 W;
+	// pushing a < 25 W mean correction into the plan adds noise.
+	residualEpsilonW = 25.0
+	// residualMaxCoVar gates Correct() on std/|mean|. Above 1.0 the
+	// noise dominates the signal — applying the mean would chase
+	// transients (a single inverter restart, a sensor glitch).
+	residualMaxCoVar = 1.0
+	// residualFullHorizon: dt ≤ this → factor = 1 (full correction).
+	residualFullHorizon = 30 * time.Minute
+	// residualFadeEnd: dt ≥ this → factor = 0 (no correction).
+	residualFadeEnd = 2 * time.Hour
+)
+
+type residualSample struct {
+	t         time.Time
+	predicted float64 // what the twin said at time t (W, ≥ 0)
+	actual    float64 // what the meter/PV sensor reported at time t (W, ≥ 0)
+}
+
+// ResidualBuffer is a thread-safe sliding window of recent (predicted,
+// actual) PV samples used to compute a short-horizon additive
+// correction to base predictions. Safe for concurrent use; cheap to
+// poll because all reads take the lock for a few microseconds.
+type ResidualBuffer struct {
+	mu      sync.Mutex
+	samples []residualSample
+}
+
+// ResidualDiag is a snapshot of the buffer state for /api/pvmodel.
+type ResidualDiag struct {
+	SampleCount   int     `json:"sample_count"`
+	MeanW         float64 `json:"mean_w"`
+	StdW          float64 `json:"std_w"`
+	WindowMinutes int     `json:"window_minutes"`
+}
+
+// NewResidualBuffer returns an empty buffer with default window +
+// capacity. Callers should hang onto a single instance per process —
+// the buffer carries observed state, not config.
+func NewResidualBuffer() *ResidualBuffer {
+	return &ResidualBuffer{
+		samples: make([]residualSample, 0, residualBufferMaxSamples),
+	}
+}
+
+// Add records one (predicted, actual) pair at time t. Drops samples
+// older than ResidualBufferWindow relative to t, then enforces the
+// max-samples cap by dropping the oldest.
+//
+// Predicted is the twin's prediction for time t; actual is the
+// summed measured PV power at time t (W, ≥ 0). Both use the
+// generation-positive convention to match liveActualPV().
+func (b *ResidualBuffer) Add(t time.Time, predicted, actual float64) {
+	if b == nil {
+		return
+	}
+	if math.IsNaN(predicted) || math.IsInf(predicted, 0) ||
+		math.IsNaN(actual) || math.IsInf(actual, 0) {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.samples = append(b.samples, residualSample{t: t, predicted: predicted, actual: actual})
+	// Age off relative to the just-added sample (most recent), so the
+	// window slides with real time even when called from tests using
+	// fixed timestamps.
+	cutoff := t.Add(-ResidualBufferWindow)
+	idx := 0
+	for ; idx < len(b.samples); idx++ {
+		if !b.samples[idx].t.Before(cutoff) {
+			break
+		}
+	}
+	if idx > 0 {
+		b.samples = b.samples[idx:]
+	}
+	// Cap.
+	if over := len(b.samples) - residualBufferMaxSamples; over > 0 {
+		b.samples = b.samples[over:]
+	}
+}
+
+// Len returns the current sample count (mostly for tests).
+func (b *ResidualBuffer) Len() int {
+	if b == nil {
+		return 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.samples)
+}
+
+// Correct returns the additive correction (W) to apply to a base
+// prediction targeting time tTarget, computed at wall time now.
+// Returns 0 when no correction should be applied (insufficient
+// samples, no bias detected, noise-dominated, target outside the
+// horizon, target in the past).
+//
+// basePrediction is accepted for future extensions (multiplicative
+// gating, sign-aware blends) but currently unused — the correction
+// is purely additive on the residual mean.
+func (b *ResidualBuffer) Correct(now, tTarget time.Time, basePrediction float64) float64 {
+	if b == nil {
+		return 0
+	}
+	_ = basePrediction
+	// Ramp-off based on dt = tTarget - now.
+	dt := tTarget.Sub(now)
+	if dt <= 0 {
+		return 0
+	}
+	if dt > residualFadeEnd {
+		return 0
+	}
+	b.mu.Lock()
+	// Drop samples older than window relative to now (the buffer ages
+	// off on Add, but if Correct is called long after the last Add the
+	// data is stale).
+	cutoff := now.Add(-ResidualBufferWindow)
+	idx := 0
+	for ; idx < len(b.samples); idx++ {
+		if !b.samples[idx].t.Before(cutoff) {
+			break
+		}
+	}
+	if idx > 0 {
+		b.samples = b.samples[idx:]
+	}
+	n := len(b.samples)
+	if n < residualMinSamples {
+		b.mu.Unlock()
+		return 0
+	}
+	var sum, sumSq float64
+	for _, s := range b.samples {
+		r := s.actual - s.predicted
+		sum += r
+		sumSq += r * r
+	}
+	b.mu.Unlock()
+	mean := sum / float64(n)
+	variance := sumSq/float64(n) - mean*mean
+	if variance < 0 {
+		variance = 0 // numerical
+	}
+	std := math.Sqrt(variance)
+	if math.Abs(mean) < residualEpsilonW {
+		return 0
+	}
+	denom := math.Abs(mean)
+	if denom < 1 {
+		denom = 1
+	}
+	if std/denom > residualMaxCoVar {
+		return 0
+	}
+	factor := residualFadeFactor(dt)
+	return mean * factor
+}
+
+// residualFadeFactor is the unit-less ramp-off:
+//   - dt ≤ 30 min → 1.0
+//   - 30 min < dt ≤ 120 min → linear 1.0 → 0.0
+//   - dt > 120 min → 0.0
+func residualFadeFactor(dt time.Duration) float64 {
+	if dt <= residualFullHorizon {
+		return 1.0
+	}
+	if dt >= residualFadeEnd {
+		return 0.0
+	}
+	mins := dt.Minutes()
+	full := residualFullHorizon.Minutes()
+	end := residualFadeEnd.Minutes()
+	return 1.0 - (mins-full)/(end-full)
+}
+
+// Diag returns a snapshot suitable for serialising to /api/pvmodel.
+// Computes mean + std over the in-window samples; does not mutate.
+func (b *ResidualBuffer) Diag(now time.Time) ResidualDiag {
+	d := ResidualDiag{WindowMinutes: int(ResidualBufferWindow.Minutes())}
+	if b == nil {
+		return d
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	cutoff := now.Add(-ResidualBufferWindow)
+	var sum, sumSq float64
+	n := 0
+	for _, s := range b.samples {
+		if s.t.Before(cutoff) {
+			continue
+		}
+		r := s.actual - s.predicted
+		sum += r
+		sumSq += r * r
+		n++
+	}
+	d.SampleCount = n
+	if n == 0 {
+		return d
+	}
+	mean := sum / float64(n)
+	variance := sumSq/float64(n) - mean*mean
+	if variance < 0 {
+		variance = 0
+	}
+	d.MeanW = mean
+	d.StdW = math.Sqrt(variance)
+	return d
+}

--- a/go/internal/pvmodel/residual_test.go
+++ b/go/internal/pvmodel/residual_test.go
@@ -1,0 +1,233 @@
+package pvmodel
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Anchor for deterministic test time math. UTC daylight afternoon so any
+// downstream "must be daylight" gates don't accidentally short-circuit.
+var residualNow = time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+
+// TestResidualBufferAdd_AppendsAndAgesOff: samples older than the buffer
+// window relative to the most-recently-added sample must be dropped.
+func TestResidualBufferAdd_AppendsAndAgesOff(t *testing.T) {
+	b := NewResidualBuffer()
+	// Add 30 samples spanning 3 hours, every 6 min, ending at residualNow.
+	// Window is 2h → only samples within last 120 min should remain.
+	for i := 0; i < 30; i++ {
+		ts := residualNow.Add(time.Duration(-29+i) * 6 * time.Minute)
+		b.Add(ts, 1000, 800)
+	}
+	// Cutoff: most recent is at residualNow. Window = 2h. Anything with
+	// t < residualNow - 2h is aged off.
+	cutoff := residualNow.Add(-2 * time.Hour)
+	got := b.Len()
+	// Count expected remaining: indices where ts >= cutoff.
+	expected := 0
+	for i := 0; i < 30; i++ {
+		ts := residualNow.Add(time.Duration(-29+i) * 6 * time.Minute)
+		if !ts.Before(cutoff) {
+			expected++
+		}
+	}
+	if got != expected {
+		t.Fatalf("after age-off: got %d samples, want %d", got, expected)
+	}
+	if expected >= 30 {
+		t.Fatalf("test invariant: expected age-off to drop something, expected=%d", expected)
+	}
+}
+
+// TestResidualBufferAdd_CapsAtMaxSamples: even within window, the buffer
+// never grows past MaxSamples; oldest drop first.
+func TestResidualBufferAdd_CapsAtMaxSamples(t *testing.T) {
+	b := NewResidualBuffer()
+	// Window 2h, MaxSamples 240. Add 500 samples at 1s cadence all within
+	// the last 2h — buffer must cap at 240, retaining the newest.
+	start := residualNow.Add(-500 * time.Second)
+	for i := 0; i < 500; i++ {
+		ts := start.Add(time.Duration(i) * time.Second)
+		b.Add(ts, float64(i), float64(i)+10) // predictable so we can verify newest-kept
+	}
+	if got := b.Len(); got != residualBufferMaxSamples {
+		t.Fatalf("got %d samples, want %d", got, residualBufferMaxSamples)
+	}
+	// Oldest kept must be sample (500 - 240) = 260; verify via the
+	// internal slice (predicted == 260).
+	b.mu.Lock()
+	oldestPred := b.samples[0].predicted
+	newestPred := b.samples[len(b.samples)-1].predicted
+	b.mu.Unlock()
+	if oldestPred != float64(500-residualBufferMaxSamples) {
+		t.Fatalf("oldest kept sample predicted=%v, want %v",
+			oldestPred, float64(500-residualBufferMaxSamples))
+	}
+	if newestPred != 499 {
+		t.Fatalf("newest kept sample predicted=%v, want 499", newestPred)
+	}
+}
+
+// TestResidualBuffer_Correct_ReturnsZeroWhenBelowMinSamples: 10 samples,
+// below MinSamples threshold (20) → no correction applied.
+func TestResidualBuffer_Correct_ReturnsZeroWhenBelowMinSamples(t *testing.T) {
+	b := NewResidualBuffer()
+	for i := 0; i < 10; i++ {
+		ts := residualNow.Add(time.Duration(-i) * time.Minute)
+		b.Add(ts, 1000, 1500) // big bias, but below MinSamples
+	}
+	target := residualNow.Add(15 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	if got != 0 {
+		t.Fatalf("below MinSamples: got correction %v, want 0", got)
+	}
+}
+
+// TestResidualBuffer_Correct_ReturnsZeroWhenVarianceHigh: bias 100 W but
+// std 200 W → noise dominates signal → no correction.
+func TestResidualBuffer_Correct_ReturnsZeroWhenVarianceHigh(t *testing.T) {
+	b := NewResidualBuffer()
+	// 30 samples with mean residual ~100, std ~200.
+	// Generate by alternating +300 and -100 → mean +100, std 200.
+	resids := []float64{300, -100, 300, -100, 300, -100, 300, -100, 300, -100,
+		300, -100, 300, -100, 300, -100, 300, -100, 300, -100,
+		300, -100, 300, -100, 300, -100, 300, -100, 300, -100}
+	for i, r := range resids {
+		ts := residualNow.Add(time.Duration(-i) * time.Minute)
+		// actual - predicted = r ⇒ pick predicted=1000, actual=1000+r.
+		b.Add(ts, 1000, 1000+r)
+	}
+	target := residualNow.Add(15 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	if got != 0 {
+		t.Fatalf("high-variance: got correction %v, want 0", got)
+	}
+}
+
+// TestResidualBuffer_Correct_AppliesConstantBias: 30 samples with mean
+// residual −200 W (actual generates 200 W MORE than predicted, recall
+// site-sign: more generation = more negative), std ~30 → return ~ −200
+// at full ramp-on.
+func TestResidualBuffer_Correct_AppliesConstantBias(t *testing.T) {
+	b := NewResidualBuffer()
+	// Small zigzag around −200 to keep std ~30.
+	for i := 0; i < 30; i++ {
+		ts := residualNow.Add(time.Duration(-i) * time.Minute)
+		jitter := -30.0
+		if i%2 == 0 {
+			jitter = 30.0
+		}
+		// actual - predicted = -200 + jitter
+		b.Add(ts, 1000, 1000+(-200+jitter))
+	}
+	target := residualNow.Add(15 * time.Minute) // dt < 30min → factor = 1
+	got := b.Correct(residualNow, target, 1000)
+	if math.Abs(got-(-200)) > 5 {
+		t.Fatalf("constant bias: got %v, want ~-200", got)
+	}
+}
+
+// addNiceBias seeds the buffer with 30 samples, mean residual -200 W
+// and very low std. Used for ramp-off tests.
+func addNiceBias(b *ResidualBuffer) {
+	for i := 0; i < 30; i++ {
+		ts := residualNow.Add(time.Duration(-i) * time.Minute)
+		// tiny jitter so std isn't exactly zero (we still want sigma>0
+		// but well under |mean|).
+		jitter := -2.0
+		if i%2 == 0 {
+			jitter = 2.0
+		}
+		b.Add(ts, 1000, 1000+(-200+jitter))
+	}
+}
+
+func TestResidualBuffer_Correct_RampOff_30min(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	target := residualNow.Add(30 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	// At dt=30 min, factor = 1 (boundary inclusive); expect ~ -200.
+	if math.Abs(got-(-200)) > 5 {
+		t.Fatalf("dt=30min: got %v, want ~-200 (factor=1)", got)
+	}
+}
+
+func TestResidualBuffer_Correct_RampOff_75min(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	target := residualNow.Add(75 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	// At dt=75 min, factor = 1 - (75-30)/90 = 0.5; expect ~ -100.
+	if math.Abs(got-(-100)) > 5 {
+		t.Fatalf("dt=75min: got %v, want ~-100 (factor=0.5)", got)
+	}
+}
+
+func TestResidualBuffer_Correct_RampOff_120min(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	target := residualNow.Add(120 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	// At dt=120 min, factor = 0.
+	if math.Abs(got) > 1e-6 {
+		t.Fatalf("dt=120min: got %v, want 0 (factor=0)", got)
+	}
+}
+
+func TestResidualBuffer_Correct_RampOff_Beyond2h(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	target := residualNow.Add(180 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	if math.Abs(got) > 1e-6 {
+		t.Fatalf("dt=180min: got %v, want 0", got)
+	}
+}
+
+// Past targets (dt < 0) must not be corrected either.
+func TestResidualBuffer_Correct_PastTargetIsZero(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	target := residualNow.Add(-10 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	if got != 0 {
+		t.Fatalf("dt<0: got %v, want 0", got)
+	}
+}
+
+// Tiny mean (< epsilon) should be gated to zero.
+func TestResidualBuffer_Correct_TinyMeanGated(t *testing.T) {
+	b := NewResidualBuffer()
+	// mean residual 10 W (below 25 W epsilon), tiny std.
+	for i := 0; i < 30; i++ {
+		ts := residualNow.Add(time.Duration(-i) * time.Minute)
+		jitter := -1.0
+		if i%2 == 0 {
+			jitter = 1.0
+		}
+		b.Add(ts, 1000, 1000+(10+jitter))
+	}
+	target := residualNow.Add(15 * time.Minute)
+	got := b.Correct(residualNow, target, 1000)
+	if got != 0 {
+		t.Fatalf("tiny mean: got %v, want 0", got)
+	}
+}
+
+// Diagnostic helpers expose the current state for /api/pvmodel.
+func TestResidualBuffer_Diag_SamplesAndStd(t *testing.T) {
+	b := NewResidualBuffer()
+	addNiceBias(b)
+	d := b.Diag(residualNow)
+	if d.SampleCount != 30 {
+		t.Fatalf("SampleCount=%d, want 30", d.SampleCount)
+	}
+	if d.StdW <= 0 {
+		t.Fatalf("StdW=%v, want >0", d.StdW)
+	}
+	if math.Abs(d.MeanW-(-200)) > 5 {
+		t.Fatalf("MeanW=%v, want ~-200", d.MeanW)
+	}
+}

--- a/go/internal/pvmodel/service.go
+++ b/go/internal/pvmodel/service.go
@@ -44,6 +44,12 @@ type Service struct {
 	model     *Model
 	persistMu sync.Mutex // serialises SQLite writes so a stale persist can't clobber a Reset
 
+	// Residuals captures (predicted_at_t, actual_at_t) pairs to compute a
+	// short-horizon additive correction the MPC applies on top of the
+	// structural prediction. See residual.go for the math + gates. Lives
+	// for the lifetime of the Service; cleared by Reset().
+	Residuals *ResidualBuffer
+
 	stop chan struct{}
 	done chan struct{}
 }
@@ -58,6 +64,7 @@ func NewService(st *state.Store, tel *telemetry.Store, cs ClearSkyFunc, cf Cloud
 		Cloud:          cf,
 		SampleInterval: 60 * time.Second,
 		PersistEvery:   10,
+		Residuals:      NewResidualBuffer(),
 		stop:           make(chan struct{}),
 		done:           make(chan struct{}),
 	}
@@ -338,11 +345,23 @@ func (s *Service) sample() {
 		return
 	}
 
+	// Capture (predicted_at_now, actual_at_now) for the residual buffer
+	// BEFORE running the RLS update — otherwise the model's prediction
+	// already incorporates the sample we're about to use as ground
+	// truth, and the residual collapses to ~0. Predict against the
+	// structural model only (no now-anchor) since the residual layer
+	// is correcting that structural output. The Residuals buffer
+	// itself applies the gates / fade / variance check.
 	s.mu.Lock()
+	predicted := s.model.Predict(cs, cloud, now)
 	updated := s.model.Update(cs, cloud, now, pvW)
 	samples := s.model.Samples
 	mae := s.model.MAE
 	s.mu.Unlock()
+
+	if s.Residuals != nil {
+		s.Residuals.Add(now, predicted, pvW)
+	}
 
 	slog.Info("pvmodel: sample", "cs_wm2", cs, "cloud_pct", cloud, "pv_w", pvW, "samples", samples, "mae_w", mae, "updated", updated)
 
@@ -372,7 +391,9 @@ func (s *Service) persist() {
 }
 
 // Reset clears the model to a fresh prior (useful after a system change
-// — new panels, cleaning, etc.).
+// — new panels, cleaning, etc.). Also clears the residual buffer so a
+// stale set of "old-model" residuals doesn't bias the fresh prior's
+// predictions during the cold-start blend.
 func (s *Service) Reset() {
 	if s == nil {
 		return
@@ -380,6 +401,31 @@ func (s *Service) Reset() {
 	s.mu.Lock()
 	rated := s.model.RatedW
 	s.model = NewModel(rated)
+	s.Residuals = NewResidualBuffer()
 	s.mu.Unlock()
 	s.persist()
+}
+
+// ResidualCorrect is the integration point for the MPC. Returns the
+// additive correction (W) to apply to a base prediction targeting
+// tTarget, computed at wall time `now`. Returns 0 when residuals are
+// unavailable, insufficient, or noise-dominated. See ResidualBuffer.Correct.
+//
+// Sign convention: this returns generation-positive W (same as the
+// underlying pvmodel.Predict). Callers consuming site-sign PV (e.g.
+// mpc.buildSlots which negates) should match the sign at their boundary.
+func (s *Service) ResidualCorrect(now, tTarget time.Time, basePrediction float64) float64 {
+	if s == nil || s.Residuals == nil {
+		return 0
+	}
+	return s.Residuals.Correct(now, tTarget, basePrediction)
+}
+
+// ResidualDiagSnapshot returns the current residual-buffer state for
+// /api/pvmodel diagnostics. Zero-valued when the buffer is empty.
+func (s *Service) ResidualDiagSnapshot() ResidualDiag {
+	if s == nil || s.Residuals == nil {
+		return ResidualDiag{WindowMinutes: int(ResidualBufferWindow.Minutes())}
+	}
+	return s.Residuals.Diag(time.Now())
 }


### PR DESCRIPTION
## Summary

Adds a **short-horizon residual correction** layer on top of the PV
twin's structural RLS prediction. A 2 h rolling buffer of
(predicted_at_t, actual_at_t) residuals feeds an additive bias, faded
linearly over a 30 → 120 min horizon. Beyond 2 h the structural model
is again the best estimate.

## Why

The RLS twin's forgetting factor (~3 h half-life @ 60 s cadence) is
tuned to capture orientation, shading and slow soiling drift. It does
not respond fast enough to "today's persistent NWP bias" — e.g. when
measured cloud cover is heavier than the forecast assumed for the last
90 minutes, structural predictions stay biased high until RLS chews
through the samples needed to adapt. The MPC then plans against a too-
sunny outlook for the next 30-90 minutes.

## Design

- `pvmodel.ResidualBuffer` (`go/internal/pvmodel/residual.go`): thread-
  safe sliding window; samples added on every successful RLS update
  (predicted captured *before* `Update` so the model hasn't yet
  incorporated the sample we're using as ground truth).
- `Correct(now, tTarget, base)` returns additive W with these gates:
  - ≥ 20 samples in the 2 h window
  - `|mean residual|` ≥ 25 W (otherwise "no bias detected")
  - `std / |mean|` ≤ 1.0 (otherwise noise-dominated)
  - `dt ≤ 0` → 0; `dt > 120 min` → 0
  - Ramp-off factor: `1.0` for `dt ≤ 30 min`, linear 1→0 to 120 min.
- Wiring: new `mpc.Service.PVResidualCorrect` optional hook (nil = no
  correction). Applied inside `buildSlots` on the slot midpoint, after
  the twin prediction and before `selectPlannerPVW`. Floored at 0.
- Diagnostics on `GET /api/pvmodel`: `pv_residual_correction_w` (what
  the planner would apply 15 min out), `pv_residual_sample_count`,
  `pv_residual_mean_w`, `pv_residual_std_w`, `pv_residual_window_minutes`.

## Why PV only / load deferred

Load is multimodal — appliances cycling on and off can produce a high-
mean / high-variance residual stream that a rolling-mean correction
would chase as noise. The variance gate would catch most of it, but
risk/reward is poor without dedicated diagnostics. Revisit when load
observability data is in (other PRs in flight).

## Test plan

- [x] `TestResidualBufferAdd_AppendsAndAgesOff` — 30 samples spanning 3h, only those within 2h remain.
- [x] `TestResidualBufferAdd_CapsAtMaxSamples` — 500 samples capped at 240, newest kept.
- [x] `TestResidualBuffer_Correct_ReturnsZeroWhenBelowMinSamples` — 10 samples → 0.
- [x] `TestResidualBuffer_Correct_ReturnsZeroWhenVarianceHigh` — mean 100, std 200 → 0.
- [x] `TestResidualBuffer_Correct_AppliesConstantBias` — mean −200, std ~30 → returns ~−200 at full ramp.
- [x] `TestResidualBuffer_Correct_RampOff_30min` — factor 1.0.
- [x] `TestResidualBuffer_Correct_RampOff_75min` — factor 0.5.
- [x] `TestResidualBuffer_Correct_RampOff_120min` — factor 0.0.
- [x] `TestResidualBuffer_Correct_RampOff_Beyond2h` — factor 0.0.
- [x] `TestResidualBuffer_Correct_PastTargetIsZero` — dt < 0 → 0.
- [x] `TestResidualBuffer_Correct_TinyMeanGated` — `|mean| < 25 W` → 0.
- [x] `TestResidualBuffer_Diag_SamplesAndStd` — `Diag()` snapshot fields populated.
- [x] `TestBuildSlots_AppliesPVResidualCorrection` — mocked PVResidualCorrector applies −200 W to slot 0 only; slot 1 unaffected.
- [x] `make verify` clean (vet + full test suite + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)