### PR TITLE
fix: Codex review follow-ups for v0.107.0 (P1 + P2)

### DIFF
--- a/.changeset/codex-followups-loadmodel-and-carveouts.md
+++ b/.changeset/codex-followups-loadmodel-and-carveouts.md
@@ -1,0 +1,42 @@
+---
+"forty-two-watts": patch
+---
+
+**Codex review follow-ups for v0.107.0** — fixes 2 P1 and 2 P2 review
+findings on the dispatch / loadmodel changes shipped in v0.107.0.
+
+**P1: Heating coefficient survives restarts.** `main.go` had been calling
+`loadSvc.SetHeatingCoef(cfg.Weather.HeatingWPerDegC)` at startup, which
+unconditionally overwrote any value persisted from previous training.
+After every binary update the adaptive fit was thrown away. New
+`SeedHeatingCoef(w)` only writes the value when the model has no samples
+yet — operator config is the cold-start prior, observation drives the
+value once learning has begun. `SetHeatingCoef` remains for explicit
+operator overrides.
+
+**P1: Cover-load carve-out actually chases grid=0.** The PR #378
+carve-out only set `useEnergyPath = false`; in production `main.go` wires
+both `SlotDirective` and `PlanTarget`, so the code fell into the legacy
+`!useEnergyPath` branch and called `SetGridTarget(plannedImportW)` —
+chasing the planned positive import instead of grid=0. Result: cover-
+load slot with a 1.7 kW planned import would back the battery off all
+the way to idle instead of covering live load. Fixed by forcing
+`SetGridTarget(0)` for carve-out slots and skipping the legacy
+PlanTarget block when a carve-out predicate fires.
+
+**P2: Live-export gate predicate tightened.** `passiveArbitrageIdleSlot`
+used `dir.BatteryEnergyWh <= idleWhGate`, which is true for *any*
+negative-energy slot (planned discharge). Tightened to
+`|BatteryEnergyWh| ≤ idleWhGate` so the predicate names what it does
+(true idle only). The planned-discharge case is now folded into
+`coverLoadDischargeSlot`, which was also extended to cover
+`planner_passive_arbitrage` (not just `planner_arbitrage`), and the
+live-export gate now fires on either predicate.
+
+**P2: SlotDeliveryStats catches sign mismatches.** Planned `-425 Wh`
+discharge vs actual `+425 Wh` charge would have scored `|actual| /
+|planned| = 1.0` = "on target" — the largest possible miss, invisible
+on `/api/status`. New `SignMismatchCount` field fires when planned and
+actual have opposite signs (and both exceed the idle cutoff). The
+magnitude over/under counters then only fire on same-sign cases,
+keeping their semantics clean.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -669,10 +669,14 @@ func main() {
 		loadPeakW = 5000
 	}
 	loadSvc := loadmodel.NewService(st, tel, cfg.SiteMeterDriver(), loadPeakW)
+	// SeedHeatingCoef — operator config is a cold-start prior. Once the
+	// load model has accumulated samples in production, its
+	// telemetry-fit HeatingW_per_degC survives restart and the config
+	// value is ignored. See loadmodel/service.go for the rationale.
 	if cfg.Weather != nil {
-		loadSvc.SetHeatingCoef(cfg.Weather.HeatingWPerDegC)
+		loadSvc.SeedHeatingCoef(cfg.Weather.HeatingWPerDegC)
 	} else {
-		loadSvc.SetHeatingCoef(0)
+		loadSvc.SeedHeatingCoef(0)
 	}
 	// Temperature source for heating-gain fit: same forecast cache.
 	loadSvc.Temp = func(t time.Time) (float64, bool) {

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2369,6 +2369,104 @@ func TestPlannerPassiveArbitrageCoverLoadBacksOffOnLoadUndershoot(t *testing.T) 
 	}
 }
 
+// planner_arbitrage cover-load slot must chase grid=0, not the plan's
+// forecasted positive import. The PR #378 carve-out only sets
+// useEnergyPath=false; production wires both SlotDirective and PlanTarget,
+// so falling through to the !useEnergyPath block called PlanTarget which
+// returned `("self_consumption", +1700, true)` and then SetGridTarget(+1700)
+// made PI try to hit +1.7 kW import — undoing the carve-out's whole point.
+// The fix routes carve-out slots to grid_target=0 unconditionally.
+// Cover-load discharge slot (planned discharge to offset import) under
+// live PV surplus: don't absorb the surplus into the battery. The slot
+// was planned with the assumption of expected import; if live shows
+// export instead, charging would steal export revenue AND the cover-
+// load discharge purpose is moot (no load to cover). Right behaviour:
+// hold battery near 0, let surplus export. Mirror of the passive
+// idle-slot gate but for the discharge-intent slot. Codex P2 / #375
+// follow-up — extends live-export gate to cover-load-discharge slots
+// in both planner_arbitrage and planner_passive_arbitrage.
+func TestCoverLoadDischargeDoesNotAbsorbLiveSurplus(t *testing.T) {
+	for _, mode := range []Mode{ModePlannerArbitrage, ModePlannerPassiveArbitrage} {
+		t.Run(string(mode), func(t *testing.T) {
+			now := time.Now()
+			d := SlotDirective{
+				SlotStart:       now,
+				SlotEnd:         now.Add(15 * time.Minute),
+				BatteryEnergyWh: -600, // planned discharge to cover load
+				Strategy:        "arbitrage",
+				PlannedGridW:    0, // forecast: cover load, no export anticipated
+				HasPlannedGridW: true,
+			}
+			// Live: PV-surplus exporting via the meter, battery already
+			// pulling 1.6 kW. The reactive PI on grid=0 would otherwise
+			// ramp charge UP to absorb the surplus, swallowing PV export
+			// at high spot.
+			store := seedStore(-100, []struct {
+				name          string
+				currentW, soc float64
+			}{
+				{"ferroamp", 1600, 0.5},
+			})
+			st := NewState(0, 0, "ferroamp")
+			st.Mode = mode
+			st.UseEnergyDispatch = true
+			st.SlewRateW = 10000
+			st.MinDispatchIntervalS = 0
+			st.SlotDirective = func(time.Time) (SlotDirective, bool) { return d, true }
+			targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+			if len(targets) != 1 {
+				t.Fatalf("want 1 target, got %d", len(targets))
+			}
+			if math.Abs(targets[0].TargetW) > 1 {
+				t.Errorf("TargetW = %.0f W — cover-load discharge slot with live PV surplus must not absorb (battery should be ramped back to 0)", targets[0].TargetW)
+			}
+		})
+	}
+}
+
+func TestPlannerArbitrageCoverLoadChasesGridZeroNotPlannedImport(t *testing.T) {
+	now := time.Now()
+	d := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -800, // planned discharge — cover-load slot
+		Strategy:        "arbitrage",
+		PlannedGridW:    1700, // forecast: still importing 1.7 kW even with the discharge
+		HasPlannedGridW: true,
+	}
+	// Live: importing 1500 W, batteries idle. The carve-out's promise is
+	// "chase grid=0 so a forecast-load undershoot doesn't lock discharge
+	// off". If PlanTarget's +1700 wins, PI sees grid=1500 vs setpoint=1700
+	// and tries to import MORE (charge battery). Battery should instead
+	// discharge ~1.5 kW to cover live load.
+	store := seedStore(1500, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 10000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return d, true }
+	// Production wiring: PlanTarget exists alongside SlotDirective.
+	// actionToSlot returns ("self_consumption", a.GridW, true) for
+	// arbitrage discharge — i.e. would set grid_target to planned import.
+	st.PlanTarget = func(time.Time) (string, float64, bool) {
+		return "self_consumption", 1700, true
+	}
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 target, got %d", len(targets))
+	}
+	if targets[0].TargetW > -500 {
+		t.Errorf("TargetW = %.0f W — cover-load slot with live import must discharge to cover (carve-out must override PlanTarget's planned-import setpoint)", targets[0].TargetW)
+	}
+}
+
 func TestPlannerSelfPlannedPVExportStopsChargingWithoutSlew(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{
@@ -4995,6 +5093,58 @@ func TestSlotMetricsLogsOverDeliveryAtSlotEnd(t *testing.T) {
 	if st.SlotDeliveryStats.OverDeliveryCount != beforeOver+1 {
 		t.Errorf("OverDeliveryCount = %d, want %d (incremented by 1 at rollover)",
 			st.SlotDeliveryStats.OverDeliveryCount, beforeOver+1)
+	}
+	if st.SlotDeliveryStats.UnderDeliveryCount != beforeUnder {
+		t.Errorf("UnderDeliveryCount = %d, want unchanged %d", st.SlotDeliveryStats.UnderDeliveryCount, beforeUnder)
+	}
+}
+
+// Planned discharge but actual charge (same magnitude) — the largest
+// possible plan-vs-reality miss must NOT register as "on target" just
+// because |actual| ≈ |planned|. Sign mismatch is a categorically
+// different failure (we did the opposite of what was planned) and needs
+// its own counter. Codex P2 / #379 follow-up.
+func TestSlotMetricsDetectsSignMismatch(t *testing.T) {
+	now := time.Now()
+	slot1Start := now.Add(-1 * time.Minute)
+	slot1 := SlotDirective{
+		SlotStart:       slot1Start,
+		SlotEnd:         slot1Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425, // planned: discharge
+	}
+	slot2Start := slot1Start.Add(15 * time.Minute)
+	slot2 := SlotDirective{
+		SlotStart:       slot2Start,
+		SlotEnd:         slot2Start.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 1700, 0.5},
+	})
+
+	active := slot1
+	st := makeSlotMetricsState("ferroamp", func(time.Time) (SlotDirective, bool) { return active, true })
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	// Same magnitude as planned, opposite direction.
+	st.slotActualWh = +425
+
+	active = slot2
+	beforeMismatch := st.SlotDeliveryStats.SignMismatchCount
+	beforeOver := st.SlotDeliveryStats.OverDeliveryCount
+	beforeUnder := st.SlotDeliveryStats.UnderDeliveryCount
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	if st.SlotDeliveryStats.SignMismatchCount != beforeMismatch+1 {
+		t.Errorf("SignMismatchCount = %d, want %d (incremented at rollover)",
+			st.SlotDeliveryStats.SignMismatchCount, beforeMismatch+1)
+	}
+	if st.SlotDeliveryStats.OverDeliveryCount != beforeOver {
+		t.Errorf("OverDeliveryCount = %d, want unchanged %d (magnitude ratio is 1.0 but the sign is wrong)",
+			st.SlotDeliveryStats.OverDeliveryCount, beforeOver)
 	}
 	if st.SlotDeliveryStats.UnderDeliveryCount != beforeUnder {
 		t.Errorf("UnderDeliveryCount = %d, want unchanged %d", st.SlotDeliveryStats.UnderDeliveryCount, beforeUnder)

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -581,6 +581,12 @@ func resetEnergyDispatchBookkeeping(state *State) {
 type SlotDeliveryStats struct {
 	OverDeliveryCount  uint64 `json:"over_delivery_count"`
 	UnderDeliveryCount uint64 `json:"under_delivery_count"`
+	// SignMismatchCount counts slots where the fleet moved energy in the
+	// opposite direction from the plan (planned discharge → actual
+	// charge, or vice-versa) for non-idle slots. Caught separately
+	// because the magnitude-only over/under check would happily report
+	// `|−425| ≈ |+425|` as on-target — the largest possible miss.
+	SignMismatchCount uint64 `json:"sign_mismatch_count"`
 }
 
 // slotDeliveryOverThreshold + slotDeliveryUnderThreshold define the
@@ -638,24 +644,39 @@ func updateSlotDeliveryMetrics(state *State, currentTotalW float64, now time.Tim
 		// so this accumulator keeps its own slotActualPlannedWh.
 		plannedWh := state.slotActualPlannedWh
 		if math.Abs(plannedWh) > slotDeliveryIdleWhCutoff {
-			ratio := math.Abs(state.slotActualWh) / math.Max(math.Abs(plannedWh), 1)
-			switch {
-			case ratio > slotDeliveryOverThreshold:
-				slog.Info("dispatch slot over-delivery",
+			actualWh := state.slotActualWh
+			// Sign mismatch is the categorical failure mode: we moved
+			// energy in the opposite direction from the plan. Caught
+			// before the magnitude-ratio check below, which would
+			// otherwise treat opposite-sign-equal-magnitude (planned
+			// −425, actual +425) as ratio 1.0 = on target.
+			if plannedWh*actualWh < 0 && math.Abs(actualWh) > slotDeliveryIdleWhCutoff {
+				slog.Info("dispatch slot sign mismatch",
 					"mode", state.Mode,
 					"planned_wh", plannedWh,
-					"actual_wh", state.slotActualWh,
-					"ratio", ratio,
+					"actual_wh", actualWh,
 					"slot_start", state.slotActualSlotStart)
-				state.SlotDeliveryStats.OverDeliveryCount++
-			case ratio < slotDeliveryUnderThreshold:
-				slog.Info("dispatch slot under-delivery",
-					"mode", state.Mode,
-					"planned_wh", plannedWh,
-					"actual_wh", state.slotActualWh,
-					"ratio", ratio,
-					"slot_start", state.slotActualSlotStart)
-				state.SlotDeliveryStats.UnderDeliveryCount++
+				state.SlotDeliveryStats.SignMismatchCount++
+			} else {
+				ratio := math.Abs(actualWh) / math.Max(math.Abs(plannedWh), 1)
+				switch {
+				case ratio > slotDeliveryOverThreshold:
+					slog.Info("dispatch slot over-delivery",
+						"mode", state.Mode,
+						"planned_wh", plannedWh,
+						"actual_wh", actualWh,
+						"ratio", ratio,
+						"slot_start", state.slotActualSlotStart)
+					state.SlotDeliveryStats.OverDeliveryCount++
+				case ratio < slotDeliveryUnderThreshold:
+					slog.Info("dispatch slot under-delivery",
+						"mode", state.Mode,
+						"planned_wh", plannedWh,
+						"actual_wh", actualWh,
+						"ratio", ratio,
+						"slot_start", state.slotActualSlotStart)
+					state.SlotDeliveryStats.UnderDeliveryCount++
+				}
 			}
 		}
 		state.slotActualSlotStart = dir.SlotStart
@@ -997,6 +1018,12 @@ func ComputeDispatch(
 	// triggered by LIVE grid sign rather than planned grid — since
 	// passive_arbitrage idle slots can be set with planned grid near zero).
 	passiveArbitrageIdleSlot := false
+	// coverLoadDischargeSlot: planner_arbitrage discharge slot the DP
+	// picked for covering load rather than peak export (PlannedGridW ≈ 0).
+	// Same outer-scope lift as passiveArbitrageIdleSlot so the post-block
+	// fall-through can recognise carve-out slots and force grid_target=0
+	// instead of letting PlanTarget set the planned import.
+	coverLoadDischargeSlot := false
 	var currentDirective SlotDirective
 
 	// ---- Manual hold: highest-priority override ----
@@ -1044,8 +1071,16 @@ func ComputeDispatch(
 				// Charge slots (BatteryEnergyWh > idleWh) still use the energy
 				// path so the DP's deliberate grid-charge intent is honoured.
 				const idleWhGate = 50.0
+				// |BatteryEnergyWh| ≤ idleWhGate — true idle only. A
+				// planned-discharge slot is also ≤ idleWhGate by the
+				// signed comparison alone (negative numbers satisfy
+				// the inequality), and would incorrectly route the
+				// live-export charge block onto a deliberate discharge
+				// decision. passive_arbitrage doesn't plan discharge
+				// today; the predicate is defensive. Codex P2 / #375
+				// follow-up.
 				passiveArbitrageIdleSlot = state.Mode == ModePlannerPassiveArbitrage &&
-					dir.BatteryEnergyWh <= idleWhGate
+					math.Abs(dir.BatteryEnergyWh) <= idleWhGate
 				// planner_arbitrage cover-load discharge slots: same fallthrough.
 				// The energy path's "extra export is bonus revenue" carve-out
 				// (see SlotDirective.PlannedGridW doc) is correct for peak-export
@@ -1060,7 +1095,18 @@ func ComputeDispatch(
 				// passive cover-load discharge (BatteryEnergyWh <= idleWh
 				// captures non-charge slots). Operator-report 2026-05-28.
 				const coverLoadExportToleranceW = 100.0
-				coverLoadDischargeSlot := state.Mode == ModePlannerArbitrage &&
+				// Same cover-load reasoning applies in both planner_arbitrage
+				// and planner_passive_arbitrage. Both modes can plan a
+				// discharge slot whose purpose is to *cover load* (not to
+				// export at peak price); both need reactive PI on grid=0
+				// when the forecast load is wrong. The earlier (#378)
+				// implementation only listed planner_arbitrage and relied
+				// on the passive_arbitrage flag's loose predicate to fold
+				// in the passive variant — Codex P2 / #375 follow-up
+				// tightened that flag to true-idle only, so include the
+				// passive mode explicitly here.
+				coverLoadDischargeSlot = (state.Mode == ModePlannerArbitrage ||
+					state.Mode == ModePlannerPassiveArbitrage) &&
 					dir.HasPlannedGridW &&
 					dir.BatteryEnergyWh < -idleWhGate &&
 					dir.PlannedGridW > -coverLoadExportToleranceW
@@ -1074,9 +1120,20 @@ func ComputeDispatch(
 				// weighted, they use the manual modes, not a planner mode.
 				effectiveMode = ModeSelfConsumption
 				state.PlanStale = false
+				// Carve-out slots must chase grid=0, not the legacy
+				// PlanTarget's planned grid. main.go wires PlanTarget
+				// alongside SlotDirective; for arbitrage cover-load,
+				// PlanTarget returns ("self_consumption", planned_import),
+				// and falling through to the !useEnergyPath branch below
+				// would SetGridTarget(+plannedImport) — defeating the
+				// reactive carve-out entirely. Force the setpoint here
+				// and skip the legacy lookup. Codex P1, PR #378 follow-up.
+				if passiveArbitrageIdleSlot || coverLoadDischargeSlot {
+					state.SetGridTarget(0)
+				}
 			}
 		}
-		if !useEnergyPath {
+		if !useEnergyPath && !passiveArbitrageIdleSlot && !coverLoadDischargeSlot {
 			var modeStr string
 			var gridW float64
 			ok := false
@@ -1246,8 +1303,13 @@ func ComputeDispatch(
 	// baselineGridW removes the batteries' current contribution from the
 	// live meter — same shape as planner_self's planned-baseline gate, but
 	// computed from telemetry instead of the (possibly-stale) plan.
+	// Extended to cover-load discharge slots too (#379 follow-up): a
+	// planned-discharge slot whose forecast load doesn't materialise must
+	// not turn into "absorb the live PV surplus" via reactive PI on grid=0.
+	// Battery stays at 0 in both directions for the slot — neither
+	// reactive charge from PV nor force-export discharge.
 	passiveArbitrageIdleLiveExportGate := false
-	if passiveArbitrageIdleSlot {
+	if passiveArbitrageIdleSlot || coverLoadDischargeSlot {
 		baselineGridW := gridW - currentTotal
 		if baselineGridW < -mpc.IdleGateThresholdW {
 			passiveArbitrageIdleLiveExportGate = true

--- a/go/internal/loadmodel/service.go
+++ b/go/internal/loadmodel/service.go
@@ -374,13 +374,41 @@ func (s *Service) persist() error {
 }
 
 // SetHeatingCoef lets the operator declare heating-load sensitivity
-// from config. Units: W per °C below 18°C. 0 disables.
+// explicitly. Units: W per °C below 18°C. 0 disables. Always overwrites
+// the current value across all profiles. Use SeedHeatingCoef on startup
+// so a learned coefficient survives restarts.
 func (s *Service) SetHeatingCoef(w float64) {
 	if s == nil {
 		return
 	}
 	s.mu.Lock()
 	for _, model := range s.models {
+		model.HeatingW_per_degC = w
+	}
+	s.mu.Unlock()
+}
+
+// SeedHeatingCoef applies an operator-config heating-load sensitivity
+// only as a cold-start prior. Per profile: if the model already has
+// telemetry-driven samples (Samples > 0), its learned coefficient is
+// preserved; the seed value is ignored for that profile.
+//
+// This is the startup-path entry point. Operator config is the prior;
+// observation drives the value once learning has begun. Without this
+// guard, every restart would clobber the learned coefficient with the
+// (often-stale) config value — defeating the adaptive fit.
+//
+// Operators who want to forcibly reset the coefficient should hit the
+// reset endpoint (which clears bucket samples) or call SetHeatingCoef.
+func (s *Service) SeedHeatingCoef(w float64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	for _, model := range s.models {
+		if model.Samples > 0 {
+			continue
+		}
 		model.HeatingW_per_degC = w
 	}
 	s.mu.Unlock()

--- a/go/internal/loadmodel/service_test.go
+++ b/go/internal/loadmodel/service_test.go
@@ -21,6 +21,39 @@ func TestResetPreservesHeatingCoefficient(t *testing.T) {
 	}
 }
 
+// TestSeedHeatingCoefDoesNotOverwriteLearnedValue — restart on a deployment
+// where the load model has been adapting must not clobber the learned
+// HeatingW_per_degC with the operator-config seed. Without this guarantee
+// every binary update silently throws away weeks of online fit. The
+// startup wiring in cmd/forty-two-watts/main.go uses SeedHeatingCoef
+// precisely because operator config is a *prior*, not an override.
+func TestSeedHeatingCoefDoesNotOverwriteLearnedValue(t *testing.T) {
+	s := NewService(nil, telemetry.NewStore(), "site", 4000)
+	// Simulate a model that has been adapting in production.
+	s.mu.Lock()
+	m := s.activeModelLocked()
+	m.HeatingW_per_degC = 80.0
+	m.Samples = 500
+	s.mu.Unlock()
+
+	s.SeedHeatingCoef(300) // operator config value carried into a restart
+
+	if got := s.Model().HeatingW_per_degC; got != 80.0 {
+		t.Errorf("learned heating coef must survive seed-only call: got %.0f, want 80", got)
+	}
+}
+
+func TestSeedHeatingCoefAppliesOnColdStart(t *testing.T) {
+	s := NewService(nil, telemetry.NewStore(), "site", 4000)
+	// Fresh model — no samples observed yet.
+
+	s.SeedHeatingCoef(300)
+
+	if got := s.Model().HeatingW_per_degC; got != 300 {
+		t.Errorf("cold-start seed should apply: got %.0f, want 300", got)
+	}
+}
+
 func TestProfileSwitchTrainsOnlyActiveProfile(t *testing.T) {
 	tel := telemetry.NewStore()
 	tel.Update("site", telemetry.DerMeter, 1000, nil, nil)


### PR DESCRIPTION
## Summary

Four Codex review findings on the dispatch / loadmodel changes that shipped in v0.107.0. Two P1 + two P2.

### P1 — Heating coefficient survives restarts ([#377](https://github.com/frahlg/forty-two-watts/pull/377) review)

`main.go` called `loadSvc.SetHeatingCoef(cfg.Weather.HeatingWPerDegC)` at startup, unconditionally overwriting the persisted online-fit value. Every binary update wiped the adaptive learning. New `SeedHeatingCoef(w)` is a no-op when the model has samples; operator config is the cold-start prior, observation drives the value once learning has begun.

### P1 — Cover-load carve-out forces grid_target=0 ([#378](https://github.com/frahlg/forty-two-watts/pull/378) review)

The cover-load carve-out only set `useEnergyPath=false`; production wires both `SlotDirective` and `PlanTarget`, so `!useEnergyPath` called `PlanTarget` and `SetGridTarget(plannedImportW)`. A cover-load slot with +1.7 kW planned import then made PI try to *import* 1.7 kW — the opposite of the carve-out's purpose. Fix routes both carve-out predicates (`passiveArbitrageIdleSlot`, `coverLoadDischargeSlot`) to `SetGridTarget(0)` and skips the legacy PlanTarget block.

### P2 — Predicate tightened to true idle ([#375](https://github.com/frahlg/forty-two-watts/pull/375) review)

`passiveArbitrageIdleSlot` used `BatteryEnergyWh <= idleWhGate`, true for any negative-energy slot. Tightened to `|BatteryEnergyWh| <= idleWhGate`. The planned-discharge case folds into `coverLoadDischargeSlot`, which is now extended to `planner_passive_arbitrage` too (was arbitrage-only). The live-export gate fires on either predicate.

### P2 — SlotDeliveryStats catches sign mismatches ([#379](https://github.com/frahlg/forty-two-watts/pull/379) review)

Planned `-425 Wh` vs actual `+425 Wh` would have scored `|actual|/|planned| = 1.0 = on-target` — the largest possible miss, invisible on `/api/status`. New `SignMismatchCount` fires when planned and actual have opposite signs (and both above idle cutoff); magnitude over/under counters then only fire on same-sign cases.

## Test plan

- [x] `TestSeedHeatingCoefDoesNotOverwriteLearnedValue`
- [x] `TestSeedHeatingCoefAppliesOnColdStart`
- [x] `TestPlannerArbitrageCoverLoadChasesGridZeroNotPlannedImport`
- [x] `TestCoverLoadDischargeDoesNotAbsorbLiveSurplus/{arbitrage,passive_arbitrage}`
- [x] `TestSlotMetricsDetectsSignMismatch`
- [x] Full `go test ./...` green (unit + e2e)
- [x] `make verify-all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)