### PR TITLE
fix(pvmodel): unanchored predictor for MPC to avoid double residual correction

### DIFF
--- a/.changeset/pvmodel-unanchored-mpc-predictor.md
+++ b/.changeset/pvmodel-unanchored-mpc-predictor.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+fix(pvmodel): MPC now consumes the unanchored structural PV predictor so the rolling residual correction (PR #381) is not applied twice. Previously `mpcSvc.PV` was wired to `pvSvc.Predict`, which already folds in the live-vs-model now-anchor; combined with `PVResidualCorrect` the planner saw the structural-vs-live bias subtracted twice and could plan as if PV was ~0 W on a sunny day with a heavy downward residual. A new `pvmodel.Service.PredictStructural` returns the RLS-only prediction; the anchored `Predict` is kept for UI overlays and dispatch's live-reading path.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -715,7 +715,13 @@ func main() {
 		// dispatch later has to scale via the joint allocator).
 		mpcSvc.FuseMaxW = cfg.Fuse.MaxPowerW()
 		if pvSvc != nil {
-			mpcSvc.PV = pvSvc.Predict
+			// Use the unanchored structural predictor here: the MPC also
+			// receives PVResidualCorrect, which captures the same
+			// structural-vs-live bias the now-anchor would apply, so
+			// wiring Predict (anchored) would double-correct and the
+			// planner would see ~0 W PV on a sunny day with a heavy
+			// downward residual. See pvmodel.Service.PredictStructural.
+			mpcSvc.PV = pvSvc.PredictStructural
 			mpcSvc.PVResidualCorrect = pvSvc.ResidualCorrect
 		}
 		mpcSvc.Load = loadSvc.Predict

--- a/go/internal/mpc/service_test.go
+++ b/go/internal/mpc/service_test.go
@@ -120,6 +120,76 @@ func TestBuildSlots_AppliesPVResidualCorrection(t *testing.T) {
 	}
 }
 
+// TestBuildSlots_NoDoubleCorrection: regression for the PR #381
+// follow-up. The MPC must consume the UNANCHORED structural PV
+// predictor plus the residual corrector — wiring the anchored
+// predictor (which already folds in the same structural-vs-live bias)
+// produces a double-correction so the planner sees ~0 W PV on a sunny
+// day with a heavy downward residual.
+//
+// Worked example (Codex's reproduction):
+//
+//	structural prediction  = 1000 W
+//	live PV measurement    =  500 W  (heavy downward bias of −500 W)
+//	→ anchored Predict     ≈  500 W  (the now-anchor already pulled it)
+//	→ ResidualCorrect      = −500 W  (rolling mean of the same bias)
+//
+// Wiring `PV = pvSvc.Predict` (anchored) + `PVResidualCorrect` gives the
+// planner ≈ 0 W. Wiring `PV = pvSvc.PredictStructural` + `PVResidualCorrect`
+// (the fix) gives the planner ≈ 500 W — the bias is corrected exactly
+// once, by the residual layer that is designed for it.
+//
+// We simulate both wirings here and assert the structural one matches
+// the single-correction outcome.
+func TestBuildSlots_NoDoubleCorrection(t *testing.T) {
+	ts0 := time.Date(2026, 4, 15, 14, 0, 0, 0, time.UTC).UnixMilli()
+	cloud := 30.0
+	forecastPV := 0.0 // disable forecast blending to expose the pure twin path
+
+	const structuralW = 1000.0
+	const anchoredW = 500.0 // what Predict would return after the now-anchor
+	const residualW = -500.0
+
+	// Slot 0 midpoint — buildSlots passes this to both PV and PVResidualCorrect.
+	correctedSlot := time.UnixMilli(ts0 + 15*30*1000).UTC()
+	pvCorrect := func(now, tTarget time.Time, base float64) float64 {
+		if tTarget.Equal(correctedSlot) {
+			return residualW
+		}
+		return 0
+	}
+
+	// --- Buggy wiring (anchored predictor + residual): double correction ---
+	slotsBuggy := buildSlots(
+		[]state.PricePoint{{SlotTsMs: ts0, SlotLenMin: 15, SpotOreKwh: 120, TotalOreKwh: 180}},
+		[]state.ForecastPoint{{SlotTsMs: ts0, SlotLenMin: 60, CloudCoverPct: &cloud, PVWEstimated: &forecastPV}},
+		2500,
+		ts0,
+		func(time.Time, float64) float64 { return anchoredW },
+		pvCorrect,
+		nil,
+	)
+	// Anchored 500 + residual -500 = 0 → site-sign PVW = 0.
+	if got, want := slotsBuggy[0].PVW, 0.0; math.Abs(got-want) > 1e-6 {
+		t.Fatalf("buggy-wiring slot 0 PVW = %f, want %f (anchored + residual double-corrects)", got, want)
+	}
+
+	// --- Correct wiring (structural predictor + residual): single correction ---
+	slotsFixed := buildSlots(
+		[]state.PricePoint{{SlotTsMs: ts0, SlotLenMin: 15, SpotOreKwh: 120, TotalOreKwh: 180}},
+		[]state.ForecastPoint{{SlotTsMs: ts0, SlotLenMin: 60, CloudCoverPct: &cloud, PVWEstimated: &forecastPV}},
+		2500,
+		ts0,
+		func(time.Time, float64) float64 { return structuralW },
+		pvCorrect,
+		nil,
+	)
+	// Structural 1000 + residual -500 = 500 → site-sign PVW = -500.
+	if got, want := slotsFixed[0].PVW, -500.0; math.Abs(got-want) > 1e-6 {
+		t.Fatalf("fixed-wiring slot 0 PVW = %f, want %f (single correction reflects live bias)", got, want)
+	}
+}
+
 // ---- upperHalfMeanPrice (arbitrage terminal valuation) ----
 
 func TestUpperHalfMeanLiftsTerminalCreditAboveOverallMean(t *testing.T) {

--- a/go/internal/pvmodel/service.go
+++ b/go/internal/pvmodel/service.go
@@ -117,8 +117,27 @@ func (s *Service) SetRated(w float64) {
 	}
 }
 
-// Predict is the main integration point: MPC + UI call this to get the
-// twin's prediction for any future instant.
+// PredictStructural returns the RLS-driven prediction WITHOUT the
+// now-anchor live-telemetry correction. This is the surface the MPC and
+// residual-buffer sampler consume: the residual buffer measures and
+// corrects exactly the same structural-vs-live bias the now-anchor
+// would otherwise apply, so layering both produces a double-correction
+// bug (PR #381 follow-up). Keep `Predict` (anchored) for any path that
+// wants the live-blended prediction (UI overlays, dispatch "now" gate).
+func (s *Service) PredictStructural(t time.Time, cloudPct float64) float64 {
+	if s == nil {
+		return 0
+	}
+	cs := s.ClearSky(t)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.model.Predict(cs, cloudPct, t)
+}
+
+// Predict is the main integration point for the UI + dispatch live-reading
+// path: it returns the twin's prediction with the live-telemetry "now
+// anchor" folded in. The MPC and the residual-buffer sampler should use
+// PredictStructural instead — see that method's doc for why.
 //
 // Near-future predictions are anchored to live telemetry: if the model's
 // "what PV should be doing right now" disagrees with what PV IS doing

--- a/go/internal/pvmodel/service_test.go
+++ b/go/internal/pvmodel/service_test.go
@@ -220,3 +220,140 @@ func TestService_PredictFallsBackWhenNoTelemetry(t *testing.T) {
 		t.Errorf("fallback should land near the raw prior (~900 W), got %.0f", got)
 	}
 }
+
+// ---- PredictStructural (unanchored) ----
+
+// TestPredict_AppliesNowAnchor — same scenario as
+// TestService_PredictAnchorsOnLiveTelemetry but framed as the explicit
+// pre-condition for PredictStructural's contract: with live telemetry
+// disagreeing with the model, Predict IS pulled toward the measurement.
+func TestPredict_AppliesNowAnchor(t *testing.T) {
+	tel := telemetry.NewStore()
+	tel.Update("pv", telemetry.DerPV, -8000, nil, nil)
+
+	svc := &Service{
+		Tele:     tel,
+		ClearSky: func(time.Time) float64 { return 800 },
+		Cloud:    func(time.Time) (float64, bool) { return 80, true },
+		model:    NewModel(10000),
+	}
+
+	rawPrior := svc.model.Predict(800, 80, time.Now())
+	anchored := svc.Predict(time.Now(), 80)
+	// The anchored prediction must be pulled UP toward 8000 W relative
+	// to the raw prior (~715 W) — the live PV is dramatically larger
+	// than what the forecast cloud cover suggests.
+	if anchored <= rawPrior*1.5 {
+		t.Errorf("Predict (anchored) should be pulled up by live 8 kW; got %.0f W (raw prior %.0f W)", anchored, rawPrior)
+	}
+}
+
+// TestPredictStructural_DoesNotApplyNowAnchor: under the same live-
+// disagreement scenario, PredictStructural returns the raw RLS output
+// untouched. This is the property that prevents double-correction when
+// the residual buffer is also wired.
+func TestPredictStructural_DoesNotApplyNowAnchor(t *testing.T) {
+	tel := telemetry.NewStore()
+	// 8 kW live, but model predicts ~715 W from the prior.
+	tel.Update("pv", telemetry.DerPV, -8000, nil, nil)
+
+	svc := &Service{
+		Tele:     tel,
+		ClearSky: func(time.Time) float64 { return 800 },
+		Cloud:    func(time.Time) (float64, bool) { return 80, true },
+		model:    NewModel(10000),
+	}
+
+	now := time.Now()
+	rawPrior := svc.model.Predict(800, 80, now)
+	structural := svc.PredictStructural(now, 80)
+	if math.Abs(structural-rawPrior) > 1e-6 {
+		t.Errorf("PredictStructural = %.6f W, want %.6f W (no anchor; live telemetry must be ignored)", structural, rawPrior)
+	}
+
+	// Sanity: the anchored Predict path DOES respond — confirms the
+	// telemetry plumbing is wired so the "doesn't respond" assertion
+	// above is meaningful, not a no-op.
+	anchored := svc.Predict(now, 80)
+	if anchored <= structural*1.5 {
+		t.Fatalf("test setup broken: anchored Predict (%.0f W) should differ from structural (%.0f W); live telemetry not reaching applyNowAnchor", anchored, structural)
+	}
+}
+
+// TestPredictStructural_StillRespectsRLS: the unanchored variant is not
+// a frozen baseline — it tracks the RLS coefficients. Feed enough
+// training samples to shift Beta and verify the structural prediction
+// follows.
+func TestPredictStructural_StillRespectsRLS(t *testing.T) {
+	svc := &Service{
+		ClearSky: func(time.Time) float64 { return 800 },
+		Cloud:    func(time.Time) (float64, bool) { return 20, true },
+		model:    NewModel(5000),
+	}
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	before := svc.PredictStructural(now, 20)
+
+	// Drive ~60 RLS updates against a synthetic "actual" that is well
+	// above what the cold-start prior would predict. RLS should track
+	// the new operating point.
+	target := before * 1.6
+	for i := 0; i < 60; i++ {
+		svc.mu.Lock()
+		svc.model.Update(800, 20, now, target)
+		svc.mu.Unlock()
+	}
+	after := svc.PredictStructural(now, 20)
+	if after <= before*1.1 {
+		t.Errorf("PredictStructural did not track RLS update: before=%.0f W, after=%.0f W (target was %.0f W)", before, after, target)
+	}
+}
+
+// TestResidualBufferSampler_UsesStructuralPrediction: when sample()
+// records into the residual buffer, the "predicted" component must be
+// the structural prediction (no now-anchor), not the anchored Predict.
+// Otherwise the buffer captures (anchored, actual) and the residual
+// double-counts the same correction the anchor already applied —
+// exactly the bug we're fixing.
+//
+// We set up a Service where Predict would anchor heavily upward (live
+// 8 kW vs raw prior ~715 W) and then drive a single sample(). The
+// recorded `predicted` should match the raw model prior, not the
+// anchored 3.5 kW.
+func TestResidualBufferSampler_UsesStructuralPrediction(t *testing.T) {
+	tel := telemetry.NewStore()
+	tel.Update("pv", telemetry.DerPV, -8000, nil, nil)
+
+	svc := &Service{
+		Tele:         tel,
+		ClearSky:     func(time.Time) float64 { return 800 },
+		Cloud:        func(time.Time) (float64, bool) { return 80, true },
+		model:        NewModel(10000),
+		Residuals:    NewResidualBuffer(),
+		PersistEvery: 10, // avoid mod-by-zero in sample(); no Store means persist() no-ops
+	}
+
+	// Verify the test setup: anchored vs structural disagree.
+	now := time.Now()
+	structural := svc.PredictStructural(now, 80)
+	anchored := svc.Predict(now, 80)
+	if anchored <= structural*1.5 {
+		t.Fatalf("test setup broken: need anchored ≫ structural to detect the bug, got anchored=%.0f structural=%.0f", anchored, structural)
+	}
+
+	svc.sample()
+
+	if got := svc.Residuals.Len(); got != 1 {
+		t.Fatalf("residual buffer should have exactly one sample after sample(), got %d", got)
+	}
+	svc.Residuals.mu.Lock()
+	rec := svc.Residuals.samples[0]
+	svc.Residuals.mu.Unlock()
+	// Recorded "predicted" must be the structural value (within
+	// floating noise), not the anchored 3.5 kW.
+	if math.Abs(rec.predicted-structural) > 1.0 {
+		t.Errorf("residual sampler captured predicted=%.2f W; want structural=%.2f W (anchored would have been %.2f W)", rec.predicted, structural, anchored)
+	}
+	if rec.predicted >= anchored*0.5 {
+		t.Errorf("residual sampler captured %.0f W which looks anchored (anchored=%.0f); must be the unanchored structural %.0f", rec.predicted, anchored, structural)
+	}
+}


### PR DESCRIPTION
## Summary

Codex P1 finding on #381: the MPC was wired to `pvSvc.Predict`, which already applies the live-vs-model now-anchor. The rolling residual buffer added in #381 ALSO corrects for the same structural-vs-live bias. Layering both produces a double-correction.

**Codex worked example:**

- Structural prediction: 1000 W
- Live PV measurement: 500 W (heavy downward bias of -500 W)
- Anchored `Predict` → ~500 W (now-anchor already pulled it)
- `ResidualCorrect` → -500 W (rolling mean of the same bias)
- MPC sees PV ≈ **0 W** on a sunny day — plans as if there is no PV at all.

## Fix

- New `pvmodel.Service.PredictStructural(t, cloudPct)` — RLS-only prediction with no now-anchor.
- `mpcSvc.PV` wired to `pvSvc.PredictStructural`; combined with `PVResidualCorrect` this gives the planner a single correction (the rolling residual measures and corrects exactly the structural-vs-live bias the anchor would otherwise apply).
- `Predict` (anchored) is preserved verbatim for the UI overlay (`PredictNow` / `/api/pvmodel`) and any future dispatch live-reading consumers.
- The residual-buffer sampler in `sample()` was already calling `s.model.Predict` directly (structural, no anchor) — a regression test now pins that behaviour so a future refactor can't silently switch it to the anchored path.

## Test plan

- [x] `TestPredict_AppliesNowAnchor` — Predict IS pulled toward live measurement (pre-condition for the contract).
- [x] `TestPredictStructural_DoesNotApplyNowAnchor` — PredictStructural ignores live telemetry, returns raw RLS output.
- [x] `TestPredictStructural_StillRespectsRLS` — drive ~60 RLS updates, structural prediction follows.
- [x] `TestResidualBufferSampler_UsesStructuralPrediction` — `sample()` writes the structural prediction into the residual buffer, not the anchored one.
- [x] `TestBuildSlots_NoDoubleCorrection` — MPC integration test with both wirings; buggy (anchored + residual) → 0 W slot; fixed (structural + residual) → 500 W slot.
- [x] `make verify` clean (vet + full test suite + build).
- [x] Existing `TestService_PredictAnchorsOnLiveTelemetry` + `TestBuildSlots_AppliesPVResidualCorrection` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)