### PR TITLE
fix(control): reset energy-path bookkeeping inside reactive carve-outs

### DIFF
--- a/.changeset/carve-out-bookkeeping-reset.md
+++ b/.changeset/carve-out-bookkeeping-reset.md
@@ -1,0 +1,21 @@
+---
+"forty-two-watts": patch
+---
+
+**Hardening: cover-load and passive-arbitrage-idle carve-outs now reset stale
+energy-path bookkeeping on every tick they fire**, mirroring what
+`preparePlannerSelf` already does for `planner_self`.
+
+Without this, `slotDelivered` / `lastTickTs` / `currentDirective` could
+carry leftover state from a prior energy-path tick into the carve-out
+window. A subsequent transition back to the energy path within the same
+15-min slot (e.g., a mid-slot replan flipping the slot's intent, or an
+operator mode-hop) would then read those stale values and miscompute
+`remainingWh`. Same forward-transition risk that `planner_self` has
+guarded against since PR #131.
+
+No new behaviour, no signal change in the steady-state cover-load reactive
+path — purely defence-in-depth for plan-refinement / mode-transition
+scenarios. Two regression tests pin the bookkeeping reset for both the
+`planner_arbitrage` cover-load and the `planner_passive_arbitrage` idle
+carve-outs.

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -2467,6 +2467,96 @@ func TestPlannerArbitrageCoverLoadChasesGridZeroNotPlannedImport(t *testing.T) {
 	}
 }
 
+// Same forward-transition risk that preparePlannerSelf already guards against
+// (see resetEnergyDispatchBookkeeping comment at dispatch.go:798-803): if the
+// site spent part of a slot on the energy-allocation path before the plan
+// refined to a cover-load discharge or a passive-arbitrage idle, the stale
+// slotDelivered accumulator stays around. A subsequent transition back to
+// the energy path within the same slot (another plan refinement, an operator
+// mode-hop, etc.) would then read stale Wh and miscompute remainingWh. The
+// fix mirrors planner_self: when the reactive carve-out fires, reset the
+// energy-path bookkeeping.
+func TestPlannerArbitrageCoverLoadResetsEnergyPathBookkeeping(t *testing.T) {
+	now := time.Now()
+	d := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: -425,
+		Strategy:        "arbitrage",
+		PlannedGridW:    1700,
+		HasPlannedGridW: true,
+	}
+	store := seedStore(-800, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", -1700, 0.6},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return d, true }
+	// Simulate "we just left the energy path mid-slot" — slotDelivered has
+	// non-zero leftover, lastTickTs is in the past, currentDirective points
+	// at the now-superseded plan view.
+	st.slotDelivered = -200
+	st.lastTickTs = now.Add(-30 * time.Second)
+	st.currentDirective = SlotDirective{SlotStart: now.Add(-10 * time.Minute)}
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	if st.slotDelivered != 0 {
+		t.Errorf("slotDelivered = %.0f, want 0 — cover-load carve-out must clear stale energy-path bookkeeping", st.slotDelivered)
+	}
+	if !st.lastTickTs.IsZero() {
+		t.Errorf("lastTickTs = %v, want zero — cover-load carve-out must clear lastTickTs", st.lastTickTs)
+	}
+	if !st.currentDirective.SlotStart.IsZero() {
+		t.Errorf("currentDirective.SlotStart = %v, want zero — carve-out must clear stale directive", st.currentDirective.SlotStart)
+	}
+}
+
+func TestPlannerPassiveArbitrageIdleResetsEnergyPathBookkeeping(t *testing.T) {
+	now := time.Now()
+	d := SlotDirective{
+		SlotStart:       now,
+		SlotEnd:         now.Add(15 * time.Minute),
+		BatteryEnergyWh: 0, // idle slot
+		Strategy:        "passive_arbitrage",
+		PlannedGridW:    50,
+		HasPlannedGridW: true,
+	}
+	store := seedStore(100, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.5},
+	})
+	st := NewState(0, 0, "ferroamp")
+	st.Mode = ModePlannerPassiveArbitrage
+	st.UseEnergyDispatch = true
+	st.SlewRateW = 100_000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return d, true }
+	st.slotDelivered = 150
+	st.lastTickTs = now.Add(-1 * time.Minute)
+	st.currentDirective = SlotDirective{SlotStart: now.Add(-20 * time.Minute)}
+
+	_ = ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+
+	if st.slotDelivered != 0 {
+		t.Errorf("slotDelivered = %.0f, want 0", st.slotDelivered)
+	}
+	if !st.lastTickTs.IsZero() {
+		t.Errorf("lastTickTs = %v, want zero", st.lastTickTs)
+	}
+	if !st.currentDirective.SlotStart.IsZero() {
+		t.Errorf("currentDirective.SlotStart = %v, want zero", st.currentDirective.SlotStart)
+	}
+}
+
 func TestPlannerSelfPlannedPVExportStopsChargingWithoutSlew(t *testing.T) {
 	now := time.Now()
 	dir := SlotDirective{

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -1130,6 +1130,16 @@ func ComputeDispatch(
 				// and skip the legacy lookup. Codex P1, PR #378 follow-up.
 				if passiveArbitrageIdleSlot || coverLoadDischargeSlot {
 					state.SetGridTarget(0)
+					// Mirror preparePlannerSelf (dispatch.go:797-804):
+					// if the slot was previously on the energy path —
+					// directly or via an operator mode-hop earlier in
+					// the same 15-min window — slotDelivered /
+					// lastTickTs / currentDirective hold stale values.
+					// A future transition back to the energy path
+					// within the same slot would then read those and
+					// miscompute remainingWh. Reset on every carve-out
+					// tick (idempotent).
+					resetEnergyDispatchBookkeeping(state)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Defence-in-depth follow-up to #383 / #378. The carve-out gate added in #383 calls `SetGridTarget(0)` but does **not** call `resetEnergyDispatchBookkeeping`. `preparePlannerSelf` does both (dispatch.go:797-804) for the same reason: when the slot was previously on the energy-allocation path — directly or via an operator mode-hop earlier in the same 15-min window — `slotDelivered` / `lastTickTs` / `currentDirective` hold stale values. A subsequent transition back to the energy path within the same slot would then read those and miscompute `remainingWh`.

Symmetric with the comment at dispatch.go:798-803:
> "Reset the energy-allocation bookkeeping so a future switch to planner_cheap / planner_arbitrage within the same 15-minute slot can't read stale slotDelivered accumulated before the operator hopped through planner_self."

Adding the reset to the carve-out branch gives `planner_arbitrage` cover-load and `planner_passive_arbitrage` idle the same guarantee.

## What does NOT change

- Steady-state cover-load reactive behaviour is unchanged.
- No PI.Reset call — the existing pattern in `preparePlannerSelf` doesn't reset the PI either, and resetting per tick would prevent the integral from doing its job.

## Test plan

- [x] `TestPlannerArbitrageCoverLoadResetsEnergyPathBookkeeping` — RED before fix (slotDelivered=-200 / non-zero ts / non-zero directive), GREEN after.
- [x] `TestPlannerPassiveArbitrageIdleResetsEnergyPathBookkeeping` — same for passive idle.
- [x] Existing carve-out tests still pass.
- [x] \`make verify\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)