### PR TITLE
feat(savings): EV-aware baseline credits EMS scheduling

### DIFF
--- a/.changeset/savings-ev-aware-baseline.md
+++ b/.changeset/savings-ev-aware-baseline.md
@@ -1,0 +1,42 @@
+---
+"forty-two-watts": minor
+---
+
+**Savings: baseline now includes EV charging priced at the day's average,
+so EMS-scheduled EV laddning shows up as savings instead of zeroing out.**
+Previously the `BaselineCostOre` returned by `state.DailyCostBreakdown`
+(and surfaced by `/api/savings/daily` as `baseline_cost_ore`) was
+`Σ slot ( house_load_w × spot_total )`, where `house_load_w` was
+explicitly the meter reading minus EV (see
+`main.go`'s `loadW := gridW − batW − pvW − evW`). Two consequences:
+
+1. When the EMS scheduled EV charging onto a near-zero spot hour, that
+   energy contributed ~0 to baseline but the matching grid import still
+   went into `ActualCostOre`. Saved-tal looked flat or even negative.
+2. When the EV was charged on a higher-priced hour (cold-start, no
+   override), actual rose while baseline didn't move — the metric was
+   systematically biased toward "lost" whenever the EV was active.
+
+The breakdown now treats EV separately:
+
+- `BaselineHouseOre` keeps the slot-by-slot house pricing (unchanged
+  behaviour for the EV-less case).
+- `BaselineEvOre = EVWh × AvgImportOreKwh / 1000` prices the day's EV
+  energy at the day's time-weighted average spot. Interpretation: "a
+  dumb charger with no timing awareness would have paid the day's avg
+  per kWh". Smart scheduling onto cheap hours then surfaces as savings;
+  charging on a peak shows up as a penalty. Symmetric.
+- `BaselineCostOre = BaselineHouseOre + BaselineEvOre` (sum exposed for
+  back-compat).
+- `EVWh` is derived per history sample as
+  `grid_w − bat_w − pv_w − load_w` (clamped non-negative), the inverse
+  of `main.go`'s identity. No schema change.
+
+The `/api/savings/daily` response gains `ev_wh`, `baseline_house_ore`,
+and `baseline_ev_ore` fields so the UI can render the EV share of
+savings separately. Existing fields (`baseline_cost_ore`, `saved_ore`,
+`flat_cost_ore`) keep their names; their values now incorporate the EV
+term.
+
+Historical days will re-render with the new baseline once a process
+restart clears the savings cache; volume columns are unchanged.

--- a/go/internal/api/api_savings.go
+++ b/go/internal/api/api_savings.go
@@ -17,8 +17,11 @@ type daySavings struct {
 	ImportWh         float64
 	ExportWh         float64
 	LoadWh           float64
+	EVWh             float64
 	ImportCostOre    float64
 	ExportRevenueOre float64
+	BaselineHouseOre float64
+	BaselineEvOre    float64
 	BaselineCostOre  float64
 	AvgImportOreKwh  float64
 	AvgExportOreKwh  float64
@@ -34,8 +37,11 @@ func fromBreakdown(b state.DayCostBreakdown, resolution string) daySavings {
 		ImportWh:         b.ImportWh,
 		ExportWh:         b.ExportWh,
 		LoadWh:           b.LoadWh,
+		EVWh:             b.EVWh,
 		ImportCostOre:    b.ImportCostOre,
 		ExportRevenueOre: b.ExportRevenueOre,
+		BaselineHouseOre: b.BaselineHouseOre,
+		BaselineEvOre:    b.BaselineEvOre,
 		BaselineCostOre:  b.BaselineCostOre,
 		AvgImportOreKwh:  b.AvgImportOreKwh,
 		AvgExportOreKwh:  b.AvgExportOreKwh,
@@ -178,16 +184,19 @@ func (s *Server) handleSavingsDaily(w http.ResponseWriter, r *http.Request) {
 		tSaved += ds.SavedOre
 
 		out = append(out, map[string]any{
-			"day":                dayKey,
-			"import_wh":          ds.ImportWh,
-			"export_wh":          ds.ExportWh,
-			"load_wh":            ds.LoadWh,
-			"import_cost_ore":    ds.ImportCostOre,
-			"export_revenue_ore": ds.ExportRevenueOre,
-			"actual_cost_ore":    ds.ActualCostOre,
-			"baseline_cost_ore":  ds.BaselineCostOre,
-			// Deprecated compatibility alias: this now means the same
-			// load-only baseline as baseline_cost_ore, not a flat-average tariff.
+			"day":                 dayKey,
+			"import_wh":           ds.ImportWh,
+			"export_wh":           ds.ExportWh,
+			"load_wh":             ds.LoadWh,
+			"ev_wh":               ds.EVWh,
+			"import_cost_ore":     ds.ImportCostOre,
+			"export_revenue_ore":  ds.ExportRevenueOre,
+			"actual_cost_ore":     ds.ActualCostOre,
+			"baseline_house_ore":  ds.BaselineHouseOre,
+			"baseline_ev_ore":     ds.BaselineEvOre,
+			"baseline_cost_ore":   ds.BaselineCostOre,
+			// Deprecated compatibility alias: now equals baseline_cost_ore
+			// (house slot-priced + EV at daily-avg), not a flat-average tariff.
 			"flat_cost_ore":      ds.FlatCostOre,
 			"saved_ore":          ds.SavedOre,
 			"avg_import_ore_kwh": ds.AvgImportOreKwh,

--- a/go/internal/state/cost.go
+++ b/go/internal/state/cost.go
@@ -9,17 +9,29 @@ import (
 // DayCostBreakdown decomposes a historical range into actual net grid cost and
 // a no-PV/no-battery baseline. All monetary values are in öre.
 //
-// BaselineCostOre prices recorded house load as if every Wh had been bought
-// from the grid. ActualCostOre prices the real grid-boundary import/export.
-// Their difference is the operator-facing savings from PV self-consumption,
-// battery shifting, and export revenue.
+// BaselineCostOre prices the household's total consumption — split between
+// inflexible house load (priced slot-by-slot at the spot total) and flexible
+// EV charging (priced at the day's time-weighted average import) — as if
+// every Wh had been bought from the grid. The EV-as-average treatment exists
+// because the EMS schedules EV charging into low-price slots: pricing those
+// kWh at the slot they actually landed in would zero out the credit owed to
+// the scheduler. Crediting them at the day's average price says "a dumb
+// charger with no timing awareness would have paid this much" and lets the
+// shifted timing show up as savings.
+//
+// ActualCostOre prices the real grid-boundary import/export. Their
+// difference is the operator-facing savings from PV self-consumption,
+// battery shifting, export revenue, and EV scheduling.
 type DayCostBreakdown struct {
 	ImportWh         float64
 	ExportWh         float64
-	LoadWh           float64
+	LoadWh           float64 // house load (excludes EV) — kept stable for live chart
+	EVWh             float64 // EV charging energy
 	ImportCostOre    float64 // Σ slot ( import_wh × total_ore_kwh ) / 1000
 	ExportRevenueOre float64 // Σ slot ( export_wh × export_price_ore ) / 1000
-	BaselineCostOre  float64 // Σ slot ( load_wh × total_ore_kwh ) / 1000
+	BaselineHouseOre float64 // Σ slot ( house_load_wh × total_ore_kwh ) / 1000
+	BaselineEvOre    float64 // ev_wh × AvgImportOreKwh / 1000
+	BaselineCostOre  float64 // BaselineHouseOre + BaselineEvOre
 	AvgImportOreKwh  float64 // time-weighted mean of total_ore_kwh over slots in range
 	AvgExportOreKwh  float64 // time-weighted mean of effective export price over slots in range
 	PriceSlotCount   int     // overlapping price slots used for the cost model
@@ -101,6 +113,11 @@ func (s *Store) DailyCostBreakdown(sinceMs, untilMs int64, zone string, ep Expor
 	out.AvgImportOreKwh = avgImp
 	out.AvgExportOreKwh = avgExp
 	out.PriceSlotCount = priceSlots
+	// Price EV energy at the day's time-weighted average import. If the
+	// range has no overlapping price slots, AvgImportOreKwh is 0 and the
+	// EV term collapses cleanly to 0 — matching the "no prices" rendering.
+	out.BaselineEvOre = out.EVWh * avgImp / 1000.0
+	out.BaselineCostOre = out.BaselineHouseOre + out.BaselineEvOre
 	return out, nil
 }
 
@@ -148,17 +165,37 @@ func (s *Store) loadPriceSlotsForRange(zone string, sinceMs, untilMs int64) ([]p
 // Slots are walked with a sliding pointer: both sides are ascending, so for
 // each midpoint we advance until the slot's EndMs is past the midpoint.
 // Samples whose midpoint has no covering slot still count toward ImportWh,
-// ExportWh, and LoadWh but contribute zero to cost / revenue.
+// ExportWh, LoadWh, and EVWh but contribute zero to cost / revenue.
+//
+// EV power is derived per row as `grid_w − bat_w − pv_w − load_w` (clamped
+// non-negative — the same identity main.go uses in reverse to compute
+// `load_w` for the history rows). Pricing of EVWh is deferred to the
+// caller (DailyCostBreakdown applies the day's avg import).
 func (s *Store) integrateHistoryRange(sinceMs, untilMs int64, slots []priceSlot, ep ExportPricing) (DayCostBreakdown, error) {
 	rows, err := s.db.Query(`
 		WITH all_rows AS (
-			SELECT ts_ms, COALESCE(grid_w, 0) AS grid_w, COALESCE(load_w, 0) AS load_w FROM history_hot  WHERE ts_ms BETWEEN ? AND ?
+			SELECT ts_ms,
+			       COALESCE(grid_w, 0) AS grid_w,
+			       COALESCE(load_w, 0) AS load_w,
+			       COALESCE(bat_w,  0) AS bat_w,
+			       COALESCE(pv_w,   0) AS pv_w
+			FROM history_hot  WHERE ts_ms BETWEEN ? AND ?
 			UNION ALL
-			SELECT ts_ms, COALESCE(grid_w, 0),           COALESCE(load_w, 0)           FROM history_warm WHERE ts_ms BETWEEN ? AND ?
+			SELECT ts_ms,
+			       COALESCE(grid_w, 0),
+			       COALESCE(load_w, 0),
+			       COALESCE(bat_w,  0),
+			       COALESCE(pv_w,   0)
+			FROM history_warm WHERE ts_ms BETWEEN ? AND ?
 			UNION ALL
-			SELECT ts_ms, COALESCE(grid_w, 0),           COALESCE(load_w, 0)           FROM history_cold WHERE ts_ms BETWEEN ? AND ?
+			SELECT ts_ms,
+			       COALESCE(grid_w, 0),
+			       COALESCE(load_w, 0),
+			       COALESCE(bat_w,  0),
+			       COALESCE(pv_w,   0)
+			FROM history_cold WHERE ts_ms BETWEEN ? AND ?
 		)
-		SELECT ts_ms, grid_w, load_w FROM all_rows ORDER BY ts_ms ASC
+		SELECT ts_ms, grid_w, load_w, bat_w, pv_w FROM all_rows ORDER BY ts_ms ASC
 	`,
 		sinceMs, untilMs,
 		sinceMs, untilMs,
@@ -177,8 +214,8 @@ func (s *Store) integrateHistoryRange(sinceMs, untilMs int64, slots []priceSlot,
 	)
 	for rows.Next() {
 		var ts int64
-		var gridW, loadW float64
-		if err := rows.Scan(&ts, &gridW, &loadW); err != nil {
+		var gridW, loadW, batW, pvW float64
+		if err := rows.Scan(&ts, &gridW, &loadW, &batW, &pvW); err != nil {
 			return DayCostBreakdown{}, err
 		}
 		if !havePrev {
@@ -206,8 +243,15 @@ func (s *Store) integrateHistoryRange(sinceMs, untilMs int64, slots []priceSlot,
 			loadWh := loadW * float64(dtMs) / 3600000.0
 			out.LoadWh += loadWh
 			if covering != nil {
-				out.BaselineCostOre += loadWh * covering.TotalOre / 1000.0
+				out.BaselineHouseOre += loadWh * covering.TotalOre / 1000.0
 			}
+		}
+
+		// EV = grid_w − bat_w − pv_w − load_w. Clamp negative noise to
+		// zero (matches main.go's clamp on load_w going the other way).
+		evW := gridW - batW - pvW - loadW
+		if evW > 0 {
+			out.EVWh += evW * float64(dtMs) / 3600000.0
 		}
 
 		wh := gridW * float64(dtMs) / 3600000.0

--- a/go/internal/state/cost.go
+++ b/go/internal/state/cost.go
@@ -165,7 +165,10 @@ func (s *Store) loadPriceSlotsForRange(zone string, sinceMs, untilMs int64) ([]p
 // Slots are walked with a sliding pointer: both sides are ascending, so for
 // each midpoint we advance until the slot's EndMs is past the midpoint.
 // Samples whose midpoint has no covering slot still count toward ImportWh,
-// ExportWh, LoadWh, and EVWh but contribute zero to cost / revenue.
+// ExportWh, and LoadWh but contribute zero to cost / revenue. EVWh is the
+// exception: it is gated on coverage too, because it feeds the priced EV
+// baseline (BaselineEvOre) — counting gap-hour EV would inflate savings
+// with no matching actual cost.
 //
 // EV power is derived per row as `grid_w − bat_w − pv_w − load_w` (clamped
 // non-negative — the same identity main.go uses in reverse to compute
@@ -249,8 +252,12 @@ func (s *Store) integrateHistoryRange(sinceMs, untilMs int64, slots []priceSlot,
 
 		// EV = grid_w − bat_w − pv_w − load_w. Clamp negative noise to
 		// zero (matches main.go's clamp on load_w going the other way).
+		// Gate on `covering`: EVWh feeds BaselineEvOre (priced at the
+		// daily average), so counting EV charged in a price gap would
+		// credit a baseline with no matching actual import cost —
+		// phantom savings. The house baseline gates the same way above.
 		evW := gridW - batW - pvW - loadW
-		if evW > 0 {
+		if evW > 0 && covering != nil {
 			out.EVWh += evW * float64(dtMs) / 3600000.0
 		}
 

--- a/go/internal/state/cost_test.go
+++ b/go/internal/state/cost_test.go
@@ -242,6 +242,208 @@ func TestDailyCostBreakdown_FlatAverageIsHalfOpenAndTimeWeighted(t *testing.T) {
 	}
 }
 
+// EV charging counter-factual: the EMS schedules the car onto the cheap
+// hour, and the baseline must price those kWh at the day's average so the
+// scheduling shows up as savings instead of zeroing out.
+func TestDailyCostBreakdown_EVChargingPricedAtDailyAverage(t *testing.T) {
+	s := freshStore(t)
+
+	// Two 1-h slots, big spread: 0 öre vs 400 öre. Time-weighted avg =
+	// 200 öre/kWh.
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 0, TotalOreKwh: 0, Source: "test"},
+		{Zone: "SE3", SlotTsMs: 3600000, SlotLenMin: 60, SpotOreKwh: 400, TotalOreKwh: 400, Source: "test"},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+
+	// Hour 1 (0 öre): house = 0, EV charges at 11 kW → grid imports 11 kW.
+	// Hour 2 (400 öre): house = 0, EV off → grid 0.
+	// House load_w is the "house minus EV" component; EV is derived as
+	// grid_w − bat_w − pv_w − load_w = 11000 in hour 1, 0 in hour 2.
+	if err := s.BulkRecordHistory([]HistoryPoint{
+		{TsMs: 0, GridW: 11000, LoadW: 0},
+		{TsMs: 3_600_000, GridW: 11000, LoadW: 0},
+		{TsMs: 7_200_000, GridW: 0, LoadW: 0},
+	}); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	b, err := s.DailyCostBreakdown(0, 7_200_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+
+	// 11 kW × 1 h = 11 kWh of EV, no house load.
+	if !approxEq(b.EVWh, 11_000, 0.01) {
+		t.Errorf("EVWh = %.4f, want 11000", b.EVWh)
+	}
+	if !approxEq(b.LoadWh, 0, 0.01) {
+		t.Errorf("LoadWh = %.4f, want 0 (no house load)", b.LoadWh)
+	}
+	// Daily avg = (0 × 1h + 400 × 1h) / 2h = 200 öre/kWh.
+	if !approxEq(b.AvgImportOreKwh, 200, 0.01) {
+		t.Errorf("AvgImportOreKwh = %.4f, want 200", b.AvgImportOreKwh)
+	}
+	// House baseline: 0. EV baseline: 11 kWh × 200 öre = 2200 öre.
+	if !approxEq(b.BaselineHouseOre, 0, 0.01) {
+		t.Errorf("BaselineHouseOre = %.4f, want 0", b.BaselineHouseOre)
+	}
+	if !approxEq(b.BaselineEvOre, 2200, 0.01) {
+		t.Errorf("BaselineEvOre = %.4f, want 2200", b.BaselineEvOre)
+	}
+	if !approxEq(b.BaselineCostOre, 2200, 0.01) {
+		t.Errorf("BaselineCostOre = %.4f, want 2200", b.BaselineCostOre)
+	}
+	// Actual: 11 kWh at 0 öre = 0.
+	if !approxEq(b.ActualCostOre(), 0, 0.01) {
+		t.Errorf("ActualCostOre = %.4f, want 0", b.ActualCostOre())
+	}
+	// Saved: full 2200 öre — the EMS picked the 0-öre hour.
+	if !approxEq(b.SavedOre(), 2200, 0.01) {
+		t.Errorf("SavedOre = %.4f, want 2200 (full daily-avg credit)", b.SavedOre())
+	}
+}
+
+// Dumb EV charging on the expensive hour must show up as a loss vs the
+// daily-average baseline — the metric is symmetric and doesn't only credit
+// good decisions.
+func TestDailyCostBreakdown_EVOnExpensiveHourPaysVsDailyAverage(t *testing.T) {
+	s := freshStore(t)
+
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 0, TotalOreKwh: 0, Source: "test"},
+		{Zone: "SE3", SlotTsMs: 3600000, SlotLenMin: 60, SpotOreKwh: 400, TotalOreKwh: 400, Source: "test"},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	// EV charges only on the 400-öre hour.
+	if err := s.BulkRecordHistory([]HistoryPoint{
+		{TsMs: 0, GridW: 0, LoadW: 0},
+		{TsMs: 3_600_000, GridW: 0, LoadW: 0},
+		{TsMs: 7_200_000, GridW: 11000, LoadW: 0},
+	}); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	b, err := s.DailyCostBreakdown(0, 7_200_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+
+	// 11 kW for 1 hour in slot 2 → 11 kWh.
+	if !approxEq(b.EVWh, 11_000, 0.01) {
+		t.Errorf("EVWh = %.4f, want 11000", b.EVWh)
+	}
+	// Baseline 11 × 200 = 2200, Actual 11 × 400 = 4400, Saved = −2200.
+	if !approxEq(b.BaselineEvOre, 2200, 0.01) {
+		t.Errorf("BaselineEvOre = %.4f, want 2200", b.BaselineEvOre)
+	}
+	if !approxEq(b.ActualCostOre(), 4400, 0.01) {
+		t.Errorf("ActualCostOre = %.4f, want 4400", b.ActualCostOre())
+	}
+	if !approxEq(b.SavedOre(), -2200, 0.01) {
+		t.Errorf("SavedOre = %.4f, want -2200 (penalty for charging on peak)", b.SavedOre())
+	}
+}
+
+// Battery charging from grid is not EV — verify we don't double-count it
+// as EV in the derivation `grid − bat − pv − load`.
+func TestDailyCostBreakdown_BatteryChargeNotMistakenForEV(t *testing.T) {
+	s := freshStore(t)
+
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 100, TotalOreKwh: 100, Source: "test"},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	// House 1 kW, battery charging 5 kW from grid → grid 6 kW import.
+	// load_w (house only) = 1000, bat_w = 5000, ev_w derived = 0.
+	if err := s.BulkRecordHistory([]HistoryPoint{
+		{TsMs: 0, GridW: 6000, LoadW: 1000, BatW: 5000},
+		{TsMs: 3_600_000, GridW: 6000, LoadW: 1000, BatW: 5000},
+	}); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	b, err := s.DailyCostBreakdown(0, 3_600_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+	if !approxEq(b.EVWh, 0, 0.01) {
+		t.Errorf("EVWh = %.4f, want 0 (battery charge isn't EV)", b.EVWh)
+	}
+	if !approxEq(b.BaselineEvOre, 0, 0.01) {
+		t.Errorf("BaselineEvOre = %.4f, want 0", b.BaselineEvOre)
+	}
+}
+
+// PV self-consumption + battery dispatch + EV charging in one fixture, to
+// make sure the three credits stack the way the comment in DayCostBreakdown
+// claims.
+func TestDailyCostBreakdown_PVBatteryAndEVStack(t *testing.T) {
+	s := freshStore(t)
+
+	if err := s.SavePrices([]PricePoint{
+		// Hour 1: cheap, EMS charges battery + EV here.
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 50, TotalOreKwh: 50, Source: "test"},
+		// Hour 2: expensive, battery discharges to cover house load.
+		{Zone: "SE3", SlotTsMs: 3600000, SlotLenMin: 60, SpotOreKwh: 250, TotalOreKwh: 250, Source: "test"},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+	// Hour 1 (cheap):
+	//   house  = 1 kW,  EV    = 11 kW,  bat = +5 kW (charging), pv = 0
+	//   grid_w = 1 + 11 + 5 = 17 kW import.
+	// Hour 2 (expensive):
+	//   house  = 1 kW,  EV    =  0,     bat = −1 kW (discharge), pv = 0
+	//   grid_w = 1 + 0 + (−1) = 0.
+	if err := s.BulkRecordHistory([]HistoryPoint{
+		{TsMs: 0, GridW: 17000, LoadW: 1000, BatW: 5000},
+		{TsMs: 3_600_000, GridW: 17000, LoadW: 1000, BatW: 5000},
+		{TsMs: 7_200_000, GridW: 0, LoadW: 1000, BatW: -1000},
+	}); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	b, err := s.DailyCostBreakdown(0, 7_200_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+	if !approxEq(b.EVWh, 11_000, 0.01) {
+		t.Errorf("EVWh = %.4f, want 11000", b.EVWh)
+	}
+	if !approxEq(b.LoadWh, 2000, 0.01) {
+		t.Errorf("LoadWh = %.4f, want 2000", b.LoadWh)
+	}
+	// Daily avg = (50+250)/2 = 150 öre/kWh.
+	if !approxEq(b.AvgImportOreKwh, 150, 0.01) {
+		t.Errorf("AvgImportOreKwh = %.4f, want 150", b.AvgImportOreKwh)
+	}
+	// Baselines:
+	//   house: 1 kWh × 50 + 1 kWh × 250 = 300 öre.
+	//   ev   : 11 kWh × 150 = 1650 öre.
+	//   total = 1950 öre.
+	if !approxEq(b.BaselineHouseOre, 300, 0.01) {
+		t.Errorf("BaselineHouseOre = %.4f, want 300", b.BaselineHouseOre)
+	}
+	if !approxEq(b.BaselineEvOre, 1650, 0.01) {
+		t.Errorf("BaselineEvOre = %.4f, want 1650", b.BaselineEvOre)
+	}
+	if !approxEq(b.BaselineCostOre, 1950, 0.01) {
+		t.Errorf("BaselineCostOre = %.4f, want 1950", b.BaselineCostOre)
+	}
+	// Actual: 17 kWh × 50 = 850 öre on hour 1, 0 on hour 2.
+	if !approxEq(b.ActualCostOre(), 850, 0.01) {
+		t.Errorf("ActualCostOre = %.4f, want 850", b.ActualCostOre())
+	}
+	// Saved = 1950 − 850 = 1100 öre — EV scheduling + battery shifting
+	// + cheap-hour charging all contribute.
+	if !approxEq(b.SavedOre(), 1100, 0.01) {
+		t.Errorf("SavedOre = %.4f, want 1100", b.SavedOre())
+	}
+}
+
 func TestDailyCostBreakdown_EmptyRange(t *testing.T) {
 	s := freshStore(t)
 	b, err := s.DailyCostBreakdown(0, 1_000_000, "SE3", ExportPricing{})

--- a/go/internal/state/cost_test.go
+++ b/go/internal/state/cost_test.go
@@ -305,6 +305,50 @@ func TestDailyCostBreakdown_EVChargingPricedAtDailyAverage(t *testing.T) {
 	}
 }
 
+// Regression: EV energy charged during a price GAP (no covering slot) must
+// NOT inflate the EV baseline. Before the fix, EVWh counted uncovered
+// samples and BaselineEvOre priced them at the daily average — manufacturing
+// savings with no matching actual import cost. The house baseline already
+// gates on coverage (BaselineHouseOre only accrues when covering != nil); EV
+// must too. Mirrors the rationale in cost.go.
+func TestDailyCostBreakdown_EVInPriceGapExcludedFromBaseline(t *testing.T) {
+	s := freshStore(t)
+
+	// Only ONE slot: hour 1 [0, 3.6M) at 100 öre. Hour 2 [3.6M, 7.2M) has
+	// no price slot — a gap.
+	if err := s.SavePrices([]PricePoint{
+		{Zone: "SE3", SlotTsMs: 0, SlotLenMin: 60, SpotOreKwh: 100, TotalOreKwh: 100, Source: "test"},
+	}); err != nil {
+		t.Fatalf("save prices: %v", err)
+	}
+
+	// EV charges 11 kW across BOTH hours (grid imports 11 kW, no house load):
+	//   row @3.6M → EV over (0, 3.6M]   midpoint 1.8M  → COVERED
+	//   row @7.2M → EV over (3.6M, 7.2M] midpoint 5.4M → GAP (no slot)
+	if err := s.BulkRecordHistory([]HistoryPoint{
+		{TsMs: 0, GridW: 11000, LoadW: 0},
+		{TsMs: 3_600_000, GridW: 11000, LoadW: 0},
+		{TsMs: 7_200_000, GridW: 11000, LoadW: 0},
+	}); err != nil {
+		t.Fatalf("record history: %v", err)
+	}
+
+	b, err := s.DailyCostBreakdown(0, 7_200_000, "SE3", ExportPricing{})
+	if err != nil {
+		t.Fatalf("breakdown: %v", err)
+	}
+
+	// Only the covered hour's 11 kWh of EV counts toward the priced baseline;
+	// the gap hour's 11 kWh must be excluded (no phantom savings).
+	if !approxEq(b.EVWh, 11_000, 0.01) {
+		t.Errorf("EVWh = %.4f, want 11000 (gap-hour EV excluded)", b.EVWh)
+	}
+	// avg import = 100 öre (single slot). Baseline EV = 11 kWh × 100 = 1100 öre.
+	if !approxEq(b.BaselineEvOre, 1100, 0.01) {
+		t.Errorf("BaselineEvOre = %.4f, want 1100 (gap EV must not inflate baseline)", b.BaselineEvOre)
+	}
+}
+
 // Dumb EV charging on the expensive hour must show up as a loss vs the
 // daily-average baseline — the metric is symmetric and doesn't only credit
 // good decisions.


### PR DESCRIPTION
## Summary

- `BaselineCostOre` now includes the EV's energy demand, priced at the day's time-weighted average spot. Smart EV scheduling onto cheap hours surfaces as savings; charging on a peak shows up as a symmetric penalty.
- Splits the baseline into `BaselineHouseOre` (slot-by-slot house load × spot, unchanged) and `BaselineEvOre` (`EVWh × AvgImportOreKwh / 1000`). `BaselineCostOre = BaselineHouseOre + BaselineEvOre`.
- Derives EV per history row as `grid_w − bat_w − pv_w − load_w` (clamped ≥ 0) — inverse of `main.go`'s identity that produces `load_w`. No schema change.
- `/api/savings/daily` gains `ev_wh`, `baseline_house_ore`, `baseline_ev_ore`. Existing field names (`baseline_cost_ore`, `saved_ore`, `flat_cost_ore`) are unchanged; their values now incorporate the EV term.

## Why

Previously `load_w` (stored in `history_*`) is "house minus EV", so the baseline never accounted for EV consumption while `ActualCostOre` always did. Result: EV scheduling onto a 0-öre hour produced 0 savings credit, and charging on any non-cheap hour drove the dashboard into the red. The metric was biased against the EMS every time the car drew current. This PR fixes the accounting without inventing new telemetry — daily-avg is the "dumb charger with no timing awareness" counter-factual.

## Test plan

- [x] Existing `TestDailyCostBreakdown_*` still pass (no-EV semantics unchanged)
- [x] New `TestDailyCostBreakdown_EVChargingPricedAtDailyAverage` — EV on cheap hour → full daily-avg credit
- [x] New `TestDailyCostBreakdown_EVOnExpensiveHourPaysVsDailyAverage` — penalty is symmetric
- [x] New `TestDailyCostBreakdown_BatteryChargeNotMistakenForEV` — derivation isolates EV from battery
- [x] New `TestDailyCostBreakdown_PVBatteryAndEVStack` — three credits stack as documented
- [x] `make verify` (vet + test + build), `make verify-all` (cross-compile linux/arm64 + amd64 + windows)
- [ ] Verify on Erik's instance: today's "Saved" number reflects the EV-shifting work the planner has been doing all along
- [ ] Spot-check that the savings cache on the Pi clears at restart and historical days re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)