### PR TITLE
fix(relay): landing page rejected every approval code as "Wrong code"

### DIFF
--- a/.changeset/relay-landing-page-token-const.md
+++ b/.changeset/relay-landing-page-token-const.md
@@ -1,0 +1,19 @@
+---
+"forty-two-watts": patch
+---
+
+**Fix: relay landing page rejected every approval code as "Wrong code"
+even when the friend typed the right one.** The `fmt.Fprintf` that
+renders the landing HTML in `ftw-relay`'s `publicLanding` passed format
+arguments in the wrong order, so the embedded JS `const TOKEN` was
+populated with the token state (`"pending"`) instead of the actual
+session token. The Activate button then POSTed to
+`/h/pending/approve`; the relay couldn't find that token and returned
+`403 Forbidden`, which the page surfaced as "Wrong code" regardless of
+what was typed. As a side effect "From:" showed the token, "Intent:"
+was empty, and "State:" showed the intent.
+
+Argument order is now `as → intent → state → token`, matching the
+positional verbs in `landingHTML`. A regression test
+(`TestLandingPageTokenConstMatchesPath`) pins the JS const + each label
+row so a future reshuffle can't silently regress the approve POST path.

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -134,7 +134,16 @@ func (r *Relay) publicLanding(w http.ResponseWriter, req *http.Request) {
 	// surfaces "friend opened the URL — waiting for them to enter the code".
 	r.Tokens.MarkPendingHit(tok)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, landingHTML, esc(tok), esc(t.As()), esc(t.Intent()), t.State())
+	// Format args (in landingHTML positional order):
+	//   1. "From: %s"        — claimed identity (host-supplied "as")
+	//   2. "Intent: %s"      — what the host says the session is for
+	//   3. "State: %s"       — current token state
+	//   4. "const TOKEN = %q" — the actual session token, used by the JS
+	//      to POST to /h/<token>/approve. Getting this wrong is fatal:
+	//      the approve POST hits the wrong path and the relay returns
+	//      403, which the JS surfaces as "Wrong code" even when the
+	//      friend typed the correct 4-digit code.
+	fmt.Fprintf(w, landingHTML, esc(t.As()), esc(t.Intent()), t.State(), tok)
 }
 
 func (r *Relay) tunnelSessionInfo(w http.ResponseWriter, req *http.Request) {

--- a/go/cmd/ftw-relay/handlers_test.go
+++ b/go/cmd/ftw-relay/handlers_test.go
@@ -157,6 +157,48 @@ func TestLandingPageHasCodeEntryForm(t *testing.T) {
 	}
 }
 
+// TestLandingPageTokenConstMatchesPath pins the format-args wiring in
+// publicLanding. Regression for the "wrong code even when right code"
+// bug: a misordered fmt.Fprintf put the token *state* into the JS
+// const TOKEN, so the page's approve POST hit /h/<state>/approve and
+// the relay returned 403 (token-not-found mapped to forbidden), which
+// the JS surfaced as "Wrong code" regardless of the code the friend
+// typed.
+func TestLandingPageTokenConstMatchesPath(t *testing.T) {
+	r := newTestRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "alpha-beta-gamma", TTL: time.Hour,
+		ApprovalCode: "1234", Intent: "intent-text", As: "@friend",
+	})
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/h/alpha-beta-gamma")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := readBody(resp.Body)
+	resp.Body.Close()
+	html := string(body)
+
+	// The JS const that drives the approve POST must be the actual
+	// token. Anything else (state, intent, as) means /h/<wrong>/approve
+	// returns 403 and the friend sees "Wrong code" forever.
+	if !strings.Contains(html, `const TOKEN = "alpha-beta-gamma";`) {
+		t.Fatalf("landing-page JS const TOKEN is not the session token:\n%s", html)
+	}
+	// And the "From:" row must show the claimed identity, not the
+	// token — the friend uses that to sanity-check who they're talking to.
+	if !strings.Contains(html, `<p>From: <code>@friend</code></p>`) {
+		t.Fatalf(`expected "From: @friend" in landing page:\n%s`, html)
+	}
+	if !strings.Contains(html, `<p>Intent: intent-text</p>`) {
+		t.Fatalf(`expected "Intent: intent-text" in landing page:\n%s`, html)
+	}
+	if !strings.Contains(html, `<code id="state">pending</code>`) {
+		t.Fatalf(`expected state "pending" in landing page:\n%s`, html)
+	}
+}
+
 func TestApproveFlipsState(t *testing.T) {
 	r := newTestRelay()
 	_, _ = r.Tokens.Register(TokenRegistration{


### PR DESCRIPTION
## Summary

- `fmt.Fprintf` in `publicLanding` passed format args in the wrong order, so the embedded JS `const TOKEN` got `t.State()` (`"pending"`) instead of the actual session token. Every Activate click POSTed to `/h/pending/approve` → relay 403 → page showed **"Wrong code"** no matter what the friend typed. Side effects: "From:" rendered the token, "Intent:" was empty, "State:" rendered the intent.
- Fix: arg order is now `as → intent → state → token`, matching the positional verbs in `landingHTML`.
- New regression test `TestLandingPageTokenConstMatchesPath` pins the JS const + each label row so a future reshuffle can't silently regress the approve POST path.

## Live diagnosis

Reproduced against `relay.fortytwowatts.com` while my pi was tunneling a pair session:

```
<p>From: <code>buzz-arrow-leaf-linen-haven-haven</code></p>   ← token in "From:" slot
<p>Intent: </p>                                                ← empty
<p class="muted">State: <code id="state">diag-claude-2</code>  ← intent in "State:" slot
const TOKEN = "pending";                                       ← BUG
```

After deploy (manual `scp` + `systemctl restart` on the relay VM, rollback binary kept at `/usr/local/bin/ftw-relay~`):

```
const TOKEN = "grove-cosy-cosy-boat-gray-harbor";  ← real token
Intent: verify-fix-post                            ← right row
State: pending                                     ← right row
POST right code → 204
POST wrong code → 403
```

## Test plan

- [x] `go test ./cmd/ftw-relay/...` passes
- [x] New `TestLandingPageTokenConstMatchesPath` fails on the buggy arg order
- [x] Verified end-to-end against prod relay after deploy

## Follow-ups

- CI builds `ftw-relay-linux-amd64` for the next release; until that's cut, the deployed binary on the relay VM is built from this branch's HEAD (kept hot-patched outside the release pipeline). Once the release lands, re-pull from GH Releases per `docs/relay-deploy.md` to get back on the canonical artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)