### PR TITLE
feat(relay): subdomain-per-session routing (Host header) — PR 1

### DIFF
--- a/.changeset/relay-subdomain-routing.md
+++ b/.changeset/relay-subdomain-routing.md
@@ -1,0 +1,23 @@
+---
+"forty-two-watts": patch
+---
+
+**Relay: subdomain-per-session routing (PR 1 of the subdomain track).**
+`ftw-relay` now accepts an optional `-base-domain` flag (e.g.
+`fortytwowatts.com`). When set, a request whose `Host` is
+`<token>.<base-domain>` is served as that pair session — the dashboard
+sees verbatim root-absolute paths (`/api/status`, `/style.css`) instead
+of the `/h/<token>/web` prefix that the frontend's absolute paths can't
+survive. The legacy `/h/<token>/…` path family keeps working unchanged
+alongside it for one release. With the flag unset (default), Host routing
+is off and nothing changes — local/dev and existing deploys are
+unaffected until the wildcard DNS + cert land.
+
+Also fixes a latent bug in the existing path-mode web tunnel: query
+strings (`/api/history?range=24h&points=288`) are now preserved through
+the tunnel instead of being dropped, and the friend landing page builds
+its approve/dashboard/MCP URLs from explicit server-injected paths rather
+than a positional token argument (structurally prevents the
+"Wrong code" arg-order class of bug).
+
+See `docs/goals/relay-subdomain-sessions.md`. Grant-exchange auth is PR 2.

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -18,6 +18,25 @@ type Relay struct {
 	Tokens      *TokenRegistry
 	Owners      *OwnerRegistry
 	PollTimeout time.Duration // 0 → 25s default
+
+	// BaseDomain enables subdomain-per-session routing. When set (e.g.
+	// "fortytwowatts.com") a request whose Host is "<token>.<BaseDomain>"
+	// is served as that session — the dashboard sees normal root-absolute
+	// paths instead of the /h/<token>/web prefix. Empty disables Host
+	// routing entirely (every request falls through to the path-based
+	// control mux), which is what local/dev + the existing tests want.
+	// See docs/goals/relay-subdomain-sessions.md.
+	BaseDomain string
+}
+
+// reservedLabels are first-level labels under BaseDomain that are never
+// treated as a session token, so wildcard DNS (*.<BaseDomain> → relay)
+// can't accidentally turn the control-plane host (or the marketing site)
+// into a "session". The apex itself is handled separately in sessionToken.
+var reservedLabels = map[string]bool{
+	"relay":   true, // control plane: /tunnel/*, /h/*, /me/*
+	"www":     true,
+	"subetha": true, // legacy raw-TCP relay name
 }
 
 type registerRequest struct {
@@ -34,8 +53,27 @@ type registerResponse struct {
 	ApprovalURL string `json:"approval_url"`
 }
 
-// Handler returns the mux for this relay.
+// Handler returns the HTTP handler for this relay. When BaseDomain is set
+// it first inspects the Host header: "<token>.<BaseDomain>" is served as a
+// session (subdomain mode); anything else (the apex, reserved labels, raw
+// IPs, the control-plane host) falls through to the path-based control mux.
+// The /h/<token>/... path family stays live alongside subdomain mode for
+// one release so existing pair URLs keep working during the transition.
 func (r *Relay) Handler() http.Handler {
+	mux := r.controlMux()
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if tok, ok := r.sessionToken(req.Host); ok {
+			r.serveSession(w, req, tok)
+			return
+		}
+		mux.ServeHTTP(w, req)
+	})
+}
+
+// controlMux is the path-routed surface: tunnel control plane, the legacy
+// /h/<token>/... pair family, and owner remote access. Served for every
+// request whose Host is not a session subdomain.
+func (r *Relay) controlMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", r.healthz)
 	mux.HandleFunc("GET /tunnel/{host_id}/next", r.tunnelNext)
@@ -56,6 +94,38 @@ func (r *Relay) Handler() http.Handler {
 	mux.HandleFunc("/me/{site_id}/{rest...}", r.meTunnel)
 	mux.HandleFunc("/me/{site_id}", r.meRoot)
 	return mux
+}
+
+// sessionToken extracts the session token from a request Host when it
+// matches the "<token>.<BaseDomain>" subdomain scheme. It returns ("",
+// false) for the apex, reserved labels, multi-level names, non-matching
+// domains (raw IPs, localhost), and when BaseDomain is unset.
+//
+// The relay sits behind Cloudflare, which preserves the original Host
+// header, so req.Host is the name the friend's browser actually used.
+func (r *Relay) sessionToken(host string) (string, bool) {
+	if r.BaseDomain == "" {
+		return "", false
+	}
+	h := host
+	if i := strings.IndexByte(h, ':'); i >= 0 { // strip :port
+		h = h[:i]
+	}
+	h = strings.ToLower(strings.TrimSuffix(h, ".")) // tolerate trailing root dot
+	base := strings.ToLower(r.BaseDomain)
+	if h == base {
+		return "", false // apex is control plane, never a session
+	}
+	label, ok := strings.CutSuffix(h, "."+base)
+	if !ok || label == "" || strings.Contains(label, ".") {
+		// Not our domain, or a multi-level name (a.b.<base>) outside the
+		// flat first-level token scheme.
+		return "", false
+	}
+	if reservedLabels[label] {
+		return "", false
+	}
+	return label, true
 }
 
 func (r *Relay) pollTimeout() time.Duration {
@@ -123,6 +193,39 @@ func (r *Relay) tunnelRegister(w http.ResponseWriter, req *http.Request) {
 	})
 }
 
+// landingPaths are the three relative URLs the landing-page JS needs.
+// They differ between path mode (/h/<token>/…) and subdomain mode (/…),
+// so the template itself stays agnostic to the routing scheme — and there
+// is no positional token argument to get wrong (the cause of the
+// "Wrong code" landing bug).
+type landingPaths struct {
+	approve   string // where the code form POSTs
+	dashboard string // "open the dashboard" link target
+	mcp       string // path appended to location.origin for the MCP one-liner
+}
+
+// pathModeLanding builds the legacy /h/<token>/... URLs.
+func pathModeLanding(tok string) landingPaths {
+	return landingPaths{
+		approve:   "/h/" + tok + "/approve",
+		dashboard: "/h/" + tok + "/web/",
+		mcp:       "/h/" + tok + "/mcp",
+	}
+}
+
+// subdomainLanding builds the session-root URLs (Host = <token>.<base>).
+func subdomainLanding() landingPaths {
+	return landingPaths{approve: "/approve", dashboard: "/", mcp: "/mcp"}
+}
+
+func (r *Relay) renderLanding(w http.ResponseWriter, tok string, t *Token, lp landingPaths) {
+	// Bump the pending-approval counter so the operator's dashboard
+	// surfaces "friend opened the URL — waiting for them to enter the code".
+	r.Tokens.MarkPendingHit(tok)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, landingHTML, esc(t.As()), esc(t.Intent()), t.State(), lp.approve, lp.dashboard, lp.mcp)
+}
+
 func (r *Relay) publicLanding(w http.ResponseWriter, req *http.Request) {
 	tok := req.PathValue("token")
 	t, err := r.Tokens.Get(tok)
@@ -130,11 +233,33 @@ func (r *Relay) publicLanding(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
-	// Bump the pending-approval counter so the operator's dashboard
-	// surfaces "friend opened the URL — waiting for them to enter the code".
-	r.Tokens.MarkPendingHit(tok)
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, landingHTML, esc(tok), esc(t.As()), esc(t.Intent()), t.State())
+	r.renderLanding(w, tok, t, pathModeLanding(tok))
+}
+
+// serveSession handles every request that arrived on a session subdomain
+// (<token>.<BaseDomain>). Unlike path mode, the host sees verbatim
+// root-absolute paths, so the dashboard's /api/*, /style.css etc. resolve
+// correctly with no prefix stripping.
+func (r *Relay) serveSession(w http.ResponseWriter, req *http.Request, tok string) {
+	t, err := r.Tokens.Get(tok)
+	if err != nil {
+		http.NotFound(w, req)
+		return
+	}
+	// The code form POSTs here while still pending — handle before the
+	// state gate below.
+	if req.Method == http.MethodPost && req.URL.Path == "/approve" {
+		r.approve(w, req, tok)
+		return
+	}
+	// Until approved, the only thing on the subdomain is the landing page.
+	if t.State() == TokenPending && req.URL.Path == "/" {
+		r.renderLanding(w, tok, t, subdomainLanding())
+		return
+	}
+	// Active → tunnel the request verbatim to the host. tunnelPublic
+	// re-checks token state (pending → 425, expired/revoked → 410).
+	r.tunnelPublic(w, req, tok, req.URL.Path)
 }
 
 func (r *Relay) tunnelSessionInfo(w http.ResponseWriter, req *http.Request) {
@@ -155,11 +280,13 @@ func esc(s string) string {
 
 // landingHTML is the friend-side page. The 4-digit code travels with
 // the URL (shared by the host on Signal etc.); the friend types it
-// here to activate the session. Same-origin POST to /approve so there
-// are no CORS surprises.
+// here to activate the session. Same-origin POST so there are no CORS
+// surprises.
 //
-// Format args (in order): token, claimed identity (host-supplied "as"),
-// intent, current token state.
+// Format args (in order): claimed identity (host-supplied "as"), intent,
+// current token state, then three relative paths (approve, dashboard,
+// mcp) so the page works under both /h/<token>/… and <token>.<base>/
+// without baking in a routing scheme — see landingPaths.
 const landingHTML = `<!doctype html>
 <html><head><title>forty-two-watts pair session</title>
 <style>
@@ -212,7 +339,9 @@ const landingHTML = `<!doctype html>
 <p class="muted">State: <code id="state">%s</code></p>
 
 <script>
-const TOKEN = %q;
+const APPROVE_PATH = %q;
+const DASHBOARD_PATH = %q;
+const MCP_PATH = %q;
 const form = document.getElementById('approve-form');
 const codeInput = document.getElementById('code');
 const msg = document.getElementById('msg');
@@ -230,7 +359,7 @@ form.addEventListener('submit', async (e) => {
   }
   btn.disabled = true;
   try {
-    const resp = await fetch('/h/' + encodeURIComponent(TOKEN) + '/approve', {
+    const resp = await fetch(APPROVE_PATH, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ code }),
@@ -238,9 +367,9 @@ form.addEventListener('submit', async (e) => {
     if (resp.status === 204) {
       msg.className = 'ok';
       msg.innerHTML = 'Activated. You can now:<br><br>' +
-        '<strong>Browser:</strong> <a href="/h/' + encodeURIComponent(TOKEN) + '/web/">open the dashboard</a><br><br>' +
+        '<strong>Browser:</strong> <a href="' + DASHBOARD_PATH + '">open the dashboard</a><br><br>' +
         '<strong>Claude Code:</strong><br><code>claude mcp add ftw-friend --transport http ' +
-        location.origin + '/h/' + encodeURIComponent(TOKEN) + '/mcp</code>';
+        location.origin + MCP_PATH + '</code>';
       document.getElementById('state').textContent = 'active';
       btn.style.display = 'none';
       codeInput.disabled = true;
@@ -264,7 +393,12 @@ form.addEventListener('submit', async (e) => {
 </body></html>`
 
 func (r *Relay) publicApprove(w http.ResponseWriter, req *http.Request) {
-	tok := req.PathValue("token")
+	r.approve(w, req, req.PathValue("token"))
+}
+
+// approve is the shared body for both /h/<token>/approve (path mode) and
+// <token>.<base>/approve (subdomain mode).
+func (r *Relay) approve(w http.ResponseWriter, req *http.Request, tok string) {
 	var body struct {
 		Code string `json:"code"`
 	}
@@ -306,6 +440,11 @@ func (r *Relay) tunnelPublic(w http.ResponseWriter, req *http.Request, tok, inne
 	case TokenExpired, TokenRevoked:
 		http.Error(w, "session expired", http.StatusGone)
 		return
+	}
+	// Preserve the query string so the dashboard's /api/history?range=…
+	// style requests reach the host intact.
+	if q := req.URL.RawQuery; q != "" {
+		innerPath += "?" + q
 	}
 	body, _ := readBody(req.Body)
 	resp, err := r.Queue.Enqueue(req.Context(), t.HostID(), tunnel.TunneledRequest{

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -26,6 +26,7 @@ func main() {
 	cert := flag.String("cert", "", "TLS cert path (HTTPS mode if set)")
 	key := flag.String("key", "", "TLS key path (HTTPS mode if set)")
 	pollTimeout := flag.Duration("poll-timeout", 25*time.Second, "long-poll deadline per /tunnel/<host>/next call")
+	baseDomain := flag.String("base-domain", "", "apex for subdomain-per-session routing (e.g. fortytwowatts.com); empty disables Host routing")
 	flag.Parse()
 
 	if *version {
@@ -38,6 +39,7 @@ func main() {
 		Tokens:      NewTokenRegistry(),
 		Owners:      NewOwnerRegistry(),
 		PollTimeout: *pollTimeout,
+		BaseDomain:  *baseDomain,
 	}
 
 	srv := &http.Server{
@@ -60,7 +62,7 @@ func main() {
 	var err error
 	if *cert != "" && *key != "" {
 		mode = "HTTPS"
-		slog.Info("ftw-relay starting", "mode", mode, "addr", *addr, "version", Version)
+		slog.Info("ftw-relay starting", "mode", mode, "addr", *addr, "version", Version, "base_domain", *baseDomain)
 		err = srv.ListenAndServeTLS(*cert, *key)
 	} else {
 		slog.Info("ftw-relay starting", "mode", mode, "addr", *addr, "version", Version)

--- a/go/cmd/ftw-relay/subdomain_test.go
+++ b/go/cmd/ftw-relay/subdomain_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
+)
+
+// newSubdomainRelay is a relay with Host routing enabled for tests.
+func newSubdomainRelay() *Relay {
+	r := newTestRelay()
+	r.BaseDomain = "fortytwowatts.com"
+	return r
+}
+
+func TestSessionTokenParser(t *testing.T) {
+	r := newSubdomainRelay()
+	cases := []struct {
+		host    string
+		wantTok string
+		wantOK  bool
+		blurb   string
+	}{
+		{"amber-beam-drift.fortytwowatts.com", "amber-beam-drift", true, "plain subdomain"},
+		{"amber-beam-drift.fortytwowatts.com:443", "amber-beam-drift", true, "strips port"},
+		{"Amber-Beam-Drift.FortyTwoWatts.com", "amber-beam-drift", true, "lowercases"},
+		{"amber-beam-drift.fortytwowatts.com.", "amber-beam-drift", true, "tolerates trailing dot"},
+		{"relay.fortytwowatts.com", "", false, "reserved control-plane label"},
+		{"www.fortytwowatts.com", "", false, "reserved www"},
+		{"subetha.fortytwowatts.com", "", false, "reserved legacy label"},
+		{"fortytwowatts.com", "", false, "apex is not a session"},
+		{"a.b.fortytwowatts.com", "", false, "multi-level outside the flat scheme"},
+		{"127.0.0.1:8080", "", false, "raw IP"},
+		{"localhost:7378", "", false, "localhost dev"},
+		{"evil.com", "", false, "foreign domain"},
+		{"fortytwowatts.com.evil.com", "", false, "suffix-spoof"},
+	}
+	for _, c := range cases {
+		gotTok, gotOK := r.sessionToken(c.host)
+		if gotTok != c.wantTok || gotOK != c.wantOK {
+			t.Errorf("sessionToken(%q) = (%q, %v), want (%q, %v) — %s",
+				c.host, gotTok, gotOK, c.wantTok, c.wantOK, c.blurb)
+		}
+	}
+}
+
+func TestSessionTokenDisabledWhenNoBaseDomain(t *testing.T) {
+	r := newTestRelay() // BaseDomain == ""
+	if _, ok := r.sessionToken("anything.fortytwowatts.com"); ok {
+		t.Fatal("Host routing must be off when BaseDomain is empty")
+	}
+}
+
+// get issues a GET with an explicit Host header against the test server.
+func reqWithHost(t *testing.T, srv *httptest.Server, method, path, host string, body string) *http.Response {
+	t.Helper()
+	var rdr *strings.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	} else {
+		rdr = strings.NewReader("")
+	}
+	req, err := http.NewRequest(method, srv.URL+path, rdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = host // what the handler reads as req.Host
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestSubdomainLandingWhenPending(t *testing.T) {
+	r := newSubdomainRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "amber-beam", TTL: time.Hour,
+		ApprovalCode: "4827", Intent: "help me", As: "@erik",
+	})
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+
+	resp := reqWithHost(t, srv, "GET", "/", "amber-beam.fortytwowatts.com", "")
+	body, _ := readBody(resp.Body)
+	resp.Body.Close()
+	html := string(body)
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200\n%s", resp.StatusCode, html)
+	}
+	if !strings.Contains(html, `id="approve-form"`) {
+		t.Fatalf("landing form missing on subdomain:\n%s", html)
+	}
+	// Subdomain mode posts to the session-root /approve, never /h/<token>/.
+	if !strings.Contains(html, `const APPROVE_PATH = "/approve";`) {
+		t.Fatalf("APPROVE_PATH should be /approve on a subdomain:\n%s", html)
+	}
+	if !strings.Contains(html, `const DASHBOARD_PATH = "/";`) {
+		t.Fatalf("DASHBOARD_PATH should be / on a subdomain:\n%s", html)
+	}
+	if strings.Contains(html, "/h/amber-beam") {
+		t.Fatalf("subdomain landing must not reference path-mode /h/<token> URLs:\n%s", html)
+	}
+	// The code must never appear on the page.
+	if strings.Contains(html, "4827") {
+		t.Fatalf("approval code leaked onto subdomain landing page:\n%s", html)
+	}
+}
+
+func TestSubdomainApproveFlipsState(t *testing.T) {
+	r := newSubdomainRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "amber-beam", TTL: time.Hour, ApprovalCode: "4827",
+	})
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+
+	resp := reqWithHost(t, srv, "POST", "/approve", "amber-beam.fortytwowatts.com", `{"code":"4827"}`)
+	resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Fatalf("approve status %d, want 204", resp.StatusCode)
+	}
+	tok, _ := r.Tokens.Get("amber-beam")
+	if tok.State() != TokenActive {
+		t.Fatalf("token not active after approve: %v", tok.State())
+	}
+}
+
+func TestSubdomainPendingNonRootReturns425(t *testing.T) {
+	r := newSubdomainRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "amber-beam", TTL: time.Hour, ApprovalCode: "4827",
+	})
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+
+	resp := reqWithHost(t, srv, "GET", "/api/status", "amber-beam.fortytwowatts.com", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooEarly {
+		t.Fatalf("pending non-root status %d, want 425", resp.StatusCode)
+	}
+}
+
+func TestSubdomainTunnelsVerbatimWhenActive(t *testing.T) {
+	r := newSubdomainRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "amber-beam", TTL: time.Hour, ApprovalCode: "4827",
+	})
+	_ = r.Tokens.Approve("amber-beam", "4827")
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+
+	// Fake host: pull the tunneled request off the queue and answer it,
+	// echoing the path the relay forwarded so we can assert verbatim
+	// (no prefix stripping) + query preservation.
+	go func() {
+		tr, err := r.Queue.Poll(context.Background(), "host-a", 2*time.Second)
+		if err != nil {
+			return
+		}
+		out, _ := json.Marshal(map[string]string{"saw_path": tr.Path, "saw_method": tr.Method})
+		_ = r.Queue.PostResponse(tr.ReqID, tunnel.TunneledResponse{
+			Status: 200,
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body:   out,
+		})
+	}()
+
+	resp := reqWithHost(t, srv, "GET", "/api/history?range=24h&points=288", "amber-beam.fortytwowatts.com", "")
+	body, _ := readBody(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("active tunnel status %d, want 200\n%s", resp.StatusCode, body)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode echo: %v (%s)", err, body)
+	}
+	if got["saw_path"] != "/api/history?range=24h&points=288" {
+		t.Fatalf("host saw path %q, want verbatim /api/history?range=24h&points=288", got["saw_path"])
+	}
+}
+
+// Path mode keeps working with Host routing enabled, as long as the request
+// arrives on the control-plane host rather than a session subdomain.
+func TestPathModeStillWorksAlongsideSubdomain(t *testing.T) {
+	r := newSubdomainRelay()
+	_, _ = r.Tokens.Register(TokenRegistration{
+		HostID: "host-a", Token: "amber-beam", TTL: time.Hour,
+		ApprovalCode: "4827", Intent: "x", As: "@erik",
+	})
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+
+	// Control-plane host → path-routed landing.
+	resp := reqWithHost(t, srv, "GET", "/h/amber-beam", "relay.fortytwowatts.com", "")
+	body, _ := readBody(resp.Body)
+	resp.Body.Close()
+	html := string(body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("path-mode landing status %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(html, `const APPROVE_PATH = "/h/amber-beam/approve";`) {
+		t.Fatalf("path mode should use /h/<token>/approve:\n%s", html)
+	}
+	if !strings.Contains(html, `const DASHBOARD_PATH = "/h/amber-beam/web/";`) {
+		t.Fatalf("path mode should use /h/<token>/web/:\n%s", html)
+	}
+
+	// healthz on the control-plane host still works.
+	resp2 := reqWithHost(t, srv, "GET", "/healthz", "relay.fortytwowatts.com", "")
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("healthz status %d, want 200", resp2.StatusCode)
+	}
+}


### PR DESCRIPTION
First implementation PR of the subdomain track (`docs/goals/relay-subdomain-sessions.md`, PR #390).

## What

`ftw-relay` gains a `-base-domain` flag. When set, the handler inspects the `Host` header:

- `<token>.<base-domain>` → served as that pair session (new `serveSession` path)
- everything else (apex, reserved labels, raw IPs, the control-plane host) → existing path-routed `controlMux`

The `/h/<token>/…` path family stays live alongside subdomain mode for one release, so current pair URLs keep working during the transition.

## Why

The dashboard frontend assumes it owns origin-root — every `fetch('/api/...')` and asset path is root-absolute — so `/h/<token>/web/` serves a blank page (the bug behind "Open the dashboard does nothing"). On a session subdomain the host sees **verbatim root paths** and the dashboard works with zero rewriting. Same fix covers owner-access later.

## Details

- **`sessionToken()`** parses `<token>.<base>` (flat first-level scheme): strips port, lowercases, tolerates trailing dot; rejects apex, reserved labels (`relay`/`www`/`subetha`), multi-level names, and foreign/suffix-spoof hosts. Fully disabled when `-base-domain` is empty (local/dev/tests/existing deploys unaffected).
- **`serveSession()`**: `POST /approve` while pending → approve; `/` while pending → landing page; once active → tunnel everything verbatim.
- **Landing template** now takes explicit `approve`/`dashboard`/`mcp` paths instead of a positional token arg — same HTML works in both routing modes, and the "Wrong code" arg-order bug class (PR #389) can't recur structurally.
- **`tunnelPublic()`** now preserves the query string — fixes a latent drop that also hit path-mode `/h/<token>/web/` for `/api/history?range=…` etc.

## Scope / sequencing

Grant-exchange auth (the security layer) is **PR 2** — this PR keeps the existing token+code model. The capability is dormant until `-base-domain` + wildcard DNS/cert land (infra PR). `patch` changeset since nothing user-facing reaches it yet (the query-preservation fix is the one live-affecting bit).

## Tests

`subdomain_test.go`: Host parser table (13 cases incl. spoofs/reserved/multi-level), disabled-without-base-domain, subdomain landing (paths + no code leak), subdomain approve, pending-non-root → 425, active tunnel verbatim + query preservation, and path mode still working alongside. `go test ./cmd/ftw-relay/` green; `make verify` clean via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)