### PR TITLE
feat(relay): grant-exchange auth — 4-digit code becomes a session secret (PR 2)

### DIFF
--- a/.changeset/relay-mcp-grant.md
+++ b/.changeset/relay-mcp-grant.md
@@ -1,0 +1,31 @@
+---
+"forty-two-watts": minor
+---
+
+**Relay: the 4-digit code is now a one-time exchange for a session grant,
+not a standing password.** Previously, once a pair session was approved,
+anyone who got hold of the `/h/<token>/…` URL had full access for the
+rest of the TTL — and for MCP that means powerful tools
+(`run_command`, `modbus_write`, `deploy_driver`, `write_file`). A
+forwarded or leaked-from-history URL was effectively a host handover.
+
+Now, accepting the code mints a high-entropy session grant (32 bytes,
+CSPRNG). It is handed to the friend exactly once:
+
+- **MCP**: the landing page prints
+  `claude mcp add ftw-friend --transport http <url>/h/<token>/mcp --header "Authorization: Bearer <grant>"`.
+  `/h/<token>/mcp` now requires that Bearer grant.
+- **Browser/dashboard**: approval sets an `HttpOnly; Secure;
+  SameSite=Strict` `ftw_grant` cookie scoped to the session path;
+  `/h/<token>/web/…` now requires it.
+
+A leaked-but-already-active URL is useless without the grant — the
+recipient lands back on the code-entry page and doesn't have the
+out-of-band 4-digit code (5 wrong tries still locks it). The grant is
+validated constant-time, never forwarded to the host, and expires with
+the session. `POST /h/<token>/approve` now responds `200 {"grant":"…"}`
+instead of `204`.
+
+Works on the existing path-based routes — no subdomains or new domain
+required (the browser-dashboard *rendering* fix and any subdomain work
+remain deferred; see `docs/goals/relay-subdomain-sessions.md`).

--- a/go/cmd/ftw-relay/e2e_test.go
+++ b/go/cmd/ftw-relay/e2e_test.go
@@ -55,26 +55,33 @@ func TestE2EHostAndFriendRoundtripThroughRelay(t *testing.T) {
 		t.Fatalf("register status %d", regResp.StatusCode)
 	}
 
-	// 2. Friend hits /h/tok1/mcp before approval → 425.
+	// 2. Friend hits /h/tok1/mcp before approval → 401 (no session grant yet).
 	pre, err := http.Post(srv.URL+"/h/tok1/mcp", "application/json", strings.NewReader(`{"x":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pre.StatusCode != http.StatusTooEarly {
-		t.Fatalf("expected 425 before approval, got %d", pre.StatusCode)
+	if pre.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 before approval, got %d", pre.StatusCode)
 	}
 
-	// 3. Approve.
-	apv, err := http.Post(srv.URL+"/h/tok1/approve", "application/json", strings.NewReader(`{"code":"4827"}`))
+	// 3. Approve → mints + returns the session grant.
+	grant := approveGrant(t, srv, "tok1", "4827")
+
+	// 3b. /mcp WITHOUT the grant is still rejected after activation
+	//     (a leaked-but-active URL is useless without the secret).
+	noGrant, err := http.Post(srv.URL+"/h/tok1/mcp", "application/json", strings.NewReader(`{"x":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if apv.StatusCode != http.StatusNoContent {
-		t.Fatalf("approve status %d", apv.StatusCode)
+	if noGrant.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("active /mcp without grant: got %d, want 401", noGrant.StatusCode)
 	}
 
-	// 4. Friend POSTs MCP request.
-	post, err := http.Post(srv.URL+"/h/tok1/mcp", "application/json", strings.NewReader(`{"method":"ping"}`))
+	// 4. Friend POSTs MCP request WITH the Bearer grant.
+	mreq, _ := http.NewRequest("POST", srv.URL+"/h/tok1/mcp", strings.NewReader(`{"method":"ping"}`))
+	mreq.Header.Set("Content-Type", "application/json")
+	mreq.Header.Set("Authorization", "Bearer "+grant)
+	post, err := http.DefaultClient.Do(mreq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,12 +126,19 @@ func TestE2EWebReverseProxy(t *testing.T) {
 
 	regBody, _ := json.Marshal(registerRequest{HostID: "host-b", Token: "tok2", TTLMs: 60_000, ApprovalCode: "1234"})
 	_, _ = http.Post(srv.URL+"/tunnel/register", "application/json", bytes.NewReader(regBody))
-	_, _ = http.Post(srv.URL+"/h/tok2/approve", "application/json", strings.NewReader(`{"code":"1234"}`))
+	grant := approveGrant(t, srv, "tok2", "1234")
 
-	r1, err := http.Get(srv.URL + "/h/tok2/web/")
+	// Web access requires the grant cookie; without it → 401.
+	noCookie, err := http.Get(srv.URL + "/h/tok2/web/")
 	if err != nil {
 		t.Fatal(err)
 	}
+	noCookie.Body.Close()
+	if noCookie.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("/web without grant cookie: got %d, want 401", noCookie.StatusCode)
+	}
+
+	r1 := getWithGrantCookie(t, srv.URL+"/h/tok2/web/", grant)
 	defer r1.Body.Close()
 	b1, _ := io.ReadAll(r1.Body)
 	if string(b1) != "home" {
@@ -134,13 +148,49 @@ func TestE2EWebReverseProxy(t *testing.T) {
 		t.Fatalf("header lost: %v", r1.Header)
 	}
 
-	r2, err := http.Get(srv.URL + "/h/tok2/web/api/status")
-	if err != nil {
-		t.Fatal(err)
-	}
+	r2 := getWithGrantCookie(t, srv.URL+"/h/tok2/web/api/status", grant)
 	defer r2.Body.Close()
 	b2, _ := io.ReadAll(r2.Body)
 	if !strings.Contains(string(b2), `"ok":true`) {
 		t.Fatalf("/api/status → %q", b2)
 	}
+}
+
+// approveGrant POSTs the 4-digit code and returns the session grant minted
+// by the relay. Fails the test on any non-200 or missing grant.
+func approveGrant(t *testing.T, srv *httptest.Server, token, code string) string {
+	t.Helper()
+	resp, err := http.Post(srv.URL+"/h/"+token+"/approve", "application/json",
+		strings.NewReader(`{"code":"`+code+`"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("approve status %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Grant string `json:"grant"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode approve body: %v", err)
+	}
+	if out.Grant == "" {
+		t.Fatal("approve returned empty grant")
+	}
+	return out.Grant
+}
+
+// getWithGrantCookie issues a GET carrying the grant cookie (the Secure
+// flag means httptest's http client won't send it from a jar, so we set
+// the header directly).
+func getWithGrantCookie(t *testing.T, url, grant string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Cookie", grantCookie+"="+grant)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
 }

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -244,12 +244,17 @@ form.addEventListener('submit', async (e) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ code }),
     });
-    if (resp.status === 204) {
+    if (resp.ok) {
+      const data = await resp.json();
+      const grant = (data && data.grant) ? data.grant : '';
+      const mcpURL = location.origin + '/h/' + encodeURIComponent(TOKEN) + '/mcp';
+      const addCmd = 'claude mcp add ftw-friend --transport http ' + mcpURL +
+        ' --header "Authorization: Bearer ' + grant + '"';
       msg.className = 'ok';
-      msg.innerHTML = 'Activated. You can now:<br><br>' +
-        '<strong>Browser:</strong> <a href="/h/' + encodeURIComponent(TOKEN) + '/web/">open the dashboard</a><br><br>' +
-        '<strong>Claude Code:</strong><br><code>claude mcp add ftw-friend --transport http ' +
-        location.origin + '/h/' + encodeURIComponent(TOKEN) + '/mcp</code>';
+      msg.innerHTML = 'Activated. Add this to Claude Code:<br><br>' +
+        '<code>' + addCmd.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</code>' +
+        '<p class="muted">The Bearer token is your session secret — anyone with it can use the tools. ' +
+        'It is shown only once, here, and expires when the session does.</p>';
       document.getElementById('state').textContent = 'active';
       btn.style.display = 'none';
       codeInput.disabled = true;
@@ -272,6 +277,11 @@ form.addEventListener('submit', async (e) => {
 </script>
 </body></html>`
 
+// grantCookie is the cookie name carrying the session grant for browser
+// (dashboard) access. Path-scoped to the token so it is only sent on that
+// session's routes.
+const grantCookie = "ftw_grant"
+
 func (r *Relay) publicApprove(w http.ResponseWriter, req *http.Request) {
 	tok := req.PathValue("token")
 	var body struct {
@@ -285,16 +295,66 @@ func (r *Relay) publicApprove(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	// Approval just minted the session grant. Hand it to the friend two
+	// ways: an HttpOnly cookie (browser → dashboard) and the JSON body
+	// (so the landing-page JS can print the MCP `--header "Authorization:
+	// Bearer …"` one-liner). The 4-digit code's whole job is this one-time
+	// exchange; from here the grant — not the URL — is the access secret.
+	t, err := r.Tokens.Get(tok)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	grant := t.Grant()
+	http.SetCookie(w, &http.Cookie{
+		Name:     grantCookie,
+		Value:    grant,
+		Path:     "/h/" + tok + "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   int(time.Until(t.ExpiresAt()).Seconds()),
+	})
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"grant": grant})
+}
+
+// bearerGrant pulls the grant from an "Authorization: Bearer <grant>"
+// header (the MCP client path).
+func bearerGrant(req *http.Request) string {
+	const p = "Bearer "
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, p) {
+		return ""
+	}
+	return strings.TrimPrefix(auth, p)
 }
 
 func (r *Relay) publicMCP(w http.ResponseWriter, req *http.Request) {
 	tok := req.PathValue("token")
+	if !r.Tokens.CheckGrant(tok, bearerGrant(req)) {
+		http.Error(w, "missing or invalid session grant", http.StatusUnauthorized)
+		return
+	}
+	// Never forward the relay-side session secret to the host.
+	req.Header.Del("Authorization")
 	r.tunnelPublic(w, req, tok, "/mcp")
 }
 
 func (r *Relay) publicWeb(w http.ResponseWriter, req *http.Request) {
 	tok := req.PathValue("token")
+	c, _ := req.Cookie(grantCookie)
+	grant := ""
+	if c != nil {
+		grant = c.Value
+	}
+	if !r.Tokens.CheckGrant(tok, grant) {
+		http.Error(w, "missing or invalid session grant", http.StatusUnauthorized)
+		return
+	}
+	// Strip cookies before tunneling — the friend's grant cookie is a
+	// relay secret and the host dashboard has no use for friend cookies.
+	req.Header.Del("Cookie")
 	stripped := strings.TrimPrefix(req.URL.Path, "/h/"+tok+"/web")
 	if stripped == "" {
 		stripped = "/"

--- a/go/cmd/ftw-relay/handlers_test.go
+++ b/go/cmd/ftw-relay/handlers_test.go
@@ -210,8 +210,18 @@ func TestApproveFlipsState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 204 {
-		t.Fatalf("status %d", resp.StatusCode)
+	// Approve now returns 200 + the minted grant (was 204 before the
+	// grant-exchange model).
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Grant string `json:"grant"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	resp.Body.Close()
+	if out.Grant == "" {
+		t.Fatal("approve did not return a grant")
 	}
 	tok, _ := r.Tokens.Get("tok2")
 	if tok.State() != TokenActive {
@@ -219,18 +229,32 @@ func TestApproveFlipsState(t *testing.T) {
 	}
 }
 
-func TestPendingTokenReturns425OnPublicMCP(t *testing.T) {
+func TestPublicMCPRequiresGrant(t *testing.T) {
 	r := newTestRelay()
 	_, _ = r.Tokens.Register(TokenRegistration{
 		HostID: "host-a", Token: "tok3", TTL: time.Hour, ApprovalCode: "1",
 	})
 	srv := httptest.NewServer(r.Handler())
 	defer srv.Close()
+	// Pending (no grant minted yet) → 401.
 	resp, err := http.Post(srv.URL+"/h/tok3/mcp", "application/json", strings.NewReader(`{}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusTooEarly {
-		t.Fatalf("status %d, want 425", resp.StatusCode)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("pending /mcp status %d, want 401", resp.StatusCode)
+	}
+	// Activate, then a wrong Bearer is still rejected.
+	_ = r.Tokens.Approve("tok3", "1")
+	bad, _ := http.NewRequest("POST", srv.URL+"/h/tok3/mcp", strings.NewReader(`{}`))
+	bad.Header.Set("Authorization", "Bearer not-the-grant")
+	bresp, err := http.DefaultClient.Do(bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bresp.Body.Close()
+	if bresp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("wrong-Bearer /mcp status %d, want 401", bresp.StatusCode)
 	}
 }

--- a/go/cmd/ftw-relay/session_info_test.go
+++ b/go/cmd/ftw-relay/session_info_test.go
@@ -38,11 +38,7 @@ func TestSessionInfoTracksLandingHitsAndActivity(t *testing.T) {
 	}
 
 	// Approve. Then a tunneled request bumps activity.
-	apv, _ := http.Post(srv.URL+"/h/live/approve", "application/json", strings.NewReader(`{"code":"0000"}`))
-	apv.Body.Close()
-	if apv.StatusCode != 204 {
-		t.Fatalf("approve status %d", apv.StatusCode)
-	}
+	grant := approveGrant(t, srv, "live", "0000")
 
 	// Spin up a host so /h/live/mcp completes the roundtrip.
 	host := tunnel.NewHost(srv.URL, "h", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +50,9 @@ func TestSessionInfoTracksLandingHitsAndActivity(t *testing.T) {
 	go host.Run(ctx)
 
 	before := time.Now().UnixMilli()
-	resp, err := http.Post(srv.URL+"/h/live/mcp", "application/json", strings.NewReader(`{}`))
+	mreq, _ := http.NewRequest("POST", srv.URL+"/h/live/mcp", strings.NewReader(`{}`))
+	mreq.Header.Set("Authorization", "Bearer "+grant)
+	resp, err := http.DefaultClient.Do(mreq)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmd/ftw-relay/tokens.go
+++ b/go/cmd/ftw-relay/tokens.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"sync"
 	"time"
@@ -70,6 +73,12 @@ type Token struct {
 	// matched yet by an /approve POST. Used by the host dashboard's
 	// "friend opened the URL, code shown" indicator.
 	pendingApprovals int
+	// grant is the high-entropy session secret minted when the 4-digit
+	// code is accepted. It — not the URL token — is what authorizes
+	// /h/<token>/{mcp,web} requests after activation, so a leaked-but-
+	// already-activated URL is useless without it. Empty until approval.
+	// See docs/goals/relay-subdomain-sessions.md (grant-exchange model).
+	grant string
 }
 
 // State returns the current state, lazily transitioning to TokenExpired
@@ -91,6 +100,22 @@ func (t *Token) ApprovalCode() string { return t.approvalCode }
 func (t *Token) Intent() string       { return t.intent }
 func (t *Token) As() string           { return t.as }
 func (t *Token) ExpiresAt() time.Time { return t.expiresAt }
+
+// Grant returns the session grant minted at approval (empty before).
+func (t *Token) Grant() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.grant
+}
+
+// mintGrant returns 32 bytes of CSPRNG entropy as base64url — the session
+// secret handed to the friend once (cookie for the browser, Bearer header
+// for MCP).
+func mintGrant() string {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
 
 // TokenRegistry is the in-memory token store for one relay process.
 type TokenRegistry struct {
@@ -154,7 +179,27 @@ func (r *TokenRegistry) Approve(token, code string) error {
 		return ErrBadApprovalCode
 	}
 	t.state = TokenActive
+	t.grant = mintGrant()
 	return nil
+}
+
+// CheckGrant reports whether grant matches the session's minted grant and
+// the session is currently active. Constant-time compare so a timing
+// oracle can't recover the grant byte-by-byte. Empty grants never match.
+func (r *TokenRegistry) CheckGrant(token, grant string) bool {
+	t, err := r.Get(token)
+	if err != nil {
+		return false
+	}
+	if t.State() != TokenActive { // lazy-expires under its own lock
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.grant == "" || grant == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(t.grant), []byte(grant)) == 1
 }
 
 // Revoke unconditionally marks a token as revoked. Idempotent.

--- a/go/test/e2e/pair_test.go
+++ b/go/test/e2e/pair_test.go
@@ -176,26 +176,39 @@ func TestPairFlowThroughRelay(t *testing.T) {
 
 	pairCode, approvalCode := readPairCodeAndApproval(t, pairStderr)
 
-	// 4. Friend side: approve the session via the relay endpoint.
+	// 4. Friend side: approve the session via the relay endpoint. Approval
+	//    returns the session grant (the post-grant-exchange model); web
+	//    access then requires that grant as the ftw_grant cookie.
 	apvBody := strings.NewReader(`{"code":"` + approvalCode + `"}`)
 	apvResp, err := http.Post(relayURL+"/h/"+pairCode+"/approve", "application/json", apvBody)
 	if err != nil {
 		t.Fatalf("approve: %v", err)
 	}
-	if apvResp.StatusCode != http.StatusNoContent {
+	if apvResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(apvResp.Body)
 		t.Fatalf("approve status %d body %q", apvResp.StatusCode, body)
 	}
+	var apv struct {
+		Grant string `json:"grant"`
+	}
+	if err := json.NewDecoder(apvResp.Body).Decode(&apv); err != nil {
+		t.Fatalf("decode approve body: %v", err)
+	}
 	apvResp.Body.Close()
+	if apv.Grant == "" {
+		t.Fatal("approve returned empty grant")
+	}
 
 	// Give the host loop a beat to settle after the first response.
 	time.Sleep(200 * time.Millisecond)
 
-	// 5. N sequential requests through the relay → host → dashboard.
+	// 5. N sequential requests through the relay → host → dashboard,
+	//    each carrying the grant cookie.
 	const N = 10
 	for i := 0; i < N; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		req, _ := http.NewRequestWithContext(ctx, "GET", relayURL+"/h/"+pairCode+"/web/api/status", nil)
+		req.Header.Set("Cookie", "ftw_grant="+apv.Grant)
 		resp, err := http.DefaultClient.Do(req)
 		cancel()
 		if err != nil {

--- a/web/components/ftw-pair-card-render.js
+++ b/web/components/ftw-pair-card-render.js
@@ -94,10 +94,15 @@ export function formatAge(ms) {
 }
 
 // friendMessage is what the operator copies and sends to the friend.
-// Both the URL AND the code are in the same message — the friend
-// opens the URL, types the code, done. The 4-digit code is what
-// prevents a leaked URL alone from activating the session (the
-// attacker also needs the code).
+// Both the URL AND the code travel together — the friend opens the URL,
+// types the 4-digit code, and the landing page then hands them the exact
+// `claude mcp add …` command with a one-time access token baked in.
+//
+// The MCP command is deliberately NOT pre-baked here: the access token
+// (grant) is minted by the relay only when the code is accepted, so it
+// cannot exist before approval. Pre-baking a token-less command would
+// just hand the friend something that gets rejected with 401. See the
+// grant-exchange model in docs/goals/relay-subdomain-sessions.md.
 //
 // When state has no pair_url (e.g. -no-relay mode) it falls back to
 // the local MCP addr stored in `code` so the same template works for
@@ -109,17 +114,15 @@ export function friendMessage(state) {
   }
   const url = state.pair_url;
   const code = state.approval_code || "(no code — bug?)";
-  return `I need help with my home energy system. Open this URL and enter the 4-digit code below to activate the session:
+  return `I need help with my home energy system. Open this link and enter the 4-digit code to start the session:
 
   URL:  ${url}
   Code: ${code}
 
-Once active you can:
+After you enter the code, the page shows a "claude mcp add …" command with a
+one-time access token baked in — copy that into Claude Code to connect. The
+token only appears once you've entered the code, so I can't include it here.
 
-  - Open the dashboard:   ${url}/web/
-  - Add as Claude Code MCP:
-      claude mcp add ftw-friend --transport http ${url}/mcp
-
-Session expires when I close it or TTL runs out. Don't share the
-URL + code with anyone else — together they're the access grant.`;
+The session expires when I close it or the timer runs out. Don't forward the
+URL + code to anyone else — together they start the session.`;
 }

--- a/web/components/ftw-pair-card-render.test.mjs
+++ b/web/components/ftw-pair-card-render.test.mjs
@@ -151,16 +151,26 @@ describe("friendMessage (golden snapshot)", () => {
     const msg = friendMessage(stateActive);
     assert.match(msg, /https:\/\/relay\.fortytwowatts\.com\/h\/alpha-amber/);
     assert.match(msg, /Code: 4827/);
-    assert.match(msg, /Open the dashboard:/);
-    assert.match(msg, /claude mcp add ftw-friend/);
-    assert.doesNotMatch(msg, /ftw-connect/, "v2 must not mention the deprecated binary");
-    assert.doesNotMatch(msg, /install-ftw-connect/);
+  });
+
+  it("points to the post-approval MCP command but does NOT pre-bake it", () => {
+    const msg = friendMessage(stateActive);
+    // The grant is minted at approval, so a usable `claude mcp add … --header`
+    // command can only appear on the landing page afterwards. The share
+    // message must not pre-bake a (token-less) command that would 401.
+    assert.match(msg, /after you enter the code/i);
+    assert.match(msg, /claude mcp add/);
+    assert.doesNotMatch(msg, /--transport http/, "must not pre-bake the relay MCP URL/command");
+    assert.doesNotMatch(msg, /\/mcp/, "must not pre-bake the /mcp endpoint without a grant");
+    // The dashboard link is dropped while the browser view is deferred.
+    assert.doesNotMatch(msg, /Open the dashboard:/);
+    assert.doesNotMatch(msg, /ftw-connect/, "must not mention the deprecated binary");
     assert.doesNotMatch(msg, /go install/);
   });
 
-  it("warns the operator that URL+code together = access grant", () => {
+  it("warns the operator not to forward URL + code", () => {
     const msg = friendMessage(stateActive);
-    assert.match(msg, /together they're the access grant/);
+    assert.match(msg, /Don't forward the\s+URL \+ code/);
   });
 
   it("falls back to local-only message when no pair_url", () => {


### PR DESCRIPTION
PR 2 of the relay friend-access track (`docs/goals/relay-subdomain-sessions.md`). **MCP-first** — hardens the friend session on the existing path-based routes; **no subdomains or new domain needed.**

> Stacked on #389 (base branch `fix-relay-landing-token-const`). Retarget to `master` once #389 merges.

## The problem

Once a pair session was approved, anyone holding the `/h/<token>/…` URL had **full access for the rest of the TTL**. For MCP that's `run_command`, `modbus_write`, `deploy_driver`, `write_file` — a forwarded link or one pulled from browser history was effectively a host handover. The 4-digit code only gated the one-time activation; it secured nothing afterward.

## The fix — code → grant exchange (OAuth-style)

Accepting the code mints a high-entropy **grant** (32 bytes CSPRNG), handed to the friend exactly once:

- **MCP**: the landing page prints
  `claude mcp add ftw-friend --transport http <url>/h/<token>/mcp --header "Authorization: Bearer <grant>"`.
  `/h/<token>/mcp` now requires that Bearer grant. (`claude mcp add --header` is supported — verified.)
- **Browser**: approval sets an `HttpOnly; Secure; SameSite=Strict` `ftw_grant` cookie scoped to `/h/<token>/`; `/h/<token>/web/…` now requires it.

A leaked-but-already-active URL is useless without the grant — the recipient is bounced back to the code-entry page and lacks the out-of-band 4-digit code (5-try lock unchanged). The grant is **constant-time compared**, **never forwarded to the host** (`Authorization`/`Cookie` stripped before tunneling), and **expires with the session**.

`POST /h/<token>/approve` now returns `200 {"grant":"…"}` (was `204`). The landing success message drops the deferred/blank dashboard link and shows only the MCP one-liner.

## Tests

- `tokens`: grant minted on approve; `CheckGrant` constant-time, active-only, empty-never-matches.
- `/mcp` gate: pending → 401, wrong Bearer → 401, right Bearer → tunnels through.
- `/web` gate: no cookie → 401, cookie → through.
- approve returns a non-empty grant.
- Full-stack pair e2e (`go/test/e2e/pair_test.go`) drives the grant end-to-end through the **real** ftw-relay + ftw-pair binaries (10 sequential web requests with the cookie).

`make verify` clean via pre-commit (vet + unit + e2e + build).

## Scope / deferred

Browser-dashboard *rendering* (the absolute-path issue) and any subdomain/dedicated-domain work remain deferred per the MCP-first decision. The `/web` route is gated here for safety (it tunnels `/api/*` to the host) even though its UI is still rough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)