### PR TITLE
fix(mpc): include planned EV loadpoint when computing PV curtailment limit

### DIFF
--- a/.changeset/fix-mpc-curtailment-ev-loadpoint.md
+++ b/.changeset/fix-mpc-curtailment-ev-loadpoint.md
@@ -1,0 +1,11 @@
+---
+"forty-two-watts": patch
+---
+
+fix(mpc): include planned EV loadpoint power when computing PV curtailment limit
+
+`annotateCurtailment` previously only considered house load + battery charge when deciding how much PV can be safely absorbed locally before recommending `pv_limit_w`. When the planner had scheduled EV charging (`LoadpointW > 0`) in a negative-export-revenue slot, the limit would be too low and a curtailment-capable driver could starve the EV session the DP itself had chosen.
+
+The fix adds `max(0, LoadpointW)` to the local-consumption total, matching the accounting already used for battery charging. Updated godoc, docs, and added regression test.
+
+This only affects sites using both planner strategies that can produce export + a PV-curtailment-capable driver + configured loadpoints.

--- a/docs/mpc-planner.md
+++ b/docs/mpc-planner.md
@@ -196,11 +196,13 @@ Post-processing flags each plan slot with a recommended PV cap
 
 1. the slot is exporting (`grid_w < 0`)
 2. export revenue is non-positive (spot ≤ 0 or fees ≥ revenue)
-3. local consumption (load + battery charge) cannot absorb the PV
+3. local consumption (load + battery charge + any planned EV loadpoint
+   charge) cannot absorb the PV
 
 In that regime, exporting costs money and curtailing the PV is a pure
-win. The recommended limit equals `load_w + max(battery_w, 0)` — just
-enough to cover on-site absorption.
+win. The recommended limit equals `load_w + max(battery_w, 0) + max(loadpoint_w, 0)`
+— just enough to cover on-site absorption (including EV charging the
+planner itself scheduled).
 
 The MPC cost function isn't changed by curtailment; the annotation is
 a dispatch-time suggestion. A driver that advertises

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -235,8 +235,11 @@ type Action struct {
 
 	// PVLimitW is the recommended cap on PV inverter output (W, positive).
 	// 0 = no curtailment. Set by post-processing when exporting would
-	// cost money (negative export revenue after fees). Consumed by the
-	// control loop only when the driver advertises `supports_pv_curtail`.
+	// cost money (negative export revenue after fees). Includes house
+	// load + battery charge + any planned EV loadpoint charge so that
+	// curtailment does not starve loads the plan itself scheduled.
+	// Consumed by the control loop only when the driver advertises
+	// `supports_pv_curtail`.
 	PVLimitW float64 `json:"pv_limit_w,omitempty"`
 
 	// LoadpointW is the EV charger power (W, positive = charging) the
@@ -944,14 +947,16 @@ func Optimize(slots []Slot, p Params) Plan {
 //
 //   - the slot is exporting (grid_w < 0)
 //   - AND export revenue is non-positive (fee ≥ revenue, or negative spot)
-//   - AND the battery can't absorb more (already charging at max)
+//   - AND local consumption (house load + battery charge + planned EV
+//     loadpoint charge) cannot absorb the PV
 //
 // In that case exporting PV costs money with no offsetting benefit.
-// Recommended PV limit = load + battery_charge (just cover what the
-// site + battery can consume). Driver dispatches this only if it
-// advertises PV-curtailment support. The CostOre doesn't change — the
-// DP already priced this slot as-is; curtailment is a mitigation
-// applied at dispatch time.
+// Recommended PV limit = load + max(battery_w,0) + max(loadpoint_w,0) —
+// just enough to cover on-site absorption (including any EV the DP
+// scheduled). Driver dispatches this only if it advertises
+// PV-curtailment support. The CostOre doesn't change — the DP already
+// priced this slot as-is; curtailment is a mitigation applied at
+// dispatch time.
 func annotateCurtailment(plan *Plan, p Params) {
 	for i := range plan.Actions {
 		a := &plan.Actions[i]
@@ -971,10 +976,14 @@ func annotateCurtailment(plan *Plan, p Params) {
 			continue // profitable export; curtailing would discard revenue
 		}
 		// Slot is exporting. If we can't earn on export, cap PV to
-		// what's being consumed locally + stored.
+		// what's being consumed locally + stored (house + battery +
+		// any planned EV charging).
 		consumedW := a.LoadW
 		if a.BatteryW > 0 {
 			consumedW += a.BatteryW // site-sign: + = charging (absorbs PV)
+		}
+		if a.LoadpointW > 0 {
+			consumedW += a.LoadpointW
 		}
 		if consumedW < 0 {
 			consumedW = 0

--- a/go/internal/mpc/mpc_test.go
+++ b/go/internal/mpc/mpc_test.go
@@ -1013,6 +1013,41 @@ func TestCurtailmentSkipsPositiveSpotExport(t *testing.T) {
 	}
 }
 
+// TestCurtailmentIncludesLoadpoint is the regression for the bug where
+// annotateCurtailment only considered house load + battery when
+// computing the safe PV absorption limit. When the planner had
+// scheduled EV charging (LoadpointW > 0), the recommended PVLimitW
+// would understate local consumption and could starve the EV charge
+// the DP itself decided to run.
+func TestCurtailmentIncludesLoadpoint(t *testing.T) {
+	plan := &Plan{
+		Actions: []Action{
+			{
+				GridW:       -3000,
+				LoadW:       400,
+				BatteryW:    0,
+				LoadpointW:  2500, // EV scheduled by the planner
+				PVW:         -6000,
+				PriceOre:    10,
+				SpotOre:     -5, // negative export revenue → curtailment candidate
+				SlotLenMin:  60,
+				SlotStartMs: 0,
+			},
+		},
+	}
+	p := baseParams(ModeArbitrage)
+	annotateCurtailment(plan, p)
+	a := &plan.Actions[0]
+	if a.PVLimitW == 0 {
+		t.Fatal("expected PV curtailment recommendation for negative-export slot")
+	}
+	// Must include the EV load the plan scheduled.
+	expected := 400.0 + 2500.0 // load + loadpoint (battery not charging)
+	if math.Abs(a.PVLimitW-expected) > 0.1 {
+		t.Errorf("PVLimitW = %v, want %v (must account for planned EV charging)", a.PVLimitW, expected)
+	}
+}
+
 // ---- Edge cases / hardening ----
 
 func TestOptimizeWithNaNPVDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
**Problem**

`annotateCurtailment` (post-processing step in the MPC planner) computed the safe local PV absorption (`pv_limit_w`) using only house load + battery charge. When a loadpoint was active and the DP had scheduled EV charging (`LoadpointW > 0`) in a slot with non-positive export revenue, the recommended curtailment limit was too low.

A driver advertising `supports_pv_curtail` would then be told to cap PV below what the plan itself had allocated for the EV — starving a charge the optimiser decided to run.

**Fix**

Add `max(0, LoadpointW)` to the `consumedW` total in `annotateCurtailment`, exactly parallel to the existing battery-charge term. Updated:

* Action godoc
* `annotateCurtailment` comment + implementation
* Operator-facing docs in `docs/mpc-planner.md`
* Added `TestCurtailmentIncludesLoadpoint` regression (directly exercises the post-processing with a synthetic plan containing `LoadpointW`)

**Verification**

* `go test ./internal/mpc/... -run Curtailment` (all 4 tests, including new one)
* Full `make verify` (vet + test + build) via pre-commit hook
* Full `make verify-all` (cross-compile linux/arm64 + amd64 + windows) via pre-push hook
* Changeset included (patch)

This is a narrow correctness fix that only affects the intersection of planner modes that can produce negative-export slots + configured loadpoints + PV-curtailment-capable drivers. No behaviour change for the common battery-only case.

Closes the logic gap identified during the recent optimiser audit.