### PR TITLE
feat(control): site export ceiling (max_export_w) to pre-empt Ferroamp over-export fault

### DIFF
--- a/.changeset/ferroamp-export-ceiling.md
+++ b/.changeset/ferroamp-export-ceiling.md
@@ -1,0 +1,31 @@
+---
+"forty-two-watts": minor
+---
+
+**Add `site.max_export_w` — an opt-in site export ceiling below the
+physical fuse.** Some inverters trip into a protective fault on
+*sustained* grid export well under the breaker rating: the Ferroamp
+EnergyHub faults to state `0x8030` after ~8 kW of continuous midday
+export (battery discharge stacked on PV surplus) and only recovers as PV
+wanes — losing hours of solar. Recurred daily on a live
+`planner_arbitrage` site whose plan discharged the battery into the
+morning price peak while PV was already exporting; grid voltage and
+frequency were both in spec at every trip, ruling out a normal grid
+protection.
+
+`max_export_w` (W, magnitude; `0` = disabled, the default) is enforced
+on two layers:
+
+- **Dispatch** — the fuse guard's export side now scales battery
+  discharge against `min(fuse − margin, max_export_w)` via the new
+  `(*State).effectiveExportCeilingW`, mirroring the import-side
+  `effectiveImportCeilingW` / `peak_import_ceiling_w`. Hot-reloadable.
+- **MPC** — every plan slot's export limit becomes
+  `min(FuseMaxW, max_export_w)` (`clampSlotGridLimits`), so the DP never
+  *schedules* a discharge that would over-export — fixing the root cause
+  rather than only clamping at execution time. Applied at startup
+  (parity with the existing per-slot fuse plumbing).
+
+Off by default; existing sites are unaffected until they set the knob.
+The full-battery, PV-only over-export case still needs PV curtailment —
+the discharge clamp can only scale battery action, not PV.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,20 @@ site:
   gain: 0.5                       # legacy proportional gain
   slew_rate_w: 500                # max change in dispatch target per cycle
   min_dispatch_interval_s: 5      # holdoff between successive dispatches
+  max_export_w: 0                 # cap total site export (W); 0 = fuse only
 ```
+
+`max_export_w` is an **opt-in export ceiling below the physical fuse**.
+Some inverters trip into a protective fault on *sustained* grid export
+well under the breaker rating — a Ferroamp EnergyHub, for example, faults
+(state `0x8030`) after ~8 kW of continuous midday export and only recovers
+as PV wanes, losing hours of solar. Set `max_export_w` just below the
+observed trip point and the EMS enforces it two ways: the dispatch fuse
+guard scales battery discharge back so predicted export stays under it,
+and the MPC caps each plan slot's export so the planner never *schedules*
+a discharge that would over-export. `0` (default) leaves export bounded
+only by the fuse. Hot-reloads on the dispatch side; the MPC picks it up on
+restart (parity with `fuse.max_amps`). See [safety.md §3c](safety.md).
 
 ### `fuse` — shared breaker limit
 
@@ -291,6 +304,7 @@ Keys must match `drivers[].name`. Leave blank to use BMS defaults.
 | `site.grid_tolerance_w` | ✅ | Deadband applied next cycle |
 | `site.slew_rate_w` | ✅ | Applied next dispatch |
 | `site.min_dispatch_interval_s` | ✅ | |
+| `site.max_export_w` | ⚠️ | Dispatch guard hot-reloads; MPC picks it up on restart |
 | `site.control_interval_s` | ⚠️ | Picked up next cycle (current cycle uses old value) |
 | `site.watchdog_timeout_s` | ✅ | |
 | `fuse.*` | ✅ | Read fresh each cycle |

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -135,6 +135,31 @@ The scale is proportional so the per-battery distribution (from
 `distributeProportional` / `distributeWeighted` / `distributePriority`)
 is preserved while staying inside the breaker envelope.
 
+### 3c. Site export ceiling (`site.max_export_w`)
+
+Some inverters fault on *sustained* grid export **below** the breaker
+rating. Real recurring incident: a Ferroamp EnergyHub tripping to state
+`0x8030` after ~8 kW of continuous midday export (battery discharge
+stacked on PV surplus), staying down until PV waned — grid voltage
+(≤ 244 V) and frequency (≈ 50 Hz) were in spec the whole time, so the
+fuse guard and grid-protection both saw nothing wrong.
+
+`site.max_export_w` (W magnitude; `0` = disabled) lowers the export
+ceiling the guard enforces: the export side scales battery discharge
+against `min(fuse − margin, max_export_w)` via
+`(*State).effectiveExportCeilingW`, the export-side twin of the
+import-side `effectiveImportCeilingW` / `peak_import_ceiling_w`. It only
+scales **battery discharge** — when PV alone exceeds the ceiling (full
+battery, nothing to scale) the guard can't help and PV curtailment is
+the lever.
+
+The MPC enforces the same ceiling ahead of time: every plan slot's
+`Limits.MaxExportW` becomes `min(FuseMaxW, max_export_w)`
+(`clampSlotGridLimits` in `go/internal/mpc/power_limits.go`), so the DP
+never *schedules* a discharge that would over-export — fixing the root
+cause (a `planner_arbitrage` plan that discharges into a PV-exporting
+morning) instead of only clamping it at execution time.
+
 Per-phase imbalance isn't modeled in `applyFuseGuard` directly, but
 Sungrow and Ferroamp both emit per-phase data into
 `DerReading.Data` — drivers that need per-phase guards can read that

--- a/go/cmd/forty-two-watts/control_state.go
+++ b/go/cmd/forty-two-watts/control_state.go
@@ -38,5 +38,9 @@ func newControlStateFromConfig(cfg *config.Config) *control.State {
 	ctrl.DCLinkProtectionEnabled = cfg.Site.DCLinkProtectionEnabled
 	ctrl.DCLinkProtectionSoCThreshold = cfg.Site.DCLinkProtectionSoCThreshold
 	ctrl.DCLinkProtectionMarginW = cfg.Site.DCLinkProtectionMarginW
+	// Site export ceiling — opt-in, default off. The fuse guard scales
+	// battery discharge back so predicted export stays under max_export_w,
+	// protecting inverters that trip below the breaker rating.
+	ctrl.MaxExportW = cfg.Site.MaxExportW
 	return ctrl
 }

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -460,6 +460,7 @@ func main() {
 			// Mirror the startup-path default semantics — nil → 0.5,
 			// explicit 0 → disabled. See EffectiveSafetyMarginA.
 			ctrl.SiteFuseSafetyA = newCfg.Fuse.EffectiveSafetyMarginA()
+			ctrl.MaxExportW = newCfg.Site.MaxExportW
 			ctrlMu.Unlock()
 
 			// Push the new pool totals into the planner so its next
@@ -714,6 +715,11 @@ func main() {
 		// the fuse from the start (instead of producing plans that
 		// dispatch later has to scale via the joint allocator).
 		mpcSvc.FuseMaxW = cfg.Fuse.MaxPowerW()
+		// Cap planned export below the fuse when the operator set a site
+		// export ceiling, so the DP never schedules a discharge that would
+		// over-export and trip an inverter (the Ferroamp 0x8030 fault).
+		// Startup-only, matching FuseMaxW above.
+		mpcSvc.MaxExportW = cfg.Site.MaxExportW
 		if pvSvc != nil {
 			// Use the unanchored structural predictor here: the MPC also
 			// receives PVResidualCorrect, which captures the same

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -368,6 +368,17 @@ type Site struct {
 	// allowed through, smaller load-step capacity before re-curtail.
 	// Default 1000.
 	DCLinkProtectionMarginW float64 `yaml:"dc_link_protection_margin_w,omitempty" json:"dc_link_protection_margin_w,omitempty"`
+
+	// MaxExportW caps total site export (W, magnitude) below the physical
+	// fuse. 0 = disabled (export bounded only by the fuse). When > 0 it is
+	// enforced two ways: the dispatch fuse guard scales battery discharge
+	// back so predicted export stays under it, and the MPC caps each slot's
+	// export so the planner never schedules a discharge that would
+	// over-export. Protects inverters that trip on sustained export well
+	// below the breaker rating — the recurring Ferroamp EnergyHub fault
+	// state 0x8030 after ~8 kW sustained midday export, which only cleared
+	// as PV waned. Set it just under the observed trip point.
+	MaxExportW float64 `yaml:"max_export_w,omitempty" json:"max_export_w,omitempty"`
 }
 
 // DefaultFuseSafetyMarginA is the fall-back per-phase amp headroom

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -224,6 +224,16 @@ type State struct {
 	// an aggregate import-only concept (tariff). Persisted in state.db
 	// under "peak_import_ceiling_w".
 	PeakImportCeilingW float64
+
+	// MaxExportW is a hard export ceiling (W, magnitude) enforced in EVERY
+	// mode, at or below the physical fuse. Default 0 = disabled (export
+	// bounded only by the fuse). When > 0 the export side of the fuse
+	// guard uses min(fuse−margin, MaxExportW) as its threshold and scales
+	// battery discharge back so predicted export stays under it. Protects
+	// inverters that trip on sustained export well below the breaker
+	// rating — the recurring Ferroamp EnergyHub 0x8030 fault after ~8 kW
+	// sustained midday export. Sourced from site.max_export_w.
+	MaxExportW float64
 	// EV charging signal — batteries won't try to cover this much of import
 	EVChargingW float64
 
@@ -3023,15 +3033,14 @@ func applyFuseGuard(targets []DispatchTarget, store *telemetry.Store, state *Sta
 	// own per-phase limiter doesn't fire first and cause a flap.
 	//
 	// Import ceiling is the tighter of (fuse − safety margin) and the
-	// operator's tariff peak; export ceiling is fuse-only — peak is
-	// import-only (effekttariff is billed on import).
-	effFuseW := fuseMaxW - state.fuseSafetyMarginW()
-	if effFuseW < 0 {
-		effFuseW = 0
-	}
+	// operator's tariff peak; export ceiling is the tighter of (fuse −
+	// safety margin) and the operator's max_export_w protection limit —
+	// set when an inverter trips on sustained export below the breaker
+	// (recurring Ferroamp 0x8030 fault). Both share one enforcement surface.
 	effImportW := state.effectiveImportCeilingW(fuseMaxW)
+	effExportW := state.effectiveExportCeilingW(fuseMaxW)
 	importOverage := predicted - effImportW
-	exportOverage := -effFuseW - predicted
+	exportOverage := -effExportW - predicted
 	if perPhase > 0 {
 		if currentGrid >= 0 {
 			if perPhase > importOverage {
@@ -3204,6 +3213,25 @@ func (s *State) effectiveImportCeilingW(fuseMaxW float64) float64 {
 	}
 	if s != nil && s.PeakImportCeilingW > 0 && s.PeakImportCeilingW < eff {
 		eff = s.PeakImportCeilingW
+	}
+	return eff
+}
+
+// effectiveExportCeilingW returns the binding ceiling for grid export in
+// watts: the fuse limit minus its safety margin, further capped by
+// MaxExportW when the operator has opted into a site export protection
+// limit (MaxExportW > 0). Mirrors effectiveImportCeilingW on the export
+// side so the fuse guard scales battery discharge back below an inverter's
+// sustained-export trip point, not just the physical breaker. MaxExportW
+// is taken at face value (no extra safety subtraction) — the operator
+// typed the protection limit; the fuse keeps its own independent margin.
+func (s *State) effectiveExportCeilingW(fuseMaxW float64) float64 {
+	eff := fuseMaxW - s.fuseSafetyMarginW()
+	if eff < 0 {
+		eff = 0
+	}
+	if s != nil && s.MaxExportW > 0 && s.MaxExportW < eff {
+		eff = s.MaxExportW
 	}
 	return eff
 }

--- a/go/internal/control/export_ceiling_test.go
+++ b/go/internal/control/export_ceiling_test.go
@@ -1,0 +1,77 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// A site exporting 8 kW via battery discharge, with max_export_w = 5 kW set
+// below the fuse: the fuse guard must scale the discharge back so predicted
+// export lands at the export ceiling, not at the (looser) fuse limit.
+// Models the recurring Ferroamp 0x8030 fault: ~8 kW sustained midday export
+// tripped the EnergyHub even though the 16 A fuse (~11 kW) was never hit.
+func TestExportCeilingScalesBackDischarge(t *testing.T) {
+	store := telemetry.NewStore()
+	store.Update("meter", telemetry.DerMeter, -8000, nil, nil) // exporting 8 kW
+	soc := 0.5
+	store.Update("bat", telemetry.DerBattery, -8000, &soc, nil) // discharging 8 kW
+
+	state := NewState(0, 50, "meter")
+	state.MaxExportW = 5000
+
+	targets := []DispatchTarget{{Driver: "bat", TargetW: -8000}}
+	out := applyFuseGuard(targets, store, state, 11040) // fuse would allow 8 kW
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(out))
+	}
+	// predicted = grid(-8000) - bat(-8000) + target(-8000) = -8000
+	// exportOverage = -5000 - (-8000) = 3000 → discharge 8000 → 5000
+	if got := out[0].TargetW; got < -5050 || got > -4950 {
+		t.Fatalf("discharge should be scaled back to ~-5000 W (export ceiling), got %.1f", got)
+	}
+	if !out[0].Clamped {
+		t.Fatalf("target should be marked Clamped after export-ceiling scaling")
+	}
+}
+
+// With max_export_w unset (0), the export ceiling is the fuse alone, so an
+// 8 kW export under an 11 kW fuse is left untouched — back-compat guard so
+// the new knob is strictly opt-in.
+func TestExportCeilingDisabledExportsUpToFuse(t *testing.T) {
+	store := telemetry.NewStore()
+	store.Update("meter", telemetry.DerMeter, -8000, nil, nil)
+	soc := 0.5
+	store.Update("bat", telemetry.DerBattery, -8000, &soc, nil)
+
+	state := NewState(0, 50, "meter") // MaxExportW left 0
+	targets := []DispatchTarget{{Driver: "bat", TargetW: -8000}}
+	out := applyFuseGuard(targets, store, state, 11040)
+
+	if got := out[0].TargetW; got != -8000 {
+		t.Fatalf("export under fuse with no ceiling should be untouched, got %.1f", got)
+	}
+	if out[0].Clamped {
+		t.Fatalf("target should not be Clamped when within fuse and no export ceiling")
+	}
+}
+
+// Ceiling math: disabled → fuse, tighter config → config, looser config →
+// fuse still binds (operator can't raise export above the breaker).
+func TestEffectiveExportCeilingW(t *testing.T) {
+	st := NewState(0, 50, "meter")
+	const fuse = 11040.0
+
+	if got := st.effectiveExportCeilingW(fuse); got != fuse {
+		t.Fatalf("disabled (MaxExportW=0): want %.0f got %.0f", fuse, got)
+	}
+	st.MaxExportW = 5000
+	if got := st.effectiveExportCeilingW(fuse); got != 5000 {
+		t.Fatalf("tighter than fuse: want 5000 got %.0f", got)
+	}
+	st.MaxExportW = 20000
+	if got := st.effectiveExportCeilingW(fuse); got != fuse {
+		t.Fatalf("looser than fuse: fuse must still bind, want %.0f got %.0f", fuse, got)
+	}
+}

--- a/go/internal/mpc/export_ceiling_test.go
+++ b/go/internal/mpc/export_ceiling_test.go
@@ -1,0 +1,43 @@
+package mpc
+
+import "testing"
+
+// The MPC must cap each slot's export at the tighter of the fuse and the
+// operator's max_export_w, so the planner never schedules a battery
+// discharge that would over-export and trip the inverter (the recurring
+// Ferroamp 0x8030 fault). A pre-existing tighter limit (e.g. a DSO
+// curtailment signal) must never be loosened.
+func TestClampSlotGridLimitsTightensExportBelowFuse(t *testing.T) {
+	slots := []Slot{
+		{},                                      // unset → take fuse / export cap
+		{Limits: PowerLimits{MaxExportW: 3000}}, // already tighter than the cap
+		{Limits: PowerLimits{MaxExportW: 9000}}, // looser than the cap
+	}
+	clampSlotGridLimits(slots, 11000, 5000) // fuse 11 kW, export cap 5 kW
+
+	if slots[0].Limits.MaxImportW != 11000 {
+		t.Fatalf("slot0 import: want 11000 got %.0f", slots[0].Limits.MaxImportW)
+	}
+	if slots[0].Limits.MaxExportW != 5000 {
+		t.Fatalf("slot0 export: want 5000 (export cap) got %.0f", slots[0].Limits.MaxExportW)
+	}
+	if slots[1].Limits.MaxExportW != 3000 {
+		t.Fatalf("slot1 export: tighter pre-set must survive, got %.0f", slots[1].Limits.MaxExportW)
+	}
+	if slots[2].Limits.MaxExportW != 5000 {
+		t.Fatalf("slot2 export: looser pre-set must be capped to 5000, got %.0f", slots[2].Limits.MaxExportW)
+	}
+}
+
+// With no export cap configured (0), export is bounded only by the fuse —
+// back-compat with the pre-existing per-slot fuse plumbing.
+func TestClampSlotGridLimitsNoExportCapUsesFuse(t *testing.T) {
+	slots := []Slot{{}}
+	clampSlotGridLimits(slots, 11000, 0)
+	if slots[0].Limits.MaxImportW != 11000 {
+		t.Fatalf("import should be fuse (11000), got %.0f", slots[0].Limits.MaxImportW)
+	}
+	if slots[0].Limits.MaxExportW != 11000 {
+		t.Fatalf("export with no cap should be fuse (11000), got %.0f", slots[0].Limits.MaxExportW)
+	}
+}

--- a/go/internal/mpc/power_limits.go
+++ b/go/internal/mpc/power_limits.go
@@ -52,3 +52,27 @@ func (l PowerLimits) allowsExport(gridW float64) bool {
 	}
 	return -gridW <= l.MaxExportW
 }
+
+// clampSlotGridLimits bounds each slot's grid import/export so the DP never
+// schedules a flow the site can't physically sustain. Import is capped at
+// the fuse; export at the tighter of the fuse and maxExportW (the operator's
+// site export-protection limit; 0 = unset). A slot that already carries a
+// tighter limit (e.g. a DSO curtailment signal) is never loosened. No-op
+// when fuseMaxW <= 0 (fuse unconfigured) — matches the prior gating.
+func clampSlotGridLimits(slots []Slot, fuseMaxW, maxExportW float64) {
+	if fuseMaxW <= 0 {
+		return
+	}
+	exportCap := fuseMaxW
+	if maxExportW > 0 && maxExportW < exportCap {
+		exportCap = maxExportW
+	}
+	for i := range slots {
+		if slots[i].Limits.MaxImportW <= 0 || slots[i].Limits.MaxImportW > fuseMaxW {
+			slots[i].Limits.MaxImportW = fuseMaxW
+		}
+		if slots[i].Limits.MaxExportW <= 0 || slots[i].Limits.MaxExportW > exportCap {
+			slots[i].Limits.MaxExportW = exportCap
+		}
+	}
+}

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -142,6 +142,14 @@ type Service struct {
 	// execution time. Wired from main.go (cfg.Fuse → fuseMaxW).
 	FuseMaxW float64
 
+	// MaxExportW caps total site export (W, magnitude) below the fuse.
+	// When > 0, every slot's export limit becomes min(FuseMaxW, MaxExportW)
+	// so the DP never schedules a battery discharge that would over-export
+	// and trip an inverter that faults below the breaker rating (recurring
+	// Ferroamp 0x8030 fault). 0 = disabled (export bounded by the fuse).
+	// Wired from main.go (cfg.Site.MaxExportW).
+	MaxExportW float64
+
 	lastReplanAt time.Time
 	lastReason   string // "scheduled" | "reactive-pv" | "reactive-load" | "manual"
 
@@ -817,26 +825,17 @@ func (s *Service) replan(_ context.Context) *Plan {
 		return nil
 	}
 
-	// Plumb the site fuse into per-slot limits so the DP joint-plans
-	// battery + EV under the fuse constraint instead of producing plans
-	// that dispatch then has to scale at execution time. The DP already
-	// honours Slot.Limits.MaxImportW + MaxExportW (mpc.go:450); we just
-	// feed both directions — the fuse trips on |I| regardless of sign,
-	// and exporting 14 kW through an 11 kW breaker is just as bad as
-	// importing it (probably worse — the inverter's local current
-	// limiter trips first and the operator sees a sudden zero-output
-	// flap as PV+battery collapses). Pre-fix this only set MaxImportW,
-	// producing plans like 14:45 slot grid=-14.2 kW past an 11 kW fuse.
-	if s.FuseMaxW > 0 {
-		for i := range slots {
-			if slots[i].Limits.MaxImportW <= 0 || slots[i].Limits.MaxImportW > s.FuseMaxW {
-				slots[i].Limits.MaxImportW = s.FuseMaxW
-			}
-			if slots[i].Limits.MaxExportW <= 0 || slots[i].Limits.MaxExportW > s.FuseMaxW {
-				slots[i].Limits.MaxExportW = s.FuseMaxW
-			}
-		}
-	}
+	// Plumb the site fuse + export ceiling into per-slot limits so the DP
+	// joint-plans battery + EV under the grid constraints instead of
+	// producing plans dispatch then has to scale at execution time. The DP
+	// already honours Slot.Limits.MaxImportW + MaxExportW (mpc.go:450).
+	// Import is bounded by the fuse (the breaker trips on |I| regardless of
+	// sign); export by the tighter of the fuse and the operator's
+	// max_export_w — the latter protects inverters that trip on sustained
+	// export below the breaker rating (the recurring Ferroamp 0x8030
+	// fault). Pre-fix this only set MaxImportW, producing plans like a
+	// 14:45 slot grid=-14.2 kW past an 11 kW fuse.
+	clampSlotGridLimits(slots, s.FuseMaxW, s.MaxExportW)
 
 	s.mu.RLock()
 	p := s.Defaults


### PR DESCRIPTION
## Why

Fredrik's live `planner_arbitrage` site has been tripping its Ferroamp EnergyHub into **fault state `0x8030`** almost daily — investigated this session (2026-05-29).

Timeline from the TS DB (`ehub_state` bit15): onsets **05-27 10:50**, **05-28 12:13**, **05-29 09:30** — every one mid-morning, self-recovering late afternoon as PV waned (5+ h of lost solar each time). At every onset:

- **Not grid voltage** — full-resolution phase voltage peaked at **243.7 V**, never near the 253 V trip.
- **Not frequency** — 49.9–50.04 Hz.
- **Not the `pplim` curtail trap** — 0 curtail commands sent; `supports_pv_curtail` off.
- The one consistent precursor: **sustained ~8 kW grid export**, with the SSO DC bus spiking 762→796 V *at* the trip (a consequence — the inverter/EMS trips first, then PV is cut and the ESOs drop off the bus).

Root cause in code: the MPC (`planner_arbitrage`) plans a morning battery **discharge** into the price peak while PV is already exporting, and **nothing caps total site export below the fuse**. The fuse guard only clamps at ~11 kW (16 A); the EnergyHub faults well under that. The planner never models the trip, so it loses hours of PV for a few öre of arbitrage.

A prior fix (#310, "DC-link protective PV curtail") targets a different scenario (high-SoC PV surplus) via PV curtail, is opt-in/disabled here, and is a no-op on this site (no safe PV-curtail lever) — so it never caught this.

## What

New opt-in **`site.max_export_w`** (W magnitude; `0` = disabled, default), enforced on two layers:

- **Dispatch** — the fuse guard's export side scales battery discharge against `min(fuse−margin, max_export_w)` via new `(*State).effectiveExportCeilingW`, the export-side twin of `effectiveImportCeilingW` / `peak_import_ceiling_w`. Hot-reloadable.
- **MPC** — every plan slot's export limit becomes `min(FuseMaxW, max_export_w)` (`clampSlotGridLimits`), so the DP never *schedules* a discharge that would over-export. Startup-only, parity with the existing per-slot fuse plumbing.

Off by default → existing sites unaffected until they set the knob.

## Limitation

The discharge clamp can only scale **battery action**. The full-battery, PV-only over-export case (05-27/28, battery at 100% SoC) still needs PV curtailment, which on Ferroamp is the `pplim` trap — out of scope here.

## Tests (TDD, red→green)

- `control`: `TestExportCeilingScalesBackDischarge`, `TestExportCeilingDisabledExportsUpToFuse`, `TestEffectiveExportCeilingW`.
- `mpc`: `TestClampSlotGridLimitsTightensExportBelowFuse`, `TestClampSlotGridLimitsNoExportCapUsesFuse`.
- `make verify` green (vet + full test incl. e2e + build).

## Operator note

To activate on the affected site, set `site.max_export_w` just below the observed ~8 kW trip point (e.g. `6000`). Docs: `docs/configuration.md` + `docs/safety.md` §3c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)