### PR TITLE
fix(loadpoint): asymmetric step smoothing for surplus_only EV charging

### DIFF
--- a/.changeset/ev-surplus-step-smoothing.md
+++ b/.changeset/ev-surplus-step-smoothing.md
@@ -1,0 +1,22 @@
+---
+"forty-two-watts": patch
+---
+
+**surplus_only EV charging: smooth the step setpoint so the EV and home
+battery stop fighting over the same PV surplus.** The surplus_only setpoint
+magnitude tracked the *instant* surplus and snapped to an `allowed_steps_w`
+step every 5 s tick. Because `surplusW = −gridW + batW + evW` counts the home
+battery's current charge power as EV-available, a single-tick wobble (the
+battery briefly backing off, a cloud edge, a load twitch) ratcheted the EV up
+a step it couldn't hold — it collapsed the next tick, and the repeated
+multi-kW load swing whipsawed the home battery's reactive PI into integrator
+windup, so the battery stopped delivering its planned discharge (an EV↔battery
+limit cycle; observed live as `ev_w` swinging 0–4.7 kW and the battery
+under-delivering to ~4% of plan).
+
+The step setpoint now uses **asymmetric smoothing**: down-steps still track the
+instant surplus (the no-import promise is unchanged), but an **up-step is gated
+on the rolling average** — the EV only climbs to a higher step when the smoothed
+surplus sustains it. This breaks the limit cycle: the EV ramps up only on a
+genuine surplus rise and the home battery's PI stays stable. Pause/resume
+hysteresis and the no-import guarantee are untouched.

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -82,6 +82,12 @@ type Controller struct {
 	surplusWin      map[string]*surplusWindow
 	surplusPaused   map[string]bool
 	surplusPausedAt map[string]time.Time
+	// surplusStepW is the last applied surplus_only step per loadpoint.
+	// Used for asymmetric step smoothing: down-steps track instant surplus
+	// (no-import promise), up-steps are gated on the rolling average so a
+	// transient surplus spike can't ratchet the EV up a step it can't hold
+	// (which would whipsaw the home battery's PI). See computeSurplusCmd.
+	surplusStepW map[string]float64
 
 	// vehicleStatus reports the matched vehicle driver + its
 	// charging_state for a given loadpoint, so the controller can
@@ -1478,23 +1484,47 @@ func (c *Controller) computeSurplusCmd(now time.Time, lpCfg Config, wantW, curre
 	c.setSurplusPause(lpCfg.ID, paused, pausedAt)
 
 	if paused {
+		// Reset the step memory so the next resume ramps up fresh under
+		// the avg gate rather than from a stale pre-pause level.
+		c.setSurplusStepW(lpCfg.ID, 0)
 		return 0
 	}
-	// Setpoint tracks INSTANT surplus, not the rolling average. The
-	// avg smooths the pause/resume decision so we don't cycle the
-	// contactor on transients (that's the user-stated intent: "avg
-	// over 4 ticks to determine pause"), but using avg for the
-	// setpoint magnitude lags reality — on a slowly dropping cloud
-	// front the EV would hold its previous draw for ~20 s while
-	// live PV had already fallen below it, and the difference
-	// leaks straight into grid import. Tracking instant keeps the
-	// no-import promise tight; the home battery's reactive PI in
-	// self_consumption fills sub-tick gaps.
+	// Setpoint magnitude: down-steps track INSTANT surplus (keeps the
+	// no-import promise tight — on a dropping cloud front the EV must shed
+	// load immediately or it leaks straight into grid import). Up-steps are
+	// gated on the rolling AVERAGE.
 	target := wantW
 	if instant < target {
 		target = instant
 	}
-	return SnapChargeW(target, lpCfg.MinChargeW, lpCfg.MaxChargeW, steps3)
+	snapped := SnapChargeW(target, lpCfg.MinChargeW, lpCfg.MaxChargeW, steps3)
+
+	// Asymmetric step smoothing (operator report 2026-05-30). surplusW counts
+	// the home battery's current charge power as EV-available, so a single-
+	// tick wobble (the battery briefly backing off, a cloud edge, the load
+	// twitching) would ratchet the EV UP a step it can't hold — it collapses
+	// the next tick, and the repeated multi-kW load swing whipsaws the home
+	// battery's reactive PI into integrator windup, so the battery stops
+	// delivering its planned discharge (EV ↔ battery limit cycle). Requiring
+	// the smoothed average to ALSO clear the higher step lets the EV ramp up
+	// only on a sustained rise. Down-steps stay instant (above), so the
+	// no-import guarantee is unaffected.
+	prev := c.getSurplusStepW(lpCfg.ID)
+	if snapped > prev {
+		avgTarget := wantW
+		if avg < avgTarget {
+			avgTarget = avg
+		}
+		avgSnapped := SnapChargeW(avgTarget, lpCfg.MinChargeW, lpCfg.MaxChargeW, steps3)
+		if avgSnapped < snapped {
+			snapped = avgSnapped
+			if snapped < prev {
+				snapped = prev // never force a down-step on an up-tick
+			}
+		}
+	}
+	c.setSurplusStepW(lpCfg.ID, snapped)
+	return snapped
 }
 
 // pickSurplusSteps returns the step set surplus_only should snap to
@@ -1857,6 +1887,21 @@ func (c *Controller) setSurplusPause(id string, paused bool, at time.Time) {
 	} else {
 		delete(c.surplusPausedAt, id)
 	}
+}
+
+func (c *Controller) getSurplusStepW(id string) float64 {
+	c.surplusMu.Lock()
+	defer c.surplusMu.Unlock()
+	return c.surplusStepW[id]
+}
+
+func (c *Controller) setSurplusStepW(id string, w float64) {
+	c.surplusMu.Lock()
+	defer c.surplusMu.Unlock()
+	if c.surplusStepW == nil {
+		c.surplusStepW = map[string]float64{}
+	}
+	c.surplusStepW[id] = w
 }
 
 // computeCommand resolves the W setpoint for a plugged loadpoint.

--- a/go/internal/loadpoint/controller_surplus_test.go
+++ b/go/internal/loadpoint/controller_surplus_test.go
@@ -89,6 +89,69 @@ func TestSurplusCmd_PauseResumeHysteresis(t *testing.T) {
 	}
 }
 
+// TestSurplusCmd_UpStepGatedOnAverage is the anti-flap regression
+// (operator report 2026-05-30). The surplus_only setpoint magnitude must
+// only step UP when the rolling average sustains the higher step — a single-
+// tick instant-surplus spike (the home battery briefly backing off, a cloud
+// edge) must NOT ratchet the EV up a step it can't hold. Down-steps stay
+// instant so the no-import promise is preserved. Without the gate the EV
+// jumps steps every tick and the load swing whipsaws the home battery's PI
+// into windup, starving its planned discharge.
+func TestSurplusCmd_UpStepGatedOnAverage(t *testing.T) {
+	c := NewController(NewManager(), nil, nil, nil)
+	cfg := surplusTestConfig() // steps {0, 1380, 4140, 6900}
+	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
+	// Force the 1Φ day-lock so pickSurplusSteps returns the full step set
+	// every tick (otherwise the forecast-driven phase logic would vary it).
+	c.phaseLocked1P = map[string]bool{cfg.ID: true}
+	c.phaseLockedAt = map[string]time.Time{cfg.ID: now}
+
+	var surplus float64
+	c.SetSiteSurplusForEV(func() (float64, bool) { return surplus, true })
+	step := func(s float64) float64 {
+		surplus = s
+		got := c.computeSurplusCmd(now, cfg, 11040, 0)
+		now = now.Add(5 * time.Second)
+		return got
+	}
+
+	// Settle on a sustained 2000 W surplus → snaps to the 1380 W step.
+	var settled float64
+	for i := 0; i < 5; i++ {
+		settled = step(2000)
+	}
+	if settled <= 0 {
+		t.Fatalf("expected a positive settled step, got %v", settled)
+	}
+
+	// A SINGLE-tick spike to 5000 W must not ratchet the EV up — the 4-tick
+	// rolling average has barely moved, so the higher step isn't sustained.
+	spike := step(5000)
+	if spike > settled {
+		t.Errorf("one-tick surplus spike ratcheted EV up: settled=%v spike=%v "+
+			"(up-step must be gated on the rolling average)", settled, spike)
+	}
+
+	// Now SUSTAIN 5000 W: once the average clears the higher step, the EV
+	// ramps up.
+	var sustained float64
+	for i := 0; i < 5; i++ {
+		sustained = step(5000)
+	}
+	if sustained <= settled {
+		t.Errorf("sustained surplus rise did not step EV up: settled=%v sustained=%v",
+			settled, sustained)
+	}
+
+	// Down-steps are immediate (no-import promise): drop the surplus and the
+	// EV sheds to a lower step on the very next tick, no avg gating.
+	down := step(2000)
+	if down >= sustained {
+		t.Errorf("down-step was not immediate: sustained=%v down=%v "+
+			"(down must track instant surplus)", sustained, down)
+	}
+}
+
 // TestSurplusCmd_MinPauseHold verifies that even with the rolling avg
 // instantly above the resume threshold, the loadpoint stays paused for
 // at least surplusMinPauseHold after a pause edge. Without this guard


### PR DESCRIPTION
## Problem (diagnosed live on the production Pi)

`surplus_only` EV charging was oscillating violently — `ev_w` swinging **0–4.7 kW** every few seconds — and it dragged the **home battery** down with it: the battery under-delivered its planned discharge to **~4% of plan** (`dispatch slot under-delivery ratio=0.037`), its reactive PI stuck in wrong-direction integrator windup.

**Root cause:** the surplus_only setpoint *magnitude* tracked the **instant** surplus and snapped to an `allowed_steps_w` step every 5 s tick. Because `surplusW = −gridW + batW + evW` counts the home battery's current charge power as EV-available, any one-tick wobble (battery briefly backing off, cloud edge, load twitch) ratcheted the EV **up** a step it couldn't hold. It collapsed the next tick, and the repeated multi-kW load swing whipsawed the battery PI — a classic **EV ↔ battery limit cycle**, both loops fighting over the same PV surplus.

## Fix: asymmetric step smoothing

- **Down-steps** still track the **instant** surplus — the no-import promise is unchanged (the EV sheds load immediately when PV drops).
- **Up-steps** are now gated on the **rolling average** — the EV only climbs to a higher step when the *smoothed* surplus sustains it, so a transient spike can't ratchet it up.

This breaks the limit cycle: the EV ramps up only on a genuine surplus rise, and the home battery's PI stays stable. Pause/resume hysteresis is untouched. Adds a per-loadpoint last-step memory.

## Verification

- `TestSurplusCmd_UpStepGatedOnAverage` — transient spike is held at the sustained step, a sustained rise climbs, a drop sheds immediately (red before, green after).
- Full `internal/loadpoint` suite + `go vet` + `go test ./...` green, no regressions.
- **Deployed + verified live on the production Pi:** `ev_w` steadied from a 0–4.7 kW swing to a flat **3.57 kW**, `grid_w` → ~0, battery calm (`bat_w` 0, no whipsaw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)