### PR TITLE
fix(easee): pause+resume contactor on live 1Φ→3Φ phase flip

### DIFF
--- a/.changeset/easee-phase-flip-pause-resume.md
+++ b/.changeset/easee-phase-flip-pause-resume.md
@@ -1,0 +1,15 @@
+---
+"forty-two-watts": patch
+---
+
+**Easee driver: pause+resume the contactor on a live phase flip so 1Φ→3Φ
+actually takes effect.** The Easee only latches its phase count when a session
+(re)starts — writing `phaseMode=3` while a session is actively charging at 1Φ
+leaves the contactor on a single phase, so a loadpoint that crossed from 1Φ to
+3Φ (e.g. a schedule ramping to 11 kW) stayed throttled to ~3.7 kW. Field-
+confirmed: only a manual pause+resume flipped it.
+
+The driver now pauses charging before writing the new `phaseMode` on a real
+mid-session flip (`last_sent_phases` already set); the existing auto-resume
+(offer > 0 while paused) re-closes the contactor on the new phase count. The
+first command of a session is unaffected (no live contactor to recycle).

--- a/drivers/easee_cloud.lua
+++ b/drivers/easee_cloud.lua
@@ -614,6 +614,22 @@ function driver_command(action, power_w, cmd)
         -- the charger's.
         local phase_changed = false
         if last_sent_phases ~= requested_phases then
+            -- A live phase flip (notably 1Φ→3Φ) won't move the Easee
+            -- contactor while a session is charging: the phase count is only
+            -- latched when a session (re)starts. So on a real mid-session flip
+            -- pause first; the phaseMode write reconfigures, and the auto-
+            -- resume below (amps > 0 && paused_state) re-closes the contactor
+            -- on the new phase count. Operator-confirmed: a manual
+            -- pause+resume was the only thing that flipped 1Φ→3Φ. Skip on the
+            -- first command of a session (last_sent_phases == nil) — there's no
+            -- live contactor to recycle. 2026-05-30.
+            if last_sent_phases ~= nil then
+                if post_command("/commands/pause_charging") then
+                    paused_state = true
+                    host.log("info", "Easee: pause to flip phaseMode " ..
+                        tostring(last_sent_phases) .. "→" .. tostring(requested_phases))
+                end
+            end
             local pm_err = write_setting(charger_serial, {phaseMode = requested_phases})
             if pm_err == nil then
                 phases = requested_phases


### PR DESCRIPTION
The Easee latches its phase count only when a session (re)starts, so writing `phaseMode=3` mid-charge left the contactor on 1Φ and a schedule ramping to 11 kW stayed throttled to ~3.7 kW (field-confirmed: only a manual pause+resume flipped it). The driver now pauses before the phaseMode write on a real mid-session flip; the existing auto-resume re-closes on the new phase count. Lua parse-checked; deployed + verified live (EV now pulls 11 kW 3-phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)