### PR TITLE
fix(loadpoint): reactive per-phase fuse clamp for the EV charger

### DIFF
--- a/.changeset/per-phase-fuse-clamp.md
+++ b/.changeset/per-phase-fuse-clamp.md
@@ -1,0 +1,16 @@
+---
+"forty-two-watts": patch
+---
+
+fix(loadpoint): reactive per-phase fuse clamp for the EV charger
+
+The site-level fuse guard only protects the three-phase *total* — a single
+phase can still trip from house-load imbalance (a vacuum, kettle or oven on
+one leg) stacked on top of the EV's per-phase draw, which forced manual
+ramp-downs in the Tesla app. The loadpoint now reads the site meter's live
+per-phase currents (`meter_l1_a/l2_a/l3_a`) and reactively caps the EV's
+`max_amps_per_phase`: the worst phase drops by the full overage the instant
+it nears the breaker, and recovers at 1 A/tick once there is headroom
+(fast-down / slow-up servo, deadband below the limit). Pure, table-tested
+`nextFusePhaseCapA`; clamp disabled cleanly when per-phase telemetry is
+absent.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1089,6 +1089,29 @@ func main() {
 			}
 			return ctrl.FuseEVMaxW, true
 		})
+		// Wire the live per-phase site-meter current reader. The control
+		// package's fuse guard is site-TOTAL only (sum across phases);
+		// a single phase can still trip from house-load imbalance (e.g.
+		// a vacuum or oven on L1) stacked on top of the EV's per-phase
+		// draw. This reader feeds the loadpoint's reactive per-phase EV
+		// clamp (applyPerPhaseFuseClamp), which lowers max_amps_per_phase
+		// the instant the worst phase approaches the breaker. Reads the
+		// same meter_lN_a metrics the fuse_over_limit notifier uses.
+		lpController.SetPerPhaseMeterAmps(func() (float64, float64, float64, bool) {
+			cfgMu.RLock()
+			siteMeter := cfg.SiteMeterDriver()
+			cfgMu.RUnlock()
+			if siteMeter == "" {
+				return 0, 0, 0, false
+			}
+			l1, _, ok1 := tel.LatestMetric(siteMeter, "meter_l1_a")
+			l2, _, ok2 := tel.LatestMetric(siteMeter, "meter_l2_a")
+			l3, _, ok3 := tel.LatestMetric(siteMeter, "meter_l3_a")
+			if !ok1 && !ok2 && !ok3 {
+				return 0, 0, 0, false
+			}
+			return l1, l2, l3, true
+		})
 		// Wire the matched-vehicle reader for auto-wake. When the
 		// loadpoint is commanding power but the matched Tesla
 		// reports `Stopped` / `Disconnected` / `Complete`, the

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -416,6 +416,11 @@ func main() {
 	// pointer in sync without forcing a process restart.
 	var deps *api.Deps
 
+	// Forward-declared before the reload watcher so the reload callback
+	// can keep the loadpoint controller's per-phase EV fuse clamp in sync
+	// with hot-reloaded fuse params. Assigned later (loadpoint.NewController).
+	var lpController *loadpoint.Controller
+
 	// ---- Config hot-reload watcher ----
 	watcher, err := configreload.New(*configPath, cfgMu, cfg, ctrlMu, ctrl,
 		func(newCfg, oldCfg *config.Config) {
@@ -461,6 +466,20 @@ func main() {
 			// explicit 0 → disabled. See EffectiveSafetyMarginA.
 			ctrl.SiteFuseSafetyA = newCfg.Fuse.EffectiveSafetyMarginA()
 			ctrlMu.Unlock()
+
+			// Keep the loadpoint controller's per-phase EV fuse clamp in
+			// sync with hot-reloaded fuse params — previously startup-only,
+			// so an operator tuning max_amps / margin from the UI updated
+			// the control-package battery lever (above) but left the EV
+			// clamp on the stale startup value until restart. SetSiteFuse
+			// takes its own lock; call it outside ctrlMu.
+			if lpController != nil {
+				lpController.SetSiteFuse(loadpoint.SiteFuse{
+					MaxAmps:  newCfg.Fuse.MaxAmps,
+					Voltage:  newCfg.Fuse.Voltage,
+					PhaseCnt: newCfg.Fuse.Phases,
+				})
+			}
 
 			// Push the new pool totals into the planner so its next
 			// replan uses the right CapacityWh / MaxChargeW /
@@ -700,12 +719,6 @@ func main() {
 	loadSvc.Start(ctx)
 	defer loadSvc.Stop()
 	slog.Info("loadmodel started", "peak_w", loadPeakW, "quality", loadSvc.Model().Quality())
-
-	// Forward-declared so the MPC spec builder closure (set below) can
-	// push grid-deferred state into the runtime controller. The
-	// controller itself is constructed further down once its
-	// dependencies (planAdapter, telAdapter, registry) are wired.
-	var lpController *loadpoint.Controller
 
 	// ---- Start MPC planner (optional) ----
 	mpcSvc = buildMPC(cfg, st, tel, capacities)

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -45,6 +45,13 @@ type Controller struct {
 	// EV cooperatively share the site fuse.
 	fuseEVMax func() (float64, bool)
 
+	// perPhaseMeterAmps returns the live site-meter per-phase currents (L1,
+	// L2, L3). Wired from telemetry; nil disables the per-phase fuse clamp.
+	perPhaseMeterAmps func() (l1, l2, l3 float64, ok bool)
+	// fusePhaseCapA holds the per-loadpoint per-phase EV current cap carried
+	// between ticks by the reactive per-phase fuse clamp (tickOne goroutine).
+	fusePhaseCapA map[string]float64
+
 	// siteSurplusForEVW returns the live PV surplus that this loadpoint
 	// could legally claim under surplus_only — i.e. *what's left of PV
 	// after house load*, regardless of what the home battery is
@@ -374,6 +381,15 @@ func (c *Controller) SetFuseEVMax(f func() (float64, bool)) {
 	c.fuseEVMax = f
 }
 
+// SetPerPhaseMeterAmps wires the live site-meter per-phase current reader
+// used by the per-phase fuse clamp.
+func (c *Controller) SetPerPhaseMeterAmps(f func() (l1, l2, l3 float64, ok bool)) {
+	if c == nil {
+		return
+	}
+	c.perPhaseMeterAmps = f
+}
+
 // SetSiteSurplusForEV wires a per-tick "PV surplus available to the
 // EV" reader for the surplus_only clamp. The function returns total
 // W the EV could safely claim without forcing site import — typically
@@ -432,6 +448,80 @@ func (c *Controller) SetPeakRemainingSurplusW(f func() (float64, bool)) {
 // neither a sticky operator hold nor a stale MPC budget can drive
 // the fuse over limit, and the cooldown prevents fuse flap when a
 // transient overload clears momentarily.
+// ---- Per-phase fuse clamp (operator report 2026-05-30) ----
+//
+// The dispatch fuse guard protects the 3-phase TOTAL import; it is blind to
+// per-phase imbalance, so a phase carrying house load + the EV's full offer can
+// exceed the breaker while the site total looks fine (observed: L1 ~18 A on a
+// 16 A fuse). This reactive clamp lowers the EV's per-phase offer whenever the
+// worst measured phase nears the breaker.
+
+// fusePhaseMarginA is the per-phase amp headroom held below the breaker.
+const fusePhaseMarginA = 1.0
+
+// fusePhaseStepUpA is how fast the per-phase EV cap recovers per tick once a
+// phase has headroom — gentle enough not to re-trip, quick enough to ramp back.
+const fusePhaseStepUpA = 1.0
+
+// nextFusePhaseCapA reactively caps the EV's per-phase offer so the worst
+// measured site-meter phase stays at or below (fuseA - marginA). Reductions are
+// immediate (the full overage) to protect the breaker; ramp-up is gradual
+// (stepA/tick). prevCapA <= 0 means "uninitialised" -> start from the full fuse.
+// Pure for testability.
+func nextFusePhaseCapA(prevCapA, worstMeterA, fuseA, marginA, stepA float64) float64 {
+	if fuseA <= 0 {
+		return prevCapA
+	}
+	limit := fuseA - marginA
+	capA := prevCapA
+	if capA <= 0 {
+		capA = fuseA
+	}
+	switch {
+	case worstMeterA > limit:
+		capA -= worstMeterA - limit
+	case worstMeterA+stepA <= limit:
+		capA += stepA
+	}
+	if capA < 0 {
+		capA = 0
+	}
+	if capA > fuseA {
+		capA = fuseA
+	}
+	return capA
+}
+
+// applyPerPhaseFuseClamp lowers the EV's per-phase offer (cmd["max_amps_per_phase"])
+// when any live site-meter phase nears the breaker. The dispatch fuse guard
+// only protects the 3-phase TOTAL, so an imbalanced phase (house load + the
+// EV's full offer) can trip the breaker while the total looks fine. Reactive:
+// see nextFusePhaseCapA. Called just before the cmd is dispatched so it caps
+// whatever the paths above set. Operator report 2026-05-30.
+func (c *Controller) applyPerPhaseFuseClamp(lpCfg Config, cmd map[string]any) {
+	if c == nil || c.perPhaseMeterAmps == nil || c.site.MaxAmps <= 0 {
+		return
+	}
+	l1, l2, l3, ok := c.perPhaseMeterAmps()
+	if !ok {
+		return
+	}
+	worst := math.Max(l1, math.Max(l2, l3))
+	if c.fusePhaseCapA == nil {
+		c.fusePhaseCapA = map[string]float64{}
+	}
+	capA := nextFusePhaseCapA(c.fusePhaseCapA[lpCfg.ID], worst, c.site.MaxAmps, fusePhaseMarginA, fusePhaseStepUpA)
+	c.fusePhaseCapA[lpCfg.ID] = capA
+	if capA >= c.site.MaxAmps {
+		return
+	}
+	if existing, has := cmd["max_amps_per_phase"].(float64); !has || capA < existing {
+		cmd["max_amps_per_phase"] = capA
+		slog.Info("loadpoint per-phase fuse clamp",
+			"lp", lpCfg.ID, "worst_phase_a", worst, "ev_cap_a", capA, "fuse_a", c.site.MaxAmps)
+	}
+}
+
 func (c *Controller) applyFuseClampAndCooldown(now time.Time, lpCfg Config, wantW float64) float64 {
 	if c == nil {
 		return wantW
@@ -1211,6 +1301,7 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		}
 	}
 
+	c.applyPerPhaseFuseClamp(lpCfg, cmd)
 	payload, err := json.Marshal(cmd)
 	if err != nil {
 		return

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -68,6 +68,9 @@ type Controller struct {
 	// disables the per-phase fields in the cmd; the driver then
 	// falls back to its own configured defaults.
 	site SiteFuse
+	// siteMu guards site against concurrent SetSiteFuse hot-reloads
+	// (config-reload goroutine) vs the tick goroutine's reads.
+	siteMu sync.RWMutex
 
 	// holds is the manual-override registry: per-loadpoint power +
 	// phase parameters that win over the MPC-driven dispatch until
@@ -499,7 +502,11 @@ func nextFusePhaseCapA(prevCapA, worstMeterA, fuseA, marginA, stepA float64) flo
 // see nextFusePhaseCapA. Called just before the cmd is dispatched so it caps
 // whatever the paths above set. Operator report 2026-05-30.
 func (c *Controller) applyPerPhaseFuseClamp(lpCfg Config, cmd map[string]any) {
-	if c == nil || c.perPhaseMeterAmps == nil || c.site.MaxAmps <= 0 {
+	if c == nil || c.perPhaseMeterAmps == nil {
+		return
+	}
+	fuseA := c.siteFuse().MaxAmps
+	if fuseA <= 0 {
 		return
 	}
 	l1, l2, l3, ok := c.perPhaseMeterAmps()
@@ -510,15 +517,15 @@ func (c *Controller) applyPerPhaseFuseClamp(lpCfg Config, cmd map[string]any) {
 	if c.fusePhaseCapA == nil {
 		c.fusePhaseCapA = map[string]float64{}
 	}
-	capA := nextFusePhaseCapA(c.fusePhaseCapA[lpCfg.ID], worst, c.site.MaxAmps, fusePhaseMarginA, fusePhaseStepUpA)
+	capA := nextFusePhaseCapA(c.fusePhaseCapA[lpCfg.ID], worst, fuseA, fusePhaseMarginA, fusePhaseStepUpA)
 	c.fusePhaseCapA[lpCfg.ID] = capA
-	if capA >= c.site.MaxAmps {
+	if capA >= fuseA {
 		return
 	}
 	if existing, has := cmd["max_amps_per_phase"].(float64); !has || capA < existing {
 		cmd["max_amps_per_phase"] = capA
 		slog.Info("loadpoint per-phase fuse clamp",
-			"lp", lpCfg.ID, "worst_phase_a", worst, "ev_cap_a", capA, "fuse_a", c.site.MaxAmps)
+			"lp", lpCfg.ID, "worst_phase_a", worst, "ev_cap_a", capA, "fuse_a", fuseA)
 	}
 }
 
@@ -953,7 +960,17 @@ func (c *Controller) SetSiteFuse(f SiteFuse) {
 	if c == nil {
 		return
 	}
+	c.siteMu.Lock()
 	c.site = f
+	c.siteMu.Unlock()
+}
+
+// siteFuse returns a snapshot of the site fuse under read lock, safe
+// against a concurrent SetSiteFuse hot-reload.
+func (c *Controller) siteFuse() SiteFuse {
+	c.siteMu.RLock()
+	defer c.siteMu.RUnlock()
+	return c.site
 }
 
 // SetManualHold pins the given loadpoint to a fixed dispatch payload
@@ -1147,23 +1164,24 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		case lpCfg.MinPhaseHoldS > 0:
 			cmd["min_phase_hold_s"] = lpCfg.MinPhaseHoldS
 		}
+		site := c.siteFuse()
 		switch {
 		case hold.Voltage > 0:
 			cmd["voltage"] = hold.Voltage
-		case c.site.Voltage > 0:
-			cmd["voltage"] = c.site.Voltage
+		case site.Voltage > 0:
+			cmd["voltage"] = site.Voltage
 		}
 		switch {
 		case hold.MaxAmpsPerPhase > 0:
 			cmd["max_amps_per_phase"] = hold.MaxAmpsPerPhase
-		case c.site.MaxAmps > 0:
-			cmd["max_amps_per_phase"] = c.site.MaxAmps
+		case site.MaxAmps > 0:
+			cmd["max_amps_per_phase"] = site.MaxAmps
 		}
 		switch {
 		case hold.SitePhases > 0:
 			cmd["site_phases"] = hold.SitePhases
-		case c.site.MaxAmps > 0:
-			cmd["site_phases"] = c.site.Phases()
+		case site.MaxAmps > 0:
+			cmd["site_phases"] = site.Phases()
 		}
 	} else {
 		cmdW, planReady := c.computeCommand(now, lpCfg, sample.PowerW)
@@ -1292,11 +1310,12 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		// ceiling using the actual mains voltage instead of hard-coding
 		// 230 V × 16 A. Drivers that don't support phase switching can
 		// safely ignore these fields.
-		if c.site.MaxAmps > 0 {
-			cmd["max_amps_per_phase"] = c.site.MaxAmps
-			cmd["site_phases"] = c.site.Phases()
+		site := c.siteFuse()
+		if site.MaxAmps > 0 {
+			cmd["max_amps_per_phase"] = site.MaxAmps
+			cmd["site_phases"] = site.Phases()
 		}
-		if v := c.site.Voltage; v > 0 {
+		if v := site.Voltage; v > 0 {
 			cmd["voltage"] = v
 		}
 	}

--- a/go/internal/loadpoint/controller_fusephase_test.go
+++ b/go/internal/loadpoint/controller_fusephase_test.go
@@ -1,18 +1,60 @@
 package loadpoint
+
 import "testing"
-func TestNextFusePhaseCapA(t *testing.T){
-	const fuse,margin,step=16.0,1.0,1.0 // limit = 15
-	cases:=[]struct{name string;prev,worst,want float64}{
-		{"over-limit drops by overage",16,18,13},  // 16-(18-15)
-		{"deadband holds",13,15,13},
-		{"headroom ramps up",13,13,14},            // 13+1=14<=15
-		{"never exceeds fuse",16,10,16},
-		{"severe house overage floors at 0",2,20,0},
-		{"uninit starts at fuse",0,10,16},          // 16, 10+1<=15 -> +1 -> 17 -> clamp 16
+
+func TestNextFusePhaseCapA(t *testing.T) {
+	const fuse, margin, step = 16.0, 1.0, 1.0 // limit = 15
+	cases := []struct {
+		name              string
+		prev, worst, want float64
+	}{
+		{"over-limit drops by overage", 16, 18, 13}, // 16-(18-15)
+		{"deadband holds", 13, 15, 13},
+		{"headroom ramps up", 13, 13, 14}, // 13+1=14<=15
+		{"never exceeds fuse", 16, 10, 16},
+		{"severe house overage floors at 0", 2, 20, 0},
+		{"uninit starts at fuse", 0, 10, 16}, // 16, 10+1<=15 -> +1 -> 17 -> clamp 16
 	}
-	for _,tc:=range cases{
-		if got:=nextFusePhaseCapA(tc.prev,tc.worst,fuse,margin,step);got!=tc.want{
-			t.Errorf("%s: nextFusePhaseCapA(prev=%v,worst=%v)=%v want %v",tc.name,tc.prev,tc.worst,got,tc.want)
+	for _, tc := range cases {
+		if got := nextFusePhaseCapA(tc.prev, tc.worst, fuse, margin, step); got != tc.want {
+			t.Errorf("%s: nextFusePhaseCapA(prev=%v,worst=%v)=%v want %v", tc.name, tc.prev, tc.worst, got, tc.want)
 		}
+	}
+}
+
+// TestSiteFuseHotReloadAppliesToPerPhaseClamp guards the fix where the
+// loadpoint's per-phase EV clamp ignored hot-reloaded fuse params (it read
+// the startup-only c.site). After SetSiteFuse the clamp must use the new
+// fuse: a worst phase that's safe at fuse=16 becomes a clamp at fuse=11.
+func TestSiteFuseHotReloadAppliesToPerPhaseClamp(t *testing.T) {
+	c := &Controller{}
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	if got := c.siteFuse().MaxAmps; got != 16 {
+		t.Fatalf("siteFuse MaxAmps = %v, want 16", got)
+	}
+	c.SetPerPhaseMeterAmps(func() (float64, float64, float64, bool) { return 13, 5, 5, true })
+
+	// fuse 16 (limit 15): worst 13 A is safe → no clamp.
+	cmd := map[string]any{"max_amps_per_phase": 16.0}
+	c.applyPerPhaseFuseClamp(Config{ID: "lp"}, cmd)
+	if cmd["max_amps_per_phase"].(float64) != 16.0 {
+		t.Fatalf("fuse 16, worst 13 A: expected no clamp, got %v", cmd["max_amps_per_phase"])
+	}
+
+	// Hot-reload the fuse down to 11 (limit 10): worst 13 A is now over.
+	c.SetSiteFuse(SiteFuse{MaxAmps: 11, Voltage: 230, PhaseCnt: 3})
+	if got := c.siteFuse().MaxAmps; got != 11 {
+		t.Fatalf("after hot-reload siteFuse MaxAmps = %v, want 11", got)
+	}
+	// The servo ramps the cap down across ticks; within a couple it must
+	// clamp the EV below the new fuse.
+	var capped float64
+	for i := 0; i < 3; i++ {
+		cmd = map[string]any{"max_amps_per_phase": 11.0}
+		c.applyPerPhaseFuseClamp(Config{ID: "lp"}, cmd)
+		capped = cmd["max_amps_per_phase"].(float64)
+	}
+	if capped >= 11.0 {
+		t.Fatalf("hot-reloaded fuse 11, worst 13 A: expected EV cap < 11, got %v", capped)
 	}
 }

--- a/go/internal/loadpoint/controller_fusephase_test.go
+++ b/go/internal/loadpoint/controller_fusephase_test.go
@@ -1,0 +1,18 @@
+package loadpoint
+import "testing"
+func TestNextFusePhaseCapA(t *testing.T){
+	const fuse,margin,step=16.0,1.0,1.0 // limit = 15
+	cases:=[]struct{name string;prev,worst,want float64}{
+		{"over-limit drops by overage",16,18,13},  // 16-(18-15)
+		{"deadband holds",13,15,13},
+		{"headroom ramps up",13,13,14},            // 13+1=14<=15
+		{"never exceeds fuse",16,10,16},
+		{"severe house overage floors at 0",2,20,0},
+		{"uninit starts at fuse",0,10,16},          // 16, 10+1<=15 -> +1 -> 17 -> clamp 16
+	}
+	for _,tc:=range cases{
+		if got:=nextFusePhaseCapA(tc.prev,tc.worst,fuse,margin,step);got!=tc.want{
+			t.Errorf("%s: nextFusePhaseCapA(prev=%v,worst=%v)=%v want %v",tc.name,tc.prev,tc.worst,got,tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The control-package fuse guard (`applyFuseGuard` / `forceFuseDischarge`) protects the **three-phase total** import. A single phase can still trip the breaker from house-load imbalance — a vacuum, kettle or oven on one leg — stacked on top of the EV's per-phase draw, while the site total looks fine. Observed live: **L1 ~18 A on a 16 A fuse**, forcing manual ramp-downs in the Tesla app.

The existing per-phase **battery** lever (`perPhaseOverageW` → `forceFuseDischarge`) already discharges the home battery to relieve an over-current phase — but only while the battery has SoC headroom. When the battery is empty/maxed there was **no per-phase lever on the EV**, so the breaker stayed over until a human intervened.

## Fix

The loadpoint now reads the site meter's live per-phase currents (`meter_l1_a/l2_a/l3_a`) and reactively caps the EV's `max_amps_per_phase`:

- **Fast-down**: the worst phase drops the cap by the full overage the instant it nears the breaker (`fuseA − marginA`, margin 1 A).
- **Slow-up**: recovers 1 A/tick once there is headroom, with a deadband below the limit — no re-trip oscillation.
- Pure, table-tested `nextFusePhaseCapA`; clamp **no-ops cleanly** when per-phase telemetry is absent.
- Import-only (`math.Max`, no `abs`): the EV only adds import current, so it ignores export-side phases that lowering the EV can't help — and coordinates naturally with the abs-based battery lever via the shared meter reading.

Net behaviour: the **battery absorbs a single-phase spike first** (EV stays fast); the EV clamp only engages if the phase *stays* over (battery empty/maxed) — exactly the "battery does the work, EV is the backstop" intent.

## Test

`TestNextFusePhaseCapA` — over-limit drops by overage, deadband holds, ramps up 1 A/tick, never exceeds fuse, floors at 0 on severe overage, uninitialised starts at fuse. Full `go test ./...` + `go vet` green incl. e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)