### PR TITLE
docs(deploy): Mac mini + generic Linux server support

### DIFF
--- a/.changeset/deploy-mac-linux.md
+++ b/.changeset/deploy-mac-linux.md
@@ -1,0 +1,26 @@
+---
+"forty-two-watts": minor
+---
+
+**Document and support running off a Mac mini or a generic Linux server.**
+The Docker stack already ran on any Linux box via `docker-compose.yml`,
+but that file uses `network_mode: host` — a Linux-kernel feature that, on
+macOS, binds to the Docker Desktop VM rather than the Mac, leaving the
+dashboard unreachable and silently breaking device discovery.
+
+- **`docker-compose.macos.yml`** — a self-contained macOS compose file
+  that swaps host networking for bridge networking with published ports
+  (`8080`, `1883`). The app reaches the embedded broker by service name
+  (`mosquitto:1883`), and the `ftw-updater` sidecar is wired to the
+  macOS file so the in-app Update/Restart buttons recreate the right
+  containers.
+- **`scripts/install-macos.sh`** — one-shot macOS installer: verifies
+  Docker Desktop is up, lays out `~/forty-two-watts`, fetches the macOS
+  compose file + broker config, and brings the stack up. The Linux
+  installer now bails early with a pointer when run on macOS.
+- **`docs/deploy-platforms.md`** — new guide covering both the generic
+  Linux server path (Ubuntu/NUC/VM: install, `ufw`, device-identity
+  caveats) and the Mac mini path (Docker Desktop networking caveats:
+  point MQTT at `mosquitto`, use explicit driver IPs since mDNS/broadcast
+  don't cross the VM boundary, keep-it-running tips). `docker-compose.yml`
+  and `operations.md` now cross-reference it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ charge another.
 - `docs/ml-models.md` — PV + load + price twins, MPC inputs (NEW)
 - `docs/api.md` — HTTP endpoint reference (NEW)
 - `docs/operations.md` — deploy, backup, upgrade, troubleshooting (NEW)
+- `docs/deploy-platforms.md` — running on a Mac mini or generic Linux server (Ubuntu/NUC/VM) via Docker (NEW)
 - `docs/testing.md` — test strategy, sims, e2e recipe (NEW)
 - `docs/configuration.md` — YAML schema reference
 - `docs/battery-models.md` — ARX(1), RLS, cascade, self-tune

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,8 @@ light theme can flip it cleanly.
 - `docs/ml-models.md` — PV + load + price twins, MPC inputs (NEW)
 - `docs/api.md` — HTTP endpoint reference (NEW)
 - `docs/operations.md` — deploy, backup, upgrade, troubleshooting (NEW)
+- `docs/deploy-platforms.md` — running on a Mac mini or generic Linux server (Ubuntu/NUC/VM) via Docker (NEW)
+- `docs/rpi-image.md` — turnkey Raspberry Pi SD-card image
 - `docs/self-update.md` — in-app update flow + ftw-updater sidecar architecture
 - `docs/nova-integration.md` — opt-in federation to Sourceful Nova Core (MQTT + ES256 JWT, clean schema + legacy adapter)
 - `docs/testing.md` — test strategy, sims, e2e recipe (NEW)

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,121 @@
+# forty-two-watts — macOS (Docker Desktop) deployment
+#
+# Use this file INSTEAD of docker-compose.yml on a Mac (e.g. a Mac mini
+# running as an always-on home server). It is self-contained — do not
+# layer it on top of docker-compose.yml with `-f`.
+#
+#   Start:    docker compose -f docker-compose.macos.yml up -d
+#   Logs:     docker compose -f docker-compose.macos.yml logs -f
+#   Upgrade:  docker compose -f docker-compose.macos.yml pull && \
+#             docker compose -f docker-compose.macos.yml up -d
+#   Stop:     docker compose -f docker-compose.macos.yml down
+#
+# WHY A SEPARATE FILE.  The Linux compose file uses `network_mode: host`,
+# which on macOS does NOT bind to the Mac's network — Docker Desktop runs
+# every container inside a Linux VM, so "host" means the VM, not macOS.
+# The dashboard would be unreachable and mDNS/broadcast discovery would
+# fail silently. This file uses bridge networking with published ports
+# instead, which is the only thing that works on Docker Desktop.
+#
+# NETWORKING CAVEATS ON macOS (read docs/deploy-platforms.md for detail):
+#   - The app reaches the embedded broker by SERVICE NAME, not localhost.
+#     In config.yaml set the MQTT host to `mosquitto` (port 1883), NOT
+#     `localhost` / `127.0.0.1`. There is no host networking to make
+#     localhost mean "the broker".
+#   - mDNS (`zap.local`) and UDP broadcast device discovery do NOT cross
+#     the Docker Desktop VM boundary. Configure every driver with an
+#     EXPLICIT IP address. Outbound unicast TCP (Modbus TCP to a known
+#     inverter/meter IP) works fine through Docker Desktop's NAT.
+#   - LAN devices that push to the broker (e.g. a Pixii PowerShaper)
+#     reach it at <mac-ip>:1883 because port 1883 is published below.
+#   - ARP-based device identity (`mac:<addr>`) won't resolve across the
+#     VM boundary, so device_id falls back to `make:serial` (preferred,
+#     set by the driver) or `ep:<endpoint>`. See docs/device-identity.md.
+#
+# PERSISTENT STATE.  config.yaml, state.db, battery models and the cold/
+# Parquet archive live in ./data and survive image upgrades. Unlike the
+# Linux file, you do NOT need to chown ./data to uid 100:101 — Docker
+# Desktop's file sharing (VirtioFS/gRPC-FUSE) maps host ownership
+# transparently, so the container's ftw user can always write to it.
+# Just `mkdir -p ./data` before the first `up`.
+
+services:
+  forty-two-watts:
+    # Tag is variable so the ftw-updater sidecar can pin to a specific
+    # release on `update`. Manual `up -d` (no env set) → :latest.
+    image: ghcr.io/frahlg/forty-two-watts:${FTW_IMAGE_TAG:-latest}
+    container_name: forty-two-watts
+    restart: unless-stopped
+
+    environment:
+      # In-app self-update feature (version banner + Update/Restart
+      # buttons). Wired to the ftw-updater sidecar below.
+      FTW_SELFUPDATE_ENABLED: "1"
+
+    # Bridge networking + a published port. The dashboard is reachable at
+    # http://localhost:8080/ on the Mac itself and http://<mac-ip>:8080/
+    # from other devices on the LAN. (Host networking is intentionally
+    # NOT used — see the header.)
+    ports:
+      - "8080:8080"
+
+    volumes:
+      - ./data:/app/data
+      # Shared tmpfs with the updater — the main app reads state.json from
+      # here to render update progress in the UI; it never writes to it.
+      - update-ipc:/run/ftw-update
+
+  ftw-updater:
+    image: ghcr.io/frahlg/forty-two-watts-updater:latest
+    container_name: ftw-updater
+    restart: unless-stopped
+
+    # No outbound network — the sidecar reaches the Docker Desktop daemon
+    # over its Unix socket and the main app over a socket in update-ipc.
+    network_mode: none
+
+    environment:
+      # Point the sidecar's internal `docker compose -f <path>` at THIS
+      # file (not docker-compose.yml). The host daemon interprets the
+      # bind paths, so it must be the real macOS path the user launched
+      # compose from.
+      FTW_UPDATER_COMPOSE: ${PWD:-.}/docker-compose.macos.yml
+      # Keep the project name stable so the sidecar recreates the real
+      # containers instead of a parallel set. Defaults to the directory
+      # name compose derives; pin it to match your manual invocation.
+      COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:-forty-two-watts}
+
+    volumes:
+      # The Docker Desktop socket — the one privileged resource the
+      # sidecar touches, so it can `compose pull` + recreate the main
+      # service. Docker Desktop exposes this at the usual path.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Bind the project dir at its host path, read-only, for the same
+      # reason as the Linux file: the daemon resolves `./data` relative
+      # to this path. ${PWD} is the macOS dir at `up` time.
+      - ${PWD:-.}:${PWD:-.}:ro
+      - update-ipc:/run/ftw-update
+
+  # ---------------------------------------------------------------------
+  # MQTT broker (Eclipse Mosquitto)
+  #
+  # The main app reaches this broker at `mosquitto:1883` over the compose
+  # project network (NOT localhost — there is no host networking on
+  # macOS). LAN devices reach it at <mac-ip>:1883 via the published port.
+  # Remove this service if you dial out to a broker elsewhere on the LAN.
+  # ---------------------------------------------------------------------
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: forty-two-watts-mosquitto
+    restart: unless-stopped
+
+    ports:
+      - "1883:1883"
+
+    volumes:
+      - ./mosquitto/config:/mosquitto/config:ro
+      - mosquitto-data:/mosquitto/data
+
+volumes:
+  update-ipc:
+  mosquitto-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# forty-two-watts — Home Energy Management System
+# forty-two-watts — Home Energy Management System (Linux)
 #
 # Pulls the pre-built multi-arch image (linux/amd64 + linux/arm64) from
 # GitHub Container Registry. No local build needed.
@@ -7,6 +7,13 @@
 #   Logs:     docker compose logs -f
 #   Upgrade:  docker compose pull && docker compose up -d
 #   Stop:     docker compose down
+#
+# PLATFORM:  This file uses `network_mode: host`, a Linux-kernel feature.
+# It is the right file for a Raspberry Pi, an Ubuntu/Debian server, a
+# NUC, or a Linux VM. On macOS (e.g. a Mac mini) host networking binds to
+# the Docker Desktop VM, not to the Mac, so the dashboard is unreachable
+# and discovery breaks silently — use docker-compose.macos.yml instead.
+# See docs/deploy-platforms.md for the full Mac mini + generic-Linux guide.
 #
 # Persistent state — config.yaml, state.db, battery models, cold/
 # Parquet files — lives in ./data and survives image upgrades. The

--- a/docs/deploy-platforms.md
+++ b/docs/deploy-platforms.md
@@ -1,0 +1,256 @@
+# Deploying on a Mac mini or a generic Linux server
+
+The fastest supported path to a running forty-two-watts is the Raspberry
+Pi SD-card image ([rpi-image.md](rpi-image.md)). But the same multi-arch
+Docker images run anywhere Docker does — this guide covers the two most
+common "I already have a box" cases:
+
+- a **Mac mini** (or any Mac) running as an always-on home server, and
+- a **generic Linux server** — Ubuntu, Debian, an Intel NUC, a VM, etc.
+
+Both pull the exact same pre-built images from GHCR
+(`ghcr.io/frahlg/forty-two-watts` + `…-updater`), published for
+`linux/amd64` and `linux/arm64`. No local build step.
+
+> **Which file do I use?**
+>
+> | Platform | Compose file | Networking |
+> |---|---|---|
+> | Linux (Pi, Ubuntu, NUC, VM) | `docker-compose.yml` | `network_mode: host` |
+> | macOS (Mac mini, etc.) | `docker-compose.macos.yml` | bridge + published ports |
+>
+> They are **alternatives**, not layers — pick one, don't combine them
+> with `-f`. The split exists because `network_mode: host` is a
+> Linux-kernel feature; on macOS it binds to the Docker Desktop VM, not
+> to the Mac, so the dashboard would be unreachable. See
+> [§ macOS networking](#macos-networking-what-changes-and-why) below.
+
+---
+
+## Generic Linux server (Ubuntu / Debian / NUC / VM)
+
+This is the same flow as the Pi, minus the SD-card image. If you're on a
+Debian-family distro the one-shot installer does everything:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install.sh | bash
+```
+
+It installs Docker Engine + the compose plugin, adds you to the `docker`
+group, creates `~/forty-two-watts/data` with the right ownership, fetches
+`docker-compose.yml`, and brings the stack up. Override the install
+location with `FTW_DIR=/srv/ftw`, the image with `FTW_IMAGE=…`. See
+[`scripts/install.sh`](../scripts/install.sh) for every env knob.
+
+### Manual install (any Linux)
+
+If you'd rather not pipe a script to bash, or you're on a non-Debian
+distro (Fedora, Arch, openSUSE), do it by hand:
+
+```bash
+# 1. Docker Engine + compose plugin — use your distro's instructions:
+#    https://docs.docker.com/engine/install/
+
+# 2. Lay out the deploy directory.
+mkdir -p ~/forty-two-watts/data
+cd ~/forty-two-watts
+
+# 3. The container runs as uid 100 / gid 101 (the alpine `ftw` user).
+#    A host bind-mount must be owned by those ids or SQLite can't create
+#    state.db inside it.
+sudo chown -R 100:101 ./data
+
+# 4. Grab the compose file + broker config.
+curl -fsSLO https://raw.githubusercontent.com/frahlg/forty-two-watts/master/docker-compose.yml
+mkdir -p mosquitto/config
+curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/mosquitto/config/mosquitto.conf \
+  -o mosquitto/config/mosquitto.conf
+
+# 5. Pull + start.
+docker compose pull
+docker compose up -d
+```
+
+Open `http://<server-ip>:8080/` from another device on the LAN, or
+`http://localhost:8080/` on the box itself. First run drops you at the
+`/setup` wizard.
+
+### Linux-specific notes
+
+- **Firewall.** Ubuntu Server commonly ships `ufw`. The dashboard
+  (`8080`) and the broker (`1883`) need to be reachable from the LAN:
+
+  ```bash
+  sudo ufw allow from 192.168.0.0/16 to any port 8080 proto tcp
+  sudo ufw allow from 192.168.0.0/16 to any port 1883 proto tcp
+  ```
+
+  (Adjust the subnet to your LAN. With `network_mode: host` there is no
+  Docker-published port for `ufw` to special-case — the process listens
+  directly on the host, so a normal `ufw` rule is all you need.)
+
+- **Same L2 as your hardware = stable device identity.** With host
+  networking the container shares the host's ARP table, so TCP devices
+  on the same subnet resolve to a `mac:<addr>` `device_id` and battery
+  models survive IP changes. A server on a *different* VLAN from your
+  inverters falls back to `make:serial` (preferred, set by the driver)
+  or `ep:<endpoint>`. See [device-identity.md](device-identity.md).
+
+- **In-app updates work out of the box.** The `ftw-updater` sidecar in
+  `docker-compose.yml` drives the web UI's Update / Restart buttons. See
+  [self-update.md](self-update.md).
+
+- **Run it as a boot service?** Docker's `restart: unless-stopped`
+  already survives reboots once `docker.service` is enabled
+  (`sudo systemctl enable docker`). If you'd rather run the **native
+  binary** under systemd instead of Docker, that's the
+  [operations.md](operations.md) path (`make build-amd64` + the
+  [`deploy/forty-two-watts.service`](../deploy/forty-two-watts.service)
+  unit).
+
+---
+
+## Mac mini (Docker Desktop)
+
+A Mac mini makes a tidy always-on home server. The catch is networking:
+Docker Desktop runs every container inside a hidden Linux VM, so the
+Linux `network_mode: host` trick doesn't reach macOS. Use the dedicated
+[`docker-compose.macos.yml`](../docker-compose.macos.yml) — it swaps host
+networking for bridge networking with published ports, which is the only
+thing that works on Docker Desktop.
+
+### Quick install
+
+With Docker Desktop installed and running, the one-shot installer does
+the rest (lay out the directory, fetch the macOS compose file, start the
+stack):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install-macos.sh | bash
+```
+
+Prefer to do it by hand? The manual steps are below.
+
+### Setup
+
+```bash
+# 1. Install Docker Desktop for Mac (Apple Silicon or Intel — the images
+#    are multi-arch, so either works):
+#    https://docs.docker.com/desktop/install/mac-install/
+#    Make sure Docker Desktop is running before continuing.
+
+# 2. Lay out the deploy directory.
+mkdir -p ~/forty-two-watts/data
+cd ~/forty-two-watts
+
+# NOTE: no `chown 100:101` here. Docker Desktop's file sharing maps host
+# ownership transparently, so the container's ftw user can always write
+# to ./data. (Running that chown on macOS would do nothing useful.)
+
+# 3. Grab the macOS compose file + broker config.
+curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/docker-compose.macos.yml \
+  -o docker-compose.macos.yml
+mkdir -p mosquitto/config
+curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/mosquitto/config/mosquitto.conf \
+  -o mosquitto/config/mosquitto.conf
+
+# 4. Pull + start (note the -f on every command).
+docker compose -f docker-compose.macos.yml pull
+docker compose -f docker-compose.macos.yml up -d
+```
+
+Open `http://localhost:8080/` on the Mac, or `http://<mac-ip>:8080/`
+from another device. First run drops you at the `/setup` wizard.
+
+> Tip: typing `-f docker-compose.macos.yml` on every command gets old.
+> Either `export COMPOSE_FILE=docker-compose.macos.yml` in your shell, or
+> rename the file to `compose.yaml` (Docker's default-discovered name) so
+> plain `docker compose up -d` finds it.
+
+### macOS networking: what changes, and why
+
+Everything below follows from one fact: **containers run in the Docker
+Desktop Linux VM, not directly on macOS.** That VM sits behind a NAT.
+
+| Concern | On Linux (host net) | On macOS (this file) |
+|---|---|---|
+| Dashboard reachable | host binds `:8080` directly | published `8080:8080` |
+| Reach embedded broker | `localhost:1883` | **`mosquitto:1883`** (service name) |
+| LAN device → broker | `<host-ip>:1883` | `<mac-ip>:1883` (published) |
+| Modbus TCP to a known IP | ✅ direct | ✅ via Docker Desktop NAT |
+| mDNS (`zap.local`) | ✅ | ❌ doesn't cross the VM |
+| UDP broadcast discovery | ✅ | ❌ doesn't cross the VM |
+| ARP `mac:<addr>` identity | ✅ shared ARP table | ❌ → `make:serial` / `ep:` |
+
+Two things you **must** account for in `config.yaml`:
+
+1. **Point MQTT at `mosquitto`, not `localhost`.** Without host
+   networking, `localhost` inside the container is the container itself.
+   The embedded broker is reachable by its compose service name:
+
+   ```yaml
+   # config.yaml — MQTT-based drivers on macOS
+   mqtt:
+     host: mosquitto      # NOT localhost / 127.0.0.1
+     port: 1883
+   ```
+
+   A broker elsewhere on the LAN is reachable by its IP as normal
+   (outbound unicast works through the NAT).
+
+2. **Give every driver an explicit IP — no auto-discovery.** mDNS names
+   like `zap.local` and broadcast-based discovery don't cross the VM
+   boundary. A Sourceful Zap, for example, must be configured with its
+   numeric address (`192.168.1.x`) rather than `zap.local`. Modbus TCP
+   to a known inverter/meter IP works fine — that's plain outbound
+   unicast.
+
+If a device shows up with an `ep:<endpoint>` `device_id` instead of
+`make:serial`, that's expected on macOS (the ARP path is unavailable) and
+harmless as long as the driver sets make + serial. See
+[device-identity.md](device-identity.md).
+
+### In-app updates on macOS
+
+The `ftw-updater` sidecar is wired into `docker-compose.macos.yml` and
+works on Docker Desktop — its `FTW_UPDATER_COMPOSE` points at the macOS
+file so the Update / Restart buttons recreate the right containers. If
+you'd rather upgrade by hand, the manual path is:
+
+```bash
+cd ~/forty-two-watts
+docker compose -f docker-compose.macos.yml pull
+docker compose -f docker-compose.macos.yml up -d
+```
+
+### Keeping it running
+
+Docker Desktop does not auto-start at login by default. To make the Mac
+mini a true appliance:
+
+- Docker Desktop → **Settings → General → "Start Docker Desktop when you
+  sign in"**, and disable **"Open Docker Dashboard at startup"**.
+- Enable auto-login for the server account (System Settings → Users &
+  Groups → Automatically log in as …) so a reboot brings Docker — and
+  therefore the `restart: unless-stopped` stack — back up unattended.
+- Prevent sleep: System Settings → **Energy** → "Prevent automatic
+  sleeping when the display is off", or `sudo pmset -a sleep 0`.
+
+---
+
+## Backup, restore, troubleshooting
+
+These are platform-independent — the state lives in `./data` regardless
+of OS. [operations.md § 7](operations.md#7-backup--restore) covers backup
+and restore; [§ 8](operations.md#8-troubleshooting-runbook) is the
+troubleshooting runbook. The only Docker-specific wrinkle: stop the stack
+with `docker compose … down` (add `-f docker-compose.macos.yml` on a Mac)
+before snapshotting `./data` for a consistent SQLite copy.
+
+## See also
+
+- [rpi-image.md](rpi-image.md) — the turnkey Raspberry Pi SD-card image
+- [operations.md](operations.md) — native-binary + systemd deploy, backup, runbook
+- [self-update.md](self-update.md) — the in-app Update/Restart mechanism
+- [device-identity.md](device-identity.md) — how `device_id` is resolved
+- [configuration.md](configuration.md) — full `config.yaml` schema

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,13 @@
 
 The operator's guide. From "I have a fresh Raspberry Pi" to "I can debug a hung driver at 3am".
 
+> This doc covers the **native-binary + systemd** deploy and the
+> platform-independent runbook (logs, backup, troubleshooting). If you'd
+> rather run the **Docker** stack — the default for most installs — see
+> [deploy-platforms.md](deploy-platforms.md) for the Mac mini and
+> generic-Linux (Ubuntu/NUC/VM) guides, or [rpi-image.md](rpi-image.md)
+> for the turnkey Raspberry Pi SD-card image.
+
 Sign convention reminder: throughout this doc, `grid_w > 0` means **import** (buying from grid), `grid_w < 0` means **export** (selling). Battery `bat_w > 0` means **charging** (load, draws from grid), `bat_w < 0` means **discharging** (source, reduces import). PV `pv_w` is always ≤ 0 (generation pushes energy into the site). See [site-convention.md](site-convention.md) for the full convention.
 
 ## 1. Build + cross-compile

--- a/scripts/install-macos.sh
+++ b/scripts/install-macos.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# forty-two-watts one-shot installer for macOS (Docker Desktop).
+#
+# The Linux installer (scripts/install.sh) can't run here — macOS has no
+# apt-get, no host networking, and Docker Desktop is a GUI app that can't
+# be installed unattended from a shell. This script does the rest: it
+# verifies Docker Desktop is up, lays out the deploy directory, fetches
+# the macOS compose file + broker config, and brings the stack up.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/scripts/install-macos.sh | bash
+#
+# What this does:
+#   1. Verifies Docker Desktop is installed and the daemon is running.
+#   2. Creates ~/forty-two-watts/data (no chown needed — Docker Desktop
+#      maps host ownership transparently).
+#   3. Fetches docker-compose.macos.yml + mosquitto.conf from the repo.
+#   4. Pulls the multi-arch images from GHCR and starts the stack.
+#
+# Safe to re-run — every step is idempotent, and `docker compose up -d`
+# picks up changes without destroying the ./data state.
+#
+# Override via env vars (optional):
+#   FTW_DIR=/path/to/dir   # install location (default: ~/forty-two-watts)
+#   FTW_BRANCH=some-branch # pull files from a non-master branch
+
+set -euo pipefail
+
+# ---- Config (override via env) ----
+REPO="frahlg/forty-two-watts"
+BRANCH="${FTW_BRANCH:-master}"
+INSTALL_DIR="${FTW_DIR:-$HOME/forty-two-watts}"
+RAW="https://raw.githubusercontent.com/${REPO}/${BRANCH}"
+COMPOSE_FILE="docker-compose.macos.yml"
+
+# Banner
+cat <<'BANNER'
+
+  ┌─────────────────────────────────────────────────┐
+  │     forty-two-watts installer (macOS)           │
+  │     Home Energy Management System               │
+  └─────────────────────────────────────────────────┘
+
+BANNER
+
+# ---- Platform guard ----
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "ERROR: this script is for macOS. On Linux, use scripts/install.sh." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: 'curl' is required (it ships with macOS — odd that it's missing)." >&2
+  exit 1
+fi
+
+# ---- 1. Docker Desktop ----
+echo "==[1/4]== Checking Docker Desktop"
+if ! command -v docker >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+    Docker is not installed.
+
+    Install Docker Desktop for Mac (Apple Silicon or Intel — the images
+    are multi-arch, so either works), start it, then re-run this script:
+
+        https://docs.docker.com/desktop/install/mac-install/
+
+    Or via Homebrew:  brew install --cask docker
+EOF
+  exit 1
+fi
+
+# `docker info` fails fast if the daemon (the Docker Desktop VM) isn't up.
+if ! docker info >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+    Docker is installed but the daemon isn't running.
+
+    Open Docker Desktop (from Applications or Spotlight), wait for the
+    whale icon in the menu bar to stop animating, then re-run this script.
+EOF
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: the 'docker compose' plugin is missing. Update Docker Desktop." >&2
+  exit 1
+fi
+echo "    Docker Desktop is running."
+
+# ---- 2. Install directory ----
+echo ""
+echo "==[2/4]== Preparing install directory: $INSTALL_DIR"
+# No chown to uid 100:101 here, unlike the Linux installer: Docker
+# Desktop's file sharing maps host ownership transparently, so the
+# container's ftw user can always write to ./data.
+mkdir -p "$INSTALL_DIR/data" "$INSTALL_DIR/mosquitto/config"
+
+# ---- 3. Compose file + broker config ----
+echo ""
+echo "==[3/4]== Fetching $COMPOSE_FILE + mosquitto.conf from $BRANCH"
+curl -fsSL "${RAW}/${COMPOSE_FILE}" -o "$INSTALL_DIR/${COMPOSE_FILE}"
+curl -fsSL "${RAW}/mosquitto/config/mosquitto.conf" \
+  -o "$INSTALL_DIR/mosquitto/config/mosquitto.conf"
+
+# ---- 4. Pull + start ----
+echo ""
+echo "==[4/4]== Pulling images + starting the stack"
+cd "$INSTALL_DIR"
+docker compose -f "$COMPOSE_FILE" pull
+docker compose -f "$COMPOSE_FILE" up -d
+
+# ---- Summary ----
+# en0 is Wi-Fi on most Macs; en1 is the wired port on a Mac mini. Try a
+# couple before falling back to localhost.
+HOST_IP=""
+for IFACE in en0 en1 en2; do
+  HOST_IP="$(ipconfig getifaddr "$IFACE" 2>/dev/null || true)"
+  [ -n "$HOST_IP" ] && break
+done
+[ -z "$HOST_IP" ] && HOST_IP="localhost"
+
+cat <<EOF
+
+──────────────────────────────────────────────────────────────────
+  ✓ forty-two-watts is running.
+
+  Open the dashboard:
+     http://${HOST_IP}:8080/         (from another device on the LAN)
+     http://localhost:8080/          (from this Mac)
+
+  First-time setup wizard:
+     http://localhost:8080/setup
+
+  Install directory:    ${INSTALL_DIR}
+  Persistent data:      ${INSTALL_DIR}/data/
+    └── config.yaml, state.db, battery models, cold/ rolloff
+
+  Manage the stack (from ${INSTALL_DIR}):
+     docker compose -f ${COMPOSE_FILE} logs -f                          # tail logs
+     docker compose -f ${COMPOSE_FILE} pull && docker compose -f ${COMPOSE_FILE} up -d  # upgrade
+     docker compose -f ${COMPOSE_FILE} down                             # stop
+
+  macOS networking notes (see docs/deploy-platforms.md):
+     • In config.yaml, point MQTT drivers at host: mosquitto (NOT localhost).
+     • Give every driver an explicit IP — mDNS (zap.local) and broadcast
+       discovery do not cross the Docker Desktop VM boundary.
+
+──────────────────────────────────────────────────────────────────
+EOF

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,6 +43,26 @@ cat <<'BANNER'
 
 BANNER
 
+# ---- Platform guard ----
+# This installer is Linux-only (apt-get, get.docker.com, `hostname -I`,
+# usermod, host networking). On macOS the deploy story is different —
+# Docker Desktop + the dedicated macOS compose file. Bail early with a
+# pointer instead of failing halfway through with cryptic errors.
+if [ "$(uname -s)" = "Darwin" ]; then
+  cat >&2 <<'EOF'
+This installer is for Linux only.
+
+On macOS, install Docker Desktop and use docker-compose.macos.yml:
+
+  mkdir -p ~/forty-two-watts/data && cd ~/forty-two-watts
+  curl -fsSL https://raw.githubusercontent.com/frahlg/forty-two-watts/master/docker-compose.macos.yml -o docker-compose.macos.yml
+  docker compose -f docker-compose.macos.yml up -d
+
+Full walkthrough: docs/deploy-platforms.md
+EOF
+  exit 1
+fi
+
 # ---- Prerequisites ----
 if ! command -v curl >/dev/null 2>&1; then
   echo "ERROR: 'curl' is required. Install with:" >&2


### PR DESCRIPTION
## Summary

Adds a dedicated macOS Docker deploy path and a cross-platform deploy guide. The existing `docker-compose.yml` uses `network_mode: host` — a Linux-kernel feature that, on macOS, binds to the Docker Desktop VM rather than the Mac, leaving the dashboard unreachable and silently breaking device discovery.

## Changes

- **`docker-compose.macos.yml`** — self-contained macOS compose file using bridge networking + published ports (`8080`, `1883`). App reaches the embedded broker by service name (`mosquitto:1883`); the `ftw-updater` sidecar is wired to this file so in-app Update/Restart recreate the right containers.
- **`scripts/install-macos.sh`** — one-shot macOS installer: verifies Docker Desktop is up, lays out `~/forty-two-watts`, fetches the macOS compose file + broker config, brings the stack up. The Linux installer (`scripts/install.sh`) now bails early with a pointer when run on macOS.
- **`docs/deploy-platforms.md`** — new guide covering the generic Linux server path (Ubuntu/NUC/VM: install, `ufw`, device-identity caveats) and the Mac mini path (Docker Desktop networking caveats: point MQTT at `mosquitto`, use explicit driver IPs since mDNS/broadcast don't cross the VM boundary).
- `docker-compose.yml`, `docs/operations.md`, `CLAUDE.md`, `AGENTS.md` cross-reference the new guide.

## Notes

- Docs/scripts only — no Go code touched.
- Changeset included (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)