### PR TITLE
[codex] fix web UI state regressions

### DIFF
--- a/.changeset/fix-web-ui-states.md
+++ b/.changeset/fix-web-ui-states.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Fix dashboard UI state regressions around settings edits, notification history, history cakes, and the Plan Today horizon.

--- a/web/components/ftw-notif-history.js
+++ b/web/components/ftw-notif-history.js
@@ -104,7 +104,22 @@ export class FtwNotifHistory extends FtwElement {
     var cutoff = Date.now() - windowMs;
     var fails = rows.filter(r => r.status === "failed" && (r.ts_ms || 0) >= cutoff).length;
     this._failCount = fails;
-    this.update();
+    this._updateDot();
+  }
+
+  _updateDot() {
+    var dot = this.shadowRoot.querySelector(".dot");
+    if (!dot) {
+      this.update();
+      return;
+    }
+    if (this._failCount > 0) {
+      dot.textContent = this._failCount > 99 ? "99+" : String(this._failCount);
+      dot.classList.remove("hidden");
+    } else {
+      dot.textContent = "";
+      dot.classList.add("hidden");
+    }
   }
 
   async _open() {

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -3083,6 +3083,7 @@
   var historyCakeWrap = $("history-cake");
   var historyCakeEl = $("history-cake-el");
   var historyCakeWaitingForUpgrade = false;
+  var historyCakeReqSeq = 0;
 
   // historyState mirrors both toggles so the Bars/Cakes view and
   // the Week/Month range stay coordinated. Only the cake re-fetches
@@ -3091,6 +3092,7 @@
   var historyState = { range: "week", view: "bars" };
 
   function fetchHistoryCake() {
+    var seq = ++historyCakeReqSeq;
     historyCakeEl = $("history-cake-el");
     if (!historyCakeEl || typeof historyCakeEl.setTotals !== "function") {
       if (!historyCakeWaitingForUpgrade && window.customElements && customElements.whenDefined) {
@@ -3105,11 +3107,13 @@
     if (historyCakeWrap) historyCakeWrap.classList.add("loading");
     var days = historyState.range === "month" ? 30 : 7;
     var clearLoading = function () {
+      if (seq !== historyCakeReqSeq) return;
       if (historyCakeWrap) historyCakeWrap.classList.remove("loading");
     };
     fetch("/api/energy/daily?days=" + days)
       .then(function (r) { return r.json(); })
       .then(function (j) {
+        if (seq !== historyCakeReqSeq) return;
         var arr = (j && j.days) || [];
         var totals = { import_wh: 0, load_wh: 0, export_wh: 0, pv_wh: 0 };
         for (var i = 0; i < arr.length; i++) {

--- a/web/plan.js
+++ b/web/plan.js
@@ -43,7 +43,7 @@
   function horizonBounds(horizon) {
     const now = Date.now();
     if (horizon === "today") {
-      return { tMin: localMidnight(0), tMax: localMidnight(1) };
+      return { tMin: Math.max(localMidnight(0), now - 30 * 60 * 1000), tMax: localMidnight(1) };
     }
     if (horizon === "tomorrow") {
       return { tMin: localMidnight(1), tMax: localMidnight(2) };

--- a/web/settings/tabs/control.js
+++ b/web/settings/tabs/control.js
@@ -41,7 +41,7 @@
         '</div></div>' +
         '</fieldset>' +
         '<fieldset><legend>PV surplus absorber</legend>' +
-        '<p style="color:var(--ink-dim);font-size:0.85rem;margin:0 0 8px">' +
+        '<p style="color:var(--fg-dim);font-size:0.85rem;margin:0 0 8px">' +
         'Opt-in underlay for planner_cheap / planner_arbitrage. ' +
         'When the plan would still leave the grid exporting beyond the threshold AND ' +
         'average battery SoC is below the cap, the leftover export is redirected into the battery ' +

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -357,6 +357,7 @@
         var sel = document.getElementById("driver-catalog-picker");
         var nameEl = document.getElementById("driver-catalog-name");
         if (!sel || !sel.value) return;
+        ctx.captureCurrentTab();
         var chosen = sel.options[sel.selectedIndex];
         var protocols = (chosen.dataset.protocols || "").split("+");
         var name = (nameEl.value || "").trim() || chosen.dataset.id || ("driver-" + config.drivers.length);


### PR DESCRIPTION
## Summary

Fixes several small dashboard state regressions found in the web/UI sweep:

- Preserve unsaved Settings > Devices edits when adding a driver from the catalog.
- Keep the notification history modal open while the header badge poll refreshes.
- Ignore stale History Cakes responses after quick Week/Month toggles.
- Make the Plan Today horizon focus on the remaining visible plan window instead of wasting most of the canvas on past hours.
- Replace an undefined settings text color token with the theme-aware foreground dim token.

Includes a patch changeset for the user-visible UI fixes.

## Validation

- `npm test`
- `node --check web/plan.js && node --check web/next-app.js && node --check web/settings/tabs/devices.js && node --check web/settings/tabs/control.js && node --check web/components/ftw-notif-history.js`
- pre-commit `make verify`
- pre-push `make verify-all`