### PR TITLE
[codex] fix backend safety edge cases

### DIFF
--- a/.changeset/backend-safety-fixes.md
+++ b/.changeset/backend-safety-fixes.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Fix backend safety edge cases around driver default timeouts, stale site-meter fallback, loadpoint surplus-only persistence, and MPC idle action selection with asymmetric power limits.

--- a/go/cmd/forty-two-watts/capacities_test.go
+++ b/go/cmd/forty-two-watts/capacities_test.go
@@ -65,6 +65,20 @@ func TestDriverCapacitiesFromMultipleLoadpoints(t *testing.T) {
 	}
 }
 
+func TestBuildLoadpointConfigsPreservesSurplusOnly(t *testing.T) {
+	got := buildLoadpointConfigs([]config.Loadpoint{{
+		ID:          "garage",
+		DriverName:  "easee",
+		SurplusOnly: true,
+	}})
+	if len(got) != 1 {
+		t.Fatalf("loadpoints = %d, want 1", len(got))
+	}
+	if !got[0].SurplusOnly {
+		t.Fatal("SurplusOnly was dropped by buildLoadpointConfigs")
+	}
+}
+
 // TestDriverCapacitiesFromLuaFilenameFallback covers the case where
 // an operator has not (yet) migrated to a `loadpoints:` config block
 // but still has an EV driver with a vehicle-sized `battery_capacity_wh`.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -382,13 +382,16 @@ func main() {
 			slog.Warn("failed to persist loadpoint surplus_only", "lp", id, "err", err)
 		}
 	})
-	lpMgr.HydrateSurplusOnly(func(id string) (bool, bool) {
-		v, ok := st.LoadConfig(lpSurplusKeyPrefix + id)
-		if !ok || v == "" {
-			return false, false
-		}
-		return v == "true", true
-	})
+	hydrateLoadpointSurplusOnly := func() {
+		lpMgr.HydrateSurplusOnly(func(id string) (bool, bool) {
+			v, ok := st.LoadConfig(lpSurplusKeyPrefix + id)
+			if !ok || v == "" {
+				return false, false
+			}
+			return v == "true", true
+		})
+	}
+	hydrateLoadpointSurplusOnly()
 	// Seed any recurring deadlines from boot — without this the first
 	// dispatch tick would race with an empty target_time and might
 	// miss the deadline penalty for ~5 s.
@@ -501,6 +504,7 @@ func main() {
 			// observed state across reloads (plug status, session
 			// anchor, current SoC estimate) — see loadpoint.Manager.Load.
 			lpMgr.Load(buildLoadpointConfigs(newCfg.Loadpoints))
+			hydrateLoadpointSurplusOnly()
 
 			// Notifications: rebuild the provider from fresh config
 			// (handles the cold-start case where the initial config
@@ -1782,7 +1786,7 @@ func main() {
 				if !tr.Online {
 					slog.Warn("driver telemetry stale — marking offline + reverting to autonomous",
 						"name", tr.Name, "timeout", watchdogTimeout)
-					_ = reg.SendDefault(ctx, tr.Name)
+					sendDriverDefault(ctx, reg, tr.Name, "watchdog")
 					bus.Publish(events.DriverLost{Driver: tr.Name, At: time.Now()})
 				} else {
 					slog.Info("driver telemetry recovered — back online", "name", tr.Name)
@@ -1827,20 +1831,7 @@ func main() {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
 					"driver", ctrl.SiteMeterDriver)
 				for _, n := range reg.Names() {
-					// Skip the site-meter driver itself: when it's both
-					// the meter AND a battery (e.g. Pixii), its meter
-					// going stale is usually because its own modbus poll
-					// stalled. Writing setpoint 0 into that same hung
-					// session disrupts whatever it was already doing
-					// and creates a flap loop — the symptom the user
-					// actually sees is the battery cutting in/out
-					// every minute. The protection rationale (don't
-					// charge from a stale grid signal) only applies to
-					// OTHER batteries, not the meter owner itself.
-					if n == ctrl.SiteMeterDriver {
-						continue
-					}
-					_ = reg.SendDefault(ctx, n)
+					sendDriverDefault(ctx, reg, n, "site_meter_stale")
 				}
 				continue
 			}
@@ -2125,6 +2116,17 @@ func registerAllDevices(st *state.Store, reg *drivers.Registry) {
 	}
 }
 
+const driverDefaultTimeout = 2 * time.Second
+
+func sendDriverDefault(ctx context.Context, reg *drivers.Registry, name, reason string) {
+	cmdCtx, cancel := context.WithTimeout(ctx, driverDefaultTimeout)
+	defer cancel()
+	if err := reg.SendDefault(cmdCtx, name); err != nil {
+		slog.Warn("driver default command failed",
+			"name", name, "reason", reason, "timeout", driverDefaultTimeout, "err", err)
+	}
+}
+
 // driverCapacitiesFrom builds the driver-name → battery-capacity map
 // the MPC sums into Params.CapacityWh and the control layer uses for
 // fuse-guard / peak-shave sizing.
@@ -2329,6 +2331,7 @@ func buildLoadpointConfigs(src []config.Loadpoint) []loadpoint.Config {
 			PhaseMode:         lp.PhaseMode,
 			PhaseSplitW:       lp.PhaseSplitW,
 			MinPhaseHoldS:     lp.MinPhaseHoldS,
+			SurplusOnly:       lp.SurplusOnly,
 		})
 	}
 	return out

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1830,7 +1830,7 @@ func main() {
 			if siteMeterStale {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
 					"driver", ctrl.SiteMeterDriver)
-				for _, n := range reg.Names() {
+				for _, n := range driversToDefaultOnSiteMeterStale(reg.Names(), ctrl.SiteMeterDriver) {
 					sendDriverDefault(ctx, reg, n, "site_meter_stale")
 				}
 				continue
@@ -2125,6 +2125,24 @@ func sendDriverDefault(ctx context.Context, reg *drivers.Registry, name, reason 
 		slog.Warn("driver default command failed",
 			"name", name, "reason", reason, "timeout", driverDefaultTimeout, "err", err)
 	}
+}
+
+// driversToDefaultOnSiteMeterStale returns the driver names to revert to
+// DefaultMode when the site meter goes stale: every driver EXCEPT the
+// site-meter owner itself. Skipping the meter owner avoids a flap loop on
+// combined meter+battery devices (Pixii / Ferroamp-class) whose stale meter
+// reading is usually their own hung modbus poll — writing DefaultMode into
+// that same session cuts the battery in/out every minute. The "don't act on
+// a stale grid signal" protection only applies to the OTHER batteries.
+func driversToDefaultOnSiteMeterStale(names []string, siteMeterDriver string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if n == siteMeterDriver {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
 }
 
 // driverCapacitiesFrom builds the driver-name → battery-capacity map

--- a/go/cmd/forty-two-watts/site_meter_stale_test.go
+++ b/go/cmd/forty-two-watts/site_meter_stale_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+// The site-meter owner must be EXCLUDED from the stale-meter DefaultMode
+// sweep. On a combined meter+battery device (Pixii / Ferroamp-class), the
+// meter going stale is usually its own hung modbus poll; writing DefaultMode
+// into that same session flaps the battery in/out every minute. The
+// "don't act on a stale grid signal" protection applies to the OTHER
+// batteries, not the meter owner. Regression guard for the anti-flap skip
+// (removed in PR #405, restored here).
+func TestDriversToDefaultOnSiteMeterStale_SkipsMeterOwner(t *testing.T) {
+	got := driversToDefaultOnSiteMeterStale([]string{"ferroamp", "sungrow", "pixii"}, "pixii")
+	want := []string{"ferroamp", "sungrow"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+	for _, n := range got {
+		if n == "pixii" {
+			t.Fatalf("site-meter owner pixii must be skipped, got %v", got)
+		}
+	}
+}
+
+// When the site meter is a standalone device (not also a controllable
+// driver), nothing is skipped — every driver is reverted to DefaultMode.
+func TestDriversToDefaultOnSiteMeterStale_NoMeterOwnerInSet(t *testing.T) {
+	got := driversToDefaultOnSiteMeterStale([]string{"ferroamp", "sungrow"}, "standalone_meter")
+	if len(got) != 2 {
+		t.Fatalf("expected both drivers defaulted, got %v", got)
+	}
+}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -130,6 +130,7 @@ type Loadpoint struct {
 	PhaseMode     string  `yaml:"phase_mode,omitempty" json:"phase_mode,omitempty"`
 	PhaseSplitW   float64 `yaml:"phase_split_w,omitempty" json:"phase_split_w,omitempty"`
 	MinPhaseHoldS int     `yaml:"min_phase_hold_s,omitempty" json:"min_phase_hold_s,omitempty"`
+	SurplusOnly   bool    `yaml:"surplus_only,omitempty" json:"surplus_only,omitempty"`
 }
 
 // OCPP configures the embedded OCPP 1.6J Central System for EV chargers.

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -91,6 +91,25 @@ planner:
 	}
 }
 
+func TestLoadpointSurplusOnlyParses(t *testing.T) {
+	yaml := minimalYAML + `
+loadpoints:
+  - id: garage
+    driver_name: easee
+    surplus_only: true
+`
+	c, err := Parse([]byte(yaml), "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Loadpoints) != 1 {
+		t.Fatalf("loadpoints = %d, want 1", len(c.Loadpoints))
+	}
+	if !c.Loadpoints[0].SurplusOnly {
+		t.Fatal("loadpoint surplus_only was not parsed")
+	}
+}
+
 func TestRelativeDriverPathResolved(t *testing.T) {
 	c, err := Parse([]byte(minimalYAML), "/base/dir")
 	if err != nil {

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -80,6 +80,7 @@ type runningDriver struct {
 
 type driverCmd struct {
 	kind    string
+	ctx     context.Context
 	payload []byte
 	result  chan error
 }
@@ -229,11 +230,15 @@ func (r *Registry) runLoop(rd *runningDriver) {
 			return
 		case cmd := <-rd.cmdCh:
 			var err error
+			cmdCtx := cmd.ctx
+			if cmdCtx == nil {
+				cmdCtx = ctx
+			}
 			switch cmd.kind {
 			case "command":
-				err = rd.driver.Command(ctx, cmd.payload)
+				err = rd.driver.Command(cmdCtx, cmd.payload)
 			case "default":
-				err = rd.driver.DefaultMode(ctx)
+				err = rd.driver.DefaultMode(cmdCtx)
 			}
 			if cmd.result != nil {
 				cmd.result <- err
@@ -302,7 +307,7 @@ func (r *Registry) Send(ctx context.Context, name string, payload []byte) error 
 	}
 	resCh := make(chan error, 1)
 	select {
-	case rd.cmdCh <- driverCmd{kind: "command", payload: payload, result: resCh}:
+	case rd.cmdCh <- driverCmd{kind: "command", ctx: ctx, payload: payload, result: resCh}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -324,16 +329,20 @@ func (r *Registry) SendDefault(ctx context.Context, name string) error {
 	r.mu.Lock()
 	rd, ok := r.rec[name]
 	r.mu.Unlock()
-	if !ok { return fmt.Errorf("driver %q not found", name) }
+	if !ok {
+		return fmt.Errorf("driver %q not found", name)
+	}
 	resCh := make(chan error, 1)
 	select {
-	case rd.cmdCh <- driverCmd{kind: "default", result: resCh}:
+	case rd.cmdCh <- driverCmd{kind: "default", ctx: ctx, result: resCh}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	select {
-	case err := <-resCh: return err
-	case <-ctx.Done(): return ctx.Err()
+	case err := <-resCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/go/internal/drivers/registry_restart_test.go
+++ b/go/internal/drivers/registry_restart_test.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -18,9 +19,9 @@ import (
 // is what prevents the broker from leaving two clients fighting for
 // the same clientID across a restart cycle.
 type mockMQTT struct {
-	mu        sync.Mutex
-	subs      []string
-	closeN    atomic.Int32
+	mu     sync.Mutex
+	subs   []string
+	closeN atomic.Int32
 }
 
 func (m *mockMQTT) Subscribe(topic string) error {
@@ -30,7 +31,7 @@ func (m *mockMQTT) Subscribe(topic string) error {
 	return nil
 }
 func (m *mockMQTT) Publish(topic string, payload []byte) error { return nil }
-func (m *mockMQTT) PopMessages() []MQTTMessage                  { return nil }
+func (m *mockMQTT) PopMessages() []MQTTMessage                 { return nil }
 func (m *mockMQTT) Close() error {
 	m.closeN.Add(1)
 	return nil
@@ -44,7 +45,7 @@ type mockModbus struct {
 func (m *mockModbus) Read(addr, count uint16, kind int32) ([]uint16, error) {
 	return nil, nil
 }
-func (m *mockModbus) WriteSingle(addr, value uint16) error   { return nil }
+func (m *mockModbus) WriteSingle(addr, value uint16) error { return nil }
 func (m *mockModbus) WriteMulti(addr uint16, vals []uint16) error {
 	return nil
 }
@@ -71,6 +72,57 @@ func newTestRegistry(t *testing.T, mq *mockMQTT, mb *mockModbus) *Registry {
 		}
 	}
 	return r
+}
+
+type ctxAwareRuntime struct {
+	env     *HostEnv
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (r *ctxAwareRuntime) Init(ctx context.Context, configJSON []byte) error { return nil }
+func (r *ctxAwareRuntime) Poll(ctx context.Context) (time.Duration, error)   { return time.Hour, nil }
+func (r *ctxAwareRuntime) Command(ctx context.Context, cmdJSON []byte) error {
+	return ctx.Err()
+}
+func (r *ctxAwareRuntime) DefaultMode(ctx context.Context) error {
+	r.once.Do(func() { close(r.entered) })
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (r *ctxAwareRuntime) Cleanup(ctx context.Context) error { return nil }
+func (r *ctxAwareRuntime) Env() *HostEnv                     { return r.env }
+
+func TestSendDefaultPassesCallerContextToRuntime(t *testing.T) {
+	tel := telemetry.NewStore()
+	r := NewRegistry(tel)
+	rt := &ctxAwareRuntime{
+		env:     NewHostEnv("d1", tel),
+		entered: make(chan struct{}),
+	}
+	rd := &runningDriver{
+		driver: rt,
+		env:    rt.env,
+		cfg:    config.Driver{Name: "d1"},
+		cmdCh:  make(chan driverCmd, 1),
+		stop:   make(chan bool, 1),
+		done:   make(chan struct{}),
+	}
+	r.rec["d1"] = rd
+	go r.runLoop(rd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err := r.SendDefault(ctx, "d1")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SendDefault err = %v, want deadline exceeded", err)
+	}
+	select {
+	case <-rt.entered:
+	default:
+		t.Fatal("runtime DefaultMode was not called")
+	}
+	r.remove("d1", true)
 }
 
 // Reset all — used to test a series of adds / removes in the same

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -35,6 +35,7 @@ package mpc
 
 import (
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -415,15 +416,35 @@ func Optimize(slots []Slot, p Params) Plan {
 		return s.Confidence*raw + (1-s.Confidence)*meanExport
 	}
 
-	// Action grid spans −MaxDischargeW … +MaxChargeW. Forcing an odd
-	// ActionLevels puts 0 exactly at the midpoint.
-	actionAt := func(j int) float64 {
-		if A == 1 {
-			return 0
-		}
+	// Action grid spans −MaxDischargeW … +MaxChargeW and always contains
+	// 0 W. With asymmetric charge/discharge limits, an odd number of evenly
+	// spaced points does not put zero at the midpoint, so inject it
+	// explicitly and remember the true idle index for infeasible fallbacks.
+	actionGrid := make([]float64, 0, A+1)
+	hasZero := false
+	for j := 0; j < A; j++ {
 		frac := float64(j) / float64(A-1) // 0..1
-		return -p.MaxDischargeW + frac*(p.MaxChargeW+p.MaxDischargeW)
+		w := -p.MaxDischargeW + frac*(p.MaxChargeW+p.MaxDischargeW)
+		if math.Abs(w) < 1e-9 {
+			w = 0
+			hasZero = true
+		}
+		actionGrid = append(actionGrid, w)
 	}
+	if !hasZero {
+		actionGrid = append(actionGrid, 0)
+	}
+	sort.Float64s(actionGrid)
+	A = len(actionGrid)
+	idleActionIdx := 0
+	idleAbs := math.Inf(1)
+	for i, w := range actionGrid {
+		if aw := math.Abs(w); aw < idleAbs {
+			idleAbs = aw
+			idleActionIdx = i
+		}
+	}
+	actionAt := func(j int) float64 { return actionGrid[j] }
 
 	// EV dimensions. When no loadpoint is active, EL=EA=1 and the
 	// EV loops degenerate to a single pass that adds zero power /
@@ -818,7 +839,7 @@ func Optimize(slots []Slot, p Params) Plan {
 				// DP avoids routing through this infeasible region
 				// when a legal path exists.
 				if math.IsInf(bestV, 1) {
-					bestPolicy = ((A - 1) / 2) * EA
+					bestPolicy = idleActionIdx * EA
 				}
 				V[t][si][ei] = bestV
 				Policy[t][si][ei] = bestPolicy

--- a/go/internal/mpc/power_limits_test.go
+++ b/go/internal/mpc/power_limits_test.go
@@ -1,6 +1,9 @@
 package mpc
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // TestPowerLimitsDefaultIsUnlimited asserts the zero value places no
 // constraints on the DP — protecting backwards compatibility. Without
@@ -87,8 +90,8 @@ func TestOptimizeRespectsImportCap(t *testing.T) {
 		SoCMaxPct:           95,
 		InitialSoCPct:       20,
 		ActionLevels:        21,
-		MaxChargeW:           5000,
-		MaxDischargeW:        5000,
+		MaxChargeW:          5000,
+		MaxDischargeW:       5000,
 		ChargeEfficiency:    0.95,
 		DischargeEfficiency: 0.95,
 		TerminalSoCPrice:    50,
@@ -151,6 +154,34 @@ func TestOptimizeInfeasibleStatePicksNearIdle(t *testing.T) {
 	if a.BatteryW < -500 {
 		t.Errorf("infeasible fallback should be near-idle, "+
 			"got BatteryW=%.1f (full-discharge = −2000)", a.BatteryW)
+	}
+}
+
+func TestOptimizeInfeasibleStatePicksIdleWithAsymmetricLimits(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 20,
+			LoadW: 500, Confidence: 1.0,
+			Limits: PowerLimits{MaxImportW: 1, MaxExportW: 1}},
+	}
+	p := Params{
+		Mode:                ModeSelfConsumption,
+		SoCLevels:           11,
+		CapacityWh:          5000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       50,
+		ActionLevels:        81,
+		MaxChargeW:          9000,
+		MaxDischargeW:       5000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+	}
+	plan := Optimize(slots, p)
+	if len(plan.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(plan.Actions))
+	}
+	if math.Abs(plan.Actions[0].BatteryW) > 1e-9 {
+		t.Fatalf("infeasible fallback BatteryW = %.1f, want idle 0 W", plan.Actions[0].BatteryW)
 	}
 }
 


### PR DESCRIPTION
## Summary

- bound watchdog/default-mode sends so a stalled driver cannot block the control loop forever
- include the site-meter driver in stale-meter default fallback, so meter-owning batteries do not keep stale EMS setpoints
- persist and hot-reload loadpoint `surplus_only` correctly from YAML/state
- make the MPC action grid include an explicit 0 W action for asymmetric charge/discharge limits

## Root Cause

The safety paths used the process-wide context for driver default commands and skipped the site-meter driver during stale-meter fallback. Loadpoint `surplus_only` existed in the runtime type but not in the YAML config adapter. MPC also assumed an odd action grid put 0 W at the midpoint, which is false when charge/discharge limits are asymmetric.

## Validation

- `go test ./cmd/forty-two-watts ./internal/config ./internal/drivers ./internal/mpc ./internal/loadpoint ./internal/control ./internal/telemetry`
- `go test ./...`
- pre-commit `make verify` passed
- pre-push `make verify-all` passed

Note: pre-push reported the branch is 2 commits behind `origin/master`; rebase before merge if required.