### PR TITLE
fix(relay): stop stranding friend requests after an idle long-poll cycle (help-a-friend e2e)

### DIFF
--- a/.changeset/relay-poll-waiter-strand.md
+++ b/.changeset/relay-poll-waiter-strand.md
@@ -1,0 +1,23 @@
+---
+"forty-two-watts": patch
+---
+
+**Fix: help-a-friend hung after the session sat idle past one long-poll
+cycle.** The relay's tunnel queue (`go/internal/tunnel/queue.go`) leaked a
+waiter channel every time a host long-poll timed out: `Poll` returned
+`ErrPollTimeout` (and on the context-cancel path too) without removing its
+entry from `q.waiters[hostID]`. The next friend request was then handed by
+`Enqueue` to that abandoned, never-read buffered channel and silently lost —
+the request blocked until the friend's client gave up.
+
+This bit the real flow because a friend naturally takes longer than one
+poll-timeout (25 s in production) between approving the session and pasting
+the `claude mcp add …` command, so the **first** MCP request reliably landed
+after a poll had already stranded a waiter. Result: `initialize` (or
+`tools/list`) hung and Claude Code reported the MCP server as unreachable,
+even though approval and the grant exchange had succeeded.
+
+`Poll` now deregisters its waiter on both the timeout and context-cancel
+exits, and if a producer claimed the waiter in the same instant it delivers
+that buffered request instead of dropping it. Regression tests cover the
+timeout-strand, ctx-cancel-strand, and the producer/timeout handoff race.

--- a/docs/ftw-pair.md
+++ b/docs/ftw-pair.md
@@ -19,10 +19,12 @@ pair with people you'd already give shell to.
 
 Open the dashboard at `http://<pi>:8080`, scroll to the **Pair session**
 card, fill in an optional intent and pick a TTL, then click **Start pair
-session**. The card flips to active mode within a few seconds showing a
-**6-word token** (e.g. `garage-coffee-river-bicycle-window-cat`) with a
-**Copy** button. Copy the token and send it to the friend over any channel
-— Signal, SMS, Slack DM.
+session**. The card flips to active mode within a few seconds showing the
+friend's **URL** (built from a 6-word token, e.g.
+`garage-coffee-river-bicycle-window-cat`) and a prominent **4-digit code**,
+with **Copy URL + code** / **Copy code** buttons. Send both to the friend
+over any channel — Signal, SMS, Slack DM. They open the URL and type the
+code to activate the session; you don't approve anything yourself.
 
 To end the session early, click **Abort** on the card.
 
@@ -32,10 +34,12 @@ Or, if you prefer the terminal:
 forty-two-watts pair --intent "help me write a goodwe XS driver" --ttl 4h
 ```
 
-The CLI prints the token directly:
+The CLI prints the token, URL and code directly:
 
 ```
 PAIR CODE: garage-coffee-river-bicycle-window-cat
+PAIR URL:  https://relay.fortytwowatts.com/h/garage-coffee-river-bicycle-window-cat
+APPROVAL CODE (share with the friend): 4827
 TTL: 4h0m0s — sidecar will exit at expiry
 ```
 
@@ -53,36 +57,41 @@ forty-two-watts pair --abort
 https://relay.fortytwowatts.com/h/garage-coffee-river-bicycle-window-cat
 ```
 
-The friend opens it in any modern browser. The landing page displays
-a **4-digit code** and waits. The friend reads the code to the host
-over a voice channel (phone call, Signal voice, etc.) — that voice
-channel is the second factor; a leaked URL alone cannot complete the
-handshake.
+...along with the **4-digit code** the dashboard showed. The friend opens
+the URL in any modern browser, types the code on the landing page, and
+clicks **Activate**. The host doesn't click anything — entering the code
+*is* the approval. (The URL and the code together start the session, so the
+host shares both; the grant minted below, not the URL, is what guards the
+session afterward.)
 
-The host hears the code, sees the matching code on the dashboard's
-pair card, and clicks **Allow**. The page then reveals two
-ready-to-paste blocks:
+On the correct code the relay mints a one-time **session grant** and the
+page reveals two ready-to-paste blocks:
 
-1. For Claude Code (or any MCP-aware agent):
+1. For Claude Code (or any MCP-aware agent) — note the Bearer header
+   carrying the grant:
    ```bash
    claude mcp add ftw-friend --transport http \
-     https://relay.fortytwowatts.com/h/<token>/mcp
+     https://relay.fortytwowatts.com/h/<token>/mcp \
+     --header "Authorization: Bearer <grant>"
    ```
-2. For the browser dashboard:
+2. For the browser dashboard (the grant rides in an HttpOnly cookie the
+   same page sets):
    ```
    https://relay.fortytwowatts.com/h/<token>/web/
    ```
 
-Both URLs are live for the rest of the TTL (default 4 h). The host
-can revoke from the dashboard at any time.
+The grant — not the URL — is the access secret from here on, so a URL that
+leaks after activation is useless without it. Both blocks are live for the
+rest of the TTL (default 4 h). The host can revoke from the dashboard at any
+time.
 
 When the work is done, **the friend opens the PR from their own
 machine** — they clone the 42W repo locally (the agent does this for
 them via its own shell), apply the changes they wrote on the owner's
 instance, and run `gh pr create` with the `pair-session.md` template.
 
-The owner doesn't touch git or GitHub. They share the URL, approve
-the connection, let the friend work, and get a PR link back.
+The owner doesn't touch git or GitHub. They share the URL + code, let the
+friend work, and get a PR link back.
 
 ## Relay
 
@@ -151,9 +160,9 @@ what changed on the owner's instance.
 | Step | Owner | Friend |
 |---|---|---|
 | Trigger pair session | Click **Start pair session** in the dashboard (or `forty-two-watts pair --intent "..."`) | — |
-| Share URL | Copy from the dashboard card, send via Signal/SMS/Slack | Receive |
+| Share URL + code | Copy URL + 4-digit code from the dashboard card, send via Signal/SMS/Slack | Receive |
 | Connect | — | Open the URL in a browser |
-| Approve | Hears the 4-digit code on voice, clicks **Allow** on the dashboard | Reads the code aloud |
+| Activate | Shares the code with the URL — no dashboard click needed | Types the code on the landing page → gets the `claude mcp add` command |
 | Develop the driver / debug | — | Drives their agent (Claude Code, Codex, …) through the relay-tunneled MCP / dashboard |
 | Open the PR | — | Clones repo locally, `gh pr create` from own machine |
 | Review the PR | Reviews via GitHub web UI | — |
@@ -169,11 +178,12 @@ PR the friend opens.
 a 17-tool HTTP surface on `localhost:9999` (REST at `/tools/<name>` +
 MCP at `/mcp`, sharing the same Tool[] and audit log), then registers
 a 6-word token with the HTTPS relay at `relay.fortytwowatts.com` and
-starts a long-poll loop. When a friend opens the URL, the relay
-displays a 4-digit code; the host approves on its dashboard with the
-matching code (heard over voice). After approval, the relay forwards
-friend HTTP traffic to the host: `/h/<token>/mcp` lands on the local
-MCP server, `/h/<token>/web/...` proxies to the dashboard at
+starts a long-poll loop. When a friend opens the URL, the landing page
+asks for the 4-digit code the host shared; the friend types it and the
+relay mints a one-time session grant. From then on the friend's requests
+carry that grant (Bearer header for MCP, HttpOnly cookie for the
+dashboard) and the relay forwards them to the host: `/h/<token>/mcp` lands
+on the local MCP server, `/h/<token>/web/...` proxies to the dashboard at
 `localhost:8080`. The friend's machine never installs anything —
 their agent uses Claude Code's `--transport http` directly against
 the relay URL.
@@ -217,10 +227,12 @@ regardless of whether the PR is merged.
 host. Check the host can `curl https://relay.fortytwowatts.com/healthz`.
 Use `-relay http://localhost:7378` to point at a local relay for testing.
 
-**Friend gets `425 Too Early`** — the host hasn't approved the session
-yet. The friend hits the URL, the relay shows the 4-digit code, the
-friend reads it on voice, the host clicks Allow on the dashboard.
-Without approval, MCP and web paths return 425.
+**Friend gets `425 Too Early`** — the session hasn't been activated yet.
+The friend must open the URL and type the 4-digit code the host shared;
+that mints the grant. Until then, MCP and web paths return 425. (A `401`
+instead means the request reached an active session without the grant —
+re-copy the `claude mcp add` line, including its `Authorization: Bearer`
+header.)
 
 **Agent can't reach the dashboard** — confirm the host's `ftw-pair`
 process is still running and the long-poll loop is healthy. `curl

--- a/go/cmd/ftw-pair/main.go
+++ b/go/cmd/ftw-pair/main.go
@@ -116,7 +116,7 @@ func main() {
 		go handle.Host.Run(ctx)
 		fmt.Fprintf(os.Stderr, "PAIR CODE: %s\n", handle.Token)
 		fmt.Fprintf(os.Stderr, "PAIR URL:  %s\n", handle.PublicURL)
-		fmt.Fprintf(os.Stderr, "APPROVAL CODE (tell host on voice): %s\n", handle.ApprovalCode)
+		fmt.Fprintf(os.Stderr, "APPROVAL CODE (share with the friend): %s\n", handle.ApprovalCode)
 	}
 	fmt.Fprintf(os.Stderr, "TTL: %s — sidecar will exit at expiry\n", *ttl)
 
@@ -197,10 +197,10 @@ func main() {
 // includes live tool_count + last_tools + clients_connected, plus the
 // relay-side metadata (PairURL + ApprovalCode + SessionState +
 // LastActivityMs) so the dashboard <ftw-pair-card> can show the URL
-// to share, the 4-digit voice-channel code, and live presence.
+// and 4-digit code to share, and live presence.
 //
 // All four relay fields are zero in -no-relay mode and the dashboard
-// degrades gracefully (omits the URL row, hides the Allow form).
+// degrades gracefully (omits the URL + code rows).
 func postPairStatusFull(apiBase, code string, sess *Session, audit *Audit, tun *TunnelHandle) error {
 	body := map[string]any{
 		"session_id":        sess.ID,

--- a/go/internal/api/api_pair.go
+++ b/go/internal/api/api_pair.go
@@ -55,10 +55,11 @@ type PairStatus struct {
 	// dashboard renders this verbatim — operator copies + sends.
 	PairURL string `json:"pair_url,omitempty"`
 
-	// ApprovalCode is the 4-digit voice-channel cross-check code.
-	// Friend reads it from the relay landing page; operator types it
-	// into the dashboard's Allow form. The matching POST flips the
-	// relay's token state from pending → active.
+	// ApprovalCode is the 4-digit activation code. The operator shares it
+	// with the friend alongside the URL; the friend types it on the relay
+	// landing page, which mints the session grant and flips the relay's
+	// token state from pending → active. The operator does not approve on
+	// the dashboard — entering the code is the approval.
 	ApprovalCode string `json:"approval_code,omitempty"`
 
 	// SessionState mirrors the relay-side token state ("pending",

--- a/go/internal/tunnel/queue_strand_test.go
+++ b/go/internal/tunnel/queue_strand_test.go
@@ -1,0 +1,143 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestPollTimeoutDoesNotStrandEnqueue is the regression for the relay hang
+// that broke help-a-friend end-to-end: a Poll that times out must not leave
+// its waiter channel registered. If it does, the next Enqueue hands the
+// request to that abandoned (buffered, never-read) channel and the friend's
+// request is lost forever — it hangs until the client gives up.
+//
+// In practice a friend approves the session, then takes more than one
+// poll-timeout (25s in prod) to paste the `claude mcp add` command, so the
+// FIRST real MCP request always lands after at least one poll has timed out.
+func TestPollTimeoutDoesNotStrandEnqueue(t *testing.T) {
+	q := NewQueue()
+	ctx := context.Background()
+
+	// 1. A poll times out with no request available.
+	if _, err := q.Poll(ctx, "h1", 10*time.Millisecond); !errors.Is(err, ErrPollTimeout) {
+		t.Fatalf("first poll: want ErrPollTimeout, got %v", err)
+	}
+
+	// 2. A friend request is enqueued; a live poller must be able to pick it up.
+	done := make(chan error, 1)
+	go func() {
+		_, err := q.Enqueue(ctx, "h1", TunneledRequest{Method: "POST", Path: "/mcp"})
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond) // let Enqueue register the request
+
+	// 3. A fresh poll must deliver the enqueued request.
+	req, err := q.Poll(ctx, "h1", time.Second)
+	if err != nil {
+		t.Fatalf("live poll after a timed-out poll: request was stranded: %v", err)
+	}
+	if err := q.PostResponse(req.ReqID, TunneledResponse{Status: 200}); err != nil {
+		t.Fatalf("post response: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueue never completed — request lost to a stale waiter")
+	}
+}
+
+// TestPollCtxCancelDoesNotStrandEnqueue is the same invariant for the
+// context-cancellation exit path (host shutdown / client disconnect): a
+// cancelled Poll must also deregister its waiter.
+func TestPollCtxCancelDoesNotStrandEnqueue(t *testing.T) {
+	q := NewQueue()
+
+	cctx, ccancel := context.WithCancel(context.Background())
+	pollErr := make(chan error, 1)
+	go func() {
+		_, err := q.Poll(cctx, "h1", time.Second)
+		pollErr <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	ccancel()
+	if err := <-pollErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled poll: want context.Canceled, got %v", err)
+	}
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() {
+		_, err := q.Enqueue(ctx, "h1", TunneledRequest{Method: "POST", Path: "/mcp"})
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+
+	req, err := q.Poll(ctx, "h1", time.Second)
+	if err != nil {
+		t.Fatalf("live poll after a cancelled poll: request was stranded: %v", err)
+	}
+	if err := q.PostResponse(req.ReqID, TunneledResponse{Status: 200}); err != nil {
+		t.Fatalf("post response: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueue never completed — request lost to a stale waiter")
+	}
+}
+
+// TestPollHandoffRaceDeliversRequest covers the race where Enqueue claims a
+// waiter at the same instant that waiter's Poll hits its deadline: the
+// request must still be delivered (to the timing-out poller), never dropped.
+func TestPollHandoffRaceDeliversRequest(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		q := NewQueue()
+		ctx := context.Background()
+
+		gotReq := make(chan TunneledRequest, 1)
+		go func() {
+			// Very short deadline so this poll is racing the enqueue below.
+			req, err := q.Poll(ctx, "h1", time.Millisecond)
+			if err == nil {
+				gotReq <- req
+			}
+		}()
+
+		enqDone := make(chan TunneledResponse, 1)
+		go func() {
+			resp, _ := q.Enqueue(ctx, "h1", TunneledRequest{Method: "GET", Path: "/x"})
+			enqDone <- resp
+		}()
+
+		// Drain: whoever ends up holding the request answers it. If the poll
+		// won the race it delivers via gotReq; otherwise a follow-up poll does.
+		go func() {
+			select {
+			case req := <-gotReq:
+				_ = q.PostResponse(req.ReqID, TunneledResponse{Status: 200})
+			case <-time.After(500 * time.Millisecond):
+			}
+		}()
+		go func() {
+			// Backup poller in case the racing poll timed out empty-handed.
+			req, err := q.Poll(ctx, "h1", 300*time.Millisecond)
+			if err == nil {
+				_ = q.PostResponse(req.ReqID, TunneledResponse{Status: 200})
+			}
+		}()
+
+		select {
+		case <-enqDone:
+		case <-time.After(time.Second):
+			t.Fatalf("iter %d: request dropped in poll/enqueue handoff race", i)
+		}
+	}
+}

--- a/web/components/ftw-pair-card.js
+++ b/web/components/ftw-pair-card.js
@@ -2,9 +2,10 @@
 //
 // v2 of the friend onboarding (Phase 1+2 of relay-as-tunnel):
 //   - shows the public URL the operator copies + sends to the friend
-//   - shows the 4-digit voice-channel approval code prominently
-//   - exposes an Allow form that POSTs the matching code to the relay
-//     once the friend reads it back on voice
+//   - shows the 4-digit activation code prominently, alongside a
+//     "Copy URL + code" button — the operator shares both; the friend
+//     types the code on the relay landing page to activate (no Allow
+//     click on the dashboard, the grant-exchange model approves on entry)
 //   - replaces the misleading "0 clients connected" with a real
 //     last-activity presence indicator backed by the relay's
 //     /tunnel/sessions/<token>/info endpoint


### PR DESCRIPTION
## Why help-a-friend hung end-to-end

The relay tunnel queue (`go/internal/tunnel/queue.go`) leaked a waiter
channel every time a host long-poll timed out. `Poll` returned
`ErrPollTimeout` (and on the ctx-cancel path) **without removing its entry
from `q.waiters[hostID]`**. The next `Enqueue` handed the friend's request to
that abandoned, never-read buffered channel — the request was silently lost
and blocked until the client gave up.

This bit the real flow because a friend naturally takes longer than one
poll-timeout (25s in prod) between entering the code and pasting
`claude mcp add …`, so the **first** MCP request always landed after a poll
had already stranded a waiter. Result: `initialize` / `tools/list` hung even
though approval + the grant exchange had succeeded — i.e. "the MCP server is
unreachable", exactly the e2e failure.

## The fix

`Poll` now deregisters its waiter on both the timeout and ctx-cancel exits,
and if a producer claimed the waiter in the same instant it delivers that
buffered request instead of dropping it. Regression tests cover the
timeout-strand, ctx-cancel-strand, and the producer/timeout handoff race.

## Verification

- New unit tests fail on `master`, pass after the fix; full tunnel suite
  green under `-race`.
- Live with the real `ftw-relay` + `ftw-pair` binaries: with a 2s
  poll-timeout every post-idle MCP request hung before, returns 200 in
  <2ms after.
- **Against the production relay** (`relay.fortytwowatts.com`, now running
  this binary): a full `initialize → notifications/initialized →
  tools/list` (17 tools) handshake survives 28–30s idle gaps. Pre-fix the
  first post-idle request stranded.

## Second commit — docs

The grant-exchange model shipped in #394 but `docs/ftw-pair.md` and several
comments still described the old "friend reads the code over voice, operator
clicks **Allow** on the dashboard" model. There is no Allow click anymore:
the operator shares URL + code, the friend types the code to activate, which
mints the grant. Doc/comment-only, no behaviour change.

## Deploy note

The production relay VM has been hot-patched with this binary
(`v0.109.0-hotfix-poll-waiter`); the previous binary is backed up on the VM.
Once this merges and a release cuts, the relay should be reset to the
official release asset per `docs/relay-deploy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)