### PR TITLE
feat(ui): expose pv_forecast_safety_k on the Planner settings tab

### DIFF
--- a/.changeset/ui-pv-forecast-safety-k.md
+++ b/.changeset/ui-pv-forecast-safety-k.md
@@ -1,0 +1,9 @@
+---
+"forty-two-watts": minor
+---
+
+**Settings UI: expose `pv_forecast_safety_k` on the Planner tab.** The
+downside-PV safety factor (v0.111.0) was config-only; it now has a "PV forecast
+safety (k)" field under Settings → Planner (default 1.0, with inline help).
+Operators can dial it down to 0 to use the full battery, or up to keep more
+reserve on uncertain days, without editing config.yaml.

--- a/web/index.html
+++ b/web/index.html
@@ -677,7 +677,7 @@
   <script src="/settings/tabs/price.js?v=tabsplit1"></script>
   <script src="/settings/tabs/weather.js?v=tabsplit1"></script>
   <script src="/settings/tabs/batteries.js?v=tabsplit1"></script>
-  <script src="/settings/tabs/planner.js?v=tabsplit1"></script>
+  <script src="/settings/tabs/planner.js?v=pvsafetyk"></script>
   <script src="/settings/tabs/ha.js?v=tabsplit1"></script>
   <script src="/settings/tabs/notifications.js?v=tabsplit1"></script>
   <script src="/settings/tabs/ev.js?v=tabsplit1"></script>

--- a/web/legacy.html
+++ b/web/legacy.html
@@ -352,7 +352,7 @@
   <script src="/settings/tabs/price.js?v=tabsplit1"></script>
   <script src="/settings/tabs/weather.js?v=tabsplit1"></script>
   <script src="/settings/tabs/batteries.js?v=tabsplit1"></script>
-  <script src="/settings/tabs/planner.js?v=tabsplit1"></script>
+  <script src="/settings/tabs/planner.js?v=pvsafetyk"></script>
   <script src="/settings/tabs/ha.js?v=tabsplit1"></script>
   <script src="/settings/tabs/notifications.js?v=tabsplit1"></script>
   <script src="/settings/tabs/ev.js?v=tabsplit1"></script>

--- a/web/settings/tabs/planner.js
+++ b/web/settings/tabs/planner.js
@@ -20,6 +20,10 @@
           "Highest SoC the planner will charge to (percent). 90 = 90%.") +
         '</div></div>' +
         '<div class="field-row"><div>' +
+        field("PV forecast safety (k)", "planner.pv_forecast_safety_k", "number", 1.0,
+          "How conservative the planner is about solar that might not arrive. It plans against forecast − k×σ, where σ is the live PV-forecast error. Higher k keeps more battery reserve on uncertain/cloudy days; 1.0 is the default; 0 = use the full battery (no hedge). On clear days and in winter the hedge is ~0 automatically.") +
+        '</div></div>' +
+        '<div class="field-row"><div>' +
         field("Base load (W)", "planner.base_load_w", "number", 0,
           "Constant household load estimate used when the load twin has no data yet.") +
         '</div><div>' +


### PR DESCRIPTION
## What

Adds a **PV forecast safety (k)** field under **Settings → Planner**, exposing
the `pv_forecast_safety_k` config knob shipped in v0.111.0 (downside-PV
planning). Default 1.0, with inline help.

- 0 → no hedge (use the full battery)
- 1.0 → default
- higher → keep more reserve on uncertain/cloudy days

## Notes

- The config field is `*float64` (unset → 1.0). The settings helper's
  `field(label, path, type, dflt, …)` shows the default for an unset value, and
  saving round-trips a plain number through `POST /api/config` (→ `*float64`;
  `0` is preserved as an explicit "no hedge").
- Bumped the `planner.js` cache-buster (`?v=tabsplit1` → `?v=pvsafetyk`) in
  `index.html` + `legacy.html` so the field appears after an in-app update.
- Web-only; `planner.js` passes `node --check`. No Go change (the config field
  + wiring already exist on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)