### PR TITLE
feat(loadpoint): manual charge-current slider (Tesla-style amps override)

### DIFF
--- a/.changeset/manual-charge-current.md
+++ b/.changeset/manual-charge-current.md
@@ -1,0 +1,17 @@
+---
+"forty-two-watts": minor
+---
+
+**Manual charge-current slider for EV loadpoints (Tesla-style).** You can now set
+the charge current (amps) to the car from the dashboard instead of fiddling with
+the car or wallbox. The Loadpoints panel gets a per-loadpoint **Charge current**
+slider (6 A → the charger's max) with an **Auto** button.
+
+- Setting a current is a manual override that **persists until you pick Auto or
+  the car unplugs**, and it overrides surplus-only/schedule (you asked to charge
+  now) — but the fuse guard still applies.
+- The controller converts amps→watts at the loadpoint's phase count and commands
+  that explicit phase mode, so the per-phase current the wallbox sets equals the
+  slider. Above the charger's max it clamps.
+- New endpoints: `POST/GET/DELETE /api/loadpoints/{id}/charge_current`;
+  `/api/loadpoints` now reports `manual_current_a` + `manual_current_max_a`.

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -295,6 +295,9 @@ func (s *Server) routes() {
 	s.handle("POST /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHold)
 	s.handle("DELETE /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHoldClear)
 	s.handle("GET  /api/loadpoints/{id}/manual_hold", s.handleLoadpointManualHoldGet)
+	s.handle("POST /api/loadpoints/{id}/charge_current", s.handleLoadpointChargeCurrent)
+	s.handle("DELETE /api/loadpoints/{id}/charge_current", s.handleLoadpointChargeCurrentClear)
+	s.handle("GET  /api/loadpoints/{id}/charge_current", s.handleLoadpointChargeCurrentGet)
 	s.handle("POST /api/battery/manual_hold", s.handleBatteryManualHold)
 	s.handle("DELETE /api/battery/manual_hold", s.handleBatteryManualHoldClear)
 	s.handle("GET  /api/battery/manual_hold", s.handleBatteryManualHoldGet)
@@ -2315,6 +2318,12 @@ func (s *Server) handleLoadpoints(w http.ResponseWriter, r *http.Request) {
 	states := s.deps.Loadpoints.States()
 	if s.deps.Tel != nil {
 		decorateLoadpointsWithVehicle(states, s.deps.Tel)
+	}
+	if s.deps.LoadpointCtrl != nil {
+		for i := range states {
+			states[i].ManualCurrentA, states[i].ManualCurrentMaxA =
+				s.deps.LoadpointCtrl.ManualCurrentInfo(states[i].ID)
+		}
 	}
 	writeJSON(w, 200, map[string]any{
 		"enabled":    true,

--- a/go/internal/api/api_loadpoint_current.go
+++ b/go/internal/api/api_loadpoint_current.go
@@ -1,0 +1,80 @@
+package api
+
+import "net/http"
+
+// User-facing charge-current override — the dashboard amps slider (Tesla-style
+// "set my charge current"). Distinct from the diagnostics manual_hold: it has
+// no expiry, overrides surplus/schedule (the user asked to charge now), and is
+// cleared automatically when the car unplugs. Lives in its own file per the
+// api/CLAUDE.md split; registered via routes() in api.go.
+
+type chargeCurrentRequest struct {
+	Amps float64 `json:"amps"`
+}
+
+type chargeCurrentResponse struct {
+	Amps float64 `json:"amps"`            // active override (0 = Auto/off)
+	MaxA float64 `json:"max_a,omitempty"` // charger max, for the slider upper bound
+}
+
+// lpCurrentPreflight resolves + validates the loadpoint id, writing the error
+// response itself. Returns (id, true) on success.
+func (s *Server) lpCurrentPreflight(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if s.deps.LoadpointCtrl == nil {
+		writeJSON(w, 503, map[string]string{"error": "loadpoint controller not available"})
+		return "", false
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, 400, map[string]string{"error": "id required"})
+		return "", false
+	}
+	if s.deps.Loadpoints == nil {
+		writeJSON(w, 404, map[string]string{"error": "loadpoints not configured"})
+		return "", false
+	}
+	if _, ok := s.deps.Loadpoints.State(id); !ok {
+		writeJSON(w, 404, map[string]string{"error": "loadpoint not found"})
+		return "", false
+	}
+	return id, true
+}
+
+// handleLoadpointChargeCurrent — POST /api/loadpoints/{id}/charge_current
+// Body {"amps": N}. amps <= 0 clears the override (Auto). The override persists
+// until cleared or the car unplugs.
+func (s *Server) handleLoadpointChargeCurrent(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.lpCurrentPreflight(w, r)
+	if !ok {
+		return
+	}
+	var req chargeCurrentRequest
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	s.deps.LoadpointCtrl.SetManualCurrent(id, req.Amps)
+	amps, maxA := s.deps.LoadpointCtrl.ManualCurrentInfo(id)
+	writeJSON(w, 200, chargeCurrentResponse{Amps: amps, MaxA: maxA})
+}
+
+// handleLoadpointChargeCurrentClear — DELETE — back to Auto.
+func (s *Server) handleLoadpointChargeCurrentClear(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.lpCurrentPreflight(w, r)
+	if !ok {
+		return
+	}
+	s.deps.LoadpointCtrl.ClearManualCurrent(id)
+	_, maxA := s.deps.LoadpointCtrl.ManualCurrentInfo(id)
+	writeJSON(w, 200, chargeCurrentResponse{Amps: 0, MaxA: maxA})
+}
+
+// handleLoadpointChargeCurrentGet — GET — active override + slider max.
+func (s *Server) handleLoadpointChargeCurrentGet(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.lpCurrentPreflight(w, r)
+	if !ok {
+		return
+	}
+	amps, maxA := s.deps.LoadpointCtrl.ManualCurrentInfo(id)
+	writeJSON(w, 200, chargeCurrentResponse{Amps: amps, MaxA: maxA})
+}

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -83,6 +83,12 @@ type Controller struct {
 	// compute-from-plan path.
 	holdMu sync.Mutex
 	holds  map[string]ManualHold
+	// manualCurrent is the user-facing "set my charge current" override (the
+	// dashboard amps slider, like the Tesla app). Unlike a diagnostics hold it
+	// persists — no expiry — until the user picks Auto or the car unplugs
+	// (tickOne clears it on the disconnect edge). Value is amps; 0/absent means
+	// no override → normal surplus/schedule/plan dispatch. Guarded by holdMu.
+	manualCurrent map[string]float64
 
 	// surplusMu protects surplusWin + surplusPaused, the per-loadpoint
 	// state that smooths the surplus_only pause/resume decision over
@@ -1057,6 +1063,93 @@ func (c *Controller) GetManualHold(id string, now time.Time) (ManualHold, bool) 
 	return h, true
 }
 
+// SetManualCurrent installs the user-facing charge-current override (amps) for
+// a loadpoint. It persists until ClearManualCurrent, a SetManualCurrent(≤0), or
+// the car unplugs (tickOne clears it on the disconnect edge). amps ≤ 0 clears.
+func (c *Controller) SetManualCurrent(id string, amps float64) {
+	if c == nil {
+		return
+	}
+	c.holdMu.Lock()
+	defer c.holdMu.Unlock()
+	if c.manualCurrent == nil {
+		c.manualCurrent = map[string]float64{}
+	}
+	if amps <= 0 {
+		delete(c.manualCurrent, id)
+		return
+	}
+	c.manualCurrent[id] = amps
+}
+
+// ClearManualCurrent removes the charge-current override. Idempotent.
+func (c *Controller) ClearManualCurrent(id string) {
+	if c == nil {
+		return
+	}
+	c.holdMu.Lock()
+	defer c.holdMu.Unlock()
+	delete(c.manualCurrent, id)
+}
+
+// GetManualCurrent returns the override amps for a loadpoint, ok=false when none.
+func (c *Controller) GetManualCurrent(id string) (float64, bool) {
+	if c == nil {
+		return 0, false
+	}
+	c.holdMu.Lock()
+	defer c.holdMu.Unlock()
+	a, ok := c.manualCurrent[id]
+	return a, ok
+}
+
+// ManualCurrentInfo returns the active override amps (0 if none) and the
+// charger's max settable amps — the amps that map to the loadpoint's
+// MaxChargeW at its phase count — for the dashboard slider's upper bound.
+func (c *Controller) ManualCurrentInfo(id string) (amps, maxA float64) {
+	if c == nil {
+		return 0, 0
+	}
+	amps, _ = c.GetManualCurrent(id)
+	if c.manager == nil {
+		return amps, 0
+	}
+	for _, cfg := range c.manager.Configs() {
+		if cfg.ID != id {
+			continue
+		}
+		fuse := c.siteFuse()
+		v := fuse.Voltage
+		if v <= 0 {
+			v = 230
+		}
+		phases := manualCurrentPhases(cfg, fuse)
+		if cfg.MaxChargeW > 0 {
+			maxA = cfg.MaxChargeW / (v * float64(phases))
+		}
+		break
+	}
+	return amps, maxA
+}
+
+// manualCurrentPhases is the phase count used to convert the override amps to
+// power and to pick the commanded phase_mode, so the driver's per-phase current
+// equals the slider. Explicit loadpoint PhaseMode wins; otherwise the service-
+// entrance phase count (3φ install → 3, single-phase → 1).
+func manualCurrentPhases(lpCfg Config, fuse SiteFuse) int {
+	switch lpCfg.PhaseMode {
+	case "1p":
+		return 1
+	case "3p":
+		return 3
+	default:
+		if fuse.PhaseCnt == 1 {
+			return 1
+		}
+		return 3
+	}
+}
+
 // Tick runs one dispatch cycle for every configured loadpoint.
 // Safe to call even when no loadpoints are configured. Idempotent —
 // calling it twice in the same moment produces the same commands.
@@ -1118,6 +1211,9 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	}
 	c.manager.Observe(lpCfg.ID, sample.Connected, sample.PowerW, sample.SessionWh, sample.RequestActive)
 	if !sample.Connected {
+		// Car unplugged → the session is over; drop any user charge-current
+		// override so the next car/session resumes normal auto dispatch.
+		c.ClearManualCurrent(lpCfg.ID)
 		c.resetSurplusSession(lpCfg.ID)
 		return
 	}
@@ -1206,6 +1302,37 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 		case hold.SitePhases > 0:
 			cmd["site_phases"] = hold.SitePhases
 		case site.MaxAmps > 0:
+			cmd["site_phases"] = site.Phases()
+		}
+	} else if amps, mcOK := c.GetManualCurrent(lpCfg.ID); mcOK && amps > 0 {
+		// User charge-current override (dashboard amps slider, Tesla-style).
+		// Charge NOW at the requested amps — overrides surplus_only and the
+		// plan budget (the user explicitly asked to charge) — but still
+		// respects the fuse. Convert amps→watts at the loadpoint's phase count
+		// and command that explicit phase_mode so the driver's per-phase
+		// current equals the slider.
+		site := c.siteFuse()
+		v := site.Voltage
+		if v <= 0 {
+			v = 230
+		}
+		phases := manualCurrentPhases(lpCfg, site)
+		wantW := amps * v * float64(phases)
+		if lpCfg.MaxChargeW > 0 && wantW > lpCfg.MaxChargeW {
+			wantW = lpCfg.MaxChargeW
+		}
+		wantW = c.applyFuseClampAndCooldown(now, lpCfg, wantW)
+		cmd["power_w"] = wantW
+		if phases == 1 {
+			cmd["phase_mode"] = "1p"
+		} else {
+			cmd["phase_mode"] = "3p"
+		}
+		if site.Voltage > 0 {
+			cmd["voltage"] = site.Voltage
+		}
+		if site.MaxAmps > 0 {
+			cmd["max_amps_per_phase"] = site.MaxAmps
 			cmd["site_phases"] = site.Phases()
 		}
 	} else {

--- a/go/internal/loadpoint/controller_manual_current_test.go
+++ b/go/internal/loadpoint/controller_manual_current_test.go
@@ -1,0 +1,77 @@
+package loadpoint
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Manual charge-current is the user-facing "set my amps" override (the Tesla-app
+// slider). Unlike the diagnostics manual_hold it persists until the user picks
+// Auto or the car unplugs, overrides surplus/schedule (the user asked to charge
+// now), but still respects the fuse. The controller converts amps→watts at the
+// loadpoint's phase count and commands that explicit phase_mode so the driver's
+// per-phase current equals the slider.
+
+func runManualCurrentTick(t *testing.T, cfg Config, amps float64, now time.Time) (sentCommand, *Controller) {
+	t.Helper()
+	dir := &Directive{
+		SlotStart:         now.Add(-1 * time.Second),
+		SlotEnd:           now.Add(60 * time.Minute),
+		LoadpointEnergyWh: map[string]float64{cfg.ID: 6000},
+	}
+	sender := &fakeSender{}
+	samples := map[string]EVSample{cfg.DriverName: {Connected: true, PowerW: 0}}
+	c := newTestController(t, []Config{cfg}, dir, samples, sender)
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	c.SetManualCurrent(cfg.ID, amps)
+	c.Tick(context.Background(), now)
+	if len(sender.calls) != 1 {
+		t.Fatalf("expected 1 send, got %d", len(sender.calls))
+	}
+	return sender.calls[0], c
+}
+
+func TestManualCurrentCommandsAmpsAndOverridesPlanner(t *testing.T) {
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	cfg := holdLoadpoint() // MaxChargeW 11000, PhaseMode "auto"
+	cmd, _ := runManualCurrentTick(t, cfg, 10, now)
+	// auto + 3-phase fuse → 3p; 10 A × 230 V × 3 = 6900 W (≤ 11000 cap).
+	if cmd.power != 6900 {
+		t.Errorf("power = %.0f, want 6900 (10 A × 230 V × 3φ)", cmd.power)
+	}
+	if cmd.phaseMode != "3p" {
+		t.Errorf("phase_mode = %q, want \"3p\" so the driver sets 10 A/phase", cmd.phaseMode)
+	}
+}
+
+func TestManualCurrentClampedToChargerMax(t *testing.T) {
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	cfg := holdLoadpoint()
+	// 20 A × 230 × 3 = 13800 W, above the 11000 W charger ceiling → clamp.
+	cmd, _ := runManualCurrentTick(t, cfg, 20, now)
+	if cmd.power != cfg.MaxChargeW {
+		t.Errorf("power = %.0f, want %.0f (clamped to charger max)", cmd.power, cfg.MaxChargeW)
+	}
+}
+
+func TestManualCurrentClearedOnUnplug(t *testing.T) {
+	now := time.Date(2026, 4, 26, 18, 0, 0, 0, time.UTC)
+	cfg := holdLoadpoint()
+	dir := &Directive{SlotStart: now.Add(-time.Second), SlotEnd: now.Add(time.Hour),
+		LoadpointEnergyWh: map[string]float64{cfg.ID: 6000}}
+	sender := &fakeSender{}
+	samples := map[string]EVSample{cfg.DriverName: {Connected: true, PowerW: 0}}
+	c := newTestController(t, []Config{cfg}, dir, samples, sender)
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	c.SetManualCurrent(cfg.ID, 12)
+	if a, ok := c.GetManualCurrent(cfg.ID); !ok || a != 12 {
+		t.Fatalf("precondition: manual current should be 12 A, got %v %v", a, ok)
+	}
+	// Car unplugs.
+	samples[cfg.DriverName] = EVSample{Connected: false}
+	c.Tick(context.Background(), now.Add(5*time.Second))
+	if _, ok := c.GetManualCurrent(cfg.ID); ok {
+		t.Error("manual current must be cleared on unplug")
+	}
+}

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -155,6 +155,13 @@ type State struct {
 	MaxChargeW    float64   `json:"max_charge_w"`
 	AllowedStepsW []float64 `json:"allowed_steps_w,omitempty"`
 
+	// ManualCurrentA is the active user "set my charge current" override (amps,
+	// the dashboard slider). 0 = Auto (no override → normal dispatch).
+	// ManualCurrentMaxA is the charger's max settable amps, for the slider's
+	// upper bound. Populated by the API layer from the loadpoint controller.
+	ManualCurrentA    float64 `json:"manual_current_a"`
+	ManualCurrentMaxA float64 `json:"manual_current_max_a,omitempty"`
+
 	// SurplusOnly mirrors Config.SurplusOnly with any runtime override
 	// (set via POST /api/loadpoints/{id}/target). Always emitted (no
 	// omitempty) so a polling client can distinguish "explicitly off"

--- a/web/index.html
+++ b/web/index.html
@@ -686,7 +686,7 @@
   <script src="/models.js?v=diag1"></script>
   <script src="/plan.js?v=diag1"></script>
   <script src="/twins.js?v=diag1"></script>
-  <script src="/loadpoints.js?v=lp1"></script>
+  <script src="/loadpoints.js?v=amps"></script>
   <script src="/diagnose.js?v=diag1"></script>
   <script src="/update-badge.js?v=modal1" defer></script>
   <script>

--- a/web/loadpoints.js
+++ b/web/loadpoints.js
@@ -25,12 +25,36 @@
   // typical overnight charging window plus the next afternoon.
   const SCHEDULE_SLOTS = 96;
 
+  // true while the user is dragging an amps slider, so the 10 s poll doesn't
+  // rebuild the DOM out from under the drag.
+  let suspendRefresh = false;
+
   async function fetchAll() {
+    if (suspendRefresh) return;
     const [lps, plan] = await Promise.all([
       fetch('/api/loadpoints').then(r => r.json()).catch(() => ({ loadpoints: [] })),
       fetch('/api/mpc/plan').then(r => r.json()).catch(() => null),
     ]);
     render(lps && lps.loadpoints ? lps.loadpoints : [], plan);
+  }
+
+  // Charge-current control: a Tesla-style amps slider per loadpoint. Sets a
+  // manual override (POST /charge_current) that persists until Auto or the car
+  // unplugs; overrides surplus/schedule. Range is 6 A → the charger's max.
+  function chargeCurrentControl(lp) {
+    const maxA = Math.round(lp.manual_current_max_a > 0 ? lp.manual_current_max_a : 16);
+    const minA = 6;
+    const manual = lp.manual_current_a > 0;
+    const val = manual ? Math.round(lp.manual_current_a) : maxA;
+    const label = manual ? `${Math.round(lp.manual_current_a)} A · manual` : 'Auto';
+    return `<div class="lp-amps">` +
+      `<div class="lp-amps-head"><span class="lp-cfg-key">Charge current</span>` +
+      `<span class="lp-amps-val${manual ? ' lp-amps-manual' : ''}">${label}</span></div>` +
+      `<div class="lp-amps-row">` +
+      `<input class="lp-amps-slider" type="range" min="${minA}" max="${maxA}" step="1" value="${val}" ` +
+      `data-lp-id="${lp.id}" aria-label="Charge current (amps)">` +
+      `<button class="lp-amps-auto" data-lp-id="${lp.id}"${manual ? '' : ' disabled'}>Auto</button>` +
+      `</div></div>`;
   }
 
   function fmtW(w) {
@@ -169,6 +193,7 @@
       `<div class="lp-card-header"><h3>${lp.id}</h3></div>` +
       '<div class="lp-card-body">' +
       configBlock(lp) +
+      chargeCurrentControl(lp) +
       scheduleTable(lp, plan) +
       '</div></div>';
   }
@@ -222,7 +247,43 @@
     }
   }
 
+  function postChargeCurrent(id, amps) {
+    return fetch(`/api/loadpoints/${encodeURIComponent(id)}/charge_current`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amps }),
+    }).catch(() => {});
+  }
+
   function init() {
+    // Delegate on the stable grid so handlers survive the poll's innerHTML swap.
+    const grid = document.getElementById('loadpoints-grid');
+    if (grid) {
+      grid.addEventListener('input', (e) => {
+        const t = e.target;
+        if (!t.classList || !t.classList.contains('lp-amps-slider')) return;
+        suspendRefresh = true; // freeze the poll while dragging
+        const box = t.closest('.lp-amps');
+        const lbl = box && box.querySelector('.lp-amps-val');
+        if (lbl) { lbl.textContent = `${t.value} A · manual`; lbl.classList.add('lp-amps-manual'); }
+        const auto = box && box.querySelector('.lp-amps-auto');
+        if (auto) auto.disabled = false;
+      });
+      grid.addEventListener('change', async (e) => {
+        const t = e.target;
+        if (!t.classList || !t.classList.contains('lp-amps-slider')) return;
+        await postChargeCurrent(t.getAttribute('data-lp-id'), parseFloat(t.value));
+        suspendRefresh = false;
+        fetchAll();
+      });
+      grid.addEventListener('click', async (e) => {
+        const t = e.target;
+        if (!t.classList || !t.classList.contains('lp-amps-auto')) return;
+        await fetch(`/api/loadpoints/${encodeURIComponent(t.getAttribute('data-lp-id'))}/charge_current`,
+          { method: 'DELETE' }).catch(() => {});
+        suspendRefresh = false;
+        fetchAll();
+      });
+    }
     fetchAll();
     setInterval(fetchAll, REFRESH_MS);
   }

--- a/web/style.css
+++ b/web/style.css
@@ -1748,6 +1748,49 @@ body.advanced #ui-mode-toggle { color: #fbbf24; }
   background: var(--amber, var(--accent, #5566ff));
   border-color: transparent;
 }
+.lp-amps {
+  padding: 8px 0 4px;
+  margin-top: 4px;
+  border-top: 1px solid var(--line, rgba(255,255,255,0.08));
+}
+.lp-amps-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+.lp-amps-val {
+  font-family: var(--mono, monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.74rem;
+  color: var(--fg-dim, var(--text-dim, #94a3b8));
+}
+.lp-amps-val.lp-amps-manual { color: var(--amber, var(--accent, #5566ff)); }
+.lp-amps-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.lp-amps-slider {
+  flex: 1;
+  height: 4px;
+  cursor: pointer;
+  accent-color: var(--amber, var(--accent, #5566ff));
+}
+.lp-amps-auto {
+  font-family: var(--mono, monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border: 1px solid var(--line, rgba(255,255,255,0.08));
+  border-radius: 3px;
+  background: transparent;
+  color: var(--fg, var(--text, #e2e8f0));
+  cursor: pointer;
+}
+.lp-amps-auto:disabled { opacity: 0.4; cursor: default; }
+.lp-amps-auto:not(:disabled):hover { border-color: var(--amber, var(--accent, #5566ff)); }
 .lp-schedule-wrap {
   /* Bound the table height so a 16-row plan doesn't push the card
      off-screen on a small viewport. The diag-table inherits a sticky


### PR DESCRIPTION
## Why

Field request (Stefsko on Discord): *"Jag skulle gärna se ett reglage för att
justera laddström till bilen — Tesla har det i sin app, men Volvon måste man
justera ute i bilen."* Set the EV charge current from the dashboard.

## What

A user-facing **manual charge-current override**, distinct from the diagnostics
`manual_hold`: no expiry, overrides surplus-only/schedule (the user explicitly
asked to charge now), respects the fuse, and **clears automatically when the car
unplugs**.

- **Controller:** `SetManualCurrent` / `ClearManualCurrent` / `GetManualCurrent`
  + `ManualCurrentInfo` (override amps + charger max). `tickOne` converts
  amps→watts at the loadpoint's phase count, clamps to `MaxChargeW` + the fuse,
  and commands the matching `phase_mode` so the wallbox's **per-phase current
  equals the slider**. Cleared on the disconnect edge.
- **API:** `POST/GET/DELETE /api/loadpoints/{id}/charge_current`;
  `/api/loadpoints` now reports `manual_current_a` + `manual_current_max_a`.
- **UI:** a per-loadpoint **Charge current** slider (6 A → charger max) + **Auto**
  on the Loadpoints panel — theme-tokened, amber accent, poll suspended while
  dragging so the 10 s refresh doesn't fight the drag.

## Decisions (per @fredde)

- **(b)** a real persistent override (not the 30-min `manual_hold`).
- Persists until **Auto or unplug** — "start there, refine on user feedback".
- Slider max = **the charger's** max amps (`MaxChargeW / (V × phases)`), not the
  car's.
- A manual current currently **overrides surplus_only** (Tesla mental model:
  set the current, it charges from grid). Flagged in the changeset for field
  feedback.

## Tests

- Controller: commands the right amps (10 A × 230 V × 3φ = 6900 W), clamps to
  the charger max, clears on unplug.
- loadpoint + api green under `-race`; `loadpoints.js` passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)