### PR TITLE
fix(ui): battery node shows just the target (drop charge/discharge suffix)

### DIFF
--- a/.changeset/battery-node-target-overflow.md
+++ b/.changeset/battery-node-target-overflow.md
@@ -1,0 +1,9 @@
+---
+"forty-two-watts": patch
+---
+
+ui(flow): drop the "· charging/discharging" suffix on battery nodes
+
+The battery node in the energy-flow view showed `target −83 W · discharging`,
+which overflowed the node circle. The suffix is now removed — the live W value
+and SoC% already convey direction — so the label reads just `target −83 W`.

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -370,16 +370,11 @@
     el.textContent = (soc * 100).toFixed(1) + " %";
     el.className = "live-stat-value is-neutral";
   }
-  function batteryStateLabel(w) {
-    var watts = Number(w) || 0;
-    var idleW = flowIdleKw() * 1000;
-    if (watts > idleW) return "charging";
-    if (watts < -idleW) return "discharging";
-    return "idle";
-  }
   function batteryTargetLine(targetW) {
     if (targetW == null || !isFinite(targetW)) return "";
-    return "target " + formatW(targetW) + " · " + batteryStateLabel(targetW);
+    // Just the target — the "· charging/discharging" suffix overflowed the
+    // node circle; the live W value + SoC% already convey direction.
+    return "target " + formatW(targetW);
   }
 
   function smoothDisplayNumber(key, value, now) {


### PR DESCRIPTION
## What

The battery node in the energy-flow view rendered `target −83 W · discharging`, and the `· charging/discharging` suffix overflowed the node circle (see report). Drop the suffix — the live W value and SoC% already convey direction — so it reads `target −83 W`.

`web/next-app.js`: `batteryTargetLine` no longer appends the state label; the now-unused `batteryStateLabel` helper is removed. `flowIdleKw` is still used by `isFlowIdle`. `node --check` clean.

## Test plan

- [x] `node --check web/next-app.js` passes
- [ ] Visual: battery node label fits the circle, reads `target …W`

🤖 Generated with [Claude Code](https://claude.com/claude-code)