### PR TITLE
feat(ui): dashboard banner for DB corruption auto-recovery

### DIFF
--- a/.changeset/storage-health-banner.md
+++ b/.changeset/storage-health-banner.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": patch
+---
+
+ui: dashboard banner when the database auto-recovered from corruption
+
+The dashboard now reads the `storage` field from `GET /api/health` (added in
+the two-tier storage work) and shows a dismissible amber banner when
+`state.db` or `cache.db` was found corrupt and healed at boot — e.g. "cache.db
+was corrupt — rebuilt empty, re-fetching" or "state.db … restored from last
+snapshot". Closes the loop so DB corruption is visible at a glance instead of
+only in the logs.

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1910,11 +1910,17 @@
     Promise.all([
       fetch("/api/status").then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); }),
       fetch("/api/loadpoints").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
+      fetch("/api/health").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }),
     ])
       .then(function (results) {
         var data = results[0];
         var lp = results[1];
+        var health = results[2];
         lastStatusPayload = data;
+        // Surface DB corruption-recovery events (boot-time, immutable per
+        // process) as a top banner. Tolerant: health may be null.
+        try { updateStorageBanner(health && health.storage); }
+        catch (eSb) { /* silent */ }
         if (lp && Array.isArray(lp.loadpoints)) {
           var idx = {};
           lp.loadpoints.forEach(function (l) {
@@ -1939,6 +1945,66 @@
         setConnected(false);
         if (firstLoad) { showSetupBanner(); }
       });
+  }
+
+  // ---- Storage-health banner (DB corruption auto-recovered) ----
+  // storage = { state, cache, last_event_ms, detail } from /api/health.
+  // Heal events are set once at boot and never change, so a session-scoped
+  // dismissal (keyed on the event) hides it without losing a fresh alert
+  // after a later restart.
+  function updateStorageBanner(storage) {
+    var existing = document.getElementById("storage-banner");
+    var bad = !!storage && (
+      (storage.state && storage.state !== "ok") ||
+      (storage.cache && storage.cache !== "ok")
+    );
+    if (!bad) { if (existing) existing.remove(); return; }
+
+    var key = String(storage.last_event_ms || storage.detail || "1");
+    try {
+      if (sessionStorage.getItem("ftw-storage-banner-dismissed") === key) {
+        if (existing) existing.remove();
+        return;
+      }
+    } catch (e) { /* sessionStorage unavailable — show anyway */ }
+
+    var detail = storage.detail || "Database recovered from a problem.";
+    if (existing) {
+      var t = existing.querySelector(".storage-banner-text");
+      if (t) t.textContent = detail;
+      existing.setAttribute("data-key", key);
+      return;
+    }
+
+    var banner = document.createElement("div");
+    banner.id = "storage-banner";
+    banner.className = "storage-banner";
+    banner.setAttribute("data-key", key);
+
+    var tag = document.createElement("span");
+    tag.className = "storage-banner-tag";
+    tag.textContent = "Storage";
+
+    var text = document.createElement("span");
+    text.className = "storage-banner-text";
+    text.textContent = detail;
+
+    var dismiss = document.createElement("button");
+    dismiss.className = "storage-banner-dismiss";
+    dismiss.type = "button";
+    dismiss.setAttribute("aria-label", "Dismiss");
+    dismiss.innerHTML = "&times;";
+    dismiss.addEventListener("click", function () {
+      try { sessionStorage.setItem("ftw-storage-banner-dismissed", banner.getAttribute("data-key") || "1"); }
+      catch (e) { /* ignore */ }
+      banner.remove();
+    });
+
+    banner.appendChild(tag);
+    banner.appendChild(text);
+    banner.appendChild(dismiss);
+    var main = document.querySelector("main");
+    if (main) main.parentNode.insertBefore(banner, main);
   }
 
   // ---- Setup banner (bootstrap mode — no config yet) ----

--- a/web/style.css
+++ b/web/style.css
@@ -321,6 +321,40 @@ header h1 {
   color: #fbbf24;
 }
 
+/* ---- Storage-health banner (DB corruption auto-recovered) ---- */
+.storage-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: color-mix(in oklch, var(--amber) 14%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--amber) 45%, transparent);
+  color: var(--fg);
+  text-align: center;
+  padding: 9px 16px;
+  font-size: 0.85rem;
+}
+.storage-banner .storage-banner-tag {
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: var(--amber);
+}
+.storage-banner .storage-banner-dismiss {
+  margin-left: 8px;
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 4px;
+}
+.storage-banner .storage-banner-dismiss:hover {
+  color: var(--fg);
+}
+
 /* ---- "Add a device" prompt ---- */
 .no-devices-prompt {
   text-align: center;


### PR DESCRIPTION
## What

Closes the loop on the resilient-storage work (#417): the dashboard now surfaces the `storage` field from `GET /api/health` as a dismissible amber banner when `state.db` or `cache.db` was found corrupt and auto-healed at boot.

- `web/next-app.js` — folds a tolerant `fetch("/api/health")` into the existing `fetchStatus` `Promise.all` (heal events are boot-time/immutable, but this also catches a post-restart heal). New `updateStorageBanner(storage)` shows/updates/removes the banner; dismissal is session-scoped and keyed on the event, so a *later* corruption re-alerts.
- `web/style.css` — `.storage-banner` reusing the existing setup-banner top-strip pattern, **tokenized** per DESIGN.md (`--amber`, `--line`, `--mono`, `--fg`); no hard-coded colours. Mono uppercase "STORAGE" eyebrow + prose detail + a subtle dismiss ×.

## Verification

Rendered both states in Chrome against the real `theme.css` + `style.css` (preview harness, not committed):

- `cache.db was corrupt — rebuilt empty, re-fetching`
- `state.db was corrupt — restored from last snapshot`

Full-width amber strip, eyebrow + detail fit cleanly (no overflow), dismiss × present. `node --check web/next-app.js` clean.

## Test plan
- [x] JS syntax check; visual render of both banner variants
- [ ] Live: corrupt a dev DB, confirm banner appears on the dashboard and dismiss persists for the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)