### PR TITLE
feat(control): capability-aware battery reallocation

### DIFF
--- a/.changeset/capability-aware-battery-reallocation.md
+++ b/.changeset/capability-aware-battery-reallocation.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": minor
+---
+
+Capability-aware battery reallocation: when one battery can't move in the
+demanded direction this cycle (e.g. a Ferroamp ESO floored at its discharge
+SoC limit), the dispatcher now hands its share to a capable sibling instead
+of leaking it to the grid. Drivers signal this with two optional battery-emit
+fields, `discharge_capable` / `charge_capable`; absent → assumed capable, so
+every existing driver is unaffected. The Ferroamp driver reports both from its
+per-ESO floor/ceiling counts. Symmetric for charge (a full battery is excluded
+from the charge split).

--- a/docs/host-api.md
+++ b/docs/host-api.md
@@ -625,6 +625,8 @@ Emit telemetry for a DER (Distributed Energy Resource) type. This writes the dat
 | `discharge_wh` | Wh       | no       | Lifetime energy discharged     |
 | `upper_limit_w`| W        | no       | Max charge power               |
 | `lower_limit_w`| W        | no       | Max discharge power            |
+| `discharge_capable` | bool | no  | False = pack can't discharge now (e.g. floored). Dispatcher reallocates its share to a capable sibling. Absent → capable. |
+| `charge_capable`    | bool | no  | False = pack can't charge now (e.g. at ceiling). Absent → capable. |
 
 **Example:**
 ```lua

--- a/docs/superpowers/specs/2026-06-04-capability-aware-battery-reallocation-design.md
+++ b/docs/superpowers/specs/2026-06-04-capability-aware-battery-reallocation-design.md
@@ -1,0 +1,219 @@
+# Capability-aware battery reallocation — design
+
+**Date:** 2026-06-04
+**Status:** implemented (TDD) on branch `worktree-battery-capability-reallocation` — `reallocated_w` metric deferred to fast-follow. See the "As built" notes inline.
+**Area:** `go/internal/control` (dispatch), `go/internal/telemetry`, `go/internal/drivers`, `drivers/ferroamp.lua`
+
+## Problem
+
+On a multi-battery site, when one battery internally refuses a dispatch
+direction (e.g. a Ferroamp ESO floored at its discharge SoC limit), the
+unfulfilled share is **not** reallocated to a capable sibling. It leaks
+straight to the grid.
+
+### Live evidence (2026-06-04, Fredrik's site, 192.168.192.40)
+
+Two batteries, mode `planner_passive_arbitrage`, morning low-PV:
+
+| | Ferroamp | Sungrow |
+|---|---|---|
+| SoC | 0.14 | 0.075 |
+| dispatch target | −901 W | −569 W |
+| actual `bat_w` | **0 W** | −560 W |
+| grid | **importing 903 W** | |
+
+Ferroamp metrics: `eso_discharge_capable: 0`, `eso_dispatch_commanded_w: 0`.
+The Ferroamp Lua driver's `DISCHARGE_FLOOR_SOC` (then 0.15) counted zero
+ESOs capable at 0.14 SoC, so `driver_command` took its "all units floored
+→ idle" branch and published 0 W. The Go dispatcher had allocated −901 W
+to it regardless — it has no visibility into the driver's internal floor —
+and never moved that deficit to the Sungrow, which was discharging at
+7.5 % SoC and had ample headroom. Grid import ≈ the Ferroamp's
+undelivered share.
+
+`slot_delivery_stats.under_delivery_count` read 0 throughout — the
+existing aggregate under-delivery accounting did not surface this.
+
+### Two independent root causes
+
+1. **Floor too high for the operator's intent.** Addressed separately and
+   already shipped as a per-site config override:
+   `discharge_floor_soc: 0.11` (live + saved on the Pi). Default stays
+   0.15. See `2026-05-27-ferroamp-soc-bounds-config-design.md`. **Out of
+   scope for this spec.**
+2. **No cross-battery reallocation when a sibling is incapable.** This
+   spec. The floor override reduces how often a battery floors, but the
+   genuine floored case (any battery at its true limit) must still hand
+   its share to a capable sibling rather than the grid.
+
+## Goals
+
+- When the site target is discharge and battery X cannot discharge right
+  now, X is excluded from the discharge split and its share is
+  redistributed proportionally across discharge-capable batteries, bounded
+  by each one's `maxDischargeW`.
+- Symmetric for charge: a battery at its charge ceiling is excluded from
+  the charge split; its share goes to charge-capable siblings.
+- The driver is the source of truth for "can I move this direction right
+  now" — it already knows (Ferroamp: per-ESO floor/ceiling counts).
+- When no capable battery can absorb the demand, the residual goes to the
+  grid **intentionally and observably** (a metric), not as silent leakage.
+
+## Non-goals (v1)
+
+- **Headroom-aware allocation.** The signal is a boolean (capable / not),
+  not "available watts before I hit my limit". Matches Ferroamp's discrete
+  capable-count behaviour and solves the reported case. Continuous headroom
+  is a possible v2.
+- **`weighted` / `priority` legacy distributors.** v1 wires reallocation
+  into `distributeProportional` only — the path all `planner_*` modes use.
+  The legacy weighted/priority distributors are left unchanged (flagged as
+  future work).
+- Changing the planner/MPC. The plan still allocates aggregate energy; this
+  is purely how the EMS distributes that aggregate across the fleet within
+  one cycle.
+
+## Design
+
+### Part 1 — capability signal (driver → telemetry)
+
+`host.emit("battery", {…})` gains two optional boolean fields:
+
+```lua
+host.emit("battery", { w = …, soc = …, discharge_capable = <bool>, charge_capable = <bool> })
+```
+
+- **Absent = unknown = assume capable** in that direction. Back-compatible:
+  every existing driver that doesn't set them keeps today's behaviour.
+- **As built — transport via `DerReading.Data`, not new typed fields.**
+  `emitTelemetry` already passes the whole battery emit table to
+  `Store.Update` as `data json.RawMessage`, so the flags ride along for
+  free; the dispatcher parses them once per cycle when it builds
+  `batteryInfo` (`control/dispatch.go` already does this for per-phase amps:
+  `json.Unmarshal(r.Data, …)`). This replaced the original plan of adding
+  `DischargeCapable/ChargeCapable *bool` to `DerReading` + extending the
+  `Store.Update` signature — that signature has ~50 test call sites and the
+  churn wasn't worth it when `Data` already carries the fields. No hot-path
+  cost (parse is in the per-cycle control loop, not per-poll `Update`), and
+  last-known preservation is unnecessary (the Ferroamp driver emits the
+  flags every poll).
+- `drivers/ferroamp.lua`: in `driver_poll`, set
+  `discharge_capable = (n_discharge_capable > 0)` and
+  `charge_capable = (n_charge_capable > 0)` on the battery emit. The
+  counts already exist in `driver_poll`'s per-ESO floor/ceiling loop
+  (`last_eso_discharge_capable` / `last_eso_charge_capable`). No new
+  hardware read.
+
+### Part 2 — reallocation (dispatcher)
+
+`go/internal/control/dispatch.go`:
+
+- `batteryInfo` gains `dischargeBlocked bool` and `chargeBlocked bool`
+  (as built: **"blocked", not "capable"**, so the Go zero value `false` =
+  not blocked = capable is the safe default — a directly-constructed
+  `batteryInfo` and any non-reporting driver stay capable). Populated by
+  `batteryDirectionBlocks(r.Data)`, which flags a direction blocked only
+  when the driver explicitly emits `*_capable: false`.
+- `distributeProportional` splits the **total desired** site battery power
+  (unchanged: total, not delta — keep the existing "don't distribute from
+  the delta" invariant). New step: when the desired aggregate is discharge,
+  partition online batteries into capable / incapable for that direction.
+  Distribute only across capable batteries, proportional to capacity (and
+  the existing `groupPV` locality bonus still composes). Each battery is
+  still bounded by its `maxDischargeW` (`clampWithSoC` / `DriverLimits`
+  downstream). Incapable batteries get target 0 for that direction.
+  Symmetric when the desired aggregate is charge.
+- If the capable set is empty (every battery blocked in the demanded
+  direction), **as built every battery is parked at 0** rather than falling
+  back to the plain split. The grid outcome is identical (the residual
+  imports/exports either way), but the dispatcher no longer commands a
+  setpoint every driver would only idle — the target now reflects reality.
+  This was a TDD-driven refinement of the original "fall back to today's
+  behaviour" plan.
+
+### Part 3 — safety + observability
+
+- Reallocation runs **before** slew and the fuse guard, so both still bound
+  the result. Slew also damps any transient capability flap (a one-cycle
+  false "incapable" can shift at most `SlewRateW` of power).
+- New per-cycle metric `reallocated_w` (site-level): the magnitude of power
+  moved off incapable batteries onto capable ones this cycle. 0 when no
+  reallocation fired. Makes the behaviour visible and explains residual
+  grid flow that the planner didn't intend. **As built: deferred to a
+  fast-follow.** The `control` package emits no telemetry metrics today
+  (it returns `[]DispatchTarget`; metric emission lives in `main.go`), so
+  `reallocated_w` needs new plumbing that doesn't belong in this
+  behaviour-focused PR. The core reallocation ships without it; the metric
+  is tracked as a follow-up.
+
+## Data flow
+
+```
+ferroamp.lua driver_poll
+  → host.emit("battery", {…, discharge_capable=false, charge_capable=true})
+    → lua.go parses fields
+      → telemetry.Store.Update → DerReading{DischargeCapable:&false, ChargeCapable:&true} (last-known preserved)
+        → control.ComputeDispatch builds batteryInfo{dischargeCapable:false, chargeCapable:true}
+          → distributeProportional: exclude from discharge split, reallocate to capable siblings (≤ maxDischargeW)
+            → slew → fuse guard → []DispatchTarget
+```
+
+## Edge cases
+
+- **All batteries incapable in the demanded direction** → no reallocation;
+  residual to grid; `reallocated_w` records the gap. Same physical outcome
+  as today, now intentional + observable.
+- **Capable siblings saturate `maxDischargeW`** before absorbing the full
+  share → they cap, remainder to grid, recorded.
+- **Direction must not flip.** A charge-capable-only battery is never
+  forced to discharge to fill a discharge deficit, and vice-versa.
+- **Transient flap** (driver briefly reports incapable) → bounded by slew;
+  next cycle corrects. Last-known preservation avoids nil-driven flaps.
+- **Single-battery site** → capable set is {that battery} or {} ; logic is
+  a no-op relative to today.
+
+## Testing
+
+`go/internal/control/dispatch_test.go` (table-driven, via `ComputeDispatch`
+per the package's "tests reach unexported distributors through
+ComputeDispatch" convention):
+
+1. Two batteries, site wants discharge, battery A `dischargeCapable=false`
+   → A target 0, B absorbs A's share up to its `maxDischargeW`, residual (if
+   any) to grid; `reallocated_w` > 0.
+2. Symmetric charge case (A `chargeCapable=false` at ceiling).
+3. Both incapable → no reallocation, residual recorded, no panic / no
+   division-by-zero in the proportional split.
+4. Capability absent (nil) on both → identical targets to today
+   (back-compat regression guard).
+5. Capable sibling saturates `maxDischargeW` → caps, remainder to grid.
+
+`go/internal/telemetry/store_test.go`:
+
+6. `Update` with `discharge_capable=false` then a later emit omitting it →
+   value preserved (last-known), mirroring the SoC-preservation test.
+
+`go/internal/drivers/lua_test.go`:
+
+7. `host.emit("battery", {discharge_capable=false})` round-trips to the
+   `DerReading` field.
+
+Ferroamp driver: extend an existing `driver_poll` test (or add one) to
+assert the emit carries `discharge_capable = (n_discharge_capable > 0)`.
+
+## Rollout
+
+- Pure additive, behind the "absent = capable" default → no behaviour
+  change for any driver until it opts in by emitting the fields.
+- Ferroamp opts in immediately (this PR). Sungrow and others can adopt
+  later; until then they're always treated as capable (today's behaviour).
+- Changeset: `minor` (new telemetry field + dispatcher behaviour, driver
+  capability support).
+
+## Open questions
+
+- Should `reallocated_w` also feed the reactive-replan trigger (so a
+  persistent reallocation nudges the MPC to stop planning discharge into a
+  battery that keeps refusing)? Leaning **no** for v1 — the planner already
+  re-plans on PV/load divergence, and threading capability into the MPC is
+  a larger change. Flag for follow-up.

--- a/drivers/ferroamp.lua
+++ b/drivers/ferroamp.lua
@@ -725,6 +725,17 @@ function driver_poll()
             if wprod_n > 0 then battery.discharge_wh = mj_to_wh(wprod_sum) end
             if wcons_n > 0 then battery.charge_wh    = mj_to_wh(wcons_sum) end
 
+            -- Per-direction capability for the dispatcher's reallocation
+            -- (docs/.../capability-aware-battery-reallocation). Mirrors the
+            -- eso_*_capable counts that already drive our own EHub dispatch
+            -- scaling: when every ESO is floored/ceilinged the pack can't
+            -- move that way this cycle, so the dispatcher should hand its
+            -- share to a capable sibling instead of commanding a setpoint
+            -- driver_command would only idle. Absent on legacy fields →
+            -- the dispatcher assumes capable, so this is purely additive.
+            battery.discharge_capable = n_discharge_capable > 0
+            battery.charge_capable    = n_charge_capable > 0
+
             host.emit("battery", battery)
             if battery.v then host.emit_metric("battery_dc_v", battery.v) end
             if battery.a then host.emit_metric("battery_dc_a", battery.a) end

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -907,6 +907,17 @@ type batteryInfo struct {
 	group         string  // inverter-affinity tag; empty = untagged (#143)
 	maxChargeW    float64 // per-driver cap; 0 = use MaxCommandW default (#145)
 	maxDischargeW float64 // per-driver cap; 0 = use MaxCommandW default (#145)
+
+	// Per-direction blocks the driver reports this cycle. A battery that
+	// can't move in the demanded direction (e.g. a Ferroamp ESO floored at
+	// its SoC limit) is excluded from that direction's split so its share
+	// goes to a capable sibling instead of leaking to the grid. Stored as
+	// "blocked" rather than "capable" so the zero value (false = not blocked
+	// = capable) is the safe default: a battery a driver never flags, and
+	// any directly-constructed batteryInfo, stays capable. See
+	// batteryDirectionBlocks + distributeProportional.
+	dischargeBlocked bool
+	chargeBlocked    bool
 }
 
 // chargeCap returns the effective per-battery charge ceiling, falling
@@ -927,6 +938,29 @@ func (b batteryInfo) dischargeCap() float64 {
 		return b.maxDischargeW
 	}
 	return MaxCommandW
+}
+
+// batteryDirectionBlocks reads the optional discharge_capable / charge_capable
+// flags a driver may include in its battery emit (DerReading.Data) and reports
+// whether the battery is BLOCKED in each direction this cycle. A direction is
+// blocked only when the driver explicitly emits that *_capable flag as false
+// (e.g. the Ferroamp driver when all its ESOs are floored). Absent, empty, or
+// unparseable → not blocked: a driver that doesn't report capability is
+// assumed able, keeping this backward-compatible with every existing driver.
+func batteryDirectionBlocks(data json.RawMessage) (dischargeBlocked, chargeBlocked bool) {
+	if len(data) == 0 {
+		return false, false
+	}
+	var c struct {
+		DischargeCapable *bool `json:"discharge_capable"`
+		ChargeCapable    *bool `json:"charge_capable"`
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return false, false
+	}
+	dischargeBlocked = c.DischargeCapable != nil && !*c.DischargeCapable
+	chargeBlocked = c.ChargeCapable != nil && !*c.ChargeCapable
+	return
 }
 
 // ComputeDispatch runs one cycle of the control loop and returns the targets
@@ -1272,15 +1306,18 @@ func ComputeDispatch(
 			soc = *r.SoC
 		}
 		lim := state.DriverLimits[name]
+		dischargeBlocked, chargeBlocked := batteryDirectionBlocks(r.Data)
 		batteries = append(batteries, batteryInfo{
-			driver:        name,
-			capacityWh:    cap,
-			currentW:      r.SmoothedW,
-			soc:           soc,
-			online:        h.IsOnline(),
-			group:         state.InverterGroups[name],
-			maxChargeW:    lim.MaxChargeW,
-			maxDischargeW: lim.MaxDischargeW,
+			driver:           name,
+			capacityWh:       cap,
+			currentW:         r.SmoothedW,
+			soc:              soc,
+			online:           h.IsOnline(),
+			group:            state.InverterGroups[name],
+			maxChargeW:       lim.MaxChargeW,
+			maxDischargeW:    lim.MaxDischargeW,
+			dischargeBlocked: dischargeBlocked,
+			chargeBlocked:    chargeBlocked,
 		})
 	}
 	onlineBats := make([]batteryInfo, 0, len(batteries))
@@ -2618,6 +2655,48 @@ func liveCurtailLimitW(state *State, store *telemetry.Store) (float64, bool) {
 // to today. With no `groupPV` info or during discharge, the algorithm
 // collapses to a single capacity-proportional split. Issue #143.
 func distributeProportional(bats []batteryInfo, totalCorrection float64, groupPV map[string]float64) []DispatchTarget {
+	var currentTotal float64
+	for _, b := range bats {
+		currentTotal += b.currentW
+	}
+	desiredTotal := currentTotal + totalCorrection
+
+	// Capability-aware reallocation. A battery that can't move in the
+	// demanded direction this cycle (discharge when desiredTotal < 0, charge
+	// when > 0) is excluded from the split and parked at 0; the split runs
+	// over the capable subset only, so its share is absorbed by capable
+	// siblings instead of leaking to the grid. No-op when every battery is
+	// capable (the common case — all existing drivers report capable). When
+	// NONE are capable, splitByCapacityAndPV(nil) returns nil and every
+	// battery stays parked at 0 — an honest target (the residual goes to the
+	// grid regardless, but we don't command a discharge no driver can honour).
+	if desiredTotal != 0 {
+		capable := make([]batteryInfo, 0, len(bats))
+		parked := make([]DispatchTarget, 0)
+		for _, b := range bats {
+			blocked := b.dischargeBlocked
+			if desiredTotal > 0 {
+				blocked = b.chargeBlocked
+			}
+			if blocked {
+				parked = append(parked, DispatchTarget{Driver: b.driver, TargetW: 0, Clamped: true})
+			} else {
+				capable = append(capable, b)
+			}
+		}
+		if len(parked) > 0 {
+			return append(splitByCapacityAndPV(capable, desiredTotal, groupPV), parked...)
+		}
+	}
+	return splitByCapacityAndPV(bats, desiredTotal, groupPV)
+}
+
+// splitByCapacityAndPV distributes desiredTotal across bats: charging with
+// PV-locality info prefers DC-local routing (#143); discharge, idle, or no
+// PV locality falls back to a pure capacity-proportional split. Extracted
+// from distributeProportional so the capability-aware path can run the exact
+// same split over a subset of batteries.
+func splitByCapacityAndPV(bats []batteryInfo, desiredTotal float64, groupPV map[string]float64) []DispatchTarget {
 	var totalCap float64
 	for _, b := range bats {
 		totalCap += b.capacityWh
@@ -2625,11 +2704,6 @@ func distributeProportional(bats []batteryInfo, totalCorrection float64, groupPV
 	if totalCap <= 0 {
 		return nil
 	}
-	var currentTotal float64
-	for _, b := range bats {
-		currentTotal += b.currentW
-	}
-	desiredTotal := currentTotal + totalCorrection
 
 	// Discharge, idle, or no PV locality info → capacity-only split.
 	// Discharge energy flows to the AC bus regardless of where it

--- a/go/internal/control/reallocation_test.go
+++ b/go/internal/control/reallocation_test.go
@@ -1,0 +1,198 @@
+package control
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// targetsByDriver indexes a dispatch result by driver name for assertions.
+func targetsByDriver(targets []DispatchTarget) map[string]DispatchTarget {
+	m := make(map[string]DispatchTarget, len(targets))
+	for _, t := range targets {
+		m[t.Driver] = t
+	}
+	return m
+}
+
+// A battery that reports it cannot discharge right now (e.g. a Ferroamp
+// ESO floored at its SoC limit) must be excluded from the discharge split,
+// and its share reallocated to a capable sibling — not leaked to the grid.
+func TestDischargeReallocatesAroundIncapableBattery(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, 2000, nil, nil) // importing 2000 W
+	s.DriverHealthMut("meter").RecordSuccess()
+
+	socF := 0.5
+	// ferroamp: healthy SoC but signals it can't discharge this cycle.
+	s.Update("ferroamp", telemetry.DerBattery, 0, &socF,
+		json.RawMessage(`{"discharge_capable":false,"charge_capable":true}`))
+	s.DriverHealthMut("ferroamp").RecordSuccess()
+
+	socS := 0.5
+	// sungrow: no capability fields → assumed capable (back-compat).
+	s.Update("sungrow", telemetry.DerBattery, 0, &socS, nil)
+	s.DriverHealthMut("sungrow").RecordSuccess()
+
+	st := NewState(0, 50, "meter")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000 // disable slew so a single cycle reaches the target
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(s, st,
+		caps(map[string]float64{"ferroamp": 15200, "sungrow": 9600}), 11040)
+
+	got := targetsByDriver(targets)
+	// Incapable battery must be parked at ~0 for the discharge.
+	if math.Abs(got["ferroamp"].TargetW) > 1 {
+		t.Errorf("incapable ferroamp should get ~0 W, got %.1f", got["ferroamp"].TargetW)
+	}
+	// Capable sibling must absorb the discharge (negative = discharge).
+	if got["sungrow"].TargetW >= -1 {
+		t.Errorf("capable sungrow should absorb the discharge, got %.1f", got["sungrow"].TargetW)
+	}
+}
+
+// Symmetric to the discharge case: a battery at its charge ceiling
+// (charge_capable=false) is excluded from the charge split; the capable
+// sibling absorbs the charge.
+func TestChargeReallocatesAroundFullBattery(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, -2000, nil, nil) // exporting 2000 W
+	s.DriverHealthMut("meter").RecordSuccess()
+
+	socF := 0.5
+	s.Update("ferroamp", telemetry.DerBattery, 0, &socF,
+		json.RawMessage(`{"discharge_capable":true,"charge_capable":false}`))
+	s.DriverHealthMut("ferroamp").RecordSuccess()
+
+	socS := 0.5
+	s.Update("sungrow", telemetry.DerBattery, 0, &socS, nil)
+	s.DriverHealthMut("sungrow").RecordSuccess()
+
+	st := NewState(0, 50, "meter")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(s, st,
+		caps(map[string]float64{"ferroamp": 15200, "sungrow": 9600}), 11040)
+
+	got := targetsByDriver(targets)
+	if math.Abs(got["ferroamp"].TargetW) > 1 {
+		t.Errorf("full ferroamp should get ~0 W, got %.1f", got["ferroamp"].TargetW)
+	}
+	if got["sungrow"].TargetW <= 1 {
+		t.Errorf("capable sungrow should absorb the charge (positive), got %.1f", got["sungrow"].TargetW)
+	}
+}
+
+// When the capable sibling can't absorb the whole demand (its per-driver
+// maxDischargeW caps it), it delivers what it can and the remainder is left
+// to the grid — the reallocation never forces a battery past its cap.
+func TestReallocationRespectsCapableSiblingCap(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, 3000, nil, nil) // importing 3000 W
+	s.DriverHealthMut("meter").RecordSuccess()
+
+	socF := 0.5
+	s.Update("ferroamp", telemetry.DerBattery, 0, &socF,
+		json.RawMessage(`{"discharge_capable":false}`))
+	s.DriverHealthMut("ferroamp").RecordSuccess()
+
+	socS := 0.5
+	s.Update("sungrow", telemetry.DerBattery, 0, &socS, nil)
+	s.DriverHealthMut("sungrow").RecordSuccess()
+
+	st := NewState(0, 50, "meter")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	// Cap the only capable battery well below the demand.
+	st.DriverLimits = map[string]PowerLimits{"sungrow": {MaxDischargeW: 300}}
+
+	targets := ComputeDispatch(s, st,
+		caps(map[string]float64{"ferroamp": 15200, "sungrow": 9600}), 11040)
+
+	got := targetsByDriver(targets)
+	if math.Abs(got["ferroamp"].TargetW) > 1 {
+		t.Errorf("incapable ferroamp should get ~0 W, got %.1f", got["ferroamp"].TargetW)
+	}
+	if math.Abs(got["sungrow"].TargetW+300) > 1 {
+		t.Errorf("capable sungrow should cap at its -300 W limit, got %.1f", got["sungrow"].TargetW)
+	}
+	if !got["sungrow"].Clamped {
+		t.Errorf("sungrow should be marked clamped at its cap")
+	}
+}
+
+// When no battery can move in the demanded direction, there is nothing to
+// reallocate to: the split must not crash or divide by zero, and both
+// batteries stay parked (residual goes to grid).
+func TestReallocationAllIncapableNoCrash(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, 2000, nil, nil)
+	s.DriverHealthMut("meter").RecordSuccess()
+
+	socF := 0.5
+	s.Update("ferroamp", telemetry.DerBattery, 0, &socF,
+		json.RawMessage(`{"discharge_capable":false}`))
+	s.DriverHealthMut("ferroamp").RecordSuccess()
+	socS := 0.5
+	s.Update("sungrow", telemetry.DerBattery, 0, &socS,
+		json.RawMessage(`{"discharge_capable":false}`))
+	s.DriverHealthMut("sungrow").RecordSuccess()
+
+	st := NewState(0, 50, "meter")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(s, st,
+		caps(map[string]float64{"ferroamp": 15200, "sungrow": 9600}), 11040)
+
+	got := targetsByDriver(targets)
+	// Both incapable to discharge → both must stay ~0 (no phantom discharge).
+	for _, name := range []string{"ferroamp", "sungrow"} {
+		if got[name].TargetW < -1 {
+			t.Errorf("%s is discharge-incapable but got %.1f W", name, got[name].TargetW)
+		}
+	}
+}
+
+// Back-compat guard: with no capability fields in the emit, the split is
+// identical to the pure capacity-proportional behaviour (both batteries
+// share the discharge in proportion to capacity).
+func TestNoCapabilityFieldsKeepsProportionalSplit(t *testing.T) {
+	s := telemetry.NewStore()
+	s.Update("meter", telemetry.DerMeter, 2000, nil, nil)
+	s.DriverHealthMut("meter").RecordSuccess()
+
+	socF := 0.5
+	s.Update("ferroamp", telemetry.DerBattery, 0, &socF, nil)
+	s.DriverHealthMut("ferroamp").RecordSuccess()
+	socS := 0.5
+	s.Update("sungrow", telemetry.DerBattery, 0, &socS, nil)
+	s.DriverHealthMut("sungrow").RecordSuccess()
+
+	st := NewState(0, 50, "meter")
+	st.Mode = ModeSelfConsumption
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+
+	targets := ComputeDispatch(s, st,
+		caps(map[string]float64{"ferroamp": 15200, "sungrow": 9600}), 11040)
+
+	got := targetsByDriver(targets)
+	// Both discharge, and ferroamp (larger capacity) carries the larger share.
+	if got["ferroamp"].TargetW >= -1 || got["sungrow"].TargetW >= -1 {
+		t.Fatalf("both should discharge: ferroamp=%.1f sungrow=%.1f",
+			got["ferroamp"].TargetW, got["sungrow"].TargetW)
+	}
+	if got["ferroamp"].TargetW >= got["sungrow"].TargetW {
+		t.Errorf("larger-capacity ferroamp should carry the larger discharge share: ferroamp=%.1f sungrow=%.1f",
+			got["ferroamp"].TargetW, got["sungrow"].TargetW)
+	}
+}

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -223,7 +223,12 @@ func registerHost(L *lua.LState, env *HostEnv) {
 	// Allowed fields per type:
 	//   meter   -> w, l1_w, l2_w, l3_w, l1_v, l2_v, l3_v, l1_a, l2_a, l3_a, freq_hz
 	//   pv      -> w, mppt1_v, mppt1_a, mppt2_v, mppt2_a, dc_v
-	//   battery -> w, soc, dc_v, dc_a, temp_c
+	//   battery -> w, soc, dc_v, dc_a, temp_c,
+	//              discharge_capable (optional bool), charge_capable (optional
+	//              bool) — set false when the pack physically can't move that
+	//              way right now (e.g. floored/full); the dispatcher then
+	//              hands its share to a capable sibling instead of leaking to
+	//              the grid. Absent → assumed capable (back-compat).
 	//   ev      -> w (charge power, positive when charging),
 	//              connected (bool, plug inserted),
 	//              charging (bool, current flowing),

--- a/go/internal/drivers/lua_ferroamp_capability_test.go
+++ b/go/internal/drivers/lua_ferroamp_capability_test.go
@@ -1,0 +1,78 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// The Ferroamp driver must surface its per-direction capability on the
+// battery emit so the dispatcher can reallocate around a floored pack
+// (the eso_*_capable counts already drive its own dispatch scaling). Below
+// DISCHARGE_FLOOR_SOC (default 0.15) the single ESO is not discharge-capable
+// → discharge_capable=false, while it can still charge.
+func TestFerroampEmitsDischargeBlockedBelowFloor(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	ehub := `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`
+	// soc 10 % → 0.10 < 0.15 floor → cannot discharge, can still charge.
+	eso := `{"pbat":{"val":0},"soc":{"val":10},"ubat":{"val":48},"ibat":{"val":0}}`
+	mqtt.Push("extapi/data/ehub", ehub)
+	mqtt.Push("extapi/data/eso", eso)
+
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	bat := tel.Get("ferroamp", telemetry.DerBattery)
+	if bat == nil {
+		t.Fatal("expected battery reading")
+	}
+	var c struct {
+		DischargeCapable *bool `json:"discharge_capable"`
+		ChargeCapable    *bool `json:"charge_capable"`
+	}
+	if err := json.Unmarshal(bat.Data, &c); err != nil {
+		t.Fatalf("battery Data not JSON: %v (data=%s)", err, bat.Data)
+	}
+	if c.DischargeCapable == nil || *c.DischargeCapable {
+		t.Errorf("discharge_capable = %v, want false (soc below floor)", c.DischargeCapable)
+	}
+	if c.ChargeCapable == nil || !*c.ChargeCapable {
+		t.Errorf("charge_capable = %v, want true", c.ChargeCapable)
+	}
+}
+
+// Above the floor the ESO is discharge-capable, so the field is emitted true.
+func TestFerroampEmitsDischargeCapableAboveFloor(t *testing.T) {
+	tel := telemetry.NewStore()
+	mqtt := &fakeMQTT{}
+	d, _ := newTestFerroampDriver(t, tel, mqtt)
+
+	ehub := `{"pext":{"L1":0,"L2":0,"L3":0},"ppv":{"val":0},"pbat":{"val":0}}`
+	eso := `{"pbat":{"val":0},"soc":{"val":50},"ubat":{"val":48},"ibat":{"val":0}}`
+	mqtt.Push("extapi/data/ehub", ehub)
+	mqtt.Push("extapi/data/eso", eso)
+
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	bat := tel.Get("ferroamp", telemetry.DerBattery)
+	if bat == nil {
+		t.Fatal("expected battery reading")
+	}
+	var c struct {
+		DischargeCapable *bool `json:"discharge_capable"`
+	}
+	if err := json.Unmarshal(bat.Data, &c); err != nil {
+		t.Fatalf("battery Data not JSON: %v", err)
+	}
+	if c.DischargeCapable == nil || !*c.DischargeCapable {
+		t.Errorf("discharge_capable = %v, want true (soc above floor)", c.DischargeCapable)
+	}
+}


### PR DESCRIPTION
## Summary

On a multi-battery site, when one battery internally refuses a dispatch direction (e.g. a Ferroamp ESO floored at its discharge SoC limit), its unfulfilled share used to leak straight to the grid — the dispatcher had no visibility into the driver's internal floor. Found live 2026-06-04: Ferroamp at 14 % SoC commanded −901 W discharge but delivering 0 W, grid importing ~900 W, while a capable Sungrow sibling sat at its allocated share.

This makes the dispatcher capability-aware:

- **Drivers signal per-direction capability** via two optional battery-emit fields, `discharge_capable` / `charge_capable`. Absent → assumed capable, so every existing driver is unaffected. They ride the existing `DerReading.Data` JSON (parsed once per cycle in the control loop, the same pattern already used for per-phase amps) — **no `Store.Update` signature change**.
- **Ferroamp driver** reports both from its existing per-ESO floor/ceiling counts (`n_discharge_capable` / `n_charge_capable`). No new hardware read.
- **`distributeProportional`** excludes batteries blocked in the demanded direction and runs the split over the capable subset (extracted as `splitByCapacityAndPV`), so a floored battery's share is absorbed by a capable sibling, bounded by each one's `maxDischargeW`. **Symmetric** for charge (a full battery is excluded from the charge split). When *every* battery is blocked, all park at 0 — an honest target, since the grid imports/exports the residual either way.
- `batteryInfo` stores **`blocked`** flags (not `capable`) so the Go zero value (= capable) is the safe default for any directly-constructed `batteryInfo`.

### Scope / deliberate cuts
- `reallocated_w` observability metric **deferred to a fast-follow** — the `control` package emits no telemetry metrics today (returns `[]DispatchTarget`; emission lives in `main.go`), so it needs plumbing that doesn't belong in this behaviour-focused PR.
- Legacy `weighted` / `priority` distributors left unchanged (the `planner_*` modes all use proportional).

Design spec: `docs/superpowers/specs/2026-06-04-capability-aware-battery-reallocation-design.md` (with inline "as built" notes).

## Test plan

- `go test ./...` — full suite green (0 FAIL), `go vet ./...` + `go build ./...` clean.
- 7 new tests:
  - `control`: discharge reallocation around an incapable battery; symmetric charge case; capable sibling caps at `maxDischargeW` with remainder to grid; all-blocked parks at 0 (no crash / div-by-zero); back-compat (no fields → unchanged proportional split).
  - `drivers`: Ferroamp emits `discharge_capable=false` below `DISCHARGE_FLOOR_SOC`, `true` above.
- Back-compat: every existing `control` + `drivers` test passes unchanged (absent capability → capable).

> Live note: reallocation only triggers when a pack actually reports blocked; verification is opportunistic (next real floor event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)