### PR TITLE
feat(planner): minimum arbitrage spread threshold

### DIFF
--- a/.changeset/arbitrage-cycle-threshold.md
+++ b/.changeset/arbitrage-cycle-threshold.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": minor
+---
+
+Arbitrage cycle threshold: a new planner knob, **Min arbitrage spread
+(öre/kWh)** (`planner.min_arbitrage_spread_ore_kwh`), stops the battery
+cycling for marginal gains. The planner won't cycle for grid arbitrage
+unless the price gain beats this many öre/kWh on top of round-trip losses.
+It applies only to the arbitrage modes (`planner_arbitrage` /
+`planner_passive_arbitrage`) — self-consumption is never affected — and
+biases the planner's decision only, so the savings statistics stay on real
+spot economics. Default 0 = off. Configurable from the Planner settings tab.

--- a/docs/superpowers/specs/2026-06-04-arbitrage-cycle-threshold-design.md
+++ b/docs/superpowers/specs/2026-06-04-arbitrage-cycle-threshold-design.md
@@ -1,0 +1,136 @@
+# Arbitrage cycle threshold (minimum arbitrage spread) — design
+
+**Date:** 2026-06-04
+**Status:** approved — implementing (TDD)
+**Area:** `go/internal/mpc`, `go/internal/config`, `web/settings/tabs/planner.js`
+
+## Problem
+
+Field testers (Anders, Björn, xorath, via Discord) run active arbitrage and
+want to stop the battery cycling for a gain of just a few öre. The current
+workaround — inflating the grid tariff to dampen cycling — corrupts the
+savings statistics (xorath's point): the savings module computes real spot
+economics, so anything that distorts the price distorts the reported
+savings. We need a knob that biases the *planner's decision* without
+touching the savings accounting.
+
+## Goals
+
+- A single operator knob: **minimum arbitrage spread (öre/kWh)**, "don't
+  cycle the battery for a gain smaller than this".
+- Affects the **planner decision only** — the reported savings / cost
+  (`Plan.CostOre`, the savings module) stay on real spot economics.
+- Applies to **both arbitrage modes** (`planner_arbitrage` +
+  `planner_passive_arbitrage`). Self-consumption / cheap-charge untouched
+  (their spread is retail + VAT, dwarfing any öre-level threshold).
+- Default 0 = disabled → zero behaviour change for existing installs.
+
+## Non-goals
+
+- Changing the savings module, the price forecast, or the export
+  bonus/fee economics. The threshold is purely a planner bias.
+- A per-slot or time-of-day variable threshold. One scalar for v1.
+- Suppressing self-consumption or cover-load discharge (retail spread
+  always beats the threshold; no special-casing needed).
+
+## Design
+
+### 1. The knob → a DP throughput cost
+
+Operator sets `S` öre/kWh. In the MPC DP action loop (`mpc.go`), for a
+**discharge** action (`battW < 0`) in an **arbitrage mode**, add a virtual
+cost proportional to the AC-side discharge throughput:
+
+```go
+if (p.Mode == ModeArbitrage || p.Mode == ModePassiveArbitrage) &&
+    p.MinArbitrageSpreadOreKwh > 0 && battW < 0 {
+    dischargeKWh := -battW * dtH / 1000.0 // positive magnitude
+    cost += p.MinArbitrageSpreadOreKwh * dischargeKWh
+}
+```
+
+This sits alongside the existing mode-gated cost terms (`PVChargeBonus`,
+safety-floor penalty, the self-consumption house-import bias) in the same
+action loop. Effect: the DP only schedules an arbitrage discharge when the
+slot's revenue beats the stored energy's opportunity cost **by at least
+`S` per kWh**, on top of the round-trip efficiency loss the physics
+already imposes. Taxing discharge alone suppresses the whole cycle —
+there's no point charging for a discharge that won't clear the threshold.
+
+**Why discharge-only (not charge+discharge):** a round-trip's profit is
+realised on discharge; charging is only valuable if the energy can later
+be discharged profitably. A single discharge-side term maps the operator's
+"öre/kWh" directly and keeps the math/UX simple.
+
+### 2. Savings isolation (xorath's requirement) — automatic
+
+The virtual cost enters only the DP's internal objective (`V[t][s]`). The
+reported per-slot cost is recomputed from the **raw** grid flow via
+`SlotGridCostOre(slot, gridKWh, p)` (`mpc.go` plan-emit, ~line 892), which
+never sees `MinArbitrageSpreadOreKwh`. So the threshold changes *which
+slots cycle* but never the reported `Plan.CostOre` / savings. This mirrors
+the existing rule "Plan.TotalCostOre is the raw-price re-scoring, not the
+DP objective" (mpc/CLAUDE.md).
+
+### 3. Config + wiring
+
+- `config.Planner` gains `MinArbitrageSpreadOreKwh float64`
+  (`yaml/json: min_arbitrage_spread_ore_kwh,omitempty`), default 0.
+- `mpc.Params` gains `MinArbitrageSpreadOreKwh float64`.
+- `mpc.Service` gains the field; `buildParams` copies it into `Params`
+  (exactly like `ExportBonusOreKwh` at `service.go:~862`).
+- `main.go` wires `cfg.Planner.MinArbitrageSpreadOreKwh` into the service
+  alongside the other planner params.
+
+### 4. UI
+
+`web/settings/tabs/planner.js` — add one field in the planner fieldset
+using the existing `field()` helper:
+
+```js
+field("Min arbitrage spread (öre/kWh)", "planner.min_arbitrage_spread_ore_kwh",
+  "number", 0,
+  "The battery won't cycle for grid arbitrage unless the price gain beats " +
+  "this many öre/kWh, on top of round-trip losses. 0 = off. Higher = fewer, " +
+  "deeper cycles. Self-consumption is never affected. Tune empirically.")
+```
+
+The config round-trips through `POST /api/config` as JSON, so the matching
+`json` tag on `Planner` is all the plumbing the field needs.
+
+### 5. Semantics (documented in help text)
+
+`S` is an **additional deadband on top of round-trip break-even**, applied
+per kWh discharged. The round-trip loss (~5–10 öre, price-dependent) is
+already imposed by physics; `S` stacks on top. Operators tune it
+empirically (Björn: "labba lite med värdena").
+
+## Testing (TDD)
+
+`go/internal/mpc/*_test.go`, driving `Optimize` directly with hand-built
+slots:
+
+1. **Baseline cycles on a small spread.** `S=0`, two-slot arbitrage with a
+   modest spread that clears round-trip break-even → plan charges then
+   discharges.
+2. **Threshold suppresses the marginal cycle.** Same slots, `S` set above
+   the spread → plan holds (no discharge-for-arbitrage).
+3. **Large spread still cycles.** Same `S`, a wide spread → plan still
+   cycles (threshold is a deadband, not a hard stop).
+4. **Cover-load / self-consumption discharge unaffected.** A discharge that
+   offsets house load at retail+VAT spread is not suppressed even with a
+   non-trivial `S` (passive_arbitrage mode).
+5. **Savings isolation.** `Plan.CostOre` (and `TotalCostOre`) for a given
+   dispatch are identical with `S=0` and `S>0` — the reported cost is
+   independent of the threshold.
+6. **Mode gating.** `S>0` in `ModeSelfConsumption` / `ModeCheapCharge` is a
+   no-op (the term only applies in the two arbitrage modes).
+
+`go/internal/config/config_test.go`: round-trip + default-zero for the new
+field (and any validation if a negative value should be rejected → clamp
+or error; v1: reject negative in `Validate`).
+
+## Rollout
+
+- Additive, default 0 → no behaviour change until an operator sets it.
+- Changeset: `minor` (new planner config + UI field + planner behaviour).

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -752,6 +752,9 @@ func main() {
 		// Downside-PV safety planning (forecast − k·σ) — replaces the old SoC
 		// safety floor. Unset config → default 1.0; explicit 0 → raw forecast.
 		mpcSvc.PVForecastSafetyK = cfg.Planner.PVSafetyK()
+		if cfg.Planner != nil {
+			mpcSvc.MinArbitrageSpreadOreKwh = cfg.Planner.MinArbitrageSpreadOreKwh
+		}
 		mpcSvc.Load = loadSvc.Predict
 		mpcSvc.Price = priceFc.Predict
 		mpcSvc.SiteMeter = cfg.SiteMeterDriver()

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -292,6 +292,16 @@ type Planner struct {
 	ChargeEfficiency    float64 `yaml:"charge_efficiency,omitempty" json:"charge_efficiency,omitempty"`
 	DischargeEfficiency float64 `yaml:"discharge_efficiency,omitempty" json:"discharge_efficiency,omitempty"`
 	ExportOrePerKWh     float64 `yaml:"export_ore_per_kwh,omitempty" json:"export_ore_per_kwh,omitempty"` // 0 = use mean spot
+
+	// MinArbitrageSpreadOreKwh is the operator's "don't cycle the battery
+	// for marginal gains" knob, in öre per kWh. The planner won't cycle for
+	// grid arbitrage unless the price gain beats this many öre/kWh on top of
+	// round-trip losses. Applies only to the arbitrage modes
+	// (planner_arbitrage / planner_passive_arbitrage); self-consumption is
+	// never affected. It biases the planner's decision only — the savings
+	// statistics stay on real spot economics. 0 (default) = disabled.
+	MinArbitrageSpreadOreKwh float64 `yaml:"min_arbitrage_spread_ore_kwh,omitempty" json:"min_arbitrage_spread_ore_kwh,omitempty"`
+
 	// LegacyDispatch reverts the control loop from the default
 	// energy-allocation path back to the legacy PI-on-grid-target
 	// path. Provided for emergency rollback only — the energy path
@@ -1220,6 +1230,9 @@ func (c *Config) Validate() error {
 		default:
 			return fmt.Errorf("nova.schema_mode must be \"legacy\" or \"unified\", got %q", c.Nova.SchemaMode)
 		}
+	}
+	if c.Planner != nil && c.Planner.MinArbitrageSpreadOreKwh < 0 {
+		return fmt.Errorf("planner.min_arbitrage_spread_ore_kwh must be ≥ 0, got %g", c.Planner.MinArbitrageSpreadOreKwh)
 	}
 	return nil
 }

--- a/go/internal/config/config_threshold_test.go
+++ b/go/internal/config/config_threshold_test.go
@@ -1,0 +1,25 @@
+package config
+
+import "testing"
+
+func TestPlannerValidateRejectsNegativeArbitrageSpread(t *testing.T) {
+	c := &Config{
+		Site:    Site{SmoothingAlpha: 0.3},
+		Fuse:    Fuse{MaxAmps: 16, Phases: 3, Voltage: 230},
+		Planner: &Planner{Enabled: true, MinArbitrageSpreadOreKwh: -5},
+	}
+	if err := c.Validate(); err == nil {
+		t.Error("expected error for negative min_arbitrage_spread_ore_kwh")
+	}
+}
+
+func TestPlannerValidateAcceptsNonNegativeArbitrageSpread(t *testing.T) {
+	c := &Config{
+		Site:    Site{SmoothingAlpha: 0.3},
+		Fuse:    Fuse{MaxAmps: 16, Phases: 3, Voltage: 230},
+		Planner: &Planner{Enabled: true, MinArbitrageSpreadOreKwh: 20},
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("unexpected error for valid threshold: %v", err)
+	}
+}

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -190,6 +190,16 @@ type Params struct {
 	ExportFeeOreKwh   float64
 	ExportFloorOreKwh *float64
 
+	// MinArbitrageSpreadOreKwh is a virtual cost in öre per kWh of battery
+	// discharge throughput, applied ONLY in the arbitrage modes
+	// (ModeArbitrage / ModePassiveArbitrage). It is the operator's
+	// "minimum arbitrage spread": the planner won't cycle the battery for
+	// grid arbitrage unless the price gain beats this many öre/kWh on top
+	// of the round-trip efficiency loss. It biases the DP's *decision*
+	// only — the reported Plan.CostOre is recomputed from raw grid flow
+	// (SlotGridCostOre), so savings accounting is unaffected. 0 disables.
+	MinArbitrageSpreadOreKwh float64
+
 	// Loadpoint extends the DP state space with one EV charge point.
 	// Nil (default) keeps the battery-only optimization path. See
 	// LoadpointSpec for the state/action shape.
@@ -725,6 +735,25 @@ func Optimize(slots []Slot, p Params) Plan {
 								chargeFromPVkWh := chargeFromPVW * dtH / 1000.0
 								cost -= p.PVChargeBonusOreKwh * chargeFromPVkWh
 							}
+						}
+
+						// Minimum-arbitrage-spread deadband. A virtual cost
+						// per kWh of battery discharge throughput, applied only
+						// in the arbitrage modes. It makes the DP refuse a
+						// discharge whose revenue doesn't beat the stored
+						// energy's opportunity cost by at least this margin —
+						// i.e. "don't cycle for a gain smaller than S". Taxing
+						// discharge alone suppresses the whole round-trip (no
+						// point charging for a discharge that won't clear the
+						// threshold). Self-consumption / cover-load discharge
+						// is never reached here: their spread is retail+VAT,
+						// orders of magnitude above any öre-level S. The cost
+						// is virtual — Plan.CostOre is re-derived from raw grid
+						// flow below, so savings accounting is untouched.
+						if p.MinArbitrageSpreadOreKwh > 0 && battW < 0 &&
+							(p.Mode == ModeArbitrage || p.Mode == ModePassiveArbitrage) {
+							dischargeKWh := -battW * dtH / 1000.0
+							cost += p.MinArbitrageSpreadOreKwh * dischargeKWh
 						}
 
 						// Deadline slot: if this slot is the EV's

--- a/go/internal/mpc/mpc_threshold_test.go
+++ b/go/internal/mpc/mpc_threshold_test.go
@@ -1,0 +1,123 @@
+package mpc
+
+import (
+	"math"
+	"testing"
+)
+
+// Two-slot arbitrage: import at 50, export at 70 → gross spread ~14.6 öre/kWh
+// after round-trip. Starting at the SoC floor means any slot-1 discharge must
+// be funded by a slot-0 charge — i.e. a real arbitrage cycle, not dumping
+// initial SoC. This is the fixture for the threshold tests below.
+func arbitrageCycleSlots() []Slot {
+	return []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 50, Confidence: 1},
+		{StartMs: 3600000, LenMin: 60, PriceOre: 70, SpotOre: 70, Confidence: 1},
+	}
+}
+
+func arbitrageCycleParams() Params {
+	p := baseParams(ModeArbitrage)
+	p.InitialSoCPct = 10 // at the floor: discharge must be funded by a charge
+	p.TerminalSoCPrice = 0
+	return p
+}
+
+// With no threshold the planner takes the marginal cycle: charge slot 0,
+// discharge slot 1.
+func TestArbitrageBaselineTakesMarginalCycle(t *testing.T) {
+	plan := Optimize(arbitrageCycleSlots(), arbitrageCycleParams())
+	if plan.Actions[0].BatteryW <= 100 {
+		t.Fatalf("baseline should charge in slot 0 to arbitrage, got %.1f W", plan.Actions[0].BatteryW)
+	}
+}
+
+// A threshold above the spread suppresses the marginal cycle — the battery
+// holds instead of cycling for a gain below the operator's floor.
+func TestArbitrageThresholdSuppressesMarginalCycle(t *testing.T) {
+	p := arbitrageCycleParams()
+	p.MinArbitrageSpreadOreKwh = 25 // > ~14.6 öre/kWh spread
+	plan := Optimize(arbitrageCycleSlots(), p)
+	if plan.Actions[0].BatteryW > 100 {
+		t.Errorf("threshold 25 öre/kWh should suppress the cycle, but battery charged %.1f W in slot 0",
+			plan.Actions[0].BatteryW)
+	}
+	if math.Abs(plan.Actions[1].BatteryW) > 100 {
+		t.Errorf("threshold should suppress slot-1 discharge, got %.1f W", plan.Actions[1].BatteryW)
+	}
+}
+
+// The threshold is a deadband, not a hard stop: a spread well above it still
+// cycles.
+func TestArbitrageThresholdDoesNotBlockWideSpread(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 50, Confidence: 1},
+		{StartMs: 3600000, LenMin: 60, PriceOre: 200, SpotOre: 200, Confidence: 1},
+	}
+	p := arbitrageCycleParams()
+	p.MinArbitrageSpreadOreKwh = 25 // spread ~144 öre/kWh >> 25
+	plan := Optimize(slots, p)
+	if plan.Actions[0].BatteryW <= 100 {
+		t.Errorf("wide-spread cycle should survive a 25 öre/kWh threshold, got charge %.1f W",
+			plan.Actions[0].BatteryW)
+	}
+}
+
+// Cover-load discharge (self-consumption-style, retail+VAT spread) is never
+// suppressed by an öre-level threshold, even in an arbitrage mode.
+func TestThresholdDoesNotSuppressCoverLoadDischarge(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 250, SpotOre: 200, LoadW: 2000, Confidence: 1},
+	}
+	p := baseParams(ModePassiveArbitrage)
+	p.InitialSoCPct = 80
+	p.MinArbitrageSpreadOreKwh = 25
+	plan := Optimize(slots, p)
+	if plan.Actions[0].BatteryW >= -100 {
+		t.Errorf("battery should discharge to cover load despite the threshold, got %.1f W",
+			plan.Actions[0].BatteryW)
+	}
+}
+
+// Savings isolation: when the dispatch is the same with and without the
+// threshold (wide spread → both cycle fully), the reported cost must be
+// identical — the threshold biases the DP decision, never the accounting.
+func TestThresholdDoesNotAffectReportedCost(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 50, SpotOre: 50, Confidence: 1},
+		{StartMs: 3600000, LenMin: 60, PriceOre: 200, SpotOre: 200, Confidence: 1},
+	}
+	base := arbitrageCycleParams()
+	plan0 := Optimize(slots, base)
+	pS := base
+	pS.MinArbitrageSpreadOreKwh = 25
+	planS := Optimize(slots, pS)
+	for i := range plan0.Actions {
+		if math.Abs(plan0.Actions[i].BatteryW-planS.Actions[i].BatteryW) > 1 {
+			t.Fatalf("precondition: wide-spread dispatch should match with/without threshold (slot %d: %.1f vs %.1f)",
+				i, plan0.Actions[i].BatteryW, planS.Actions[i].BatteryW)
+		}
+	}
+	if math.Abs(plan0.TotalCostOre-planS.TotalCostOre) > 0.01 {
+		t.Errorf("reported TotalCostOre must not change with the threshold: %.4f vs %.4f",
+			plan0.TotalCostOre, planS.TotalCostOre)
+	}
+}
+
+// Mode gating: the threshold applies only in the arbitrage modes. A
+// self_consumption cover-load discharge is identical with and without it.
+func TestThresholdGatedOutOfSelfConsumption(t *testing.T) {
+	slots := []Slot{
+		{StartMs: 0, LenMin: 60, PriceOre: 250, SpotOre: 200, LoadW: 2000, Confidence: 1},
+	}
+	base := baseParams(ModeSelfConsumption)
+	base.InitialSoCPct = 80
+	plan0 := Optimize(slots, base)
+	pS := base
+	pS.MinArbitrageSpreadOreKwh = 25
+	planS := Optimize(slots, pS)
+	if math.Abs(plan0.Actions[0].BatteryW-planS.Actions[0].BatteryW) > 1 {
+		t.Errorf("self_consumption must be unaffected by the arbitrage threshold: %.1f vs %.1f",
+			plan0.Actions[0].BatteryW, planS.Actions[0].BatteryW)
+	}
+}

--- a/go/internal/mpc/service.go
+++ b/go/internal/mpc/service.go
@@ -167,6 +167,11 @@ type Service struct {
 	ExportBonusOreKwh float64
 	ExportFeeOreKwh   float64
 
+	// MinArbitrageSpreadOreKwh flows in from config.Planner. Copied into
+	// Params so the DP applies the arbitrage cycle deadband. See
+	// mpc.Params.MinArbitrageSpreadOreKwh.
+	MinArbitrageSpreadOreKwh float64
+
 	// ExportFloorOreKwh, when non-nil, clamps the per-slot export ore
 	// at the floor. Wired from config.Price.ExportFloorOreKwh; nil =
 	// no clamp, real spot pass-through (default).
@@ -871,6 +876,7 @@ func (s *Service) replan(_ context.Context) *Plan {
 	// to force a flat feed-in tariff).
 	p.ExportBonusOreKwh = s.ExportBonusOreKwh
 	p.ExportFeeOreKwh = s.ExportFeeOreKwh
+	p.MinArbitrageSpreadOreKwh = s.MinArbitrageSpreadOreKwh
 	p.ExportFloorOreKwh = s.ExportFloorOreKwh
 
 	// Default terminal valuation. Mode-dependent because self-consumption

--- a/web/settings/tabs/planner.js
+++ b/web/settings/tabs/planner.js
@@ -44,6 +44,10 @@
         field("Discharge efficiency", "planner.discharge_efficiency", "number", 0.95,
           "Round-trip discharge efficiency (0-1). 0.95 = 5% loss discharging.") +
         '</div></div>' +
+        '<div class="field-row"><div>' +
+        field("Min arbitrage spread (öre/kWh)", "planner.min_arbitrage_spread_ore_kwh", "number", 0,
+          "The battery won't cycle for grid arbitrage unless the price gain beats this many öre/kWh, on top of round-trip losses. 0 = off. Higher = fewer, deeper cycles. Self-consumption is never affected. Tune empirically.") +
+        '</div></div>' +
         '</fieldset>' +
         '<p style="color:var(--text-dim);font-size:0.8rem;margin-top:8px">' +
         'The planner requires working price + weather forecasts. When disabled the system runs in the manual mode set on the Control page.' +


### PR DESCRIPTION
## Summary

A new planner knob — **Min arbitrage spread (öre/kWh)**
(`planner.min_arbitrage_spread_ore_kwh`) — stops the battery cycling for marginal gains. Field testers (Anders, Björn, xorath) run active arbitrage and asked to stop cycling for a gain of just a few öre. The old workaround — inflating the grid tariff to dampen cycling — corrupts the savings statistics (anything that distorts the price distorts the reported savings). This is a planner-only bias that leaves savings on real spot economics.

- **DP cost term** (`mpc.go`): a virtual cost per kWh of battery *discharge throughput*, applied only in the arbitrage modes (`ModeArbitrage` / `ModePassiveArbitrage`). The planner only cycles when the slot's spread beats the threshold on top of round-trip losses. Taxing discharge alone suppresses the whole round-trip (no point charging for a discharge that won't clear the threshold).
- **Never touches self-consumption / cover-load discharge** — its spread is retail + VAT, orders of magnitude above any öre-level threshold.
- **Savings isolation:** the virtual cost enters only the DP objective (`V[t][s]`). The reported `Plan.CostOre` is re-derived from raw grid flow (`SlotGridCostOre`), so the threshold changes *which slots cycle* but never the reported savings.
- **Config + wiring:** `planner.min_arbitrage_spread_ore_kwh` (default 0 = off; negative rejected in `Validate`), wired `config → mpc.Service → Params` (mirrors `ExportBonusOreKwh`).
- **UI:** a field in the Planner settings tab (`web/settings/tabs/planner.js`).

Design spec: `docs/superpowers/specs/2026-06-04-arbitrage-cycle-threshold-design.md`.

## Test plan

- `go test ./...` — full suite green (0 FAIL), `go vet` + `go build` clean.
- New tests (`mpc`):
  - baseline takes a marginal cycle (S=0);
  - threshold above the spread suppresses it;
  - wide spread still cycles (deadband, not a hard stop);
  - cover-load discharge unaffected in passive_arbitrage;
  - savings isolation — identical dispatch ⇒ identical reported `TotalCostOre` with/without the threshold;
  - mode gating — no effect in self_consumption.
- New tests (`config`): negative value rejected, non-negative accepted.

## Notes / scope

- Default 0 → no behaviour change for existing installs.
- Semantics: `S` is an additional deadband **on top of** round-trip break-even, per kWh discharged (documented in the field help text). Tune empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)