### PR TITLE
Relay: per-host poll token for /tunnel/{host}/next (close host_id-race)

### DIFF
--- a/.changeset/relay-poll-token.md
+++ b/.changeset/relay-poll-token.md
@@ -1,0 +1,19 @@
+---
+"forty-two-watts": patch
+---
+
+Relay: authenticate the host long-poll with a per-host **poll token** — closes
+the `host_id`-race flagged during the owner-access hardening review.
+
+`POST /me/register` (ES256-signed) and `POST /tunnel/register` now return a poll
+token that the Pi / pair sidecar must present (header `X-FTW-Poll`) on
+`GET /tunnel/{host_id}/next` and `POST /tunnel/{host_id}/response/{req_id}`. The
+relay verifies it constant-time and rejects unknown-host / wrong-token polls. So
+a caller that merely learns a host's `host_id` can no longer poll for (and steal)
+its tunneled traffic — which carries the owner's session cookie — and an
+unregistered `host_id` can't create long-poll waiters at all. Tokens are minted
+on the verified registration, refresh on re-registration (so they survive a relay
+restart re-mint), and are GC'd after going unused.
+
+Operators: upgrade the relay and the Pi together — the hardened relay requires
+the token the updated Pi/sidecar sends.

--- a/go/cmd/forty-two-watts/owner_relay_register.go
+++ b/go/cmd/forty-two-watts/owner_relay_register.go
@@ -99,6 +99,12 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 	slog.Info("owner-access: relay registration identity",
 		"site_id", siteID, "public_key", signer.PublicKeyHex())
 
+	// Build the long-poll host up front so the registration loop can hand it the
+	// relay-minted poll token. It starts polling immediately; until the first
+	// registration sets the token its polls are 401'd and it backs off + retries.
+	host := buildOwnerHost(relayURL, hostID, tunnelMarker, apiPort)
+	go host.Run(ctx)
+
 	registerOnce := func() {
 		tsMs := time.Now().UnixMilli()
 		sig, err := signer.SignRawHex(tunnel.MeRegisterSigningString(siteID, hostID, tsMs))
@@ -125,20 +131,26 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 			return
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusNoContent {
+		if resp.StatusCode != http.StatusOK {
 			slog.Warn("owner-access: relay rejected register", "status", resp.StatusCode)
 			return
 		}
+		var out struct {
+			PollSecret string `json:"poll_secret"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			slog.Warn("owner-access: decode register response", "err", err)
+			return
+		}
+		// Update the host's poll token (a relay restart re-mints it, so refresh
+		// on every registration).
+		host.SetPollSecret(out.PollSecret)
 		slog.Info("owner-access: registered with relay", "site_id", siteID, "host_id", hostID)
 	}
 
-	// Start the long-poll loop in a goroutine so the registration
-	// retries continue independently.
-	go runOwnerLongPoll(ctx, relayURL, hostID, tunnelMarker, apiPort)
-
 	// Register immediately, then every 60s. A relay restart drops all
-	// registrations, so we re-register periodically to recover without
-	// host intervention.
+	// registrations, so we re-register periodically to recover (and refresh the
+	// poll token) without host intervention.
 	registerOnce()
 	t := time.NewTicker(60 * time.Second)
 	defer t.Stop()
@@ -152,18 +164,17 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 	}
 }
 
-// runOwnerLongPoll runs the host-side long-poll loop for the
-// owner-access tunnel. It pulls tunneled requests for this hostID and
-// reverse-proxies them to the local API server on localhost. The local
-// server's /api/owner-access/* handlers + cookie-based middleware
-// validate WebAuthn assertions and gate access to /web /mcp paths.
+// buildOwnerHost constructs (but does not run) the host-side long-poll host for
+// the owner-access tunnel. It pulls tunneled requests for this hostID and
+// reverse-proxies them to the local API server on localhost. The local server's
+// /api/owner-access/* handlers + cookie-based middleware validate WebAuthn
+// assertions and gate access to /web /mcp paths.
 //
-// We use a fresh net/http/httputil.ReverseProxy so cookies (Set-Cookie
-// on /login/finish, Cookie on subsequent requests) survive the tunnel
-// roundtrip — the JSON wire format already preserves headers, so the
-// ReverseProxy is technically optional, but it's clearer than
-// re-implementing the forwarding logic here.
-func runOwnerLongPoll(ctx context.Context, relayURL, hostID, tunnelMarker string, apiPort int) {
+// We use a fresh net/http/httputil.ReverseProxy so cookies (Set-Cookie on
+// /login/finish, Cookie on subsequent requests) survive the tunnel roundtrip.
+// The caller starts host.Run and feeds it the relay-minted poll token via
+// host.SetPollSecret once registration returns it.
+func buildOwnerHost(relayURL, hostID, tunnelMarker string, apiPort int) *tunnel.Host {
 	// Connect to the local API server on its configured port.
 	target, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", apiPort))
 	proxy := httputil.NewSingleHostReverseProxy(target)
@@ -179,11 +190,7 @@ func runOwnerLongPoll(ctx context.Context, relayURL, hostID, tunnelMarker string
 	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
 		http.Error(w, fmt.Sprintf("local api unavailable: %v", err), http.StatusBadGateway)
 	}
-	// Wrap as the tunnel.Host's handler.
-	relayBaseURL := relayURL
-	h := &ownerProxyHandler{proxy: proxy}
-	host := newOwnerTunnelHost(relayBaseURL, hostID, h)
-	host.Run(ctx)
+	return newOwnerTunnelHost(relayURL, hostID, &ownerProxyHandler{proxy: proxy})
 }
 
 type ownerProxyHandler struct {

--- a/go/cmd/ftw-pair/tunnel.go
+++ b/go/cmd/ftw-pair/tunnel.go
@@ -111,6 +111,12 @@ func StartTunnelHost(ctx context.Context, mcpAddr, apiBase string, ttl time.Dura
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("register status %d: %s", resp.StatusCode, body)
 	}
+	var regResp struct {
+		PollSecret string `json:"poll_secret"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&regResp); err != nil {
+		return nil, fmt.Errorf("decode register response: %w", err)
+	}
 
 	// Router: dispatch /mcp to the local MCP server, everything else
 	// (the /web/* family already stripped of its prefix by the relay)
@@ -133,6 +139,7 @@ func StartTunnelHost(ctx context.Context, mcpAddr, apiBase string, ttl time.Dura
 	mux.Handle("/", denyOwnerOnly(dashProxy))
 
 	host := tunnel.NewHost(relayURL, hostID, mux)
+	host.SetPollSecret(regResp.PollSecret) // authenticate this host's polls
 
 	return &TunnelHandle{
 		Host:         host,

--- a/go/cmd/ftw-relay/e2e_test.go
+++ b/go/cmd/ftw-relay/e2e_test.go
@@ -39,6 +39,7 @@ func TestE2EHostAndFriendRoundtripThroughRelay(t *testing.T) {
 
 	host := tunnel.NewHost(srv.URL, "host-a", mcpBackend)
 	host.PollTimeout = 1 * time.Second
+	host.SetPollSecret(relay.Polls.Issue("host-a")) // authenticate the host's polls
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go host.Run(ctx)
@@ -120,6 +121,7 @@ func TestE2EWebReverseProxy(t *testing.T) {
 
 	host := tunnel.NewHost(srv.URL, "host-b", dashboard)
 	host.PollTimeout = 1 * time.Second
+	host.SetPollSecret(relay.Polls.Issue("host-b")) // authenticate the host's polls
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go host.Run(ctx)

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -60,6 +60,7 @@ type Relay struct {
 	Queue       *tunnel.Queue
 	Tokens      *TokenRegistry
 	Owners      *OwnerRegistry
+	Polls       *PollSecrets
 	PollTimeout time.Duration // 0 → 25s default
 	// HomeHost, when set, maps a bare host (e.g. home.fortytwowatts.com) to
 	// the single owner Pi registered under HomeSite — forwarding every path
@@ -81,10 +82,14 @@ type registerRequest struct {
 type registerResponse struct {
 	PublicURL   string `json:"public_url"`
 	ApprovalURL string `json:"approval_url"`
+	PollSecret  string `json:"poll_secret"`
 }
 
 // Handler returns the mux for this relay.
 func (r *Relay) Handler() http.Handler {
+	if r.Polls == nil {
+		r.Polls = NewPollSecrets()
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", r.healthz)
 	mux.HandleFunc("GET /tunnel/{host_id}/next", r.tunnelNext)
@@ -245,6 +250,13 @@ func (r *Relay) healthz(w http.ResponseWriter, _ *http.Request) {
 
 func (r *Relay) tunnelNext(w http.ResponseWriter, req *http.Request) {
 	hostID := req.PathValue("host_id")
+	// Authenticate the poller against the token minted at registration, so a
+	// caller that only learned host_id can't poll for (and steal) this host's
+	// tunneled traffic. Unknown host / wrong token → 401. The host retries.
+	if r.Polls == nil || !r.Polls.Check(hostID, req.Header.Get(tunnel.PollSecretHeader)) {
+		http.Error(w, "unauthorized poll", http.StatusUnauthorized)
+		return
+	}
 	tr, err := r.Queue.Poll(req.Context(), hostID, r.pollTimeout())
 	if errors.Is(err, tunnel.ErrPollTimeout) {
 		w.WriteHeader(http.StatusNoContent)
@@ -263,6 +275,13 @@ func (r *Relay) tunnelNext(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Relay) tunnelResponse(w http.ResponseWriter, req *http.Request) {
+	hostID := req.PathValue("host_id")
+	// Same poll-token auth as tunnelNext: only the real host may post responses,
+	// so a caller knowing only host_id (+ a guessed req_id) can't inject one.
+	if r.Polls == nil || !r.Polls.Check(hostID, req.Header.Get(tunnel.PollSecretHeader)) {
+		http.Error(w, "unauthorized poll", http.StatusUnauthorized)
+		return
+	}
 	reqID := req.PathValue("req_id")
 	var resp tunnel.TunneledResponse
 	if err := json.NewDecoder(req.Body).Decode(&resp); err != nil {
@@ -309,10 +328,15 @@ func (r *Relay) tunnelRegister(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}
+	secret := ""
+	if r.Polls != nil {
+		secret = r.Polls.Issue(reg.HostID)
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(registerResponse{
 		PublicURL:   fmt.Sprintf("/h/%s", reg.Token),
 		ApprovalURL: fmt.Sprintf("/h/%s/approve", reg.Token),
+		PollSecret:  secret,
 	})
 }
 
@@ -686,7 +710,16 @@ func (r *Relay) meRegister(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	// Return the poll token this host must present on /tunnel/<host>/next. The
+	// ES256-verified registration above proves it owns host_id, so only it
+	// learns the token. Re-registration returns the same token (refreshes after
+	// a relay restart re-mints).
+	secret := ""
+	if r.Polls != nil {
+		secret = r.Polls.Issue(reg.HostID)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"poll_secret": secret})
 }
 
 // meRoot handles GET /me/<site_id> — the landing page when the operator

--- a/go/cmd/ftw-relay/handlers_test.go
+++ b/go/cmd/ftw-relay/handlers_test.go
@@ -38,6 +38,7 @@ func TestTunnelNextLongPollsAndDelivers(t *testing.T) {
 	r := newTestRelay()
 	srv := httptest.NewServer(r.Handler())
 	defer srv.Close()
+	secret := r.Polls.Issue("host-a") // the host authenticates its polls with this
 
 	respCh := make(chan tunnel.TunneledResponse, 1)
 	go func() {
@@ -47,7 +48,9 @@ func TestTunnelNextLongPollsAndDelivers(t *testing.T) {
 		}
 	}()
 
-	resp, err := http.Get(srv.URL + "/tunnel/host-a/next")
+	pollReq, _ := http.NewRequest("GET", srv.URL+"/tunnel/host-a/next", nil)
+	pollReq.Header.Set(tunnel.PollSecretHeader, secret)
+	resp, err := http.DefaultClient.Do(pollReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +67,10 @@ func TestTunnelNextLongPollsAndDelivers(t *testing.T) {
 	}
 
 	body, _ := json.Marshal(tunnel.TunneledResponse{Status: 200, Body: []byte("ok")})
-	postResp, err := http.Post(srv.URL+"/tunnel/host-a/response/"+tr.ReqID, "application/json", bytes.NewReader(body))
+	postReq, _ := http.NewRequest("POST", srv.URL+"/tunnel/host-a/response/"+tr.ReqID, bytes.NewReader(body))
+	postReq.Header.Set("Content-Type", "application/json")
+	postReq.Header.Set(tunnel.PollSecretHeader, secret)
+	postResp, err := http.DefaultClient.Do(postReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +93,9 @@ func TestTunnelNextTimesOutWith204(t *testing.T) {
 	r.PollTimeout = 50 * time.Millisecond
 	srv := httptest.NewServer(r.Handler())
 	defer srv.Close()
-	resp, err := http.Get(srv.URL + "/tunnel/host-empty/next")
+	pollReq, _ := http.NewRequest("GET", srv.URL+"/tunnel/host-empty/next", nil)
+	pollReq.Header.Set(tunnel.PollSecretHeader, r.Polls.Issue("host-empty"))
+	resp, err := http.DefaultClient.Do(pollReq)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/cmd/ftw-relay/hardening_test.go
+++ b/go/cmd/ftw-relay/hardening_test.go
@@ -159,6 +159,43 @@ func TestOwnerRegistryCapAndGC(t *testing.T) {
 	}
 }
 
+// The host poll endpoints require the registration-minted poll token, so a
+// caller that only learned host_id can't poll for (and steal) the host's
+// tunneled traffic, nor can an unregistered host_id create waiters.
+func TestTunnelPollRequiresToken(t *testing.T) {
+	r := newTestRelay()
+	r.PollTimeout = 50 * time.Millisecond
+	srv := httptest.NewServer(r.Handler())
+	defer srv.Close()
+	secret := r.Polls.Issue("host-x")
+
+	poll := func(host, token string) int {
+		req, _ := http.NewRequest("GET", srv.URL+"/tunnel/"+host+"/next", nil)
+		if token != "" {
+			req.Header.Set(tunnel.PollSecretHeader, token)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if code := poll("host-x", ""); code != http.StatusUnauthorized {
+		t.Errorf("poll without token: got %d, want 401", code)
+	}
+	if code := poll("host-x", "wrong-token"); code != http.StatusUnauthorized {
+		t.Errorf("poll with wrong token: got %d, want 401", code)
+	}
+	if code := poll("never-registered", secret); code != http.StatusUnauthorized {
+		t.Errorf("poll for unregistered host: got %d, want 401", code)
+	}
+	if code := poll("host-x", secret); code != http.StatusNoContent {
+		t.Errorf("poll with correct token: got %d, want 204", code)
+	}
+}
+
 // home.* must serve the styled offline page (not a raw timeout) when the Pi has
 // never registered.
 func TestHomeForwardServesOfflinePage(t *testing.T) {

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -59,6 +59,7 @@ func main() {
 		Queue:       tunnel.NewQueue(),
 		Tokens:      NewTokenRegistry(),
 		Owners:      owners,
+		Polls:       NewPollSecrets(),
 		PollTimeout: *pollTimeout,
 		HomeHost:    *homeHost,
 		HomeSite:    *homeSite,
@@ -98,6 +99,9 @@ func main() {
 				// home/pinned site is exempt; a live Pi re-registers every ~60s.
 				if n := r.Owners.GC(30 * time.Minute); n > 0 {
 					slog.Info("ftw-relay: owner GC", "removed", n)
+				}
+				if n := r.Polls.GC(30 * time.Minute); n > 0 {
+					slog.Info("ftw-relay: poll-token GC", "removed", n)
 				}
 			}
 		}

--- a/go/cmd/ftw-relay/me_test.go
+++ b/go/cmd/ftw-relay/me_test.go
@@ -63,18 +63,20 @@ func TestMeRegisterAndForward(t *testing.T) {
 
 	host := tunnel.NewHost(srv.URL, "host-owner", hostBackend)
 	host.PollTimeout = 1 * time.Second
+	host.SetPollSecret(relay.Polls.Issue("host-owner")) // authenticate the host's polls
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go host.Run(ctx)
 
-	// 1. Register the site → host mapping (ES256-signed).
+	// 1. Register the site → host mapping (ES256-signed). meRegister now returns
+	// 200 + {"poll_secret": …}.
 	id := newTestIdentity(t)
 	regBody := signedMeBody(t, id, "site-A", "host-owner", time.Now().UnixMilli())
 	regResp, err := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(regBody))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if regResp.StatusCode != 204 {
+	if regResp.StatusCode != 200 {
 		body, _ := io.ReadAll(regResp.Body)
 		t.Fatalf("register status=%d body=%q", regResp.StatusCode, body)
 	}
@@ -209,8 +211,8 @@ func TestMeRegisterTOFUPinRejectsDifferentKey(t *testing.T) {
 
 	owner := newTestIdentity(t)
 	first := signedMeBody(t, owner, "site-A", "host-owner", time.Now().UnixMilli())
-	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(first)); resp.StatusCode != 204 {
-		t.Fatalf("first registration status=%d want 204", resp.StatusCode)
+	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(first)); resp.StatusCode != 200 {
+		t.Fatalf("first registration status=%d want 200", resp.StatusCode)
 	}
 
 	attacker := newTestIdentity(t) // different keypair, validly self-signed
@@ -230,12 +232,12 @@ func TestMeRegisterSameKeyReRegisterUpdatesHost(t *testing.T) {
 
 	owner := newTestIdentity(t)
 	b1 := signedMeBody(t, owner, "site-A", "host-1", time.Now().UnixMilli())
-	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(b1)); resp.StatusCode != 204 {
-		t.Fatalf("first status=%d want 204", resp.StatusCode)
+	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(b1)); resp.StatusCode != 200 {
+		t.Fatalf("first status=%d want 200", resp.StatusCode)
 	}
 	b2 := signedMeBody(t, owner, "site-A", "host-2", time.Now().UnixMilli())
-	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(b2)); resp.StatusCode != 204 {
-		t.Fatalf("re-register status=%d want 204", resp.StatusCode)
+	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(b2)); resp.StatusCode != 200 {
+		t.Fatalf("re-register status=%d want 200", resp.StatusCode)
 	}
 	if got, _ := relay.Owners.Lookup("site-A"); got != "host-2" {
 		t.Fatalf("mapping = %q, want host-2 after same-key re-register", got)
@@ -259,7 +261,7 @@ func TestMeRegisterOperatorPinBeatsTOFU(t *testing.T) {
 	}
 	// The real owner still registers fine.
 	good := signedMeBody(t, owner, "site:Home", "host-owner", time.Now().UnixMilli())
-	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(good)); resp.StatusCode != 204 {
-		t.Fatalf("owner against own pin status=%d want 204", resp.StatusCode)
+	if resp, _ := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(good)); resp.StatusCode != 200 {
+		t.Fatalf("owner against own pin status=%d want 200", resp.StatusCode)
 	}
 }

--- a/go/cmd/ftw-relay/pollsecrets.go
+++ b/go/cmd/ftw-relay/pollsecrets.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"crypto/subtle"
+	"sync"
+	"time"
+)
+
+// PollSecrets maps a registered host_id to the poll token it must present on
+// /tunnel/{host_id}/next and /tunnel/{host_id}/response/{req_id}. The token is
+// minted on registration (returned to the host, which proved it owns the
+// host_id by an ES256-signed /me/register or by registering its own pair token)
+// and required on every poll, so a caller that merely learned the 48-bit
+// host_id can't race the real host for tunneled traffic.
+//
+// In-memory and ephemeral. Tokens are GC'd after they go unused (the host
+// re-registers / re-polls periodically, refreshing the seen timestamp); a relay
+// restart drops them and hosts re-register to get fresh ones.
+type PollSecrets struct {
+	mu     sync.Mutex
+	secret map[string]string
+	seen   map[string]time.Time
+}
+
+func NewPollSecrets() *PollSecrets {
+	return &PollSecrets{
+		secret: make(map[string]string),
+		seen:   make(map[string]time.Time),
+	}
+}
+
+// Issue returns the stable poll token for hostID, minting one on first use (so
+// re-registration returns the same token) and refreshing its seen timestamp.
+func (p *PollSecrets) Issue(hostID string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s, ok := p.secret[hostID]
+	if !ok {
+		s = mintGrant() // 32-byte CSPRNG base64url
+		p.secret[hostID] = s
+	}
+	p.seen[hostID] = time.Now()
+	return s
+}
+
+// Check reports whether token matches hostID's minted token (constant-time),
+// refreshing the seen timestamp on success. Unknown host / empty token → false.
+func (p *PollSecrets) Check(hostID, token string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	want, ok := p.secret[hostID]
+	if !ok || want == "" || token == "" {
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(want), []byte(token)) == 1 {
+		p.seen[hostID] = time.Now()
+		return true
+	}
+	return false
+}
+
+// GC drops tokens unused for longer than maxAge. Returns how many were removed.
+func (p *PollSecrets) GC(maxAge time.Duration) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	removed := 0
+	for h, t := range p.seen {
+		if now.Sub(t) > maxAge {
+			delete(p.secret, h)
+			delete(p.seen, h)
+			removed++
+		}
+	}
+	return removed
+}

--- a/go/cmd/ftw-relay/pollsecrets_test.go
+++ b/go/cmd/ftw-relay/pollsecrets_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestPollSecretsIssueCheckGC(t *testing.T) {
+	p := NewPollSecrets()
+	s1 := p.Issue("h1")
+	if s1 == "" {
+		t.Fatal("Issue returned an empty secret")
+	}
+	if s2 := p.Issue("h1"); s2 != s1 {
+		t.Fatalf("Issue not stable for a host: %q != %q", s2, s1)
+	}
+	if !p.Check("h1", s1) {
+		t.Fatal("correct token must verify")
+	}
+	if p.Check("h1", "wrong") {
+		t.Fatal("wrong token must NOT verify")
+	}
+	if p.Check("unknown-host", s1) {
+		t.Fatal("unknown host must NOT verify")
+	}
+	if p.Check("h1", "") {
+		t.Fatal("empty token must NOT verify")
+	}
+	// GC(0): every entry's last-seen is in the past, so all are evicted.
+	if n := p.GC(0); n < 1 {
+		t.Fatalf("GC(0) removed %d, want >= 1", n)
+	}
+	if p.Check("h1", s1) {
+		t.Fatal("token must be gone after GC")
+	}
+}

--- a/go/cmd/ftw-relay/session_info_test.go
+++ b/go/cmd/ftw-relay/session_info_test.go
@@ -45,6 +45,7 @@ func TestSessionInfoTracksLandingHitsAndActivity(t *testing.T) {
 		_, _ = w.Write([]byte("ok"))
 	}))
 	host.PollTimeout = 500 * time.Millisecond
+	host.SetPollSecret(r.Polls.Issue("h")) // authenticate the host's polls
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go host.Run(ctx)

--- a/go/internal/tunnel/host.go
+++ b/go/internal/tunnel/host.go
@@ -9,8 +9,15 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"time"
 )
+
+// PollSecretHeader carries the per-host poll token the relay minted at
+// registration. The host sends it on every poll/response so the relay can
+// authenticate it — a caller that merely knows host_id but not the secret
+// cannot race the host for tunneled traffic.
+const PollSecretHeader = "X-FTW-Poll"
 
 // Host runs a long-poll loop against a relay, dispatching tunneled
 // requests to the supplied http.Handler.
@@ -24,6 +31,24 @@ type Host struct {
 	// client timeout is slightly larger so a slow relay response is
 	// treated as a transport error, not a stuck loop.
 	PollTimeout time.Duration
+
+	mu         sync.Mutex
+	pollSecret string // relay-minted poll token (see PollSecretHeader)
+}
+
+// SetPollSecret sets the per-host poll token the relay returns at registration.
+// Safe to call concurrently with Run — re-registration refreshes it (e.g. after
+// a relay restart re-mints).
+func (h *Host) SetPollSecret(s string) {
+	h.mu.Lock()
+	h.pollSecret = s
+	h.mu.Unlock()
+}
+
+func (h *Host) getPollSecret() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.pollSecret
 }
 
 // NewHost constructs a Host. relayURL is the base URL (no trailing
@@ -67,6 +92,9 @@ func (h *Host) pollOnce(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
+	}
+	if s := h.getPollSecret(); s != "" {
+		req.Header.Set(PollSecretHeader, s)
 	}
 	resp, err := h.client.Do(req)
 	if err != nil {
@@ -120,6 +148,9 @@ func (h *Host) postResponse(ctx context.Context, reqID string, resp TunneledResp
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if s := h.getPollSecret(); s != "" {
+		req.Header.Set(PollSecretHeader, s)
+	}
 	r, err := h.client.Do(req)
 	if err != nil {
 		// Quietly drop on cancellation — shutdown noise, not an error.


### PR DESCRIPTION
The follow-up flagged in #424 (and in the 4th Codex review pass). **Stacked on #424** — base is `owner-access-relay-security-hardening`, so this diff is only the poll-token change; retarget to `master` once #424 merges.

## Problem
The host long-poll `GET /tunnel/{host_id}/next` was **unauthenticated**. The relay hands an enqueued tunneled request to whichever poller is waiting on that `host_id`, so a caller who **learns a host's `host_id`** could poll it and **receive the owner's tunneled requests** — which carry the `ftw_owner` session cookie → owner-session compromise — or race the Pi for work. Gated today only by `host_id` secrecy (48-bit random, never exposed publicly), which is fragile.

## Fix — registration-minted poll token
- The relay mints a **stable per-`host_id` poll token** on the ES256-verified `POST /me/register` and on `POST /tunnel/register`, returns it in the response, and GCs it after it goes unused (re-minted across relay restarts, idempotent per `host_id`).
- `GET /tunnel/{host_id}/next` and `POST /tunnel/{host_id}/response/{req_id}` now **require** the token (header `X-FTW-Poll`), constant-time compared. Unknown-host / wrong-token → 401. This also confines long-poll waiters to authenticated hosts.
- `tunnel.Host` carries the token (mutex-guarded, refreshable) and sends it on every poll/response. The owner flow (`owner_relay_register.go`, restructured to build the host up front + `SetPollSecret` on each registration, so a relay-restart re-mint is picked up) and the pair flow (`ftw-pair` captures it from the register response) feed it in.

## Behaviour / compat
`/me/register` now returns `200 + {"poll_secret": …}` instead of `204`. **Upgrade the relay and the Pi together** — the hardened relay requires the token the updated Pi/sidecar sends (already the operator guidance for #424).

## Tests
Poll-token store (issue stability / constant-time check / GC); poll auth (no/wrong/unknown-host token → 401, correct → 204); relay + tunnel unit tests; e2e `TestOwnerGateThroughRelay` + `TestPairFlowThroughRelay` (real binaries) exercise the token end-to-end. 39 Go packages green, `go vet` clean, native + linux/arm64.

Closes the host_id-race follow-up from #424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)