### PR TITLE
fix(dashboard): aggregate status energy totals

### DIFF
--- a/.changeset/fix-status-energy-today-stall.md
+++ b/.changeset/fix-status-energy-today-stall.md
@@ -1,0 +1,7 @@
+---
+"forty-two-watts": patch
+---
+
+Fix dashboard stalls on late-day loads by aggregating the `/api/status`
+energy-today totals in SQLite instead of loading every history sample
+since midnight into Go on every 2-second status poll.

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -698,7 +698,9 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Energy today: integrate history points since midnight local time.
-	// Each point is ~5 s apart; multiply W × dt_hours for Wh per interval.
+	// Keep this on the SQL aggregate path instead of loading raw history
+	// rows: /api/status polls every 2 s, and reading every sample since
+	// midnight made late-day dashboard loads visibly stall on Pi-sized DBs.
 	//
 	// Current slot: same integration over the fixed local 15-minute
 	// settlement window (00/15/30/45). This is deliberately observational:
@@ -709,33 +711,18 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if s.deps.State != nil {
 		now := time.Now()
 		midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-		pts, err := s.deps.State.LoadHistory(midnight.UnixMilli(), now.UnixMilli(), 0)
-		if err == nil && len(pts) > 1 {
-			var importWh, exportWh, pvWh, chargedWh, dischargedWh, loadWh float64
-			for i := 1; i < len(pts); i++ {
-				dtH := float64(pts[i].TsMs-pts[i-1].TsMs) / 3_600_000.0
-				g := pts[i].GridW
-				if g > 0 {
-					importWh += g * dtH
-				} else {
-					exportWh += -g * dtH
-				}
-				pvWh += -pts[i].PVW * dtH
-				if pts[i].BatW > 0 {
-					chargedWh += pts[i].BatW * dtH
-				} else {
-					dischargedWh += -pts[i].BatW * dtH
-				}
-				loadWh += pts[i].LoadW * dtH
-			}
+		d, err := s.deps.State.DailyEnergy(midnight.UnixMilli(), now.UnixMilli())
+		if err == nil {
 			energyToday = map[string]any{
-				"import_wh":         importWh,
-				"export_wh":         exportWh,
-				"pv_wh":             pvWh,
-				"bat_charged_wh":    chargedWh,
-				"bat_discharged_wh": dischargedWh,
-				"load_wh":           loadWh,
+				"import_wh":         d.ImportWh,
+				"export_wh":         d.ExportWh,
+				"pv_wh":             d.PVWh,
+				"bat_charged_wh":    d.BatChargedWh,
+				"bat_discharged_wh": d.BatDischargedWh,
+				"load_wh":           d.LoadWh,
 			}
+		} else {
+			slog.Warn("failed to integrate today's energy", "err", err)
 		}
 		slot, err := currentGridEnergySlot(s.deps.State, now)
 		if err == nil {


### PR DESCRIPTION
## What changed

- Switch `/api/status` energy-today totals from loading every history row since midnight to the existing SQLite `DailyEnergy` aggregate.
- Add a patch changeset so the fix is included in the next release notes.

## Why

Dashboard status polling runs every 2 seconds. Late in the day, the old path could scan and materialize thousands of history samples per poll on Pi-sized databases, making mobile dashboard loads stall or render partially.

## Validation

- `make verify-all` via pre-push hook
