### PR TITLE
dev: local docker E2E harness (relay + Pi on one machine)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /release
 *.redb
 config.yaml
+# ...except the committed example config for the local docker E2E harness.
+!deploy/local-e2e/config.yaml
 data/
 
 # Go build artifacts

--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -1,0 +1,35 @@
+# Dockerfile.relay — standalone build of the ftw-relay signaling + tunnel server.
+#
+# The relay is NOT bundled in the main forty-two-watts image (it's deployed
+# separately on its own VM). This file exists for two reasons:
+#   1. the local end-to-end harness (docker-compose.e2e.yml) — run the whole
+#      home-route stack on one machine, no real relay VM / Cloudflare; and
+#   2. self-hosters who want to run their own relay in a container.
+#
+# Mirrors the main Dockerfile's multi-stage, CGO-free, static-binary pattern.
+
+# --- Builder ---------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+RUN apk add --no-cache git
+WORKDIR /src
+
+COPY go/go.mod go/go.sum ./go/
+RUN cd go && go mod download
+COPY go/ ./go/
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+RUN cd go && \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" \
+    -o /out/ftw-relay ./cmd/ftw-relay
+
+# --- Runtime ---------------------------------------------------------------
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata && \
+    addgroup -S ftw && adduser -S ftw -G ftw
+COPY --from=builder /out/ftw-relay /usr/local/bin/ftw-relay
+USER ftw
+EXPOSE 7378
+ENTRYPOINT ["/usr/local/bin/ftw-relay"]

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,24 @@ dev:
 	(cd go && go run ./cmd/forty-two-watts -config ../config.local.yaml -web ../web) & \
 	wait
 
+# ---- Local docker E2E harness (relay + Pi on this machine) ----
+#
+# Brings up ftw-relay + a forty-two-watts "Pi" wired to dial it, so the whole
+# home-route / owner-access / pair / P2P flow runs locally with no real Pi,
+# relay VM, or Cloudflare. See docs/local-e2e-docker.md.
+#   Pi:         http://localhost:8080/
+#   Home route: http://home.fortytwowatts.localhost/
+
+e2e-docker-up:
+	docker compose -f docker-compose.e2e.yml up --build -d
+	@echo "Pi: http://localhost:8080/   Home route: http://home.fortytwowatts.localhost/"
+
+e2e-docker-logs:
+	docker compose -f docker-compose.e2e.yml logs -f
+
+e2e-docker-down:
+	docker compose -f docker-compose.e2e.yml down -v
+
 # ---- Hygiene ----
 
 fmt:

--- a/deploy/local-e2e/config.yaml
+++ b/deploy/local-e2e/config.yaml
@@ -1,0 +1,30 @@
+# Minimal config for the LOCAL docker E2E harness (docker-compose.e2e.yml).
+#
+# site.name MUST be "Home" so the derived site_id is "site:Home", matching the
+# relay's `-home-site=site:Home`. The driver below points at an address that
+# won't answer inside the container — that's intentional: the app boots and
+# serves the dashboard + owner-access + relay registration regardless (the
+# watchdog just flips the driver offline). Swap in a sim or real device when you
+# want live telemetry.
+
+site:
+  name: "Home"
+
+fuse:
+  max_amps: 16
+  phases: 3
+  voltage: 230
+
+drivers:
+  - name: my-inverter
+    lua: drivers/sungrow.lua
+    is_site_meter: true
+    battery_capacity_wh: 9600
+    capabilities:
+      modbus:
+        host: 192.0.2.10        # TEST-NET-1 (RFC 5737) — never answers, boots offline
+        port: 502
+        unit_id: 1
+
+api:
+  port: 8080

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,69 @@
+# docker-compose.e2e.yml — LOCAL end-to-end harness (relay + Pi) on ONE machine.
+#
+# Brings up the standalone ftw-relay and a forty-two-watts "Pi" wired to dial it,
+# so you can exercise the whole home-route / owner-access / pair / P2P flow
+# locally — no real Pi, no real relay VM, no Cloudflare, no certs.
+#
+#   Build + start:  make e2e-docker-up
+#   Logs:           make e2e-docker-logs
+#   Stop + wipe:    make e2e-docker-down
+#
+# Open in your browser:
+#   - Pi dashboard (LAN / loopback view):      http://localhost:8080/
+#   - Home route   (remote view via relay):    http://home.fortytwowatts.localhost/
+#
+# `*.localhost` resolves to 127.0.0.1 in every modern browser AND is treated as a
+# secure context (so WebAuthn works without a cert). The relay listens on host
+# port 80 so the browser sends `Host: home.fortytwowatts.localhost` with NO port
+# — matching the relay's home-host mux pattern exactly like prod's :443.
+#
+# WHAT THIS EXERCISES END-TO-END: the Pi dials the relay (FTW_RELAY_URL), signs
+# its ES256 /me/register, the relay TOFU-pins it, and the home route tunnels the
+# browser to the Pi — the real owner-access gate, the X-FTW-Tunnel remote/LAN
+# discriminator, the pair flow, and the P2P signaling all run for real.
+#
+# P2P (WebRTC) CAVEAT: from your Mac browser to the app CONTAINER the direct
+# DataChannel may not form (Docker Desktop NAT hides the container's ICE host
+# candidates), so traffic transparently falls back to the relay tunnel — which is
+# fine for auth/gate/registration testing. For automated browser P2P tests, add a
+# headless-Chrome container to THIS network (tier 2): container-to-container P2P
+# connects directly on the bridge net. See docs/local-e2e-docker.md.
+#
+# TOFU WARNING: the relay runs with -home-allow-tofu (no operator-pinned key), so
+# the Pi's key is trusted on first registration. TESTING ONLY — never production.
+
+services:
+  relay:
+    build:
+      context: .
+      dockerfile: Dockerfile.relay
+    container_name: ftw-e2e-relay
+    command:
+      - "-addr=:7378"
+      - "-home-host=home.fortytwowatts.localhost"
+      - "-home-site=site:Home"
+      - "-home-allow-tofu"
+    ports:
+      # Host 80 → container 7378, so the browser's Host header carries no port
+      # and matches the `home.fortytwowatts.localhost/` mux pattern.
+      - "80:7378"
+
+  forty-two-watts:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: ftw-e2e-pi
+    depends_on:
+      - relay
+    environment:
+      # The Pi dials this to register + open its owner tunnel. Container-internal
+      # DNS resolves `relay` to the service above on the bridge network.
+      FTW_RELAY_URL: "http://relay:7378"
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./deploy/local-e2e/config.yaml:/app/data/config.yaml:ro
+      - ftw-e2e-data:/app/data
+
+volumes:
+  ftw-e2e-data:

--- a/docs/local-e2e-docker.md
+++ b/docs/local-e2e-docker.md
@@ -1,0 +1,63 @@
+# Local end-to-end harness (relay + Pi in Docker)
+
+Run the **whole home-route stack on one machine** — the standalone `ftw-relay`
+plus a `forty-two-watts` "Pi" wired to dial it — with no real Pi, no relay VM, no
+Cloudflare, and no certificates. This is the fast feedback loop for anything that
+touches owner-access, the relay tunnel, the pair flow, or P2P.
+
+## Quick start
+
+```bash
+make e2e-docker-up      # build images + start relay + Pi
+make e2e-docker-logs    # follow both services
+make e2e-docker-down    # stop + wipe the state volume
+```
+
+Then open:
+
+| View | URL | What it exercises |
+|---|---|---|
+| Pi dashboard (LAN/loopback) | <http://localhost:8080/> | the local owner view — owner-access **LAN-bypass** path |
+| Home route (remote via relay) | <http://home.fortytwowatts.localhost/> | the **remote** view — relay tunnel + the `X-FTW-Tunnel` remote/LAN gate |
+
+`*.localhost` resolves to `127.0.0.1` in every modern browser and counts as a
+**secure context**, so WebAuthn/passkeys work without a cert. The relay listens on
+host port **80** so the browser's `Host` header carries no port and matches the
+relay's `home.fortytwowatts.localhost/` mux pattern exactly like prod's `:443`.
+
+## What's real here
+
+The Pi dials `FTW_RELAY_URL=http://relay:7378`, signs its **ES256 `/me/register`**,
+the relay **TOFU-pins** the key (`-home-allow-tofu`), and the home route tunnels
+the browser to the Pi. The owner-access gate, the remote/LAN discriminator, the
+pair flow, and the P2P **signaling** all run for real against the merged master
+code — so this reproduces the `#424`/`#429` security behavior and is the bench for
+the upcoming P2P-only work.
+
+> **TOFU is testing-only.** `-home-allow-tofu` trusts the Pi's key on first
+> registration. Production pins it with `-home-pubkey`. Never run the public home
+> route in TOFU mode.
+
+## P2P (WebRTC) caveat — and tier 2
+
+From your **Mac browser → app container**, the direct DTLS DataChannel often does
+not form: Docker Desktop runs containers in a Linux VM, so the container's ICE
+**host candidates** (its `172.x` address) are unreachable from macOS, and there's
+no STUN/TURN in this harness. Traffic then transparently falls back to the relay
+tunnel — perfectly fine for testing auth / gate / registration / the dashboard.
+
+To test the **real P2P DataChannel** (the signed-fingerprint handshake, the
+fail-closed gate over P2P, the browser verify code), use **tier 2**: a
+headless-Chrome (Playwright) container on this same bridge network. Container ↔
+container P2P connects **directly** — on the docker net there is no NAT, so direct
+ICE always succeeds, which is exactly what you want for a deterministic P2P test
+(no CGNAT/TURN variables). Playwright also exposes a **virtual WebAuthn
+authenticator** (CDP `WebAuthn.addVirtualAuthenticator`) so the passkey ceremony
+runs unattended. Tier 2 is not built yet — it's the next step.
+
+## Files
+
+- `docker-compose.e2e.yml` — the two services (bridge net, published ports).
+- `Dockerfile.relay` — standalone `ftw-relay` build (not in the main image).
+- `deploy/local-e2e/config.yaml` — minimal Pi config; `site.name: "Home"` →
+  `site:Home`, matching the relay's `-home-site`.


### PR DESCRIPTION
One command — `make e2e-docker-up` — brings up the standalone `ftw-relay` plus a
`forty-two-watts` "Pi" wired to dial it, reproducing the home-route /
owner-access / pair / P2P signaling flow **locally**: no real Pi, no relay VM, no
Cloudflare, no certs.

## What's in it
- `Dockerfile.relay` — standalone `ftw-relay` build (it isn't in the main image).
- `docker-compose.e2e.yml` — relay (TOFU, host `:80`) + Pi (`FTW_RELAY_URL`), bridge net.
- `deploy/local-e2e/config.yaml` — minimal `site:Home` config (+ `.gitignore` exception).
- `make e2e-docker-{up,logs,down}` + `docs/local-e2e-docker.md`.

## Why
A fast change → run → see loop for everything touching owner-access, the relay
tunnel, the pair flow, and the upcoming P2P-only work. It runs against merged
`master`, so it reproduces the #424/#429 security behavior.

## Verified locally
- Pi ES256-registers; relay TOFU-pins the key.
- Home route (`home.fortytwowatts.localhost`, `*.localhost` → 127.0.0.1, secure
  context) tunnels the browser to the Pi → HTTP 200.
- The owner gate correctly **401s** remote `/api/*` until passkey login.
- Pre-commit `make verify` (vet + test + build) green.

## Notes
- `no-changeset`: dev tooling, nothing ships to users.
- TOFU (`-home-allow-tofu`) is testing-only; production pins with `-home-pubkey`.
- P2P from a host browser falls back to the tunnel (Docker Desktop NAT hides the
  container's ICE candidates). Tier 2 (headless Chrome in the same network, where
  container↔container P2P connects directly) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)