### PR TITLE
[codex] Fix stale meter snapshot use

### DIFF
--- a/.changeset/stale-meter-snapshot.md
+++ b/.changeset/stale-meter-snapshot.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Use the locked site-meter driver snapshot when idling batteries after stale site-meter telemetry.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1892,8 +1892,8 @@ func main() {
 			}
 			if siteMeterStale {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
-					"driver", ctrl.SiteMeterDriver)
-				for _, n := range driversToDefaultOnSiteMeterStale(reg.Names(), ctrl.SiteMeterDriver) {
+					"driver", siteMeterDriver)
+				for _, n := range driversToDefaultOnSiteMeterStale(reg.Names(), siteMeterDriver) {
 					sendDriverDefault(ctx, reg, n, "site_meter_stale")
 				}
 				continue


### PR DESCRIPTION
## Summary
- use the already-snapshotted site-meter driver when logging and idling batteries on stale telemetry
- avoids reading ctrl.SiteMeterDriver outside the locked controller snapshot path

## Validation
- `go test -count=1 ./cmd/forty-two-watts ./internal/control ./internal/loadpoint ./internal/mpc ./internal/battery`
- `make e2e`