### PR TITLE
[codex] Mark web test package as modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "forty-two-watts",
   "version": "0.115.0",
   "private": true,
+  "type": "module",
   "description": "Unified Home Energy Management System — version metadata only; the application itself is Go. Changesets reads `version` from this file to drive the release tag.",
   "scripts": {
     "test": "node --test 'web/**/*.test.mjs'"


### PR DESCRIPTION
## Summary
- mark the Node package as ESM so web tests do not rely on typeless module reparsing
- keeps the existing `.mjs` test entrypoint behavior explicit

## Validation
- `npm test`