### PR TITLE
feat(home-route): inline passkey sign-in on the dashboard

### DIFF
--- a/.changeset/device-key-hardened-relay.md
+++ b/.changeset/device-key-hardened-relay.md
@@ -1,0 +1,18 @@
+---
+"forty-two-watts": minor
+---
+
+Hardened relay + device-key remote access: no anonymous path to a home Pi.
+
+The relay now serves the sign-in shell (`-home-web`) and `/api/identity` (from its
+pinned `-home-pubkey`) **itself** — an anonymous internet visitor never causes the
+relay to contact the Pi. To even open a signaling channel, the browser must prove a
+**device-key**: the relay issues a single-use nonce, the browser signs it with a
+non-extractable ECDSA P-256 key (WebCrypto, IndexedDB, minted at LAN enrollment),
+and the relay verifies it against the device-pubkeys the Pi publishes on
+`/me/register` — anything else is 403'd and the Pi is never woken. The same
+device-key mints the owner session **silently** over the channel (device-PoP), so a
+returning device signs in with no Face ID; step-up still requires a passkey, and
+revoking a device drops its key on both Pi and relay. The gate UI now conveys the
+posture (direct + end-to-end + relay-blind + "this device is remembered"). LAN-first
+enrollment; see `docs/superpowers/specs/2026-06-05-hardened-relay-device-key-design.md`.

--- a/.changeset/inline-home-signin.md
+++ b/.changeset/inline-home-signin.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": minor
+---
+
+Home route: inline sign-in on the dashboard. When you open
+`home.fortytwowatts.com` and aren't signed in, the dashboard now reveals a
+discreet "Sign in with your passkey" banner (+ a header key) and runs the
+passkey ceremony **in place**, over the same strict P2P channel — no redirect to
+`/owner-access/login.html` (which would spawn a fresh channel with no session).
+The dashboard is the door: you never have to hunt for the owner-access page.
+LAN (bypass) views and already-signed-in sessions never see it. Re-checks whoami
+when the P2P channel (re)connects, since the answer needs the channel up.

--- a/.changeset/inline-home-signin.md
+++ b/.changeset/inline-home-signin.md
@@ -2,11 +2,18 @@
 "forty-two-watts": minor
 ---
 
-Home route: inline sign-in on the dashboard. When you open
-`home.fortytwowatts.com` and aren't signed in, the dashboard now reveals a
-discreet "Sign in with your passkey" banner (+ a header key) and runs the
-passkey ceremony **in place**, over the same strict P2P channel — no redirect to
-`/owner-access/login.html` (which would spawn a fresh channel with no session).
-The dashboard is the door: you never have to hunt for the owner-access page.
-LAN (bypass) views and already-signed-in sessions never see it. Re-checks whoami
-when the P2P channel (re)connects, since the answer needs the channel up.
+Home route: a real sign-in **gate** + inline passkey login (the dashboard IS the
+door). When you open `home.fortytwowatts.com` and aren't signed in, the dashboard
+is fully covered by a clean sign-in card ("Reaching your home…" → "Sign in with
+your passkey") instead of the empty dashboard chrome — which previously rendered
+"No devices configured / run the setup wizard" to logged-out visitors and falsely
+read as an unconfigured instance. The passkey ceremony runs in place over the same
+strict P2P channel (`ownerFetch` / FIX-B) — no redirect to
+`/owner-access/login.html`. Never shown on the LAN (bypass) or once signed in; the
+"no devices" prompt is suppressed while logged out. No owner DATA is ever served
+unauthenticated — the gate is purely the lock's UI.
+
+Also: the transport indicator is now purely informational (it explains direct vs
+relayed vs connecting) rather than a click-to-toggle that, on the P2P-only route,
+just broke the channel. Part of the #438 seamless-UX layer (device-key silent
+re-auth still to come).

--- a/docs/superpowers/specs/2026-06-05-hardened-relay-device-key-design.md
+++ b/docs/superpowers/specs/2026-06-05-hardened-relay-device-key-design.md
@@ -1,0 +1,114 @@
+# Hardened relay + device-key remote access — design
+
+**Status:** direction approved by Fredrik (2026-06-05). This spec firms it up for
+review before implementation. Build with the home-route's rigor: slices → tests →
+**Codex security GO** before anything goes live.
+
+## The principle (non-negotiable)
+
+> The relay must **never** let an unauthenticated internet party reach, ping,
+> fetch from, or probe a home Pi. The **only** path to a Pi is a **device-key born
+> on that Pi's own LAN**. The relay is a dumb, hard broker: it serves the sign-in
+> bootstrap *itself*, and forwards to the Pi *only* signaling proven by a
+> device-key it can verify.
+
+Confidentiality of owner data already meets a hard stop today (every `/api/*` →
+403, double-enforced at relay + Pi gate). This redesign closes the remaining
+**contact** surface: today the relay *forwards anonymous GETs* (the static shell +
+`/api/identity`) to the Pi, so an anonymous visitor can cause the relay to touch a
+home Pi. That ends here.
+
+## What reaches a Pi today vs after this change
+
+| Surface | Today (v1) | After |
+|---|---|---|
+| Owner data/control `/api/*` | 403 at relay + Pi gate (no leak) | unchanged — 403, only over an authed channel |
+| Static app shell `GET /` etc. | **forwarded to the Pi** | **served by the relay** from its own embedded copy — Pi not touched |
+| `GET /api/identity` | **forwarded to the Pi** | **served by the relay** from its pinned `-home-pubkey` — Pi not touched |
+| Signaling `POST /signal/.../offer` | forwarded to the Pi (capped, anonymous) | forwarded **only** if it carries a valid **device-key proof**; anonymous → rejected at the relay, Pi never sees it |
+| The P2P channel | unauthenticated at open, owner auth over it | opened only by a device-key-proven peer; owner auth (or silent device-key PoP) over it |
+
+Net: **no anonymous internet request ever reaches the Pi.** The Pi is reachable
+only by a browser that holds a device-key minted on the Pi's LAN.
+
+## Architecture
+
+### 1. The relay serves the bootstrap itself (closes the GET surface)
+- `go:embed web/` into `ftw-relay`; the home host's static GETs are served from
+  the embedded bundle, **not** forwarded to the Pi. (The bundle is the same app
+  for every home host — per-Pi difference is only identity + data.)
+- `GET /api/identity` is answered by the relay from the **pinned `-home-pubkey`**
+  it already holds (+ site_id, curve). The Pi is not contacted. (The browser still
+  TOFU-pins this and verifies the Pi's *signed DTLS fingerprint* over the channel,
+  so a lying relay still can't MITM — the anti-MITM proof is unchanged.)
+- Version coupling: the relay bundle is built from the same repo at release time,
+  so `relay@X.Y.Z` ships the `X.Y.Z` web. The release pipeline already builds both.
+
+### 2. The device-key gates signaling (closes the contact surface)
+- **Mint (LAN-only, once per device):** during LAN enrollment (passkey + LAN PIN,
+  the Pi serving enroll directly), the browser generates a **non-extractable**
+  ECDSA P-256 device keypair (WebCrypto, stored in IndexedDB). The Pi pins the
+  device **public** key on `trusted_devices` (new `device_pubkey` column), bound
+  to the wallet and the enroll assertion so it can't be swapped.
+- **Publish:** the Pi pushes its set of trusted device-pubkeys to the relay on
+  `/me/register` (alongside the site key). The relay stores them per-site. These
+  are **public** keys — same posture as the site key the relay already holds.
+- **Gate (every channel open):**
+  1. Browser `GET /signal/{site}/challenge` → fresh nonce.
+  2. Browser signs the nonce with the device key.
+  3. Browser `POST /signal/{site}/offer` with `{offer, device_pubkey, sig}`.
+  4. Relay verifies `device_pubkey ∈ registered set` **and** `sig` over the nonce
+     (ES256 — the relay already does ES256-verify for `/me/register`, so this is
+     the same capability, not new trust). Valid → forward to the Pi's mailbox.
+     Invalid/absent → **reject; the Pi never sees it.**
+- First-ever remote contact is therefore impossible without a prior **LAN**
+  enrollment. Remote-first onboarding is intentionally unsupported (more secure;
+  matches the existing LAN-PIN-first model).
+
+### 3. The device-key also mints the session (silent re-auth)
+Over the opened channel the browser proves the device-key to the **Pi** (PoP over
+a Pi challenge / the DTLS exporter). The Pi verifies against the pinned
+`device_pubkey` → mints the owner session **silently** (no passkey). So "remember
+the browser / stay signed in" falls out for free, and it does **not** weaken the
+hard stop: the device-key *is* the owner's credential (LAN-born, wallet-bound).
+- **Step-up:** sensitive actions (add/remove device, remove credential) always
+  require a fresh passkey, regardless.
+- **Revoke:** removing a device drops its `device_pubkey` on the Pi **and** the
+  relay's set → that device can no longer sign in *or even signal*; it must
+  re-enroll on the LAN.
+
+## Threat model (surface by surface)
+- **Anonymous internet visitor:** gets the static shell + identity from the
+  *relay*; cannot signal (no device-key → relay rejects); **cannot reach the Pi at
+  all.** ✓
+- **Stolen device-key:** non-extractable (can't be exfiltrated from the browser);
+  revocable; step-up for sensitive actions.
+- **LAN attacker:** the LAN remains the trust boundary (existing LAN-bypass model,
+  unchanged) — that's where device-keys are minted.
+- **Compromised relay:** holds only public keys; can DoS or pass a forged offer
+  through, but the channel is E2E and the session needs the device-key/passkey, so
+  it gets **no data** — same confidentiality posture as today (availability was
+  never the relay's to guarantee).
+
+## Build slices (each its own reviewable step)
+1. **Relay serves the shell** — `go:embed web/`; home host static from the bundle,
+   not forwarded. Smoke: anonymous `GET /` hits the relay (Pi receives nothing).
+2. **Relay serves `/api/identity`** from the pinned key. Smoke: identity returned
+   with the Pi powered off.
+3. **Device-key mint + pin** — browser keygen + IndexedDB; Pi `device_pubkey`
+   column + bind at enroll/finish.
+4. **Relay signaling gate** — Pi publishes device-pubkeys on `/me/register`; relay
+   `/signal/{site}/challenge` + verify on `/offer`; reject unproven.
+5. **Silent session via device-key PoP** over the channel → Pi mints session.
+6. **Revocation** end-to-end (Pi + relay drop the key).
+7. **Tests + Codex security GO** — adversarial pass on every surface in the table
+   above before it goes live.
+
+## Open question for Fredrik (the one trade-off)
+The signaling gate makes the relay verify a device-key signature, so the relay
+learns the set of device **public** keys per site (it already holds the site
+pubkey, so this is the same kind of data — public, non-secret). The alternative —
+keeping the relay totally blind and letting the Pi cheap-reject anonymous offers —
+would leave anonymous offers *reaching* the Pi (bounded + leak-free, but a
+contact). This spec chooses the **hard** option (no anonymous contact) at the cost
+of the relay holding public device-keys. Confirm that trade is the one you want.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1628,6 +1628,18 @@ func main() {
 			// mapping would be refused anyway) — fail loud, not silent.
 			slog.Error("owner-access: remote_access enabled but no site identity; skipping relay registration", "key_path", identityKeyPath)
 		default:
+			// C1: publish this site's trusted device_pubkeys on every /me/register
+			// so the relay can gate signaling on a device-key proof (no published
+			// key → the relay forwards no signaling, fail-closed). Wired here so
+			// owner_relay_register.go stays free of a *Store dependency.
+			trustedDevicePubkeysLoader = func() []string {
+				pks, err := st.TrustedDevicePubkeys()
+				if err != nil {
+					slog.Warn("owner-access: could not load trusted device_pubkeys for relay publish", "err", err)
+					return nil
+				}
+				return pks
+			}
 			go runOwnerRelayRegistration(ctx, relayURL, "site:"+cfg.Site.Name, deriveOwnerHostID(st, cfg.Site.Name), tunnelMarker, cfg.API.Port, siteIdentity, p2pMgr)
 		}
 	}

--- a/go/cmd/forty-two-watts/owner_relay_register.go
+++ b/go/cmd/forty-two-watts/owner_relay_register.go
@@ -155,7 +155,19 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 
 	registerOnce := func() {
 		tsMs := time.Now().UnixMilli()
-		sig, err := signer.SignRawHex(tunnel.MeRegisterSigningString(siteID, hostID, tsMs))
+		// C1: publish the set of trusted device_pubkeys so the relay can gate
+		// signaling offers (C2) on a browser proving one of them. When any exist we
+		// sign the v2 string that COVERS the set, so a captured register body can't
+		// be replayed with a swapped/added key to inject one the relay would trust
+		// (the v1 signature did not cover the array — that was the bug). With no
+		// device keys yet we sign v1 and omit the field; the relay's device-gate
+		// then has nothing to admit and stays closed (fail-closed default).
+		pks := loadTrustedDevicePubkeys()
+		signString := tunnel.MeRegisterSigningString(siteID, hostID, tsMs)
+		if len(pks) > 0 {
+			signString = tunnel.MeRegisterSigningStringV2(siteID, hostID, tsMs, pks)
+		}
+		sig, err := signer.SignRawHex(signString)
 		if err != nil {
 			slog.Warn("owner-access: sign register", "err", err)
 			return
@@ -167,15 +179,7 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 			"ts_ms":      tsMs,
 			"sig":        sig,
 		}
-		// C1: publish the set of trusted device_pubkeys so the relay can gate
-		// signaling offers (C2) on a browser proving one of them. The existing
-		// ES256 register signature already authenticates this body's origin (it
-		// binds site_id→host_id at a timestamp; only the site key can mint it), so
-		// the relay accepting the device set off an authenticated register is the
-		// same trust model as accepting the host_id mapping. Omitted entirely when
-		// no device key is enrolled yet (loader nil or empty) — the relay then has
-		// no set to gate on and its device-gate stays closed (fail-closed default).
-		if pks := loadTrustedDevicePubkeys(); len(pks) > 0 {
+		if len(pks) > 0 {
 			reqBody["device_pubkeys"] = pks
 		}
 		body, _ := json.Marshal(reqBody)

--- a/go/cmd/forty-two-watts/owner_relay_register.go
+++ b/go/cmd/forty-two-watts/owner_relay_register.go
@@ -26,6 +26,33 @@ type relaySigner interface {
 	SignRawHex(msg string) (string, error)
 }
 
+// trustedDevicePubkeysLoader, when set, returns the current set of trusted
+// device_pubkeys (C1) to publish on every /me/register. It is a package-level
+// hook rather than a parameter so the single call site in main.go does not need
+// to change as this area lands in parallel — main.go wires it once, right after
+// opening the state store, with:
+//
+//	trustedDevicePubkeysLoader = func() []string {
+//	    pks, err := st.TrustedDevicePubkeys()
+//	    if err != nil { slog.Warn("owner-access: load device pubkeys", "err", err); return nil }
+//	    return pks
+//	}
+//
+// Nil (unwired) means the "device_pubkeys" field is OMITTED from the body — the
+// relay then publishes no device-key set for the site and its device-gate (C2)
+// stays closed, which is the correct fail-closed default before wiring.
+var trustedDevicePubkeysLoader func() []string
+
+// loadTrustedDevicePubkeys returns the device-key set to publish, or nil when no
+// loader is wired or it errors. Always returns a non-nil-safe slice the caller
+// only marshals when len>0, so the field is omitted rather than sent as [].
+func loadTrustedDevicePubkeys() []string {
+	if trustedDevicePubkeysLoader == nil {
+		return nil
+	}
+	return trustedDevicePubkeysLoader()
+}
+
 // deriveOwnerHostID returns a stable host_id for the owner-access
 // relay registration. It looks up (or creates) a row in the
 // state.db config table so the host_id survives restarts — important
@@ -133,13 +160,25 @@ func runOwnerRelayRegistration(ctx context.Context, relayURL, siteID, hostID, tu
 			slog.Warn("owner-access: sign register", "err", err)
 			return
 		}
-		body, _ := json.Marshal(map[string]any{
+		reqBody := map[string]any{
 			"site_id":    siteID,
 			"host_id":    hostID,
 			"public_key": signer.PublicKeyHex(),
 			"ts_ms":      tsMs,
 			"sig":        sig,
-		})
+		}
+		// C1: publish the set of trusted device_pubkeys so the relay can gate
+		// signaling offers (C2) on a browser proving one of them. The existing
+		// ES256 register signature already authenticates this body's origin (it
+		// binds site_id→host_id at a timestamp; only the site key can mint it), so
+		// the relay accepting the device set off an authenticated register is the
+		// same trust model as accepting the host_id mapping. Omitted entirely when
+		// no device key is enrolled yet (loader nil or empty) — the relay then has
+		// no set to gate on and its device-gate stays closed (fail-closed default).
+		if pks := loadTrustedDevicePubkeys(); len(pks) > 0 {
+			reqBody["device_pubkeys"] = pks
+		}
+		body, _ := json.Marshal(reqBody)
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, relayURL+"/me/register", bytes.NewReader(body))
 		if err != nil {
 			slog.Warn("owner-access: build register request", "err", err)

--- a/go/cmd/ftw-relay/auth.go
+++ b/go/cmd/ftw-relay/auth.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"math/big"
@@ -27,6 +28,49 @@ func verifyES256Hex(pubKeyHex, msg, sigHex string) bool {
 	s := new(big.Int).SetBytes(sig[32:])
 	h := sha256.Sum256([]byte(msg))
 	return ecdsa.Verify(pub, h[:], r, s)
+}
+
+// verifyES256B64URL verifies a raw R||S ECDSA-P256 signature, base64url-encoded
+// (no padding), of msg against an uncompressed X||Y public key (128 hex chars).
+//
+// This is the WebCrypto wire format: SubtleCrypto.sign("ECDSA", {hash:"SHA-256"})
+// over a P-256 key produces the 64-byte raw r||s the browser then base64url's.
+// It is the device-key proof format for the signaling-offer challenge (C2): the
+// browser proves possession of a device key the Pi trusts before the relay will
+// forward its offer to the Pi. Returns false on any decode, length, on-curve, or
+// verification failure — never panics on attacker input.
+func verifyES256B64URL(pubKeyHex, msg, sigB64URL string) bool {
+	pub, err := parseP256PubKeyHex(pubKeyHex)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(sigB64URL)
+	if err != nil || len(sig) != 64 {
+		return false
+	}
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	h := sha256.Sum256([]byte(msg))
+	return ecdsa.Verify(pub, h[:], r, s)
+}
+
+// validDevicePubKeyHex reports whether s is a syntactically valid uncompressed
+// P-256 public key in the device-key wire format: 128 lowercase hex chars that
+// decode to a point on the curve. Used to bound + canonicalise the device keys
+// the Pi publishes (C1) and the browser presents (C2) so the stored set is
+// always comparable byte-for-byte.
+func validDevicePubKeyHex(s string) bool {
+	if len(s) != 128 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false // reject uppercase + non-hex so the set is canonical
+		}
+	}
+	_, err := parseP256PubKeyHex(s)
+	return err == nil
 }
 
 // parseP256PubKeyHex parses a 64-byte (128 hex char) uncompressed P-256 public

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -71,16 +74,29 @@ type Relay struct {
 	Tokens      *TokenRegistry
 	Owners      *OwnerRegistry
 	Polls       *PollSecrets
-	Signals     *SignalMailbox // blind WebRTC signaling rendezvous (P2P-only home route)
-	OfferLimit  *IPRateLimiter // per-source-IP throttle on browser signaling offers (FIX-C)
-	TrustCFIP   bool           // honour CF-Connecting-IP from validated Cloudflare peers (-trust-cf-ip)
-	PollTimeout time.Duration  // 0 → 25s default
+	Signals     *SignalMailbox    // blind WebRTC signaling rendezvous (P2P-only home route)
+	Challenges  *SignalChallenges // single-use device-key proof nonces for the signaling offer (C2)
+	OfferLimit  *IPRateLimiter    // per-source-IP throttle on browser signaling offers (FIX-C)
+	TrustCFIP   bool              // honour CF-Connecting-IP from validated Cloudflare peers (-trust-cf-ip)
+	PollTimeout time.Duration     // 0 → 25s default
 	// HomeHost, when set, maps a bare host (e.g. home.fortytwowatts.com) to
 	// the single owner Pi registered under HomeSite — forwarding every path
 	// verbatim (no /me/<site_id> prefix) so the dashboard's absolute asset
 	// paths resolve. The Phase 4 single-home cutover.
 	HomeHost string
 	HomeSite string
+	// HomeWeb, when set, is a directory on the relay VM holding the same web/
+	// bundle the Pi serves. With it set, the home host's static GETs are served
+	// from disk at the relay (SLICE 1) instead of being forwarded to the Pi over
+	// the tunnel — the SPA shell loads even while the Pi is mid-connect, and the
+	// Pi's uplink only ever carries owner DATA (over DTLS), never asset GETs.
+	// Unset → the old forward-to-Pi behaviour (back-compat).
+	HomeWeb string
+	// HomePubKey is the pinned home-site ES256 public key (hex X||Y). When set,
+	// the relay answers GET /api/identity for the home host directly from this
+	// pin (SLICE 2) instead of forwarding to the Pi — the browser's TOFU anchor
+	// is then served even while the Pi is offline.
+	HomePubKey string
 }
 
 type registerRequest struct {
@@ -106,6 +122,9 @@ func (r *Relay) Handler() http.Handler {
 	if r.Signals == nil {
 		r.Signals = NewSignalMailbox()
 	}
+	if r.Challenges == nil {
+		r.Challenges = NewSignalChallenges()
+	}
 	if r.OfferLimit == nil {
 		// Per-source-IP token bucket on the unauthenticated browser offer endpoint
 		// (FIX-C): bounds one abusive IP without letting it lock out a legit browser
@@ -130,6 +149,7 @@ func (r *Relay) Handler() http.Handler {
 	//   - Pi:      long-poll GET /signal/{host_id}/offer + POST /signal/{host_id}/answer
 	// The Pi side is authenticated with the per-host poll secret (X-FTW-Poll), the
 	// same token minted at /me/register; the browser side is rate-limited.
+	mux.HandleFunc("GET /signal/{site_id}/challenge", r.signalChallenge)
 	mux.HandleFunc("POST /signal/{site_id}/offer", r.signalBrowserOffer)
 	mux.HandleFunc("GET /signal/{site_id}/answer", r.signalBrowserAnswer)
 	mux.HandleFunc("GET /signal/{host_id}/offer", r.signalHostOffer)
@@ -159,6 +179,7 @@ func (r *Relay) Handler() http.Handler {
 		// the home host explicitly so the rendezvous works from the dashboard
 		// origin. (The Pi's /signal/{host}/* routes need no host pin: the Pi dials
 		// the relay by its own host, not the home host.)
+		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/challenge", r.signalChallenge)
 		mux.HandleFunc("POST "+r.HomeHost+"/signal/{site_id}/offer", r.signalBrowserOffer)
 		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/answer", r.signalBrowserAnswer)
 		mux.HandleFunc(r.HomeHost+"/", r.homeStaticForward)
@@ -203,8 +224,27 @@ func (r *Relay) homeStaticForward(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "owner API is P2P-only; this relay serves static assets only", http.StatusMethodNotAllowed)
 		return
 	}
+	// SLICE 2: serve GET /api/identity from the home pubkey the relay already
+	// holds (the operator-provided -home-pubkey pin) WITHOUT forwarding to the Pi.
+	// This is the browser's TOFU anchor — a public key only, no secret/cookie — so
+	// the relay can answer it locally and the dashboard's bootstrap works even
+	// while the Pi is mid-connect or offline. Only when a key is actually pinned;
+	// otherwise fall through to the existing gate (which forwards it as the TOFU
+	// exception).
+	if req.URL.Path == "/api/identity" && r.HomePubKey != "" {
+		r.serveHomeIdentity(w)
+		return
+	}
 	if isOwnerAPIPath(req.URL.Path) {
 		http.Error(w, "owner API is P2P-only; not served over the relay", http.StatusForbidden)
+		return
+	}
+	// SLICE 1: when -home-web is set, serve the static shell from the relay's own
+	// disk instead of forwarding the GET to the Pi. The SPA loads even while the
+	// Pi is mid-connect, and the Pi's uplink only ever carries owner DATA (over
+	// DTLS), never asset GETs. Unset → the old forward-to-Pi path below.
+	if r.HomeWeb != "" {
+		r.serveHomeStaticFile(w, req)
 		return
 	}
 	hostID, registered, fresh := r.Owners.Active(r.HomeSite, homeStaleAfter)
@@ -240,6 +280,76 @@ func (r *Relay) homeStaticForward(w http.ResponseWriter, req *http.Request) {
 	}
 	w.WriteHeader(resp.Status)
 	_, _ = w.Write(resp.Body)
+}
+
+// serveHomeIdentity answers GET /api/identity for the home host from the pinned
+// home pubkey the relay already holds (SLICE 2). It returns the same shape the Pi
+// would, so the browser's TOFU bootstrap is byte-compatible whether the key comes
+// from the relay pin or (in -home-pubkey-less back-compat) the forwarded Pi
+// response. Public key only — no secret, no cookie — so serving it locally leaks
+// nothing and lets the dashboard bootstrap even while the Pi is offline.
+func (r *Relay) serveHomeIdentity(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	// Cache-Control: the pin is stable for the relay's lifetime, but keep it
+	// short so a key rotation (operator restarts the relay with a new pin)
+	// propagates quickly.
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(struct {
+		PublicKeyHex string `json:"public_key_hex"`
+		SiteID       string `json:"site_id"`
+		Algorithm    string `json:"algorithm"`
+		Curve        string `json:"curve"`
+	}{
+		PublicKeyHex: r.HomePubKey,
+		SiteID:       r.HomeSite,
+		Algorithm:    "ES256",
+		Curve:        "P-256",
+	})
+}
+
+// serveHomeStaticFile serves a static asset for the home host from the -home-web
+// directory on the relay VM (SLICE 1), with path-traversal protection and an
+// index.html fallback for "/". It NEVER forwards to the Pi. A missing file is a
+// 404; "/" (or any path that resolves to a directory) serves index.html so the
+// SPA shell loads at the root. The owner-API + method gates already ran in the
+// caller, so only safe GETs of non-/api paths reach here.
+func (r *Relay) serveHomeStaticFile(w http.ResponseWriter, req *http.Request) {
+	// Clean the request path to an absolute, slash-rooted form, then strip the
+	// leading slash so filepath.Join can't escape the web root. path.Clean
+	// collapses any ".." so a crafted "/../../etc/passwd" resolves inside the
+	// tree (or to "/"), never above it; the explicit prefix check below is belt
+	// and braces.
+	clean := path.Clean("/" + req.URL.Path)
+	if clean == "/" {
+		clean = "/index.html"
+	}
+	rel := strings.TrimPrefix(clean, "/")
+	full := filepath.Join(r.HomeWeb, filepath.FromSlash(rel))
+	// Defence in depth: confirm the resolved path is still within the web root
+	// after symlink-free join. filepath.Join already cleaned ".." out of `rel`,
+	// but a web root that is itself a relative path or a stray separator could
+	// still surprise us — refuse anything that doesn't have the root as a prefix.
+	root := filepath.Clean(r.HomeWeb)
+	if full != root && !strings.HasPrefix(full, root+string(filepath.Separator)) {
+		http.NotFound(w, req)
+		return
+	}
+	info, err := os.Stat(full)
+	if err != nil || info.IsDir() {
+		// Missing file or a directory request → serve the SPA shell so client-side
+		// routes (deep links into the dashboard) resolve to index.html, the
+		// conventional SPA fallback. If even index.html is missing, 404.
+		index := filepath.Join(root, "index.html")
+		if _, ierr := os.Stat(index); ierr != nil {
+			http.NotFound(w, req)
+			return
+		}
+		full = index
+	}
+	// Never leak an owner cookie either direction: strip any inbound Cookie (the
+	// session lives only in DTLS) — http.ServeFile sets no cookies itself.
+	req.Header.Del("Cookie")
+	http.ServeFile(w, req, full)
 }
 
 // isOwnerAPIPath reports whether a request path is part of the owner API surface
@@ -796,6 +906,15 @@ type meRegisterRequest struct {
 	PublicKey string `json:"public_key"`
 	TsMs      int64  `json:"ts_ms"`
 	Sig       string `json:"sig"`
+	// DevicePubkeys (C1) is the set of device keys the Pi trusts to signal +
+	// mint a session for this site. The Pi publishes it on the SAME
+	// ES256-signed registration, so the relay trusts the set exactly as far as
+	// it trusts the (verified) registration signature. Each entry is an
+	// uncompressed P-256 key as 128 lowercase hex (X||Y). Optional + omitempty:
+	// a registration without it leaves the site's device-key set unchanged is
+	// NOT the behaviour — see meRegister: the field, when PRESENT, replaces the
+	// set; the Pi always sends its current set so the relay mirrors it exactly.
+	DevicePubkeys []string `json:"device_pubkeys,omitempty"`
 }
 
 func (r *Relay) meRegister(w http.ResponseWriter, req *http.Request) {
@@ -837,6 +956,25 @@ func (r *Relay) meRegister(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
+	// C1: mirror the Pi's trusted device-key set for this site. The registration
+	// signature was just verified against the site's pinned key, so the relay
+	// trusts this set exactly as far as it trusts the registration. The Pi sends
+	// its FULL current set every time, so SetDeviceKeys REPLACES (not merges) —
+	// a key the owner removed on the Pi disappears from the relay on the next
+	// re-registration. Canonicalise + de-dup so the stored set compares
+	// byte-for-byte with what the browser presents on the signaling offer (C2);
+	// silently drop malformed entries rather than reject the whole registration
+	// (a single bad key must not knock the Pi's tunnel mapping offline).
+	dev := make([]string, 0, len(reg.DevicePubkeys))
+	seenDev := make(map[string]bool, len(reg.DevicePubkeys))
+	for _, k := range reg.DevicePubkeys {
+		if !validDevicePubKeyHex(k) || seenDev[k] {
+			continue
+		}
+		seenDev[k] = true
+		dev = append(dev, k)
+	}
+	r.Owners.SetDeviceKeys(reg.SiteID, dev)
 	// Return the poll token this host must present on /tunnel/<host>/next and the
 	// /signal/* rendezvous. The ES256-verified registration above proves it owns
 	// host_id, so only it learns the token. The secret is bound to the verified
@@ -861,6 +999,71 @@ func (r *Relay) meRegister(w http.ResponseWriter, req *http.Request) {
 }
 
 // ---- Blind WebRTC signaling rendezvous (P2P-only home route) ----
+
+// signalProofSigningString is the canonical message the browser signs with a
+// trusted device key to be allowed to forward a signaling offer (C2). Both ends
+// MUST build it identically — the browser (WebCrypto, raw r||s, base64url) and
+// the relay (verifyES256B64URL). Versioned ("v1") so it can evolve without a
+// silent browser↔relay mismatch; the colon-delimited (site, nonce) binds the
+// proof to THIS site and THIS single-use nonce, so a signature can't be lifted to
+// another site or replayed against a fresh nonce.
+func signalProofSigningString(siteID, nonce string) string {
+	return "ftw-signal:v1:" + siteID + ":" + nonce
+}
+
+// verifyOfferDeviceProof enforces C2: the browser proved possession of a device
+// key the Pi trusts. It returns true ONLY when (in this order, fail-closed):
+//   - device_pubkey is a well-formed P-256 key in the site's published set (C1),
+//   - sig verifies over "ftw-signal:v1:<site>:<nonce>" against that key, and
+//   - the challenge nonce was known, unexpired, and not yet used (consumed here).
+//
+// The nonce is consumed LAST and only on full success, so a request that fails
+// the key/sig check leaves the nonce spendable for the legitimate browser. A
+// valid signature already requires knowing the unguessable 32-byte nonce, so the
+// ordering doesn't create a probing oracle. Any failure → false → the caller
+// returns 403 WITHOUT contacting the Pi.
+func (r *Relay) verifyOfferDeviceProof(siteID, devicePubkey, nonce, sig string) bool {
+	if !validDevicePubKeyHex(devicePubkey) || nonce == "" || sig == "" {
+		return false
+	}
+	if !r.Owners.HasDeviceKey(siteID, devicePubkey) {
+		return false
+	}
+	if !verifyES256B64URL(devicePubkey, signalProofSigningString(siteID, nonce), sig) {
+		return false
+	}
+	// Consume the single-use nonce last: a replayed (device_pubkey, nonce, sig)
+	// triple fails here because the nonce is already gone, even though key + sig
+	// still check out.
+	return r.Challenges.Consume(siteID, nonce)
+}
+
+// signalChallenge issues a single-use, short-TTL nonce the browser signs with a
+// trusted device key on its subsequent POST /signal/{site}/offer (C2). It is
+// unauthenticated (the nonce is worthless without a device key in the site's
+// published set) but bounded: the store caps sites + per-site nonces so a flood
+// can't grow relay memory.
+func (r *Relay) signalChallenge(w http.ResponseWriter, req *http.Request) {
+	siteID := req.PathValue("site_id")
+	if siteID == "" {
+		http.Error(w, "missing site_id", http.StatusBadRequest)
+		return
+	}
+	if r.Challenges == nil {
+		http.Error(w, "signaling not configured", http.StatusServiceUnavailable)
+		return
+	}
+	nonce, expMs, ok := r.Challenges.Issue(siteID)
+	if !ok {
+		http.Error(w, "signaling at capacity", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(struct {
+		Nonce string `json:"nonce"`
+		ExpMs int64  `json:"exp_ms"`
+	}{Nonce: nonce, ExpMs: expMs})
+}
 
 // signalNonceHeader carries the rendezvous nonce the Pi echoes back to the
 // browser on a drained offer (FIX-4a). The browser supplied it as ?n=<nonce>;
@@ -907,7 +1110,7 @@ func (r *Relay) signalBrowserOffer(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "too many offers from your address", http.StatusTooManyRequests)
 		return
 	}
-	if r.Signals == nil {
+	if r.Signals == nil || r.Challenges == nil || r.Owners == nil {
 		http.Error(w, "signaling not configured", http.StatusServiceUnavailable)
 		return
 	}
@@ -920,7 +1123,38 @@ func (r *Relay) signalBrowserOffer(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "empty offer", http.StatusBadRequest)
 		return
 	}
-	if err := r.Signals.ParkOffer(siteID, nonce, body); err != nil {
+	// C2: the offer body is now a JSON envelope carrying the raw SDP PLUS a
+	// device-key proof. The browser must prove possession of a device key the Pi
+	// published (C1) by signing the single-use challenge nonce it fetched from
+	// GET /signal/{site}/challenge. We verify {device_pubkey, nonce, sig} BEFORE
+	// touching the mailbox, so a caller that can't prove a trusted device key
+	// never causes the Pi to be contacted at all.
+	var env struct {
+		SDP          string `json:"sdp"`
+		DevicePubkey string `json:"device_pubkey"`
+		Nonce        string `json:"nonce"`
+		Sig          string `json:"sig"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		http.Error(w, "malformed offer envelope", http.StatusBadRequest)
+		return
+	}
+	if env.SDP == "" {
+		http.Error(w, "empty offer", http.StatusBadRequest)
+		return
+	}
+	if !r.verifyOfferDeviceProof(siteID, env.DevicePubkey, env.Nonce, env.Sig) {
+		// Any proof failure — unknown/expired/replayed challenge nonce, a
+		// device_pubkey not in the site's published set, or a bad signature — is a
+		// flat 403, and crucially the Pi is NEVER contacted (we have not parked the
+		// offer or woken an offer-poller). Fail-closed.
+		http.Error(w, "device proof required", http.StatusForbidden)
+		return
+	}
+	// Park ONLY the raw SDP for the Pi, exactly as before C2: the Pi drains the
+	// raw SDP body (it never sees the device-proof envelope), so the Pi side is
+	// unchanged by C2. The device proof is a relay-side gate only.
+	if err := r.Signals.ParkOffer(siteID, nonce, []byte(env.SDP)); err != nil {
 		if err == errSignalRateLimited {
 			http.Error(w, "too many offers", http.StatusTooManyRequests)
 			return

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -97,6 +97,12 @@ type Relay struct {
 	// pin (SLICE 2) instead of forwarding to the Pi — the browser's TOFU anchor
 	// is then served even while the Pi is offline.
 	HomePubKey string
+	// RequireDeviceKey ENFORCES the C2 device-key signaling gate. Off (default)
+	// keeps the pre-C2 behaviour (park the raw offer, no proof) so the relay can
+	// ship slices 1+2 while a home Pi that doesn't yet publish device-keys (C1)
+	// still works. On → an offer must carry a verified device-key proof or the Pi
+	// is never contacted. Flip on only once device-keys are enrolled.
+	RequireDeviceKey bool
 }
 
 type registerRequest struct {
@@ -1152,7 +1158,26 @@ func (r *Relay) signalBrowserOffer(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "empty offer", http.StatusBadRequest)
 		return
 	}
-	// C2: the offer body is now a JSON envelope carrying the raw SDP PLUS a
+	// ROLLOUT GATE: the device-key signaling gate (C2) is only ENFORCED when
+	// -require-device-key is set. Until then the relay behaves exactly as it did
+	// before C2 — it parks the raw offer body and forwards it, no device-key proof.
+	// This lets the relay serve the shell + identity itself (slices 1+2, the
+	// anonymous-FETCH surface closed) while a home Pi that hasn't yet been upgraded
+	// to PUBLISH device-keys (C1) keeps working. Turn the flag on once device-keys
+	// are enrolled to close the anonymous-SIGNALING surface too.
+	if !r.RequireDeviceKey {
+		if err := r.Signals.ParkOffer(siteID, nonce, body); err != nil {
+			if err == errSignalRateLimited {
+				http.Error(w, "too many offers", http.StatusTooManyRequests)
+				return
+			}
+			http.Error(w, "signaling at capacity", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// C2 (enforced): the offer body is a JSON envelope carrying the raw SDP PLUS a
 	// device-key proof. The browser must prove possession of a device key the Pi
 	// published (C1) by signing the single-use challenge nonce it fetched from
 	// GET /signal/{site}/challenge. We verify {device_pubkey, nonce, sig} BEFORE

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -346,6 +346,19 @@ func (r *Relay) serveHomeStaticFile(w http.ResponseWriter, req *http.Request) {
 		}
 		full = index
 	}
+	// Defence in depth against symlink escape (review finding): the lexical prefix
+	// check above runs BEFORE symlink resolution, but http.ServeFile follows
+	// symlinks — a link inside HomeWeb pointing outside would otherwise leak the
+	// target. Resolve the final path + root and confirm the target truly stays
+	// inside the web root.
+	resolvedRoot, rerr := filepath.EvalSymlinks(root)
+	resolved, ferr := filepath.EvalSymlinks(full)
+	if rerr != nil || ferr != nil ||
+		(resolved != resolvedRoot && !strings.HasPrefix(resolved, resolvedRoot+string(filepath.Separator))) {
+		http.NotFound(w, req)
+		return
+	}
+	full = resolved
 	// Never leak an owner cookie either direction: strip any inbound Cookie (the
 	// session lives only in DTLS) — http.ServeFile sets no cookies itself.
 	req.Header.Del("Cookie")
@@ -939,8 +952,20 @@ func (r *Relay) meRegister(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "registration timestamp out of range", http.StatusUnauthorized)
 		return
 	}
-	// Verify the signature binds (site_id, host_id, ts) to the presented key.
-	msg := tunnel.MeRegisterSigningString(reg.SiteID, reg.HostID, reg.TsMs)
+	// Verify the signature binds (site_id, host_id, ts) to the presented key — and
+	// when the body carries device_pubkeys, that it ALSO covers that exact set (v2),
+	// so a captured registration body cannot be replayed with a swapped/added device
+	// key the relay would then trust for signaling (the v1 string did not cover the
+	// array — CVE-class bug found in review). A v1-only signature is still accepted
+	// (old Pi / no device keys), but then any device_pubkeys present did NOT sign and
+	// the storage step below verified the same way drops them — an attacker can't
+	// smuggle a key past a v1 signature.
+	var msg string
+	if len(reg.DevicePubkeys) > 0 {
+		msg = tunnel.MeRegisterSigningStringV2(reg.SiteID, reg.HostID, reg.TsMs, reg.DevicePubkeys)
+	} else {
+		msg = tunnel.MeRegisterSigningString(reg.SiteID, reg.HostID, reg.TsMs)
+	}
 	if !verifyES256Hex(reg.PublicKey, msg, reg.Sig) {
 		http.Error(w, "invalid registration signature", http.StatusUnauthorized)
 		return
@@ -1053,6 +1078,10 @@ func (r *Relay) signalChallenge(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "signaling not configured", http.StatusServiceUnavailable)
 		return
 	}
+	// TODO(C2-on phase, review finding #5): throttle challenge issuance with a
+	// SEPARATE per-IP limiter (sharing OfferLimit double-counts a legit
+	// challenge+offer pair). Until the device-key gate is ENFORCED this endpoint is
+	// inert (an evicted nonce gates nothing), so the DoS is not yet reachable.
 	nonce, expMs, ok := r.Challenges.Issue(siteID)
 	if !ok {
 		http.Error(w, "signaling at capacity", http.StatusServiceUnavailable)

--- a/go/cmd/ftw-relay/hardening_test.go
+++ b/go/cmd/ftw-relay/hardening_test.go
@@ -67,18 +67,19 @@ func TestTokenRegistryGC(t *testing.T) {
 // The public home route must fail closed without a pinned key.
 func TestRequireHomePin(t *testing.T) {
 	cases := []struct {
-		host, site, key string
-		tofu            bool
-		wantErr         bool
+		host, site, key, web string
+		tofu                 bool
+		wantErr              bool
 	}{
-		{"", "", "", false, false},                    // no home host configured → ok
-		{"home.test", "site:x", "abcd", false, false}, // pinned key → ok
-		{"home.test", "site:x", "", true, false},      // explicit TOFU override → ok
-		{"home.test", "site:x", "", false, true},      // public host, no pin, no override → error
-		{"", "site:x", "", false, true},               // site alone without pin → error
+		{"", "", "", "", false, false},                        // no home host configured → ok
+		{"home.test", "site:x", "abcd", "/web", false, false}, // pinned key + web → ok
+		{"home.test", "site:x", "abcd", "", false, true},      // pinned key but NO -home-web → error
+		{"home.test", "site:x", "", "/web", true, false},      // explicit TOFU override → ok
+		{"home.test", "site:x", "", "/web", false, true},      // has web but no pin → error
+		{"", "site:x", "", "", false, true},                   // site alone without pin/web → error
 	}
 	for i, c := range cases {
-		err := requireHomePin(c.host, c.site, c.key, c.tofu)
+		err := requireHomePin(c.host, c.site, c.key, c.web, c.tofu)
 		if (err != nil) != c.wantErr {
 			t.Errorf("case %d (%+v): err=%v wantErr=%v", i, c, err, c.wantErr)
 		}

--- a/go/cmd/ftw-relay/home_web_test.go
+++ b/go/cmd/ftw-relay/home_web_test.go
@@ -31,19 +31,21 @@ func TestMeRegister_PublishesDeviceKeys(t *testing.T) {
 	d1 := newDeviceKey(t)
 	d2 := newDeviceKey(t)
 	tsMs := time.Now().UnixMilli()
-	sig, err := id.SignRawHex(tunnel.MeRegisterSigningString("site:Home", "host-owner", tsMs))
+	keys := []string{
+		d1.pubKeyHex,
+		d2.pubKeyHex,
+		d1.pubKeyHex, // duplicate — must be de-duped, not double-stored
+		"not-a-key",  // malformed — must be dropped, not reject the whole reg
+	}
+	// v2 signing string covers the device_pubkeys set (so it can't be tampered).
+	sig, err := id.SignRawHex(tunnel.MeRegisterSigningStringV2("site:Home", "host-owner", tsMs, keys))
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
 	body, _ := json.Marshal(meRegisterRequest{
 		SiteID: "site:Home", HostID: "host-owner",
 		PublicKey: id.PublicKeyHex(), TsMs: tsMs, Sig: sig,
-		DevicePubkeys: []string{
-			d1.pubKeyHex,
-			d2.pubKeyHex,
-			d1.pubKeyHex, // duplicate — must be de-duped, not double-stored
-			"not-a-key",  // malformed — must be dropped, not reject the whole reg
-		},
+		DevicePubkeys: keys,
 	})
 	resp, err := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(body))
 	if err != nil {
@@ -79,7 +81,7 @@ func TestMeRegister_DeviceKeys_ReplaceOnReRegister(t *testing.T) {
 	old := newDeviceKey(t)
 	post := func(keys []string) {
 		tsMs := time.Now().UnixMilli()
-		sig, _ := id.SignRawHex(tunnel.MeRegisterSigningString("site:Home", "host-owner", tsMs))
+		sig, _ := id.SignRawHex(tunnel.MeRegisterSigningStringV2("site:Home", "host-owner", tsMs, keys))
 		body, _ := json.Marshal(meRegisterRequest{
 			SiteID: "site:Home", HostID: "host-owner",
 			PublicKey: id.PublicKeyHex(), TsMs: tsMs, Sig: sig,
@@ -220,5 +222,38 @@ func TestHomeStaticForward_ServesFromHomeWeb(t *testing.T) {
 	// An /api/ path is still refused at the relay (P2P-only) even with -home-web.
 	if r, _ := get("/api/owner-access/whoami"); r.StatusCode != http.StatusForbidden {
 		t.Fatalf("/api/* over relay status=%d, want 403 even with -home-web", r.StatusCode)
+	}
+}
+
+// TestMeRegister_DeviceKeysTamperRejected locks in the #2 fix: a registration
+// replayed with a swapped/added device_pubkeys array (not what the owner signed)
+// must be REJECTED — the v2 signature covers the set, so an injected key is never
+// trusted for signaling.
+func TestMeRegister_DeviceKeysTamperRejected(t *testing.T) {
+	relay := newSignedRelay()
+	relay.Polls = NewPollSecrets()
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+	id := newTestIdentity(t)
+	good := newDeviceKey(t)
+	attacker := newDeviceKey(t)
+	tsMs := time.Now().UnixMilli()
+	// Owner signs over the GOOD set; attacker replays with their key swapped in.
+	sig, _ := id.SignRawHex(tunnel.MeRegisterSigningStringV2("site:Home", "host-owner", tsMs, []string{good.pubKeyHex}))
+	body, _ := json.Marshal(meRegisterRequest{
+		SiteID: "site:Home", HostID: "host-owner",
+		PublicKey: id.PublicKeyHex(), TsMs: tsMs, Sig: sig,
+		DevicePubkeys: []string{attacker.pubKeyHex},
+	})
+	resp, err := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == 200 {
+		t.Fatal("tampered device_pubkeys must be rejected (the v2 signature covers the set)")
+	}
+	if relay.Owners.HasDeviceKey("site:Home", attacker.pubKeyHex) {
+		t.Fatal("attacker key must NOT be trusted after a tampered register")
 	}
 }

--- a/go/cmd/ftw-relay/home_web_test.go
+++ b/go/cmd/ftw-relay/home_web_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
+)
+
+// home_web_test.go — SLICE 1 (serve the home shell from the relay's -home-web
+// dir), SLICE 2 (answer /api/identity from the pinned home pubkey), and C1
+// (/me/register publishes the site's trusted device keys).
+
+// TestMeRegister_PublishesDeviceKeys (C1) proves a device_pubkeys array on the
+// ES256-signed /me/register is stored per-site, canonicalised + de-duped, and
+// malformed entries are dropped without rejecting the registration.
+func TestMeRegister_PublishesDeviceKeys(t *testing.T) {
+	relay := newSignedRelay()
+	relay.Polls = NewPollSecrets()
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+
+	id := newTestIdentity(t)
+	d1 := newDeviceKey(t)
+	d2 := newDeviceKey(t)
+	tsMs := time.Now().UnixMilli()
+	sig, err := id.SignRawHex(tunnel.MeRegisterSigningString("site:Home", "host-owner", tsMs))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	body, _ := json.Marshal(meRegisterRequest{
+		SiteID: "site:Home", HostID: "host-owner",
+		PublicKey: id.PublicKeyHex(), TsMs: tsMs, Sig: sig,
+		DevicePubkeys: []string{
+			d1.pubKeyHex,
+			d2.pubKeyHex,
+			d1.pubKeyHex, // duplicate — must be de-duped, not double-stored
+			"not-a-key",  // malformed — must be dropped, not reject the whole reg
+		},
+	})
+	resp, err := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("register status=%d body=%q (a malformed device key must not reject the reg)", resp.StatusCode, b)
+	}
+	if !relay.Owners.HasDeviceKey("site:Home", d1.pubKeyHex) {
+		t.Fatal("device key 1 was not published")
+	}
+	if !relay.Owners.HasDeviceKey("site:Home", d2.pubKeyHex) {
+		t.Fatal("device key 2 was not published")
+	}
+	stranger := newDeviceKey(t)
+	if relay.Owners.HasDeviceKey("site:Home", stranger.pubKeyHex) {
+		t.Fatal("a key that was never published must not be trusted")
+	}
+}
+
+// TestMeRegister_DeviceKeys_ReplaceOnReRegister proves the Pi's set REPLACES (not
+// merges): a key dropped on the Pi disappears from the relay on the next
+// re-registration with the same site key.
+func TestMeRegister_DeviceKeys_ReplaceOnReRegister(t *testing.T) {
+	relay := newSignedRelay()
+	relay.Polls = NewPollSecrets()
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+
+	id := newTestIdentity(t)
+	old := newDeviceKey(t)
+	post := func(keys []string) {
+		tsMs := time.Now().UnixMilli()
+		sig, _ := id.SignRawHex(tunnel.MeRegisterSigningString("site:Home", "host-owner", tsMs))
+		body, _ := json.Marshal(meRegisterRequest{
+			SiteID: "site:Home", HostID: "host-owner",
+			PublicKey: id.PublicKeyHex(), TsMs: tsMs, Sig: sig,
+			DevicePubkeys: keys,
+		})
+		resp, err := http.Post(srv.URL+"/me/register", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatalf("register status=%d", resp.StatusCode)
+		}
+	}
+	post([]string{old.pubKeyHex})
+	if !relay.Owners.HasDeviceKey("site:Home", old.pubKeyHex) {
+		t.Fatal("first device key not published")
+	}
+	// Re-register with a DIFFERENT set (the owner revoked `old`, added `now`).
+	now := newDeviceKey(t)
+	post([]string{now.pubKeyHex})
+	if relay.Owners.HasDeviceKey("site:Home", old.pubKeyHex) {
+		t.Fatal("revoked device key still trusted after re-register (set must REPLACE, not merge)")
+	}
+	if !relay.Owners.HasDeviceKey("site:Home", now.pubKeyHex) {
+		t.Fatal("new device key not published on re-register")
+	}
+}
+
+// TestHomeIdentity_ServedFromPin (SLICE 2) proves GET /api/identity on the home
+// host is answered from the pinned -home-pubkey WITHOUT forwarding to the Pi —
+// and works even with no Pi registered at all.
+func TestHomeIdentity_ServedFromPin(t *testing.T) {
+	const pin = "1111111111111111111111111111111111111111111111111111111111111111" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+	relay := &Relay{
+		Queue:      tunnel.NewQueue(),
+		Tokens:     NewTokenRegistry(),
+		Owners:     NewOwnerRegistry(),
+		Polls:      NewPollSecrets(),
+		Signals:    NewSignalMailbox(),
+		Challenges: NewSignalChallenges(),
+		HomeHost:   "home.test",
+		HomeSite:   "site:Home",
+		HomePubKey: pin,
+	}
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/identity", nil)
+	req.Host = "home.test"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("/api/identity from pin status=%d, want 200 (no Pi forward needed)", resp.StatusCode)
+	}
+	var out struct {
+		PublicKeyHex string `json:"public_key_hex"`
+		SiteID       string `json:"site_id"`
+		Algorithm    string `json:"algorithm"`
+		Curve        string `json:"curve"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode identity: %v", err)
+	}
+	if out.PublicKeyHex != pin {
+		t.Fatalf("public_key_hex = %q, want the pinned key", out.PublicKeyHex)
+	}
+	if out.SiteID != "site:Home" || out.Algorithm != "ES256" || out.Curve != "P-256" {
+		t.Fatalf("identity fields = %+v, want site:Home/ES256/P-256", out)
+	}
+}
+
+// TestHomeStaticForward_ServesFromHomeWeb (SLICE 1) proves that with -home-web
+// set, the home host's static GETs are served from the relay's disk (not
+// forwarded to the Pi), "/" serves index.html, traversal is blocked, and an
+// /api/ path is still refused.
+func TestHomeStaticForward_ServesFromHomeWeb(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<h1>SHELL</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.js"), []byte("console.log(1)"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A secret file OUTSIDE the web root, to prove traversal can't reach it.
+	secret := filepath.Join(filepath.Dir(dir), "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOPSECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(secret) })
+
+	relay := &Relay{
+		Queue:      tunnel.NewQueue(),
+		Tokens:     NewTokenRegistry(),
+		Owners:     NewOwnerRegistry(),
+		Polls:      NewPollSecrets(),
+		Signals:    NewSignalMailbox(),
+		Challenges: NewSignalChallenges(),
+		HomeHost:   "home.test",
+		HomeSite:   "site:Home",
+		HomeWeb:    dir,
+	}
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+
+	get := func(path string) (*http.Response, string) {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+		req.Host = "home.test"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp, string(b)
+	}
+
+	// "/" serves index.html from disk — no Pi registered, yet it works.
+	if r, body := get("/"); r.StatusCode != 200 || body != "<h1>SHELL</h1>" {
+		t.Fatalf(`GET "/" status=%d body=%q, want 200 "<h1>SHELL</h1>" from -home-web`, r.StatusCode, body)
+	}
+	// A named asset is served from disk.
+	if r, body := get("/app.js"); r.StatusCode != 200 || body != "console.log(1)" {
+		t.Fatalf("GET /app.js status=%d body=%q, want the on-disk file", r.StatusCode, body)
+	}
+	// A deep SPA route with no file falls back to index.html (SPA convention).
+	if r, body := get("/dashboard/energy"); r.StatusCode != 200 || body != "<h1>SHELL</h1>" {
+		t.Fatalf("GET /dashboard/energy status=%d body=%q, want the SPA shell", r.StatusCode, body)
+	}
+	// Path traversal must NOT escape the web root.
+	if r, body := get("/../secret.txt"); body == "TOPSECRET" {
+		t.Fatalf("path traversal leaked the secret file: status=%d body=%q", r.StatusCode, body)
+	}
+	// An /api/ path is still refused at the relay (P2P-only) even with -home-web.
+	if r, _ := get("/api/owner-access/whoami"); r.StatusCode != http.StatusForbidden {
+		t.Fatalf("/api/* over relay status=%d, want 403 even with -home-web", r.StatusCode)
+	}
+}

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -31,6 +31,7 @@ func main() {
 	homeSite := flag.String("home-site", "", "site_id the -home-host forwards to (e.g. site:Home)")
 	homePubKey := flag.String("home-pubkey", "", "operator-provisioned ES256 public key (hex X||Y) the -home-site must register with; pins the home mapping across relay restarts so it is never first-come TOFU")
 	homeWeb := flag.String("home-web", "", "path to the web/ bundle on the relay VM; when set, the home host's static GETs are served from here instead of forwarded to the Pi (SLICE 1). Unset → forward static GETs to the Pi (back-compat).")
+	requireDeviceKey := flag.Bool("require-device-key", false, "ENFORCE the device-key signaling gate (C2): an offer must carry a verified device-key proof or the Pi is never contacted. Off (default) keeps the pre-C2 behaviour so the relay can serve the shell + identity (slices 1+2) while a home Pi that doesn't yet publish device-keys keeps working. Turn on once device-keys are enrolled.")
 	homeAllowTOFU := flag.Bool("home-allow-tofu", false, "allow the home host to run WITHOUT -home-pubkey (trust-on-first-use); insecure across relay restarts — testing only")
 	trustCFIP := flag.Bool("trust-cf-ip", false, "behind Cloudflare: trust CF-Connecting-IP for the per-IP signaling throttle, but ONLY from validated Cloudflare edge peers (else the throttle keys on the shared CF edge IP). Also firewall the origin to Cloudflare's ranges.")
 	flag.Parse()
@@ -58,18 +59,19 @@ func main() {
 	}
 
 	r := &Relay{
-		Queue:       tunnel.NewQueue(),
-		Tokens:      NewTokenRegistry(),
-		Owners:      owners,
-		Polls:       NewPollSecrets(),
-		Signals:     NewSignalMailbox(),
-		Challenges:  NewSignalChallenges(),
-		TrustCFIP:   *trustCFIP,
-		PollTimeout: *pollTimeout,
-		HomeHost:    *homeHost,
-		HomeSite:    *homeSite,
-		HomeWeb:     *homeWeb,
-		HomePubKey:  *homePubKey,
+		Queue:            tunnel.NewQueue(),
+		Tokens:           NewTokenRegistry(),
+		Owners:           owners,
+		Polls:            NewPollSecrets(),
+		Signals:          NewSignalMailbox(),
+		Challenges:       NewSignalChallenges(),
+		TrustCFIP:        *trustCFIP,
+		PollTimeout:      *pollTimeout,
+		HomeHost:         *homeHost,
+		HomeSite:         *homeSite,
+		HomeWeb:          *homeWeb,
+		HomePubKey:       *homePubKey,
+		RequireDeviceKey: *requireDeviceKey,
 	}
 
 	srv := &http.Server{

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -30,6 +30,7 @@ func main() {
 	homeHost := flag.String("home-host", "", "bare host that maps to a single owner Pi (e.g. home.fortytwowatts.com); requires -home-site")
 	homeSite := flag.String("home-site", "", "site_id the -home-host forwards to (e.g. site:Home)")
 	homePubKey := flag.String("home-pubkey", "", "operator-provisioned ES256 public key (hex X||Y) the -home-site must register with; pins the home mapping across relay restarts so it is never first-come TOFU")
+	homeWeb := flag.String("home-web", "", "path to the web/ bundle on the relay VM; when set, the home host's static GETs are served from here instead of forwarded to the Pi (SLICE 1). Unset → forward static GETs to the Pi (back-compat).")
 	homeAllowTOFU := flag.Bool("home-allow-tofu", false, "allow the home host to run WITHOUT -home-pubkey (trust-on-first-use); insecure across relay restarts — testing only")
 	trustCFIP := flag.Bool("trust-cf-ip", false, "behind Cloudflare: trust CF-Connecting-IP for the per-IP signaling throttle, but ONLY from validated Cloudflare edge peers (else the throttle keys on the shared CF edge IP). Also firewall the origin to Cloudflare's ranges.")
 	flag.Parse()
@@ -62,10 +63,13 @@ func main() {
 		Owners:      owners,
 		Polls:       NewPollSecrets(),
 		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
 		TrustCFIP:   *trustCFIP,
 		PollTimeout: *pollTimeout,
 		HomeHost:    *homeHost,
 		HomeSite:    *homeSite,
+		HomeWeb:     *homeWeb,
+		HomePubKey:  *homePubKey,
 	}
 
 	srv := &http.Server{
@@ -110,6 +114,14 @@ func main() {
 				// site_ids can't grow relay memory; a live pair re-signals on demand.
 				if n := r.Signals.GC(30 * time.Minute); n > 0 {
 					slog.Info("ftw-relay: signal GC", "removed", n)
+				}
+				// Reap expired device-key challenge nonces (C2) so a flood of
+				// GET /signal/<random>/challenge can't grow relay memory; each nonce
+				// also self-expires after ~60s, so this just trims the map proactively.
+				if r.Challenges != nil {
+					if n := r.Challenges.GC(0); n > 0 {
+						slog.Info("ftw-relay: signal-challenge GC", "removed", n)
+					}
 				}
 				// Evict idle per-source-IP offer buckets (FIX-C) so a churn of source
 				// IPs can't grow the limiter map without bound; an idle IP has

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	// Fail closed: the internet-exposed home route must never run on
 	// trust-on-first-use (see requireHomePin).
-	if err := requireHomePin(*homeHost, *homeSite, *homePubKey, *homeAllowTOFU); err != nil {
+	if err := requireHomePin(*homeHost, *homeSite, *homePubKey, *homeWeb, *homeAllowTOFU); err != nil {
 		slog.Error("ftw-relay: " + err.Error())
 		os.Exit(1)
 	}
@@ -157,9 +157,14 @@ func main() {
 // the key (so a racer can't claim home.* after a relay restart drops the
 // in-memory pin) unless TOFU was explicitly allowed. Extracted from main so the
 // fail-closed rule is unit-testable.
-func requireHomePin(homeHost, homeSite, homePubKey string, allowTOFU bool) error {
-	if (homeHost != "" || homeSite != "") && homePubKey == "" && !allowTOFU {
-		return errors.New("-home-host/-home-site requires -home-pubkey to pin the home site key — refusing to run the public home route in trust-on-first-use mode. Pass the Pi's public key (it logs it at startup) via -home-pubkey, or -home-allow-tofu to override for testing")
+func requireHomePin(homeHost, homeSite, homePubKey, homeWeb string, allowTOFU bool) error {
+	if (homeHost != "" || homeSite != "") && !allowTOFU {
+		if homePubKey == "" {
+			return errors.New("-home-host/-home-site requires -home-pubkey to pin the home site key — refusing to run the public home route in trust-on-first-use mode. Pass the Pi's public key (it logs it at startup) via -home-pubkey, or -home-allow-tofu to override for testing")
+		}
+		if homeWeb == "" {
+			return errors.New("-home-host/-home-site requires -home-web — the relay must serve the sign-in shell + /api/identity itself and NEVER forward an anonymous request to the Pi (forwarding would let an unauthenticated internet visitor reach the home network). Pass the path to the web/ bundle on the relay VM, or -home-allow-tofu to override for testing")
+		}
 	}
 	return nil
 }

--- a/go/cmd/ftw-relay/owners.go
+++ b/go/cmd/ftw-relay/owners.go
@@ -23,10 +23,11 @@ import (
 // Pin so its pin survives restarts and is never first-come-first-served.
 type OwnerRegistry struct {
 	mu         sync.Mutex
-	bySite     map[string]string    // site_id → host_id
-	keyBySite  map[string]string    // site_id → pinned ES256 public key (hex X||Y)
-	seenBySite map[string]time.Time // site_id → last successful registration
-	pinned     map[string]bool      // operator-pinned sites — never capped or GC'd
+	bySite     map[string]string          // site_id → host_id
+	keyBySite  map[string]string          // site_id → pinned ES256 public key (hex X||Y)
+	seenBySite map[string]time.Time       // site_id → last successful registration
+	pinned     map[string]bool            // operator-pinned sites — never capped or GC'd
+	devKeys    map[string]map[string]bool // site_id → set of trusted device pubkeys (128 hex)
 }
 
 // maxOwnerSites bounds the number of TOFU (self-registered) sites the in-memory
@@ -44,12 +45,19 @@ var (
 	ErrTooManyOwners = errors.New("too many registered sites")
 )
 
+// maxDeviceKeysPerSite bounds the trusted device-key set a single site may
+// publish, so an authenticated-but-buggy (or compromised) Pi can't grow relay
+// memory without limit by registering an unbounded set. A household has a
+// handful of owner devices; this is generous headroom.
+const maxDeviceKeysPerSite = 64
+
 func NewOwnerRegistry() *OwnerRegistry {
 	return &OwnerRegistry{
 		bySite:     make(map[string]string),
 		keyBySite:  make(map[string]string),
 		seenBySite: make(map[string]time.Time),
 		pinned:     make(map[string]bool),
+		devKeys:    make(map[string]map[string]bool),
 	}
 }
 
@@ -89,6 +97,44 @@ func (r *OwnerRegistry) Register(siteID, hostID, pubKeyHex string) error {
 	return nil
 }
 
+// SetDeviceKeys replaces the trusted device-key set for a site (C1). It is
+// called ONLY from the ES256-verified /me/register path, so the relay trusts the
+// set exactly as far as it trusts the registration signature — the same key that
+// pins the site mapping authorises which device keys may signal for it. Keys are
+// already canonicalised (validDevicePubKeyHex) + de-duplicated by the caller;
+// the count is capped here so a compromised Pi can't grow relay memory without
+// bound. Passing an empty slice clears the set (the site trusts no device keys).
+// It NEVER creates a site mapping on its own — a Register must have run first.
+func (r *OwnerRegistry) SetDeviceKeys(siteID string, keys []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(keys) == 0 {
+		delete(r.devKeys, siteID)
+		return
+	}
+	set := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		if len(set) >= maxDeviceKeysPerSite {
+			break
+		}
+		set[k] = true
+	}
+	r.devKeys[siteID] = set
+}
+
+// HasDeviceKey reports whether pubKeyHex is in the site's published trusted
+// device-key set (C2). The signaling-offer handler calls this AFTER verifying the
+// browser's signature over the challenge nonce, so only a browser that proved
+// possession of a published device key is allowed to forward an offer to the Pi.
+// Unknown site or empty set → false (fail-closed: no device keys ⇒ no device-key
+// signaling).
+func (r *OwnerRegistry) HasDeviceKey(siteID, pubKeyHex string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	set := r.devKeys[siteID]
+	return set != nil && set[pubKeyHex]
+}
+
 // GC drops self-registered sites whose last registration is older than maxAge
 // (a Pi re-registers periodically, so a stale mapping means it is gone). Returns
 // how many were evicted. Operator-pinned sites (e.g. the home site) are never
@@ -106,6 +152,7 @@ func (r *OwnerRegistry) GC(maxAge time.Duration) int {
 			delete(r.bySite, site)
 			delete(r.seenBySite, site)
 			delete(r.keyBySite, site)
+			delete(r.devKeys, site)
 			removed++
 		}
 	}

--- a/go/cmd/ftw-relay/signal_challenge.go
+++ b/go/cmd/ftw-relay/signal_challenge.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+// signal_challenge.go — the device-key proof challenge for the signaling offer
+// (C2). Before the relay forwards a browser's WebRTC offer to the Pi, the browser
+// must prove possession of a device key the Pi published (C1) by signing a
+// single-use, short-TTL nonce the relay issued for that site:
+//
+//	GET  /signal/{site}/challenge          -> {"nonce","exp_ms"}
+//	POST /signal/{site}/offer  + device_pubkey,nonce,sig
+//	      sig over "ftw-signal:v1:<site>:<nonce>"  (raw r||s, base64url)
+//
+// The nonce is the relay's anti-replay token: the browser can't precompute a
+// signature without it, and consuming it on use stops a captured (device_pubkey,
+// nonce, sig) triple from being replayed to forward a second offer. This is what
+// gates the relay→Pi forward on a key the Pi trusts, so a stranger who merely
+// reached the home host can't make the relay contact the Pi at all.
+//
+// In-memory + ephemeral: a relay restart drops outstanding nonces and the browser
+// simply re-fetches one. The store is per-site and bounded so a flood of
+// challenge requests for many site_ids (or one) can't grow relay memory.
+
+const (
+	// signalChallengeTTL is how long an issued nonce stays valid. ~60s is ample
+	// for a browser to sign + post its offer, tight enough that a leaked nonce is
+	// useless almost immediately.
+	signalChallengeTTL = 60 * time.Second
+	// maxSignalChallengeSites bounds the number of distinct site_ids the nonce
+	// store tracks, so an unauthenticated GET /signal/<random>/challenge flood
+	// can't grow relay memory without limit. Expired sites are reclaimed lazily +
+	// by GC, so this is a hard ceiling on live sites only.
+	maxSignalChallengeSites = 4096
+	// maxSignalNoncesPerSite bounds outstanding (un-consumed) nonces for one
+	// site, so a single site_id can't be used to grow the store. A legit browser
+	// holds ~1 in-flight challenge; this tolerates a few concurrent tabs/retries.
+	// Past this the oldest nonce for the site is evicted.
+	maxSignalNoncesPerSite = 16
+)
+
+// signalChallenge is one issued nonce with its absolute expiry.
+type signalChallenge struct {
+	exp time.Time
+}
+
+// SignalChallenges issues + consumes single-use signaling-offer nonces, keyed by
+// (site_id, nonce). Safe for concurrent use; in-memory + ephemeral.
+type SignalChallenges struct {
+	mu     sync.Mutex
+	bySite map[string]map[string]signalChallenge // site_id → nonce → challenge
+}
+
+func NewSignalChallenges() *SignalChallenges {
+	return &SignalChallenges{bySite: make(map[string]map[string]signalChallenge)}
+}
+
+// Issue mints a fresh single-use nonce for siteID and returns it with its
+// absolute expiry (ms since epoch). Returns ok=false only if the store is at its
+// site ceiling for a brand-new site (surfaced as 503). The nonce is 32 bytes of
+// CSPRNG entropy, base64url — opaque + unguessable, so it can't be precomputed.
+func (c *SignalChallenges) Issue(siteID string) (nonce string, expMs int64, ok bool) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", 0, false
+	}
+	nonce = base64.RawURLEncoding.EncodeToString(b)
+	now := time.Now()
+	exp := now.Add(signalChallengeTTL)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	site := c.bySite[siteID]
+	if site == nil {
+		if len(c.bySite) >= maxSignalChallengeSites {
+			c.gcLocked(now) // try to make room by reaping expired sites first
+			if len(c.bySite) >= maxSignalChallengeSites {
+				return "", 0, false // still at capacity — refuse a new site
+			}
+		}
+		site = make(map[string]signalChallenge)
+		c.bySite[siteID] = site
+	}
+	// Bound per-site outstanding nonces: drop the soonest-to-expire (effectively
+	// the oldest) if we're over the cap, so one site can't grow the store.
+	if len(site) >= maxSignalNoncesPerSite {
+		evictOldestChallengeLocked(site)
+	}
+	site[nonce] = signalChallenge{exp: exp}
+	return nonce, exp.UnixMilli(), true
+}
+
+// Consume verifies (siteID, nonce) is a known, unexpired nonce and removes it
+// (single-use). Returns false if unknown, expired, or already consumed — in every
+// case the offer is refused and the Pi is never contacted. The lookup +
+// constant-time match avoids leaking which of "unknown" vs "wrong" via timing.
+func (c *SignalChallenges) Consume(siteID, nonce string) bool {
+	if nonce == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	site := c.bySite[siteID]
+	if site == nil {
+		return false
+	}
+	// Constant-time membership check: iterate so a present-but-wrong nonce and an
+	// absent one take the same path. The map key lookup below is the fast path;
+	// the loop only guards against trivially distinguishing existence by timing.
+	ch, present := site[nonce]
+	match := 0
+	for k := range site {
+		if subtle.ConstantTimeCompare([]byte(k), []byte(nonce)) == 1 {
+			match = 1
+		}
+	}
+	if !present || match != 1 {
+		return false
+	}
+	// Single-use: remove regardless of freshness so a captured nonce can never be
+	// replayed even within its TTL.
+	delete(site, nonce)
+	if len(site) == 0 {
+		delete(c.bySite, siteID)
+	}
+	if time.Now().After(ch.exp) {
+		return false // expired → refuse (already removed above)
+	}
+	return true
+}
+
+// evictOldestChallengeLocked drops the soonest-to-expire nonce from a site map.
+// Caller holds c.mu.
+func evictOldestChallengeLocked(site map[string]signalChallenge) {
+	var oldestKey string
+	var oldestExp time.Time
+	for k, ch := range site {
+		if oldestKey == "" || ch.exp.Before(oldestExp) {
+			oldestKey, oldestExp = k, ch.exp
+		}
+	}
+	if oldestKey != "" {
+		delete(site, oldestKey)
+	}
+}
+
+// GC reaps expired nonces (and now-empty sites). Returns how many nonces were
+// removed. Wired into the relay janitor so the store self-heals when sites go
+// quiet. maxAge is ignored — a nonce's own absolute expiry is the only clock —
+// but the parameter mirrors the other GC signatures for the janitor.
+func (c *SignalChallenges) GC(_ time.Duration) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gcLocked(time.Now())
+}
+
+// gcLocked removes every expired nonce and empty site. Caller holds c.mu.
+func (c *SignalChallenges) gcLocked(now time.Time) int {
+	removed := 0
+	for site, nonces := range c.bySite {
+		for n, ch := range nonces {
+			if now.After(ch.exp) {
+				delete(nonces, n)
+				removed++
+			}
+		}
+		if len(nonces) == 0 {
+			delete(c.bySite, site)
+		}
+	}
+	return removed
+}

--- a/go/cmd/ftw-relay/signal_challenge_test.go
+++ b/go/cmd/ftw-relay/signal_challenge_test.go
@@ -117,11 +117,12 @@ func newC2Relay(t *testing.T) *c2Relay {
 	dev := newDeviceKey(t)
 	owners.SetDeviceKeys("site:Home", []string{dev.pubKeyHex})
 	r := &Relay{
-		Owners:      owners,
-		Polls:       NewPollSecrets(),
-		Signals:     NewSignalMailbox(),
-		Challenges:  NewSignalChallenges(),
-		PollTimeout: 200 * time.Millisecond,
+		Owners:           owners,
+		Polls:            NewPollSecrets(),
+		Signals:          NewSignalMailbox(),
+		Challenges:       NewSignalChallenges(),
+		PollTimeout:      200 * time.Millisecond,
+		RequireDeviceKey: true,
 	}
 	secret := mustIssue(t, r.Polls, "host-xyz")
 	ts := httptest.NewServer(r.Handler())
@@ -267,11 +268,12 @@ func TestSignalOffer_NoDeviceKeysPublished_403(t *testing.T) {
 	}
 	// Deliberately DO NOT publish any device keys.
 	r := &Relay{
-		Owners:      owners,
-		Polls:       NewPollSecrets(),
-		Signals:     NewSignalMailbox(),
-		Challenges:  NewSignalChallenges(),
-		PollTimeout: 100 * time.Millisecond,
+		Owners:           owners,
+		Polls:            NewPollSecrets(),
+		Signals:          NewSignalMailbox(),
+		Challenges:       NewSignalChallenges(),
+		PollTimeout:      100 * time.Millisecond,
+		RequireDeviceKey: true,
 	}
 	ts := httptest.NewServer(r.Handler())
 	t.Cleanup(ts.Close)

--- a/go/cmd/ftw-relay/signal_challenge_test.go
+++ b/go/cmd/ftw-relay/signal_challenge_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// signal_challenge_test.go — C2: the device-key proof on the signaling offer. A
+// browser must (1) GET a single-use challenge nonce, (2) sign
+// "ftw-signal:v1:<site>:<nonce>" with a device key the Pi published (C1), and (3)
+// POST {device_pubkey,nonce,sig} on the offer. Only then does the relay forward
+// the SDP to the Pi. Every failure → 403 and the Pi is NEVER contacted.
+
+// TestSignalChallenge_NonceLifecycle proves the challenge store: a freshly issued
+// nonce verifies once and is consumed (single-use); a replayed, unknown, or
+// expired nonce is refused.
+func TestSignalChallenge_NonceLifecycle(t *testing.T) {
+	c := NewSignalChallenges()
+	const site = "site:Home"
+
+	nonce, expMs, ok := c.Issue(site)
+	if !ok || nonce == "" {
+		t.Fatalf("Issue returned ok=%v nonce=%q", ok, nonce)
+	}
+	if expMs <= time.Now().UnixMilli() {
+		t.Fatalf("exp_ms %d is not in the future", expMs)
+	}
+	// First consume succeeds.
+	if !c.Consume(site, nonce) {
+		t.Fatal("a fresh nonce must consume once")
+	}
+	// REPLAY: second consume of the same nonce fails (single-use).
+	if c.Consume(site, nonce) {
+		t.Fatal("a consumed nonce must NOT consume again (replay)")
+	}
+	// Unknown nonce → false.
+	if c.Consume(site, "bogus-nonce") {
+		t.Fatal("an unknown nonce must NOT consume")
+	}
+	// Unknown site → false.
+	other, _, _ := c.Issue("site:Other")
+	if c.Consume("site:Nope", other) {
+		t.Fatal("a nonce from a different site must NOT consume")
+	}
+	// Empty nonce → false.
+	if c.Consume(site, "") {
+		t.Fatal("an empty nonce must NOT consume")
+	}
+}
+
+// TestSignalChallenge_Expiry proves an expired nonce is refused even though it
+// was a real issued nonce.
+func TestSignalChallenge_Expiry(t *testing.T) {
+	c := NewSignalChallenges()
+	const site = "site:Home"
+	nonce, _, _ := c.Issue(site)
+	// Force the stored nonce to be already expired by reaching into the store
+	// (same package). This is the only way to test expiry without sleeping 60s.
+	c.mu.Lock()
+	c.bySite[site][nonce] = signalChallenge{exp: time.Now().Add(-time.Second)}
+	c.mu.Unlock()
+	if c.Consume(site, nonce) {
+		t.Fatal("an expired nonce must NOT consume")
+	}
+}
+
+// TestSignalChallenge_GCReapsExpired proves GC trims expired nonces and empty
+// sites.
+func TestSignalChallenge_GCReapsExpired(t *testing.T) {
+	c := NewSignalChallenges()
+	n1, _, _ := c.Issue("site:A")
+	c.Issue("site:B")
+	// Expire site:A's nonce.
+	c.mu.Lock()
+	c.bySite["site:A"][n1] = signalChallenge{exp: time.Now().Add(-time.Minute)}
+	c.mu.Unlock()
+	if removed := c.GC(0); removed < 1 {
+		t.Fatalf("GC removed %d, want >= 1 expired nonce", removed)
+	}
+	// site:A is now empty and gone; site:B's fresh nonce survives.
+	c.mu.Lock()
+	_, aGone := c.bySite["site:A"]
+	_, bAlive := c.bySite["site:B"]
+	c.mu.Unlock()
+	if aGone {
+		t.Fatal("expired+empty site must be reaped")
+	}
+	if !bAlive {
+		t.Fatal("a site with a fresh nonce must survive GC")
+	}
+}
+
+// c2Relay bundles a C2 test relay: a live server, the relay, the trusted device
+// key, and the Pi's poll secret.
+type c2Relay struct {
+	ts     *httptest.Server
+	r      *Relay
+	dev    *deviceKey
+	secret string
+}
+
+// newC2Relay builds a relay with a registered site, a trusted device key, and the
+// challenge store. Tests drive the Pi drain SYNCHRONOUSLY via drainOffer (which
+// long-polls once for an ALREADY-parked offer, returning at once) rather than
+// spinning a background poller — that keeps the tests fast and avoids stranding a
+// 25s server-side long-poll at server Close.
+func newC2Relay(t *testing.T) *c2Relay {
+	t.Helper()
+	owners := NewOwnerRegistry()
+	if err := owners.Register("site:Home", "host-xyz", "deadbeef"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	dev := newDeviceKey(t)
+	owners.SetDeviceKeys("site:Home", []string{dev.pubKeyHex})
+	r := &Relay{
+		Owners:      owners,
+		Polls:       NewPollSecrets(),
+		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
+		PollTimeout: 200 * time.Millisecond,
+	}
+	secret := mustIssue(t, r.Polls, "host-xyz")
+	ts := httptest.NewServer(r.Handler())
+	t.Cleanup(ts.Close)
+	return &c2Relay{ts: ts, r: r, dev: dev, secret: secret}
+}
+
+// drainOfferNow consumes any ALREADY-parked offer for the site WITHOUT blocking:
+// it calls the mailbox in-process with a zero timeout, so the no-offer case
+// returns at once (rather than stranding a 25s server-side long-poll that would
+// then block server Close). Returns the raw SDP the Pi would have drained. This
+// exercises exactly what signalHostOffer forwards (the relay parks only the raw
+// SDP under C2), so it is a faithful "did the Pi get contacted?" probe.
+func (c *c2Relay) drainOfferNow(t *testing.T) (string, bool) {
+	t.Helper()
+	data, _, ok := c.r.Signals.TakeOffer("site:Home", 0)
+	if !ok {
+		return "", false
+	}
+	return string(data), true
+}
+
+// postOffer posts a C2 offer envelope and returns the status code.
+func postOffer(t *testing.T, baseURL string, body []byte) int {
+	t.Helper()
+	resp, err := http.Post(baseURL+"/signal/"+urlSite("site:Home")+"/offer?n=00112233aabbccdd",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post offer: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// challengeFor mints a challenge nonce via the live relay handler.
+func challengeFor(t *testing.T, baseURL string) string {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/signal/" + urlSite("site:Home") + "/challenge")
+	if err != nil {
+		t.Fatalf("challenge: %v", err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Nonce string `json:"nonce"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return out.Nonce
+}
+
+// TestSignalOffer_ValidProof_Forwards proves the happy path: a correctly signed
+// offer is accepted (204) and the SDP reaches the Pi.
+func TestSignalOffer_ValidProof_Forwards(t *testing.T) {
+	c := newC2Relay(t)
+	nonce := challengeFor(t, c.ts.URL)
+	body := offerEnvelope(t, c.dev, "site:Home", nonce, "REAL-SDP")
+	if code := postOffer(t, c.ts.URL, body); code != http.StatusNoContent {
+		t.Fatalf("valid offer status = %d, want 204", code)
+	}
+	// The offer is parked; the Pi drains it at once and sees the raw SDP.
+	sdp, ok := c.drainOfferNow(t)
+	if !ok {
+		t.Fatal("valid offer never reached the Pi")
+	}
+	if sdp != "REAL-SDP" {
+		t.Fatalf("Pi drained %q, want REAL-SDP", sdp)
+	}
+}
+
+// TestSignalOffer_UnknownPubkey_403_PiNeverContacted proves a device_pubkey NOT
+// in the site's published set is refused with 403 and the Pi is never contacted
+// (nothing is parked for it to drain).
+func TestSignalOffer_UnknownPubkey_403_PiNeverContacted(t *testing.T) {
+	c := newC2Relay(t)
+	stranger := newDeviceKey(t) // a key the Pi never published
+	nonce := challengeFor(t, c.ts.URL)
+	body := offerEnvelope(t, stranger, "site:Home", nonce, "EVIL-SDP")
+	if code := postOffer(t, c.ts.URL, body); code != http.StatusForbidden {
+		t.Fatalf("unknown-pubkey offer status = %d, want 403", code)
+	}
+	if sdp, ok := c.drainOfferNow(t); ok {
+		t.Fatalf("Pi was contacted on an unknown-pubkey offer: %q", sdp)
+	}
+}
+
+// TestSignalOffer_BadSig_403 proves a malformed/forged signature is refused even
+// when the device_pubkey IS trusted and the nonce IS fresh, and nothing reaches
+// the Pi.
+func TestSignalOffer_BadSig_403(t *testing.T) {
+	c := newC2Relay(t)
+	nonce := challengeFor(t, c.ts.URL)
+	// Build a valid envelope, then corrupt the signature.
+	body := offerEnvelope(t, c.dev, "site:Home", nonce, "SDP")
+	var env map[string]string
+	_ = json.Unmarshal(body, &env)
+	env["sig"] = "AAAA" // wrong length / not a real sig
+	bad, _ := json.Marshal(env)
+	if code := postOffer(t, c.ts.URL, bad); code != http.StatusForbidden {
+		t.Fatalf("bad-sig offer status = %d, want 403", code)
+	}
+
+	// A signature for a DIFFERENT nonce (lifted from another challenge) must also
+	// fail against this nonce.
+	other := challengeFor(t, c.ts.URL)
+	lifted := offerEnvelope(t, c.dev, "site:Home", other, "SDP") // signs `other`
+	var lenv map[string]string
+	_ = json.Unmarshal(lifted, &lenv)
+	lenv["nonce"] = nonce // ...but claims `nonce`
+	mismatched, _ := json.Marshal(lenv)
+	if code := postOffer(t, c.ts.URL, mismatched); code != http.StatusForbidden {
+		t.Fatalf("nonce/sig-mismatch offer status = %d, want 403", code)
+	}
+	if _, ok := c.drainOfferNow(t); ok {
+		t.Fatal("a bad-sig offer must NOT reach the Pi")
+	}
+}
+
+// TestSignalOffer_ReplayedNonce_403 proves a (device_pubkey,nonce,sig) triple
+// that already succeeded can't be replayed: the nonce was consumed on first use.
+func TestSignalOffer_ReplayedNonce_403(t *testing.T) {
+	c := newC2Relay(t)
+	nonce := challengeFor(t, c.ts.URL)
+	body := offerEnvelope(t, c.dev, "site:Home", nonce, "SDP")
+	if code := postOffer(t, c.ts.URL, body); code != http.StatusNoContent {
+		t.Fatalf("first offer status = %d, want 204", code)
+	}
+	// Drain the first (legitimate) offer so the mailbox is empty for the replay.
+	if _, ok := c.drainOfferNow(t); !ok {
+		t.Fatal("first valid offer should have reached the Pi")
+	}
+	// Replay the exact same body — the nonce is gone, so it must be refused.
+	if code := postOffer(t, c.ts.URL, body); code != http.StatusForbidden {
+		t.Fatalf("replayed offer status = %d, want 403", code)
+	}
+}
+
+// TestSignalOffer_NoDeviceKeysPublished_403 proves fail-closed: a site that
+// published NO device keys (C1 never ran) accepts NO device-key signaling — every
+// offer is 403, the Pi is never reachable that way.
+func TestSignalOffer_NoDeviceKeysPublished_403(t *testing.T) {
+	owners := NewOwnerRegistry()
+	if err := owners.Register("site:Home", "host-xyz", "deadbeef"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	// Deliberately DO NOT publish any device keys.
+	r := &Relay{
+		Owners:      owners,
+		Polls:       NewPollSecrets(),
+		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
+		PollTimeout: 100 * time.Millisecond,
+	}
+	ts := httptest.NewServer(r.Handler())
+	t.Cleanup(ts.Close)
+
+	dev := newDeviceKey(t)
+	nonce := challengeFor(t, ts.URL)
+	body := offerEnvelope(t, dev, "site:Home", nonce, "SDP")
+	if code := postOffer(t, ts.URL, body); code != http.StatusForbidden {
+		t.Fatalf("offer with no published device keys status = %d, want 403", code)
+	}
+}

--- a/go/cmd/ftw-relay/signal_lockout_test.go
+++ b/go/cmd/ftw-relay/signal_lockout_test.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 )
@@ -14,27 +14,37 @@ import (
 // client can't vary the source IP), through the full mux so the limiter +
 // ParkOffer backstop both run.
 
-func newLockoutRelay(t *testing.T) http.Handler {
+func newLockoutRelay(t *testing.T) (http.Handler, *Relay) {
 	t.Helper()
 	owners := NewOwnerRegistry()
 	if err := owners.Register("site:Home", "host-xyz", "deadbeef"); err != nil {
 		t.Fatalf("register: %v", err)
 	}
+	owners.SetDeviceKeys("site:Home", []string{testDeviceKey.pubKeyHex})
 	r := &Relay{
 		Owners:      owners,
 		Polls:       NewPollSecrets(),
 		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
 		PollTimeout: time.Second,
 	}
-	return r.Handler()
+	return r.Handler(), r
 }
 
-// offerFromIP builds a POST /signal/site:Home/offer request whose source IP is
-// fixed to ip, with a distinct VALID (16-hex) rendezvous nonce derived from tag,
-// and serves it through h.
-func offerFromIP(h http.Handler, ip, tag string) int {
+// offerFromIP builds a SIGNED POST /signal/site:Home/offer request (C2 device
+// proof) whose source IP is fixed to ip, with a distinct VALID (16-hex)
+// rendezvous nonce derived from tag, and serves it through h. The challenge nonce
+// is minted straight from the relay's store (these tests drive the handler
+// directly, not a live server). The per-IP throttle runs BEFORE the proof check,
+// so a throttled request still returns 429 even though we supply a valid proof.
+func offerFromIP(t *testing.T, h http.Handler, r *Relay, ip, tag string) int {
+	challenge, _, ok := r.Challenges.Issue("site:Home")
+	if !ok {
+		t.Fatalf("issue challenge: store at capacity")
+	}
+	body := offerEnvelope(t, testDeviceKey, "site:Home", challenge, "OFFER-SDP")
 	req := httptest.NewRequest(http.MethodPost,
-		"/signal/site%3AHome/offer?n="+nonce16(tag), strings.NewReader("OFFER-SDP"))
+		"/signal/site%3AHome/offer?n="+nonce16(tag), bytes.NewReader(body))
 	req.RemoteAddr = ip + ":40000"
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -63,7 +73,7 @@ func nonce16(tag string) string {
 // a DIFFERENT IP can still park its offer (204). With the old per-site limit the
 // attacker's flood would 429 the legit browser too.
 func TestSignalOffer_PerIP_NoCrossLockout(t *testing.T) {
-	h := newLockoutRelay(t)
+	h, r := newLockoutRelay(t)
 	const attacker = "203.0.113.66"
 	const victim = "198.51.100.20"
 
@@ -72,7 +82,7 @@ func TestSignalOffer_PerIP_NoCrossLockout(t *testing.T) {
 	// attacker's OWN IP saturates first — proving the bound is per-IP.
 	attackerThrottled := false
 	for i := 0; i < int(siteOfferBucketCap)+int(offerBucketCapacity)+16; i++ {
-		if offerFromIP(h, attacker, "a"+fmtNonceSuffix(i)) == http.StatusTooManyRequests {
+		if offerFromIP(t, h, r, attacker, "a"+fmtNonceSuffix(i)) == http.StatusTooManyRequests {
 			attackerThrottled = true
 			break
 		}
@@ -82,7 +92,7 @@ func TestSignalOffer_PerIP_NoCrossLockout(t *testing.T) {
 	}
 
 	// THE INVARIANT: the victim, on a different IP, can still park an offer.
-	if code := offerFromIP(h, victim, "deadbeef0001"); code != http.StatusNoContent {
+	if code := offerFromIP(t, h, r, victim, "deadbeef0001"); code != http.StatusNoContent {
 		t.Fatalf("FIX-C: legit different-IP browser got %d (want 204) — attacker locked it out of site:Home", code)
 	}
 }
@@ -91,20 +101,20 @@ func TestSignalOffer_PerIP_NoCrossLockout(t *testing.T) {
 // even while the attacker keeps hammering (and getting 429s), the victim's offers
 // keep succeeding, bounded only by the victim's own generous per-IP bucket.
 func TestSignalOffer_PerIP_AttackerBoundedButVictimFlows(t *testing.T) {
-	h := newLockoutRelay(t)
+	h, r := newLockoutRelay(t)
 	const attacker = "203.0.113.99"
 	const victim = "198.51.100.50"
 
 	// Saturate the attacker first.
 	for i := 0; i < int(offerBucketCapacity)+4; i++ {
-		offerFromIP(h, attacker, "x"+fmtNonceSuffix(i))
+		offerFromIP(t, h, r, attacker, "x"+fmtNonceSuffix(i))
 	}
 	// Now interleave: attacker is throttled, victim still gets through for its
 	// first several (within its own burst).
 	victimOK := 0
 	for i := 0; i < 4; i++ {
-		offerFromIP(h, attacker, "y"+fmtNonceSuffix(i)) // attacker keeps trying (likely 429)
-		if offerFromIP(h, victim, "z"+fmtNonceSuffix(i)) == http.StatusNoContent {
+		offerFromIP(t, h, r, attacker, "y"+fmtNonceSuffix(i)) // attacker keeps trying (likely 429)
+		if offerFromIP(t, h, r, victim, "z"+fmtNonceSuffix(i)) == http.StatusNoContent {
 			victimOK++
 		}
 	}

--- a/go/cmd/ftw-relay/signal_proof_test.go
+++ b/go/cmd/ftw-relay/signal_proof_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// signal_proof_test.go — shared test helpers for the C2 device-key proof on the
+// signaling offer. A device key is an ECDSA P-256 keypair; its public form is the
+// uncompressed X||Y as 128 lowercase hex (the device_pubkey wire format), and a
+// proof signs "ftw-signal:v1:<site>:<nonce>" as raw r||s, base64url (the same
+// WebCrypto format the browser produces).
+
+// deviceKey is a test P-256 device keypair plus its wire-format public key.
+type deviceKey struct {
+	priv      *ecdsa.PrivateKey
+	pubKeyHex string // 128 lowercase hex, uncompressed X||Y
+}
+
+// genP256 mints a P-256 keypair. Split out so non-*testing.T callers (a
+// package-level var initializer) can reuse it.
+func genP256() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+// newDeviceKey mints a throwaway P-256 device keypair for tests.
+func newDeviceKey(t *testing.T) *deviceKey {
+	t.Helper()
+	priv, err := genP256()
+	if err != nil {
+		t.Fatalf("gen device key: %v", err)
+	}
+	return &deviceKey{priv: priv, pubKeyHex: devicePubKeyHex(priv)}
+}
+
+// devicePubKeyHex encodes a P-256 public key as the 128-lowercase-hex X||Y wire
+// format (32-byte big-endian X, then Y, left-padded), matching the relay's
+// parseP256PubKeyHex.
+func devicePubKeyHex(priv *ecdsa.PrivateKey) string {
+	x := priv.PublicKey.X.Bytes()
+	y := priv.PublicKey.Y.Bytes()
+	buf := make([]byte, 64)
+	copy(buf[32-len(x):32], x)
+	copy(buf[64-len(y):64], y)
+	return hex.EncodeToString(buf)
+}
+
+// signProof signs the C2 signing string for (siteID, nonce) and returns the raw
+// r||s signature as base64url (no padding) — exactly the WebCrypto wire format.
+func (d *deviceKey) signProof(t *testing.T, siteID, nonce string) string {
+	t.Helper()
+	msg := signalProofSigningString(siteID, nonce)
+	h := sha256.Sum256([]byte(msg))
+	r, s, err := ecdsa.Sign(rand.Reader, d.priv, h[:])
+	if err != nil {
+		t.Fatalf("sign proof: %v", err)
+	}
+	sig := make([]byte, 64)
+	rb, sb := r.Bytes(), s.Bytes()
+	copy(sig[32-len(rb):32], rb)
+	copy(sig[64-len(sb):64], sb)
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// offerEnvelope builds the JSON offer body the browser posts under C2: the raw
+// SDP plus the device-key proof. Field names are fixed by the wire contract.
+func offerEnvelope(t *testing.T, d *deviceKey, siteID, challengeNonce, sdp string) []byte {
+	t.Helper()
+	b, err := json.Marshal(struct {
+		SDP          string `json:"sdp"`
+		DevicePubkey string `json:"device_pubkey"`
+		Nonce        string `json:"nonce"`
+		Sig          string `json:"sig"`
+	}{
+		SDP:          sdp,
+		DevicePubkey: d.pubKeyHex,
+		Nonce:        challengeNonce,
+		Sig:          d.signProof(t, siteID, challengeNonce),
+	})
+	if err != nil {
+		t.Fatalf("marshal offer envelope: %v", err)
+	}
+	return b
+}
+
+// TestVerifyES256B64URL_RoundTrip proves the relay's base64url verify accepts a
+// genuine WebCrypto-style raw r||s signature and rejects a tampered one.
+func TestVerifyES256B64URL_RoundTrip(t *testing.T) {
+	d := newDeviceKey(t)
+	const site = "site:Home"
+	const nonce = "Zm9vYmFyZm9vYmFy" // any opaque string; the signer covers it
+	sig := d.signProof(t, site, nonce)
+	msg := signalProofSigningString(site, nonce)
+	if !verifyES256B64URL(d.pubKeyHex, msg, sig) {
+		t.Fatal("valid signature must verify")
+	}
+	// Wrong message → reject.
+	if verifyES256B64URL(d.pubKeyHex, signalProofSigningString(site, "other"), sig) {
+		t.Fatal("signature over a different nonce must NOT verify")
+	}
+	// Wrong key → reject.
+	other := newDeviceKey(t)
+	if verifyES256B64URL(other.pubKeyHex, msg, sig) {
+		t.Fatal("signature must NOT verify under a different key")
+	}
+	// Garbage signature → reject (no panic).
+	if verifyES256B64URL(d.pubKeyHex, msg, "!!!notb64!!!") {
+		t.Fatal("malformed signature must NOT verify")
+	}
+}
+
+// TestValidDevicePubKeyHex bounds the device-key wire format: 128 lowercase hex
+// on the curve, nothing else.
+func TestValidDevicePubKeyHex(t *testing.T) {
+	d := newDeviceKey(t)
+	if !validDevicePubKeyHex(d.pubKeyHex) {
+		t.Fatal("a real device pubkey must be valid")
+	}
+	bad := []string{
+		"",
+		"abcd",                               // too short
+		d.pubKeyHex + "00",                   // too long
+		"g" + d.pubKeyHex[1:],                // non-hex
+		"ABCDEF" + d.pubKeyHex[6:],           // uppercase rejected
+		hex.EncodeToString(make([]byte, 64)), // all-zero: not on curve
+	}
+	for _, s := range bad {
+		if validDevicePubKeyHex(s) {
+			t.Errorf("invalid device pubkey accepted: %q", s)
+		}
+	}
+}

--- a/go/cmd/ftw-relay/signal_test.go
+++ b/go/cmd/ftw-relay/signal_test.go
@@ -28,11 +28,12 @@ func newSignalRelay(t *testing.T) (*httptest.Server, *Relay, string) {
 	// Publish a trusted device key for the site so the C2 offer proof can pass.
 	owners.SetDeviceKeys("site:Home", []string{testDeviceKey.pubKeyHex})
 	r := &Relay{
-		Owners:      owners,
-		Polls:       NewPollSecrets(),
-		Signals:     NewSignalMailbox(),
-		Challenges:  NewSignalChallenges(),
-		PollTimeout: time.Second,
+		Owners:           owners,
+		Polls:            NewPollSecrets(),
+		Signals:          NewSignalMailbox(),
+		Challenges:       NewSignalChallenges(),
+		PollTimeout:      time.Second,
+		RequireDeviceKey: true,
 	}
 	secret := mustIssue(t, r.Polls, "host-xyz")
 	ts := httptest.NewServer(r.Handler())
@@ -365,5 +366,41 @@ func TestHomeStaticForward_FailClosed(t *testing.T) {
 	defer r4.Body.Close()
 	if r4.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("owner POST over relay status=%d, want 405 (P2P-only)", r4.StatusCode)
+	}
+}
+
+// TestSignalOffer_RolloutGateOff proves the device-key gate is DORMANT by default
+// (-require-device-key off): a raw-SDP offer with NO device-key proof is parked
+// and forwarded verbatim, so the relay can serve the shell + identity (slices
+// 1+2) while a home Pi that doesn't yet publish device-keys keeps working.
+func TestSignalOffer_RolloutGateOff(t *testing.T) {
+	owners := NewOwnerRegistry()
+	if err := owners.Register("site:Home", "host-xyz", "deadbeef"); err != nil {
+		t.Fatal(err)
+	}
+	r := &Relay{
+		Owners:      owners,
+		Polls:       NewPollSecrets(),
+		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
+		PollTimeout: time.Second,
+		// RequireDeviceKey defaults to false — the rollout default.
+	}
+	secret := mustIssue(t, r.Polls, "host-xyz")
+	ts := httptest.NewServer(r.Handler())
+	defer ts.Close()
+	const nonce = "00112233445566778899aabbccddeeff"
+	// Raw SDP, no envelope, no device-key proof.
+	resp, err := http.Post(ts.URL+"/signal/site:Home/offer?n="+nonce, "application/sdp", strings.NewReader("RAW-OFFER-SDP"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("rollout-off offer status = %d, want 204 (gate dormant)", resp.StatusCode)
+	}
+	off, _ := mustGetWithNonce(t, ts.URL+"/signal/host-xyz/offer", secret)
+	if string(off) != "RAW-OFFER-SDP" {
+		t.Fatalf("drained offer = %q, want RAW-OFFER-SDP parked verbatim", off)
 	}
 }

--- a/go/cmd/ftw-relay/signal_test.go
+++ b/go/cmd/ftw-relay/signal_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,8 +14,10 @@ import (
 	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
 )
 
-// newSignalRelay builds a relay with a registered site->host mapping and the
-// minted poll secret, returning the test server, host_id, site_id, and secret.
+// newSignalRelay builds a relay with a registered site->host mapping, a trusted
+// device key (C2), and the minted poll secret, returning the test server, the
+// relay, and the poll secret. The trusted device key is reachable via
+// r.Owners.HasDeviceKey; tests that need to sign an offer use signedOffer.
 func newSignalRelay(t *testing.T) (*httptest.Server, *Relay, string) {
 	t.Helper()
 	owners := NewOwnerRegistry()
@@ -22,16 +25,74 @@ func newSignalRelay(t *testing.T) (*httptest.Server, *Relay, string) {
 	if err := owners.Register("site:Home", "host-xyz", "deadbeef"); err != nil {
 		t.Fatalf("register: %v", err)
 	}
+	// Publish a trusted device key for the site so the C2 offer proof can pass.
+	owners.SetDeviceKeys("site:Home", []string{testDeviceKey.pubKeyHex})
 	r := &Relay{
 		Owners:      owners,
 		Polls:       NewPollSecrets(),
 		Signals:     NewSignalMailbox(),
+		Challenges:  NewSignalChallenges(),
 		PollTimeout: time.Second,
 	}
 	secret := mustIssue(t, r.Polls, "host-xyz")
 	ts := httptest.NewServer(r.Handler())
 	t.Cleanup(ts.Close)
 	return ts, r, secret
+}
+
+// testDeviceKey is a process-wide trusted device key for the signaling tests. It
+// is registered into newSignalRelay's owner registry and used by signedOffer to
+// build a valid C2 proof. (One shared key keeps the tests terse; the proof path
+// is exercised against a real P-256 keypair.)
+var testDeviceKey = mustGenDeviceKey()
+
+func mustGenDeviceKey() *deviceKey {
+	priv, err := genP256()
+	if err != nil {
+		panic("signal_test: gen device key: " + err.Error())
+	}
+	return &deviceKey{priv: priv, pubKeyHex: devicePubKeyHex(priv)}
+}
+
+// signedOffer fetches a fresh challenge nonce from the relay, signs it with the
+// trusted test device key, and POSTs the C2 offer envelope (raw SDP + proof)
+// under the given rendezvous nonce. It returns the HTTP status. This is what a
+// real browser does, so every signaling test drives the full proof path.
+func signedOffer(t *testing.T, baseURL, siteID, rendezvousNonce, sdp string) int {
+	t.Helper()
+	challenge := fetchChallenge(t, baseURL, siteID)
+	body := offerEnvelope(t, testDeviceKey, siteID, challenge, sdp)
+	resp, err := http.Post(baseURL+"/signal/"+urlSite(siteID)+"/offer?n="+rendezvousNonce,
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post signed offer: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// fetchChallenge GETs a single-use challenge nonce for siteID from the relay.
+func fetchChallenge(t *testing.T, baseURL, siteID string) string {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/signal/" + urlSite(siteID) + "/challenge")
+	if err != nil {
+		t.Fatalf("get challenge: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("challenge status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Nonce string `json:"nonce"`
+		ExpMs int64  `json:"exp_ms"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode challenge: %v", err)
+	}
+	if out.Nonce == "" {
+		t.Fatal("challenge returned an empty nonce")
+	}
+	return out.Nonce
 }
 
 // TestSignalRendezvous_OfferAnswer drives the full blind exchange: a browser
@@ -42,15 +103,10 @@ func TestSignalRendezvous_OfferAnswer(t *testing.T) {
 	ts, _, secret := newSignalRelay(t)
 	const nonce = "00112233445566778899aabbccddeeff"
 
-	// 1. Browser parks an offer for the site under its nonce.
-	resp, err := http.Post(ts.URL+"/signal/"+urlSite("site:Home")+"/offer?n="+nonce, "application/json",
-		bytes.NewReader([]byte("OFFER-SDP")))
-	if err != nil {
-		t.Fatalf("park offer: %v", err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("park offer status = %d, want 204", resp.StatusCode)
+	// 1. Browser parks a SIGNED offer (C2 device proof) for the site under its
+	//    rendezvous nonce.
+	if code := signedOffer(t, ts.URL, "site:Home", nonce, "OFFER-SDP"); code != http.StatusNoContent {
+		t.Fatalf("park offer status = %d, want 204", code)
 	}
 
 	// 2. Pi drains the offer with its poll secret (host-keyed path) and gets the
@@ -133,13 +189,7 @@ func TestSignalHostAnswer_RequiresPollSecret(t *testing.T) {
 func TestSignalOffer_RateLimited(t *testing.T) {
 	ts, _, _ := newSignalRelay(t)
 	post := func(nonce string) int {
-		url := ts.URL + "/signal/" + urlSite("site:Home") + "/offer?n=" + nonce
-		r, err := http.Post(url, "application/json", bytes.NewReader([]byte("A")))
-		if err != nil {
-			t.Fatalf("post: %v", err)
-		}
-		r.Body.Close()
-		return r.StatusCode
+		return signedOffer(t, ts.URL, "site:Home", nonce, "A")
 	}
 	// A few rapid offers (within the burst) are accepted — a legit retrying browser
 	// is never blocked on its first attempts.

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -362,6 +362,9 @@ func (s *Server) routes() {
 	s.handle("DELETE /api/owner-access/devices/{credential_id_b64}", s.handleOwnerDeviceDelete)
 	s.handle("GET  /api/owner-access/whoami", s.handleOwnerWhoami)
 	s.handle("POST /api/owner-access/logout", s.handleOwnerLogout)
+	// C3 — silent device-key PoP login over the P2P channel (open, pre-session).
+	s.handle("GET  /api/owner-access/device-challenge", s.handleOwnerDeviceChallenge)
+	s.handle("POST /api/owner-access/device-pop", s.handleOwnerDevicePoP)
 
 	// ---- Self-sovereign site identity (Phase 2) ----
 	s.handle("GET  /api/identity", s.handleIdentity)

--- a/go/internal/api/api_owner_access.go
+++ b/go/internal/api/api_owner_access.go
@@ -22,12 +22,14 @@
 package api
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/big"
 	"net"
@@ -84,6 +86,11 @@ type ownerAccessState struct {
 	enrollSessions map[string]ceremonySession
 	loginSessions  map[string]ceremonySession
 	authSessions   map[string]authSession
+
+	// devicePoPChallenges holds the in-flight single-use device-PoP challenges
+	// (C3). Value is the challenge's expiry; the entry is deleted on consume or
+	// when GC'd past TTL. See api_owner_device_pop.go.
+	devicePoPChallenges map[string]time.Time
 
 	// enrollPin is the in-memory LAN-first-enrollment PIN. Regenerated on
 	// demand (each GET /enroll-pin mints a fresh value), expires after
@@ -165,9 +172,10 @@ func (s *Server) ownerAccess() *ownerAccessState {
 	defer s.mu.Unlock()
 	if s.deps.ownerAccess == nil {
 		oa := &ownerAccessState{
-			enrollSessions: make(map[string]ceremonySession),
-			loginSessions:  make(map[string]ceremonySession),
-			authSessions:   make(map[string]authSession),
+			enrollSessions:      make(map[string]ceremonySession),
+			loginSessions:       make(map[string]ceremonySession),
+			authSessions:        make(map[string]authSession),
+			devicePoPChallenges: make(map[string]time.Time),
 		}
 		// Restore persisted sessions so a process restart doesn't sign
 		// everyone out (sessions are otherwise in-memory only).
@@ -671,7 +679,18 @@ func (s *Server) handleOwnerEnrollFinish(w http.ResponseWriter, r *http.Request)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxOwnerCeremonyBody)
+	// The C4 device_pubkey rides as an extra top-level field on the SAME finish
+	// body the WebAuthn library parses. go-webauthn's decoder ignores unknown
+	// fields, so we buffer the body once, pull device_pubkey out of it, then hand
+	// the library a fresh reader over the identical bytes. Buffering also enforces
+	// the ceremony size cap.
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxOwnerCeremonyBody))
+	if err != nil {
+		http.Error(w, "finish registration: read body", http.StatusBadRequest)
+		return
+	}
+	devicePubkey := extractDevicePubkeyField(bodyBytes)
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	cred, err := wa.FinishRegistration(user, *sess.data, r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("finish registration: %v", err), http.StatusBadRequest)
@@ -697,6 +716,12 @@ func (s *Server) handleOwnerEnrollFinish(w http.ResponseWriter, r *http.Request)
 		WalletHandle:   string(walletHandle),
 		BackupEligible: cred.Flags.BackupEligible,
 		BackupState:    cred.Flags.BackupState,
+		// Pin the freshly-minted device key (C4). Only a syntactically-valid
+		// canonical key is stored; a malformed value is dropped silently so the
+		// passkey still enrolls (the device key is an optional upgrade, not a
+		// hard requirement for the passkey itself). An empty/invalid value means
+		// "no silent device login yet" — the operator can still log in by passkey.
+		DevicePubkey: canonicalDevicePubkey(devicePubkey),
 	}
 	if err := s.deps.State.SaveTrustedDevice(dev); err != nil {
 		http.Error(w, fmt.Sprintf("save device: %v", err), http.StatusInternalServerError)
@@ -777,7 +802,19 @@ func (s *Server) handleOwnerLoginFinish(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxOwnerCeremonyBody)
+	// Optional C4 upgrade: a credential enrolled before the device-key feature
+	// can attach its device key on a later passkey login by riding device_pubkey
+	// on this finish body (same buffer-and-replay trick as enroll/finish). Only an
+	// empty slot is filled — a passkey login can never silently REPOINT a key
+	// that's already pinned (that would let a fresh-but-valid passkey assertion
+	// hijack the silent-login key). Buffering also enforces the ceremony cap.
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxOwnerCeremonyBody))
+	if err != nil {
+		http.Error(w, "finish login: read body", http.StatusBadRequest)
+		return
+	}
+	devicePubkey := canonicalDevicePubkey(extractDevicePubkeyField(bodyBytes))
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	cred, err := wa.FinishDiscoverableLogin(s.resolveDiscoverableOwner, *sess.data, r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("finish login: %v", err), http.StatusUnauthorized)
@@ -790,6 +827,14 @@ func (s *Server) handleOwnerLoginFinish(w http.ResponseWriter, r *http.Request) 
 	if err := s.deps.State.UpdateTrustedDeviceSignCount(cred.ID, cred.Authenticator.SignCount, time.Now().UnixMilli()); err != nil {
 		http.Error(w, fmt.Sprintf("update sign count: %v", err), http.StatusInternalServerError)
 		return
+	}
+	// Fill the device-key slot only if empty (allowOverwrite=false). Best-effort:
+	// the login itself already succeeded, so a failed upgrade must not 500 the
+	// operator out of a valid session.
+	if devicePubkey != "" {
+		if err := s.deps.State.SetTrustedDevicePubkey(cred.ID, devicePubkey, false); err != nil {
+			slog.Warn("owner-access: device-key upgrade on login failed", "err", err)
+		}
 	}
 	if err := s.issueOwnerSession(w, cred.ID); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -815,11 +860,16 @@ func (s *Server) handleOwnerDevicesList(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	type devOut struct {
-		CredentialIDB64 string `json:"credential_id_b64"`
-		FriendlyName    string `json:"friendly_name"`
-		CreatedAtMs     int64  `json:"created_at_ms"`
-		LastUsedMs      int64  `json:"last_used_ms"`
+		CredentialIDB64 string   `json:"credential_id_b64"`
+		FriendlyName    string   `json:"friendly_name"`
+		CreatedAtMs     int64    `json:"created_at_ms"`
+		LastUsedMs      int64    `json:"last_used_ms"`
 		Transports      []string `json:"transports,omitempty"`
+		// HasDeviceKey reports whether this credential carries a pinned device key
+		// (C4) — i.e. whether it can mint a silent device-PoP session (C3). The
+		// raw key itself is public, but the UI only needs the boolean to show an
+		// "upgrade for one-tap login" affordance, so we don't ship the 128 hex.
+		HasDeviceKey bool `json:"has_device_key"`
 	}
 	out := make([]devOut, 0, len(devices))
 	for _, d := range devices {
@@ -829,6 +879,7 @@ func (s *Server) handleOwnerDevicesList(w http.ResponseWriter, r *http.Request) 
 			CreatedAtMs:     d.CreatedAtMs,
 			LastUsedMs:      d.LastUsedMs,
 			Transports:      d.Transports,
+			HasDeviceKey:    d.DevicePubkey != "",
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/go/internal/api/api_owner_device_pop.go
+++ b/go/internal/api/api_owner_device_pop.go
@@ -1,0 +1,282 @@
+// api_owner_device_pop.go
+//
+// C3 — silent device-key proof-of-possession login over the P2P channel.
+//
+// At LAN enrollment (C4) the browser mints a non-extractable P-256 "device key"
+// and the Pi pins its public half on the new credential's trusted_devices row.
+// On a later visit the browser can then mint an owner session SILENTLY — no
+// passkey prompt — by proving possession of that pinned device key over the open
+// (already-authenticated-by-the-P2P-channel) home route:
+//
+//	GET  /api/owner-access/device-challenge -> {"challenge":"<b64url>","exp_ms":<int64>}
+//	POST /api/owner-access/device-pop        body {"device_pubkey","challenge","sig"}
+//	     sig = ECDSA-P256(SHA-256( "ftw-device-pop:v1:<site>:<challenge>" )), raw r||s, base64url
+//
+// On a valid PoP the Pi issues the SAME ftw_owner session a passkey login mints
+// (issueOwnerSession). Both paths are OPEN (pre-session) — see
+// isOwnerAccessOpenPath — because the device key IS the credential here, exactly
+// like a passkey assertion is on login/finish. The challenge is single-use, has a
+// short TTL, and is consumed on the POST so a captured PoP can't be replayed.
+//
+// Step-up / sensitive owner-management actions still require a fresh passkey
+// (authorizeOwnerManage gates those independently); a silent device session is a
+// convenience login, not an escalation.
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+)
+
+// ownerDevicePoPChallengeTTL bounds the lifetime of a device-PoP challenge.
+// ~60s is plenty for the browser to sign and POST back; short enough that a
+// leaked challenge is useless almost immediately.
+const ownerDevicePoPChallengeTTL = 60 * time.Second
+
+// maxDevicePoPChallenges caps the in-flight challenge map. device-challenge is an
+// open (pre-session) path, so without a cap a P2P client could grow Pi memory
+// within the TTL window. A real browser holds at most one open challenge.
+const maxDevicePoPChallenges = 64
+
+// maxDevicePoPBody bounds the POST body the device-pop handler decodes. A real
+// body is a few hundred bytes (a 128-hex key, a b64url challenge, a b64url sig).
+const maxDevicePoPBody = 8 << 10
+
+// devicePoPSigningString is the canonical message the browser signs for the C3
+// proof-of-possession. Domain-separated ("ftw-device-pop:v1:") and bound to BOTH
+// the site and the single-use challenge so a signature minted here can never be
+// replayed against another site or another path (e.g. the C2 signaling offer,
+// which uses the distinct "ftw-signal:v1:" tag). Both ends MUST build this
+// identically — that is the entire point of pinning the format in one place.
+func devicePoPSigningString(site, challenge string) string {
+	return fmt.Sprintf("ftw-device-pop:v1:%s:%s", site, challenge)
+}
+
+// verifyDevicePoPSig verifies a raw R||S ECDSA-P256 signature, base64url-encoded
+// (no padding), of msg against an uncompressed X||Y device public key (128 hex
+// chars). This is the WebCrypto wire format: SubtleCrypto.sign("ECDSA",
+// {hash:"SHA-256"}) over a P-256 key yields the 64-byte raw r||s the browser then
+// base64url's. It mirrors the relay's verifyES256B64URL byte-for-byte (C2/C3 share
+// the format). Returns false on any decode, length, on-curve, or verification
+// failure — never panics on attacker input.
+func verifyDevicePoPSig(pubKeyHex, msg, sigB64URL string) bool {
+	pub, err := parseDevicePubKeyHex(pubKeyHex)
+	if err != nil {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(sigB64URL)
+	if err != nil || len(sig) != 64 {
+		return false
+	}
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	h := sha256.Sum256([]byte(msg))
+	return ecdsa.Verify(pub, h[:], r, s)
+}
+
+// parseDevicePubKeyHex parses a 64-byte (128 hex char) uncompressed P-256 public
+// key as X||Y, rejecting anything that is not a valid point on the curve. Mirrors
+// the relay's parseP256PubKeyHex so the Pi and relay agree byte-for-byte on what
+// a device key is.
+func parseDevicePubKeyHex(s string) (*ecdsa.PublicKey, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != 64 {
+		return nil, errors.New("device pubkey must be 64 bytes (X||Y)")
+	}
+	x := new(big.Int).SetBytes(b[:32])
+	y := new(big.Int).SetBytes(b[32:])
+	if !elliptic.P256().IsOnCurve(x, y) {
+		return nil, errors.New("device pubkey point is not on P-256")
+	}
+	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, nil
+}
+
+// validDevicePubKeyHex reports whether s is a syntactically valid uncompressed
+// P-256 public key in the canonical device-key wire format: 128 LOWERCASE hex
+// chars that decode to a point on the curve. Rejecting uppercase keeps the stored
+// set byte-for-byte comparable with what the relay publishes (C1). Mirrors the
+// relay's validDevicePubKeyHex.
+func validDevicePubKeyHex(s string) bool {
+	if len(s) != 128 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	_, err := parseDevicePubKeyHex(s)
+	return err == nil
+}
+
+// extractDevicePubkeyField pulls the optional top-level "device_pubkey" string
+// out of a WebAuthn finish body without disturbing the rest of it. Returns "" on
+// any decode failure or when the field is absent — the caller treats that as "no
+// device key supplied" and enrolls the passkey anyway. Tolerant by design: the
+// device key is an additive convenience on top of the passkey.
+func extractDevicePubkeyField(body []byte) string {
+	var probe struct {
+		DevicePubkey string `json:"device_pubkey"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return ""
+	}
+	return probe.DevicePubkey
+}
+
+// canonicalDevicePubkey returns s iff it is a syntactically valid canonical
+// (lowercase, on-curve) 128-hex P-256 device key, else "". Storing only canonical
+// keys keeps the published set (C1) byte-for-byte comparable with what the relay
+// and browser present.
+func canonicalDevicePubkey(s string) string {
+	if validDevicePubKeyHex(s) {
+		return s
+	}
+	return ""
+}
+
+// handleOwnerDeviceChallenge mints a fresh single-use device-PoP challenge.
+// Open path (pre-session): it leaks nothing — a random nonce the browser must
+// sign with a key the Pi already trusts. Bounded + GC'd so a P2P flood can't grow
+// memory.
+func (s *Server) handleOwnerDeviceChallenge(w http.ResponseWriter, r *http.Request) {
+	ch, err := randomToken()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	exp := time.Now().Add(ownerDevicePoPChallengeTTL)
+	oa := s.ownerAccess()
+	oa.mu.Lock()
+	oa.gcDevicePoP()
+	capDevicePoP(oa.devicePoPChallenges)
+	if oa.devicePoPChallenges == nil {
+		oa.devicePoPChallenges = make(map[string]time.Time)
+	}
+	oa.devicePoPChallenges[ch] = exp
+	oa.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"challenge": ch,
+		"exp_ms":    exp.UnixMilli(),
+	})
+}
+
+// handleOwnerDevicePoP verifies a device-key proof-of-possession and, on success,
+// mints the same ftw_owner session a passkey login would. Fail-closed at every
+// step; the challenge is consumed (single-use) the moment it is recognised so a
+// captured PoP can never be replayed.
+func (s *Server) handleOwnerDevicePoP(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxDevicePoPBody)
+	var body struct {
+		DevicePubkey string `json:"device_pubkey"`
+		Challenge    string `json:"challenge"`
+		Sig          string `json:"sig"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request body", http.StatusBadRequest)
+		return
+	}
+	if body.DevicePubkey == "" || body.Challenge == "" || body.Sig == "" {
+		http.Error(w, "device_pubkey, challenge and sig are required", http.StatusBadRequest)
+		return
+	}
+	// Canonical-form gate first: reject anything that isn't a lowercase 128-hex
+	// on-curve key before touching the DB, so the stored-set comparison is always
+	// byte-for-byte.
+	if !validDevicePubKeyHex(body.DevicePubkey) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Consume the challenge: it must be known AND unexpired AND single-use. We
+	// delete it under the lock regardless of the rest of the outcome so a wrong
+	// signature can't be retried against the same challenge.
+	oa := s.ownerAccess()
+	oa.mu.Lock()
+	oa.gcDevicePoP()
+	exp, known := oa.devicePoPChallenges[body.Challenge]
+	if known {
+		delete(oa.devicePoPChallenges, body.Challenge)
+	}
+	oa.mu.Unlock()
+	if !known || time.Now().After(exp) {
+		http.Error(w, "unknown or expired challenge", http.StatusForbidden)
+		return
+	}
+
+	// The pubkey must be a PINNED trusted device. Look it up by its device key.
+	if s.deps.State == nil {
+		http.Error(w, "state store not configured", http.StatusInternalServerError)
+		return
+	}
+	dev, err := s.deps.State.LookupTrustedDeviceByPubkey(body.DevicePubkey)
+	if err != nil {
+		// Unknown device key (or DB error) — never reveal which. Fail closed.
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Verify the signature over the domain-separated, site- and challenge-bound
+	// message. Constant-time pubkey equality isn't needed (the DB lookup already
+	// matched), but we re-derive the signing string from the SERVER's site so a
+	// client can't smuggle a different binding.
+	msg := devicePoPSigningString(s.deps.SiteID, body.Challenge)
+	if !verifyDevicePoPSig(body.DevicePubkey, msg, body.Sig) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Bind the minted session to the SAME credential_id the device key pins, so a
+	// later device-delete revokes this session exactly like a passkey one. (See
+	// handleOwnerDeviceDelete: it revokes by credential_id.)
+	if err := s.issueOwnerSession(w, dev.CredentialID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"authenticated": true,
+		"friendly_name": dev.FriendlyName,
+	})
+}
+
+// gcDevicePoP drops expired device-PoP challenges. Caller holds oa.mu.
+func (oa *ownerAccessState) gcDevicePoP() {
+	now := time.Now()
+	for k, exp := range oa.devicePoPChallenges {
+		if exp.Before(now) {
+			delete(oa.devicePoPChallenges, k)
+		}
+	}
+}
+
+// capDevicePoP evicts the soonest-to-expire entries until the map is below the
+// cap, bounding it against an unauthenticated flood within the TTL window. Caller
+// holds oa.mu.
+func capDevicePoP(m map[string]time.Time) {
+	for len(m) >= maxDevicePoPChallenges {
+		var oldestKey string
+		var oldest time.Time
+		first := true
+		for k, v := range m {
+			if first || v.Before(oldest) {
+				oldestKey, oldest, first = k, v, false
+			}
+		}
+		delete(m, oldestKey)
+	}
+}

--- a/go/internal/api/api_owner_device_pop_test.go
+++ b/go/internal/api/api_owner_device_pop_test.go
@@ -1,0 +1,367 @@
+package api
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/state"
+)
+
+// newDeviceKey mints a P-256 device key and returns (private key, 128-hex
+// uncompressed X||Y public key) in the canonical lowercase form the Pi stores.
+func newDeviceKey(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	x := priv.PublicKey.X.Bytes()
+	y := priv.PublicKey.Y.Bytes()
+	buf := make([]byte, 64)
+	copy(buf[32-len(x):32], x)
+	copy(buf[64-len(y):64], y)
+	return priv, hex.EncodeToString(buf)
+}
+
+// signDevicePoP signs the C3 string for (site, challenge) and returns the raw
+// r||s 64-byte signature, base64url (no padding) — exactly what WebCrypto emits.
+func signDevicePoP(t *testing.T, priv *ecdsa.PrivateKey, site, challenge string) string {
+	t.Helper()
+	msg := "ftw-device-pop:v1:" + site + ":" + challenge
+	h := sha256.Sum256([]byte(msg))
+	r, s, err := ecdsa.Sign(rand.Reader, priv, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sig := make([]byte, 64)
+	rb, sb := r.Bytes(), s.Bytes()
+	copy(sig[32-len(rb):32], rb)
+	copy(sig[64-len(sb):64], sb)
+	return base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// mintChallenge calls the open device-challenge endpoint and returns its nonce.
+func mintChallenge(t *testing.T, srv *Server) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/owner-access/device-challenge", nil)
+	req.Host = "1.2.3.4"
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("device-challenge status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Challenge string `json:"challenge"`
+		ExpMs     int64  `json:"exp_ms"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode challenge: %v", err)
+	}
+	if out.Challenge == "" || out.ExpMs == 0 {
+		t.Fatalf("empty challenge/exp: %q", rec.Body.String())
+	}
+	return out.Challenge
+}
+
+func postDevicePoP(t *testing.T, srv *Server, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/owner-access/device-pop", bytes.NewReader(b))
+	req.Host = "1.2.3.4"
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// devicePoPDeps builds a Server whose gate is ACTIVE (TunnelMarker set) so the
+// open-path wiring is genuinely exercised, with a known SiteID for the signing
+// string and a pinned trusted device carrying devicePubkey.
+func devicePoPDeps(t *testing.T, devicePubkey string) (*Server, *Deps) {
+	t.Helper()
+	d := minDeps(t)
+	d.SiteID = "site:test-site"
+	d.TunnelMarker = "marker" // gate active — device-pop must still be reachable (open path)
+	if devicePubkey != "" {
+		if err := d.State.SaveTrustedDevice(state.TrustedDevice{
+			CredentialID: []byte("owner-cred"), PublicKey: []byte("k"),
+			FriendlyName: "owner phone", CreatedAtMs: time.Now().UnixMilli(),
+			DevicePubkey: devicePubkey,
+		}); err != nil {
+			t.Fatalf("seed device: %v", err)
+		}
+	}
+	return New(d), d
+}
+
+// Valid PoP against a pinned device mints an ftw_owner session.
+func TestDevicePoPValidIssuesSession(t *testing.T) {
+	priv, pub := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pub)
+
+	ch := mintChallenge(t, srv)
+	sig := signDevicePoP(t, priv, d.SiteID, ch)
+	rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": sig,
+	})
+	if rec.Code != 200 {
+		t.Fatalf("valid PoP status=%d body=%q", rec.Code, rec.Body.String())
+	}
+	// A session cookie must be set, and it must authenticate a subsequent
+	// (gated, tunnelled) request.
+	cookies := rec.Result().Cookies()
+	var sess *http.Cookie
+	for _, c := range cookies {
+		if c.Name == ownerAccessCookieName && c.Value != "" {
+			sess = c
+		}
+	}
+	if sess == nil {
+		t.Fatalf("no %s session cookie issued: %+v", ownerAccessCookieName, cookies)
+	}
+	// Tunnelled request (remote) carrying the minted cookie is authorized.
+	req := httptest.NewRequest("GET", "/api/owner-access/whoami", nil)
+	req.Host = "127.0.0.1"
+	req.Header.Set("X-FTW-Tunnel", "marker")
+	req.AddCookie(sess)
+	authRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(authRec, req)
+	if authRec.Code != 200 {
+		t.Fatalf("minted session should authenticate a tunnelled request: %d %q", authRec.Code, authRec.Body.String())
+	}
+}
+
+// A device key that is NOT pinned is rejected even with a valid signature.
+func TestDevicePoPUnknownPubkeyRejected(t *testing.T) {
+	// Pin one key, present a different (valid, on-curve) one.
+	_, pinned := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pinned)
+
+	strangerPriv, strangerPub := newDeviceKey(t)
+	ch := mintChallenge(t, srv)
+	sig := signDevicePoP(t, strangerPriv, d.SiteID, ch)
+	rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": strangerPub, "challenge": ch, "sig": sig,
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unknown pubkey must be 403, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatalf("no session must be minted for an unknown device key")
+	}
+}
+
+// A pinned device key with a signature that does NOT verify (wrong signer) is
+// rejected. The pubkey is in the set, but the sig was made by another key.
+func TestDevicePoPBadSigRejected(t *testing.T) {
+	_, pub := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pub)
+
+	// Sign with a DIFFERENT private key than the pinned pubkey.
+	wrongPriv, _ := newDeviceKey(t)
+	ch := mintChallenge(t, srv)
+	badSig := signDevicePoP(t, wrongPriv, d.SiteID, ch)
+	rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": badSig,
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("bad signature must be 403, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// A signature over a DIFFERENT site binding must not verify against this Pi's
+// SiteID (domain + site separation in the signing string).
+func TestDevicePoPWrongSiteBindingRejected(t *testing.T) {
+	priv, pub := newDeviceKey(t)
+	srv, _ := devicePoPDeps(t, pub)
+
+	ch := mintChallenge(t, srv)
+	// Sign with the correct key + challenge but a foreign site.
+	sig := signDevicePoP(t, priv, "site:somewhere-else", ch)
+	rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": sig,
+	})
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("wrong-site signature must be 403, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// An expired (or unknown) challenge is rejected even with an otherwise-valid
+// signature, and a consumed challenge cannot be replayed.
+func TestDevicePoPExpiredAndReplayRejected(t *testing.T) {
+	priv, pub := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pub)
+
+	// 1) Unknown challenge (never minted) → 403.
+	bogus := "this-challenge-was-never-minted"
+	sig := signDevicePoP(t, priv, d.SiteID, bogus)
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": bogus, "sig": sig,
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("unknown challenge must be 403, got %d", rec.Code)
+	}
+
+	// 2) Expired challenge: mint one, then force it stale in the map.
+	ch := mintChallenge(t, srv)
+	oa := srv.ownerAccess()
+	oa.mu.Lock()
+	oa.devicePoPChallenges[ch] = time.Now().Add(-time.Second)
+	oa.mu.Unlock()
+	expSig := signDevicePoP(t, priv, d.SiteID, ch)
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": expSig,
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("expired challenge must be 403, got %d", rec.Code)
+	}
+
+	// 3) Replay: a fresh challenge consumed by one valid PoP cannot be reused.
+	ch2 := mintChallenge(t, srv)
+	sig2 := signDevicePoP(t, priv, d.SiteID, ch2)
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch2, "sig": sig2,
+	}); rec.Code != 200 {
+		t.Fatalf("first PoP should succeed, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch2, "sig": sig2,
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("replayed challenge must be 403, got %d", rec.Code)
+	}
+}
+
+// A wrong-signature attempt CONSUMES the challenge (single-use), so a subsequent
+// correct signature against the same challenge is rejected — no oracle to retry.
+func TestDevicePoPWrongSigConsumesChallenge(t *testing.T) {
+	priv, pub := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pub)
+
+	ch := mintChallenge(t, srv)
+	wrongPriv, _ := newDeviceKey(t)
+	badSig := signDevicePoP(t, wrongPriv, d.SiteID, ch)
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": badSig,
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("bad sig must be 403, got %d", rec.Code)
+	}
+	// Now the correct sig over the SAME challenge must fail — it was consumed.
+	goodSig := signDevicePoP(t, priv, d.SiteID, ch)
+	if rec := postDevicePoP(t, srv, map[string]any{
+		"device_pubkey": pub, "challenge": ch, "sig": goodSig,
+	}); rec.Code != http.StatusForbidden {
+		t.Fatalf("challenge must be consumed by the failed attempt, got %d", rec.Code)
+	}
+}
+
+// Malformed inputs (missing fields, non-canonical pubkey) are rejected without
+// touching the DB.
+func TestDevicePoPMalformedInputs(t *testing.T) {
+	priv, pub := newDeviceKey(t)
+	srv, d := devicePoPDeps(t, pub)
+	ch := mintChallenge(t, srv)
+	sig := signDevicePoP(t, priv, d.SiteID, ch)
+
+	// Missing sig → 400.
+	if rec := postDevicePoP(t, srv, map[string]any{"device_pubkey": pub, "challenge": ch}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing sig must be 400, got %d", rec.Code)
+	}
+	// Uppercase (non-canonical) pubkey → 403 (rejected before DB).
+	upper := pub[:64] + "AA" + pub[66:]
+	if rec := postDevicePoP(t, srv, map[string]any{"device_pubkey": upper, "challenge": ch, "sig": sig}); rec.Code != http.StatusForbidden {
+		t.Fatalf("non-canonical pubkey must be 403, got %d", rec.Code)
+	}
+}
+
+// validDevicePubKeyHex is the canonical-form gate; verify it matches the relay's
+// contract: 128 lowercase hex, on-curve.
+func TestValidDevicePubKeyHex(t *testing.T) {
+	_, pub := newDeviceKey(t)
+	if !validDevicePubKeyHex(pub) {
+		t.Fatalf("freshly-minted key should be valid: %s", pub)
+	}
+	cases := []string{
+		"",                  // empty
+		pub[:126],           // too short
+		pub + "00",          // too long
+		pub[:64] + "GG" + pub[66:], // non-hex
+		// All-zero X||Y is not on the curve.
+		"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+	for i, c := range cases {
+		if validDevicePubKeyHex(c) {
+			t.Errorf("case %d should be invalid: %q", i, c)
+		}
+	}
+	// An uppercase-but-otherwise-valid key is rejected (canonical lowercase only).
+	upper := pub[:2] + "AB" + pub[4:]
+	if validDevicePubKeyHex(upper) {
+		t.Errorf("uppercase key must be rejected (canonical lowercase only): %q", upper)
+	}
+}
+
+// C4: device_pubkey supplied on enroll/finish must persist on the new
+// credential's row. We can't run a full WebAuthn ceremony in a unit test, so we
+// exercise the extraction helper + the state write the handler performs.
+func TestEnrollDevicePubkeyExtractionAndPersist(t *testing.T) {
+	_, pub := newDeviceKey(t)
+	// The finish body is the WebAuthn attestation JSON plus our extra field.
+	body := []byte(`{"id":"abc","rawId":"abc","type":"public-key","response":{"clientDataJSON":"x","attestationObject":"y"},"device_pubkey":"` + pub + `"}`)
+	got := extractDevicePubkeyField(body)
+	if got != pub {
+		t.Fatalf("extracted device_pubkey = %q, want %q", got, pub)
+	}
+	if canonicalDevicePubkey(got) != pub {
+		t.Fatalf("canonical form mismatch: %q", canonicalDevicePubkey(got))
+	}
+	// A missing field extracts to "".
+	if extractDevicePubkeyField([]byte(`{"id":"abc"}`)) != "" {
+		t.Fatalf("absent field must extract to empty")
+	}
+	// A non-canonical value canonicalises to "" (dropped, passkey still enrolls).
+	if canonicalDevicePubkey("not-a-key") != "" {
+		t.Fatalf("invalid key must canonicalise to empty")
+	}
+
+	// And the state write the handler performs round-trips + publishes.
+	d := minDeps(t)
+	if err := d.State.SaveTrustedDevice(state.TrustedDevice{
+		CredentialID: []byte("new-cred"), PublicKey: []byte("k"),
+		FriendlyName: "phone", CreatedAtMs: time.Now().UnixMilli(),
+		DevicePubkey: canonicalDevicePubkey(got),
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	pks, err := d.State.TrustedDevicePubkeys()
+	if err != nil {
+		t.Fatalf("pubkeys: %v", err)
+	}
+	if len(pks) != 1 || pks[0] != pub {
+		t.Fatalf("enrolled device_pubkey not published: %v", pks)
+	}
+}
+
+// The device-pop open path is reachable even when the gate is active and the
+// request is tunnelled (remote) — it is the silent-login surface, so it must NOT
+// require a pre-existing session. (It still mints nothing without a valid PoP.)
+func TestDevicePoPOpenPathWhenGated(t *testing.T) {
+	_, pub := newDeviceKey(t)
+	srv, _ := devicePoPDeps(t, pub)
+	// Tunnelled GET of device-challenge with NO session must reach the handler
+	// (200), not be 401'd by the gate.
+	req := httptest.NewRequest("GET", "/api/owner-access/device-challenge", nil)
+	req.Host = "127.0.0.1"
+	req.Header.Set("X-FTW-Tunnel", "marker")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("device-challenge must be an open path under the active gate, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}

--- a/go/internal/api/api_owner_gate.go
+++ b/go/internal/api/api_owner_gate.go
@@ -76,6 +76,15 @@ func isOwnerAccessOpenPath(p string) bool {
 		"/api/owner-access/enroll/finish",
 		"/api/owner-access/whoami",
 		"/api/owner-access/logout",
+		// C3 device-key PoP login: these are the silent-login analogue of
+		// login/start + login/finish — the device key IS the credential, so they
+		// must be reachable pre-session over the P2P channel. They mint a session
+		// only on a valid PoP against a PINNED trusted device; an unauthenticated
+		// caller learns nothing (challenge is a random nonce) and can mint nothing
+		// without a key the Pi already trusts. This does NOT relax the gate for any
+		// other /api/* path.
+		"/api/owner-access/device-challenge",
+		"/api/owner-access/device-pop",
 		// /api/identity is the TOFU anchor for the P2P-only home route: the
 		// browser MUST fetch + pin the Pi's PUBLIC ES256 key before it can open
 		// (and verify) a P2P channel, so this must be reachable unauthenticated

--- a/go/internal/state/store.go
+++ b/go/internal/state/store.go
@@ -578,7 +578,8 @@ func (s *Store) migrate() error {
 			last_used_ms  INTEGER NOT NULL DEFAULT 0,
 			wallet_handle TEXT    NOT NULL DEFAULT '',
 			backup_eligible INTEGER NOT NULL DEFAULT 0,
-			backup_state    INTEGER NOT NULL DEFAULT 0
+			backup_state    INTEGER NOT NULL DEFAULT 0,
+			device_pubkey TEXT    NOT NULL DEFAULT ''
 		) STRICT`,
 		`CREATE TABLE IF NOT EXISTS owner_sessions (
 			token         TEXT    PRIMARY KEY NOT NULL,
@@ -598,6 +599,13 @@ func (s *Store) migrate() error {
 	for _, col := range []struct{ name, ddl string }{
 		{"backup_eligible", "backup_eligible INTEGER NOT NULL DEFAULT 0"},
 		{"backup_state", "backup_state INTEGER NOT NULL DEFAULT 0"},
+		// device_pubkey is the per-credential P-256 device key (X||Y, 128 hex
+		// chars) minted at LAN enrollment (C4). It backs the silent device-PoP
+		// login (C3) and is published to the relay so the browser can prove it
+		// before a signaling offer is forwarded (C1/C2). Empty for credentials
+		// enrolled before this column existed; such a device can be upgraded by
+		// re-presenting the key on a later enroll/login finish.
+		{"device_pubkey", "device_pubkey TEXT NOT NULL DEFAULT ''"},
 	} {
 		if err := s.addColumnIfMissing("trusted_devices", col.name, col.ddl); err != nil {
 			return fmt.Errorf("migrate trusted_devices.%s: %w", col.name, err)

--- a/go/internal/state/trusted_devices.go
+++ b/go/internal/state/trusted_devices.go
@@ -22,6 +22,12 @@ type TrustedDevice struct {
 	WalletHandle   string // opaque wallet (owner) handle this credential belongs to
 	BackupEligible bool   // WebAuthn BE flag — must round-trip or login rejects synced passkeys
 	BackupState    bool   // WebAuthn BS flag
+	// DevicePubkey is the per-credential P-256 device key (uncompressed X||Y,
+	// 128 lowercase hex chars) minted in the browser at LAN enrollment (C4).
+	// Empty when the credential predates the device-key feature. It backs the
+	// silent device-PoP login (C3) and is published to the relay (C1) so a
+	// browser can prove it before the relay forwards a signaling offer (C2).
+	DevicePubkey string
 }
 
 func boolToInt64(b bool) int64 {
@@ -51,11 +57,11 @@ func (s *Store) SaveTrustedDevice(d TrustedDevice) error {
 	}
 	_, err := s.db.Exec(`
 		INSERT INTO trusted_devices
-			(credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state, device_pubkey)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		d.CredentialID, d.PublicKey, int64(d.SignCount), d.AAGUID,
 		strings.Join(d.Transports, ","), d.FriendlyName, d.CreatedAtMs, d.LastUsedMs, d.WalletHandle,
-		boolToInt64(d.BackupEligible), boolToInt64(d.BackupState),
+		boolToInt64(d.BackupEligible), boolToInt64(d.BackupState), d.DevicePubkey,
 	)
 	return err
 }
@@ -63,7 +69,7 @@ func (s *Store) SaveTrustedDevice(d TrustedDevice) error {
 // LoadTrustedDevices returns all enrolled passkeys, newest first.
 func (s *Store) LoadTrustedDevices() ([]TrustedDevice, error) {
 	rows, err := s.db.Query(`
-		SELECT credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state
+		SELECT credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state, device_pubkey
 		FROM trusted_devices
 		ORDER BY created_at_ms DESC`)
 	if err != nil {
@@ -76,7 +82,7 @@ func (s *Store) LoadTrustedDevices() ([]TrustedDevice, error) {
 		var signCount int64
 		var transports string
 		var be, bs int64
-		if err := rows.Scan(&d.CredentialID, &d.PublicKey, &signCount, &d.AAGUID, &transports, &d.FriendlyName, &d.CreatedAtMs, &d.LastUsedMs, &d.WalletHandle, &be, &bs); err != nil {
+		if err := rows.Scan(&d.CredentialID, &d.PublicKey, &signCount, &d.AAGUID, &transports, &d.FriendlyName, &d.CreatedAtMs, &d.LastUsedMs, &d.WalletHandle, &be, &bs, &d.DevicePubkey); err != nil {
 			return nil, err
 		}
 		d.SignCount = uint32(signCount)
@@ -98,9 +104,9 @@ func (s *Store) LookupTrustedDevice(credentialID []byte) (TrustedDevice, error) 
 	var transports string
 	var be, bs int64
 	err := s.db.QueryRow(`
-		SELECT credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state
+		SELECT credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state, device_pubkey
 		FROM trusted_devices WHERE credential_id = ?`, credentialID).
-		Scan(&d.CredentialID, &d.PublicKey, &signCount, &d.AAGUID, &transports, &d.FriendlyName, &d.CreatedAtMs, &d.LastUsedMs, &d.WalletHandle, &be, &bs)
+		Scan(&d.CredentialID, &d.PublicKey, &signCount, &d.AAGUID, &transports, &d.FriendlyName, &d.CreatedAtMs, &d.LastUsedMs, &d.WalletHandle, &be, &bs, &d.DevicePubkey)
 	if err != nil {
 		return d, err
 	}
@@ -136,4 +142,90 @@ func (s *Store) UpdateTrustedDeviceSignCount(credentialID []byte, newCount uint3
 func (s *Store) DeleteTrustedDevice(credentialID []byte) error {
 	_, err := s.db.Exec(`DELETE FROM trusted_devices WHERE credential_id = ?`, credentialID)
 	return err
+}
+
+// SetTrustedDevicePubkey pins (or upgrades) the device_pubkey on an existing
+// credential's row. Used at enroll/finish to bind the freshly-minted device key
+// to the new credential, and on login/finish to upgrade a credential enrolled
+// before the device-key feature existed. A non-empty existing value is only
+// overwritten when allowOverwrite is true, so a malicious re-presentation can
+// never silently repoint an already-pinned device key (defence in depth; the
+// caller already gates which keys it accepts). Returns sql.ErrNoRows if the
+// credential is unknown.
+func (s *Store) SetTrustedDevicePubkey(credentialID []byte, devicePubkey string, allowOverwrite bool) error {
+	q := `UPDATE trusted_devices SET device_pubkey = ? WHERE credential_id = ?`
+	if !allowOverwrite {
+		// Only fill when currently empty — never clobber an already-pinned key.
+		q = `UPDATE trusted_devices SET device_pubkey = ? WHERE credential_id = ? AND device_pubkey = ''`
+	}
+	res, err := s.db.Exec(q, devicePubkey, credentialID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Either the credential is unknown, or (no-overwrite path) it already has
+		// a pinned key. Disambiguate with a presence check so callers that only
+		// want "is this credential gone?" get the right signal.
+		var dummy int
+		if qerr := s.db.QueryRow(`SELECT 1 FROM trusted_devices WHERE credential_id = ?`, credentialID).Scan(&dummy); qerr == sql.ErrNoRows {
+			return sql.ErrNoRows
+		}
+	}
+	return nil
+}
+
+// TrustedDevicePubkeys returns the set of non-empty device_pubkeys across all
+// enrolled credentials, de-duplicated and sorted for a stable wire order. This
+// is the set the Pi publishes to the relay (C1) so a browser can prove
+// possession of a trusted device key before the relay forwards its signaling
+// offer (C2). An empty result means no enrolled credential carries a device key
+// yet (pre-feature credentials), in which case the relay device-gate is closed.
+func (s *Store) TrustedDevicePubkeys() ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT DISTINCT device_pubkey FROM trusted_devices
+		WHERE device_pubkey <> ''
+		ORDER BY device_pubkey ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var pk string
+		if err := rows.Scan(&pk); err != nil {
+			return nil, err
+		}
+		out = append(out, pk)
+	}
+	return out, rows.Err()
+}
+
+// LookupTrustedDeviceByPubkey returns the credential whose device_pubkey matches
+// (exactly, byte-for-byte) the supplied key, or sql.ErrNoRows if no pinned
+// credential carries it. The empty string never matches a row (the WHERE guard
+// excludes pre-feature rows whose device_pubkey is ''), so a caller that passes
+// "" can never be mistaken for a trusted device.
+func (s *Store) LookupTrustedDeviceByPubkey(devicePubkey string) (TrustedDevice, error) {
+	var d TrustedDevice
+	if devicePubkey == "" {
+		return d, sql.ErrNoRows
+	}
+	var signCount int64
+	var transports string
+	var be, bs int64
+	err := s.db.QueryRow(`
+		SELECT credential_id, public_key, sign_count, aaguid, transports, friendly_name, created_at_ms, last_used_ms, wallet_handle, backup_eligible, backup_state, device_pubkey
+		FROM trusted_devices WHERE device_pubkey = ? AND device_pubkey <> ''`, devicePubkey).
+		Scan(&d.CredentialID, &d.PublicKey, &signCount, &d.AAGUID, &transports, &d.FriendlyName, &d.CreatedAtMs, &d.LastUsedMs, &d.WalletHandle, &be, &bs, &d.DevicePubkey)
+	if err != nil {
+		return d, err
+	}
+	d.SignCount = uint32(signCount)
+	d.BackupEligible = be != 0
+	d.BackupState = bs != 0
+	if transports != "" {
+		d.Transports = strings.Split(transports, ",")
+	}
+	return d, nil
 }

--- a/go/internal/state/trusted_devices_test.go
+++ b/go/internal/state/trusted_devices_test.go
@@ -150,6 +150,154 @@ func TestUpdateSignCountConstantZeroIsBenign(t *testing.T) {
 	}
 }
 
+// C4: the device_pubkey minted at LAN enrollment round-trips through save +
+// load + lookup, and is exposed in the published set (C1).
+func TestTrustedDeviceDevicePubkeyRoundTrip(t *testing.T) {
+	s := openTempStore(t)
+	const pk = "aa11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff00112233445566778899aabbccdd"
+	dev := TrustedDevice{
+		CredentialID: []byte("c-dk"), PublicKey: []byte("k"),
+		FriendlyName: "phone", DevicePubkey: pk,
+	}
+	if err := s.SaveTrustedDevice(dev); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.LookupTrustedDevice(dev.CredentialID)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got.DevicePubkey != pk {
+		t.Fatalf("device_pubkey = %q, want %q", got.DevicePubkey, pk)
+	}
+	list, _ := s.LoadTrustedDevices()
+	if len(list) != 1 || list[0].DevicePubkey != pk {
+		t.Fatalf("load device_pubkey mismatch: %+v", list)
+	}
+
+	// Published set contains it.
+	pks, err := s.TrustedDevicePubkeys()
+	if err != nil {
+		t.Fatalf("pubkeys: %v", err)
+	}
+	if len(pks) != 1 || pks[0] != pk {
+		t.Fatalf("TrustedDevicePubkeys = %v, want [%q]", pks, pk)
+	}
+
+	// Lookup-by-pubkey resolves the same credential.
+	byPk, err := s.LookupTrustedDeviceByPubkey(pk)
+	if err != nil {
+		t.Fatalf("lookup by pubkey: %v", err)
+	}
+	if string(byPk.CredentialID) != "c-dk" {
+		t.Fatalf("lookup by pubkey returned wrong credential: %q", byPk.CredentialID)
+	}
+}
+
+// A credential enrolled before the device-key feature has an empty device_pubkey;
+// it must never appear in the published set, never resolve by-pubkey for "", and
+// can be upgraded in place by SetTrustedDevicePubkey.
+func TestTrustedDevicePubkeyEmptyAndUpgrade(t *testing.T) {
+	s := openTempStore(t)
+	if err := s.SaveTrustedDevice(TrustedDevice{
+		CredentialID: []byte("legacy"), PublicKey: []byte("k"), FriendlyName: "old phone",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Empty key: not published, not resolvable.
+	if pks, _ := s.TrustedDevicePubkeys(); len(pks) != 0 {
+		t.Fatalf("expected empty published set, got %v", pks)
+	}
+	if _, err := s.LookupTrustedDeviceByPubkey(""); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("empty pubkey must not resolve, got %v", err)
+	}
+
+	const pk = "bb11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff00112233445566778899aabbccdd"
+	// Upgrade fills the empty slot.
+	if err := s.SetTrustedDevicePubkey([]byte("legacy"), pk, false); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+	got, _ := s.LookupTrustedDevice([]byte("legacy"))
+	if got.DevicePubkey != pk {
+		t.Fatalf("upgrade did not persist: %q", got.DevicePubkey)
+	}
+
+	// A second no-overwrite upgrade with a DIFFERENT key must NOT clobber the
+	// already-pinned one (defence in depth against silent repointing).
+	const pk2 = "cc11bb22cc33dd44ee55ff66007788990011223344556677889900aabbccddeeff0011223344556677889900aabbccddeeff00112233445566778899aabbccdd"
+	if err := s.SetTrustedDevicePubkey([]byte("legacy"), pk2, false); err != nil {
+		t.Fatalf("no-overwrite upgrade returned err: %v", err)
+	}
+	got2, _ := s.LookupTrustedDevice([]byte("legacy"))
+	if got2.DevicePubkey != pk {
+		t.Fatalf("no-overwrite upgrade clobbered pinned key: %q", got2.DevicePubkey)
+	}
+
+	// Upgrading an unknown credential reports ErrNoRows.
+	if err := s.SetTrustedDevicePubkey([]byte("ghost"), pk, false); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("upgrade of unknown credential: want sql.ErrNoRows, got %v", err)
+	}
+}
+
+// An old state.db whose trusted_devices table predates the device_pubkey column
+// must upgrade cleanly via addColumnIfMissing, with existing rows defaulting to
+// the empty key. Simulates the real upgrade: drop the column, re-run migrations.
+func TestDevicePubkeyColumnMigratesOldSchema(t *testing.T) {
+	s := openTempStore(t)
+	// Seed a row, then simulate a pre-column DB by dropping the column.
+	if err := s.SaveTrustedDevice(TrustedDevice{
+		CredentialID: []byte("pre"), PublicKey: []byte("k"), FriendlyName: "old",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := s.db.Exec(`ALTER TABLE trusted_devices DROP COLUMN device_pubkey`); err != nil {
+		t.Fatalf("drop column to simulate old schema: %v", err)
+	}
+	// Re-running the column migration must be idempotent and re-add it.
+	if err := s.addColumnIfMissing("trusted_devices", "device_pubkey",
+		"device_pubkey TEXT NOT NULL DEFAULT ''"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// A second call is a no-op (idempotent).
+	if err := s.addColumnIfMissing("trusted_devices", "device_pubkey",
+		"device_pubkey TEXT NOT NULL DEFAULT ''"); err != nil {
+		t.Fatalf("migrate idempotent: %v", err)
+	}
+	got, err := s.LookupTrustedDevice([]byte("pre"))
+	if err != nil {
+		t.Fatalf("lookup after migrate: %v", err)
+	}
+	if got.DevicePubkey != "" {
+		t.Fatalf("migrated row should default to empty device_pubkey, got %q", got.DevicePubkey)
+	}
+}
+
+// The published set is de-duplicated and sorted so the wire order is stable
+// (the relay stores it as a set; a stable order keeps tests + diffs sane).
+func TestTrustedDevicePubkeysDedupSorted(t *testing.T) {
+	s := openTempStore(t)
+	const pkA = "aa00000000000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const pkB = "bb00000000000000000000000000000000000000000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	// Two credentials sharing pkB, one with pkA — expect [pkA, pkB] sorted, deduped.
+	mustSave := func(id, pk string) {
+		if err := s.SaveTrustedDevice(TrustedDevice{
+			CredentialID: []byte(id), PublicKey: []byte("k"), FriendlyName: id, DevicePubkey: pk,
+		}); err != nil {
+			t.Fatalf("save %s: %v", id, err)
+		}
+	}
+	mustSave("c2", pkB)
+	mustSave("c1", pkA)
+	mustSave("c3", pkB) // duplicate key on a different credential
+	pks, err := s.TrustedDevicePubkeys()
+	if err != nil {
+		t.Fatalf("pubkeys: %v", err)
+	}
+	want := []string{pkA, pkB}
+	if !reflect.DeepEqual(pks, want) {
+		t.Fatalf("TrustedDevicePubkeys = %v, want %v", pks, want)
+	}
+}
+
 func TestTrustedDeviceWalletHandleRoundTrip(t *testing.T) {
 	s := openTempStore(t)
 	dev := TrustedDevice{

--- a/go/internal/tunnel/me_register.go
+++ b/go/internal/tunnel/me_register.go
@@ -1,6 +1,10 @@
 package tunnel
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // MeRegisterSigningString is the canonical message the owner Pi signs (ES256,
 // raw R||S over SHA-256) and the relay verifies for POST /me/register. It binds
@@ -17,6 +21,20 @@ import "fmt"
 // keeping it here in the shared package rather than duplicating it.
 func MeRegisterSigningString(siteID, hostID string, tsMs int64) string {
 	return fmt.Sprintf("ftw-me-register:v1:%s:%s:%d", siteID, hostID, tsMs)
+}
+
+// MeRegisterSigningStringV2 extends v1 to also cover the published device-key set
+// (C1), so a captured registration body can't be replayed with a swapped or added
+// device_pubkeys array to inject an attacker key the relay would then trust for
+// signaling. The set is canonicalised (sorted, comma-joined) so the Pi and relay
+// agree regardless of slice order. The relay verifies v2 when a device_pubkeys
+// field is present and, on success, trusts that set; a v1-only signature (old Pi,
+// no device-keys) is still accepted but its device_pubkeys (if any were appended
+// by an attacker) are IGNORED.
+func MeRegisterSigningStringV2(siteID, hostID string, tsMs int64, devicePubkeys []string) string {
+	pk := append([]string(nil), devicePubkeys...)
+	sort.Strings(pk)
+	return fmt.Sprintf("ftw-me-register:v2:%s:%s:%d:%s", siteID, hostID, tsMs, strings.Join(pk, ","))
 }
 
 // MeRegisterMaxSkewMs bounds how far the registration timestamp may be from the

--- a/web/home-route-silent-auth.test.mjs
+++ b/web/home-route-silent-auth.test.mjs
@@ -1,0 +1,131 @@
+// node --test web/home-route-silent-auth.test.mjs
+//
+// Wiring + contract guards for the silent device-key home route (Phase 5):
+//   C2 — p2p.js proves the device to the RELAY before posting a WebRTC offer.
+//   C3 — next-app.js mints the owner session SILENTLY over the open channel
+//        (device-PoP), trying it BEFORE the passkey ceremony.
+//   C4 — enroll.html sends the device pubkey in enroll/finish so the Pi pins it.
+// These are static guards (the real crypto is covered in device-key.test.mjs);
+// they lock in the exact signing strings + field names so the relay/Pi agents
+// stay byte-for-byte aligned, and the silent-first ordering Fredrik asked for.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(join(__dirname, p), "utf8");
+
+const P2P = read("p2p.js");
+const APP = read("next-app.js");
+const ENROLL = read("owner-access/enroll.html");
+const INDEX = read("index.html");
+
+describe("C2 — p2p.js proves the device to the relay before the offer", () => {
+  it("GETs the per-site challenge endpoint", () => {
+    assert.match(P2P, /\/signal\/"\s*\+\s*encodeURIComponent\(site\)\s*\+\s*"\/challenge/,
+      "must GET /signal/<site>/challenge");
+  });
+
+  it("signs the exact C2 string ftw-signal:v1:<site>:<nonce>", () => {
+    assert.match(P2P, /"ftw-signal:v1:"\s*\+\s*site\s*\+\s*":"\s*\+\s*ch\.nonce/,
+      "signing string must be ftw-signal:v1:<site>:<nonce> byte-for-byte");
+  });
+
+  it("attaches {device_pubkey, nonce, sig} to the offer POST body", () => {
+    // The offer body is now a JSON envelope carrying the SDP + the proof fields.
+    assert.match(P2P, /sdp:\s*pc\.localDescription\.sdp/, "offer JSON carries the raw SDP");
+    assert.match(P2P, /device_pubkey:\s*proof\.device_pubkey/);
+    assert.match(P2P, /nonce:\s*proof\.nonce/);
+    assert.match(P2P, /sig:\s*proof\.sig/);
+    assert.match(P2P, /headers:\s*\{\s*"Content-Type":\s*"application\/json"\s*\}/,
+      "offer POST is application/json (envelope), not raw application/sdp");
+  });
+
+  it("fails closed (no offer) when this device has no key — sets the unenrolled state", () => {
+    assert.match(P2P, /hasDeviceKey\(\)/, "must check for a device key (without minting)");
+    assert.match(P2P, /code\s*=\s*"no-device-key"/);
+    assert.match(P2P, /unenrolled\s*=\s*true/);
+    assert.match(P2P, /isUnenrolled:/, "exposes isUnenrolled() for the gate");
+  });
+
+  it("exposes site() so next-app.js can build the C3 signing string off the SAME site", () => {
+    assert.match(P2P, /site:\s*function\s*\(\)\s*\{\s*return\s*pinnedIdentity\(\)/);
+  });
+});
+
+describe("C3 — next-app.js mints the session silently (device-PoP), passkey only as fallback", () => {
+  it("GETs the device-challenge and POSTs device-pop over ownerFetch (strict, never bare)", () => {
+    assert.match(APP, /ownerFetch\("\/api\/owner-access\/device-challenge"/,
+      "device-challenge must ride ownerFetch (strict), not bare fetch");
+    assert.match(APP, /ownerFetch\("\/api\/owner-access\/device-pop"/,
+      "device-pop must ride ownerFetch (strict), not bare fetch");
+  });
+
+  it("signs the exact C3 string ftw-device-pop:v1:<site>:<challenge>", () => {
+    assert.match(APP, /"ftw-device-pop:v1:"\s*\+\s*site\s*\+\s*":"\s*\+\s*ch\.challenge/,
+      "signing string must be ftw-device-pop:v1:<site>:<challenge> byte-for-byte");
+  });
+
+  it("POSTs {device_pubkey, challenge, sig} as the device-pop body", () => {
+    assert.match(APP, /device_pubkey:\s*key\.pubHex/);
+    assert.match(APP, /challenge:\s*ch\.challenge/);
+    assert.match(APP, /sig:\s*sig/);
+  });
+
+  it("tries the SILENT path FIRST and falls back to the passkey ceremony", () => {
+    // runSignIn calls runDevicePoP() before runPasskeySignIn().
+    assert.match(APP, /runDevicePoP\(\)\.then\(function\s*\(silentOk\)/);
+    assert.match(APP, /return runPasskeySignIn\(say\)/,
+      "passkey ceremony is the fallback, not the first move");
+    // setupAuth attempts silent auth before showing the gate.
+    assert.match(APP, /runDevicePoP\(\)\.then\(function\s*\(ok\)\s*\{[\s\S]*?showSignInGate\(\)/,
+      "setupAuth must try silent device-PoP before showing the sign-in gate");
+  });
+
+  it("does not mint a key just to probe (hasDeviceKey gate before getOrCreate)", () => {
+    assert.match(APP, /window\.ftwDeviceKey\.hasDeviceKey\(\)/);
+  });
+});
+
+describe("C4 — enroll.html pins the device key at LAN enrollment", () => {
+  it("imports the device-key store and sends device_pubkey in enroll/finish", () => {
+    assert.match(ENROLL, /import\s*\{\s*exportPubHex\s*\}\s*from\s*["']\.\/device-key\.js["']/);
+    assert.match(ENROLL, /finishBody\.device_pubkey\s*=\s*devicePubHex/,
+      "enroll/finish body must carry device_pubkey (128hex) for the Pi to pin");
+  });
+
+  it("merges device_pubkey INTO the WebAuthn registration JSON (one body, C4)", () => {
+    assert.match(ENROLL, /const\s+finishBody\s*=\s*encodeRegistrationResult\(cred\)/);
+    assert.match(ENROLL, /body:\s*JSON\.stringify\(finishBody\)/);
+  });
+});
+
+describe("index.html loads the device-key module before p2p.js consumes it", () => {
+  it("includes the device-key.js module script", () => {
+    assert.match(INDEX, /<script[^>]*type="module"[^>]*src="\/owner-access\/device-key\.js/,
+      "device-key.js must be loaded so window.ftwDeviceKey exists for p2p.js/next-app.js");
+  });
+});
+
+describe("UI clarity — the gate makes the security legible (Fredrik's ask)", () => {
+  it("the gate carries a trust line conveying direct + E2E + relay-blind", () => {
+    assert.match(INDEX, /signin-gate-trust/);
+    assert.match(INDEX, /id="signin-gate-trust-text"/);
+    // next-app.js drives its copy from the live transport state.
+    assert.match(APP, /signin-gate-trust-text/);
+    assert.match(APP, /relay never sees your home|never sees your home|forwards ciphertext/i);
+  });
+
+  it("conveys 'this device is remembered' on a silent sign-in", () => {
+    assert.match(APP, /this device is remembered/i);
+  });
+
+  it("offers a clear 'set up this device first' state instead of an unsatisfiable passkey prompt", () => {
+    assert.match(APP, /showGate\(unEnrolled\s*\?\s*"setup"\s*:\s*"signin"\)/);
+    assert.match(INDEX, /signin-gate-needs-setup/);
+    assert.match(INDEX, /Set up this device/i);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,7 @@
   <link rel="stylesheet" href="/style.css?v=lp2">
   <!-- /next-only visual redesign — layered on top of style.css and scoped
        to body.ftw-next so legacy /index.html is untouched. -->
-  <link rel="stylesheet" href="/next.css?v=next3">
+  <link rel="stylesheet" href="/next.css?v=next4">
   <!-- Three.js bare-specifier resolution. Three is vendored under
        /vendor/three/ (pinned 0.160.0) rather than pulled from a CDN
        so we have no supply-chain surface area and no SRI gap — an
@@ -86,22 +86,31 @@
       <button id="settings-btn" class="settings-btn" data-menu-label="Settings" title="Settings">⚙</button>
       <ftw-update-badge></ftw-update-badge>
       <span id="version" class="version" title="Click for version info" style="cursor:pointer">...</span>
-      <button id="signin-btn" class="icon-btn" data-menu-label="Sign in" title="Sign in with your passkey" hidden>&#128273;</button>
       <button id="signout-btn" class="icon-btn" data-menu-label="Sign out" title="Sign out" hidden>&#9211;</button>
-      <span id="p2p-status" class="p2p-status" title="Transport — click to toggle direct P2P" hidden><span class="p2p-dot"></span><span class="p2p-label"></span></span>
+      <span id="p2p-status" class="p2p-status" title="How your browser is connected to your Pi" hidden><span class="p2p-dot"></span><span class="p2p-label"></span></span>
       <span id="conn-status" class="conn-status connected" title="Connected">&#9679;</span>
     </div>
   </header>
 
-  <!-- Inline sign-in prompt: the dashboard IS the door. next-app.js (setupAuth)
-       reveals this when whoami reports the viewer isn't signed in on a remote
-       origin, and runs the passkey ceremony over the SAME strict P2P channel —
-       no redirect to /owner-access/login.html (which would spawn a fresh channel
-       with no session). Hidden on the LAN (bypass) and once signed in. -->
-  <div id="signin-banner" class="signin-banner" hidden>
-    <span class="signin-banner-text">Sign in with your passkey to see and control your home.</span>
-    <button id="signin-banner-btn" class="signin-banner-btn">Sign in</button>
-    <span id="signin-banner-msg" class="signin-banner-msg" role="status" aria-live="polite"></span>
+  <!-- Sign-in GATE: the dashboard IS the door, and when locked it shows ONLY the
+       door — never the empty dashboard chrome (which falsely reads as an
+       unconfigured instance, and is the wrong thing to show a logged-out
+       visitor). next-app.js (setupAuth) covers the dashboard on a remote origin
+       until whoami confirms a signed-in owner; the passkey ceremony runs over the
+       SAME strict P2P channel (no redirect). data-mode = connecting | signin.
+       Never shown on the LAN (bypass) or once signed in. No owner DATA is ever
+       served unauthenticated — the gate is purely the lock's UI. -->
+  <div id="signin-gate" class="signin-gate" data-mode="connecting" hidden>
+    <div class="signin-gate-card">
+      <div class="signin-gate-brand">&#9889; forty-two watts</div>
+      <p class="signin-gate-lead signin-gate-connecting">Reaching your home&hellip;</p>
+      <div class="signin-gate-auth">
+        <p class="signin-gate-lead">Sign in with your passkey to reach your home.</p>
+        <button id="signin-gate-btn" class="signin-gate-btn">Sign in</button>
+        <p class="signin-gate-msg" id="signin-banner-msg" role="status" aria-live="polite"></p>
+        <p class="signin-gate-setup">First time on this device? <a href="/owner-access/">Set it up &rarr;</a></p>
+      </div>
+    </div>
   </div>
 
   <!-- Settings Modal -->
@@ -688,7 +697,7 @@
   </ftw-modal>
 
   <script src="/p2p.js?v=p2p5"></script>
-  <script src="/next-app.js?v=next3"></script>
+  <script src="/next-app.js?v=next5"></script>
   <script src="/settings.js?v=diag1"></script>
   <script src="/settings/tabs/control.js?v=tabsplit1"></script>
   <script src="/settings/tabs/devices.js?v=tabsplit1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -121,11 +121,31 @@
     <div class="signin-gate-card">
       <div class="signin-gate-brand">&#9889; forty-two watts</div>
       <p class="signin-gate-lead signin-gate-connecting">Reaching your home&hellip;</p>
+
+      <!-- signin mode: passkey (or silent device) sign-in -->
       <div class="signin-gate-auth">
-        <p class="signin-gate-lead">Sign in with your passkey to reach your home.</p>
+        <p class="signin-gate-lead">Sign in to reach your home.</p>
         <button id="signin-gate-btn" class="signin-gate-btn">Sign in</button>
         <p class="signin-gate-msg" id="signin-banner-msg" role="status" aria-live="polite"></p>
         <p class="signin-gate-setup">First time on this device? <a href="/owner-access/">Set it up &rarr;</a></p>
+      </div>
+
+      <!-- setup mode: this device has no key — it was never set up on the LAN, so
+           it can't be remembered or proven to the relay. Send the user to the
+           home-network enrollment instead of a passkey prompt they can't satisfy. -->
+      <div class="signin-gate-needs-setup">
+        <p class="signin-gate-lead">Set up this device first.</p>
+        <p class="signin-gate-sub">This browser hasn&rsquo;t been set up to reach your home yet. Open this page on your home Wi&#8209;Fi, once, to add it &mdash; after that it signs in here automatically.</p>
+        <a class="signin-gate-btn" href="/owner-access/">Set up this device &rarr;</a>
+      </div>
+
+      <!-- Security clarity (Fredrik's ask): make the trust model legible. The
+           connection is direct & end-to-end encrypted to YOUR Pi; the relay only
+           forwards ciphertext and never sees your home. Reflected live by
+           next-app.js from the P2P transport state. -->
+      <div class="signin-gate-trust" id="signin-gate-trust">
+        <span class="signin-gate-trust-dot"></span>
+        <span class="signin-gate-trust-text" id="signin-gate-trust-text">End-to-end encrypted to your Pi. The relay never sees your home.</span>
       </div>
     </div>
   </div>
@@ -713,6 +733,11 @@
     </div>
   </ftw-modal>
 
+  <!-- Device-key store (home-route Phase 5): mints / loads this device's silent
+       login key and exposes window.ftwDeviceKey for p2p.js (C2) + next-app.js
+       (C3). A module, so it's deferred — p2p.js's warm-up connect soft-fails once
+       if it races ahead and retries promptly once the global is present. -->
+  <script type="module" src="/owner-access/device-key.js?v=devkey1"></script>
   <script src="/p2p.js?v=p2p5"></script>
   <script src="/next-app.js?v=next6"></script>
   <script src="/settings.js?v=diag1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -27,13 +27,30 @@
         'data-theme', saved || (osLight ? 'light' : 'dark'));
     })();
   </script>
+  <!-- Cover the dashboard with the sign-in gate from the FIRST paint on a remote
+       origin, so a reload never flashes the dashboard before next-app.js loads.
+       setupAuth() unlocks it once whoami confirms a signed-in owner (and the LAN
+       bypass never gates). Mirrors next-app.js's isLanFallbackOrigin, minimally. -->
+  <script>
+    (function () {
+      try {
+        var h = (location.hostname || '').toLowerCase();
+        var lan = h === 'localhost' || h === '::1' || h.indexOf('.') === -1 ||
+                  h.slice(-6) === '.local' ||
+                  /^(10\.|127\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[01])\.)/.test(h);
+        if (!lan && !/^\/me\//.test(location.pathname)) {
+          document.documentElement.classList.add('ftw-gated');
+        }
+      } catch (e) {}
+    })();
+  </script>
   <!-- Design tokens FIRST — every sheet and every <ftw-*> shadow root reads
        from :root declared in /components/theme.css. -->
   <link rel="stylesheet" href="/components/theme.css">
   <link rel="stylesheet" href="/style.css?v=lp2">
   <!-- /next-only visual redesign — layered on top of style.css and scoped
        to body.ftw-next so legacy /index.html is untouched. -->
-  <link rel="stylesheet" href="/next.css?v=next4">
+  <link rel="stylesheet" href="/next.css?v=next6">
   <!-- Three.js bare-specifier resolution. Three is vendored under
        /vendor/three/ (pinned 0.160.0) rather than pulled from a CDN
        so we have no supply-chain surface area and no SRI gap — an
@@ -100,7 +117,7 @@
        SAME strict P2P channel (no redirect). data-mode = connecting | signin.
        Never shown on the LAN (bypass) or once signed in. No owner DATA is ever
        served unauthenticated — the gate is purely the lock's UI. -->
-  <div id="signin-gate" class="signin-gate" data-mode="connecting" hidden>
+  <div id="signin-gate" class="signin-gate" data-mode="connecting">
     <div class="signin-gate-card">
       <div class="signin-gate-brand">&#9889; forty-two watts</div>
       <p class="signin-gate-lead signin-gate-connecting">Reaching your home&hellip;</p>
@@ -697,7 +714,7 @@
   </ftw-modal>
 
   <script src="/p2p.js?v=p2p5"></script>
-  <script src="/next-app.js?v=next5"></script>
+  <script src="/next-app.js?v=next6"></script>
   <script src="/settings.js?v=diag1"></script>
   <script src="/settings/tabs/control.js?v=tabsplit1"></script>
   <script src="/settings/tabs/devices.js?v=tabsplit1"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,7 @@
   <link rel="stylesheet" href="/style.css?v=lp2">
   <!-- /next-only visual redesign — layered on top of style.css and scoped
        to body.ftw-next so legacy /index.html is untouched. -->
-  <link rel="stylesheet" href="/next.css?v=next2">
+  <link rel="stylesheet" href="/next.css?v=next3">
   <!-- Three.js bare-specifier resolution. Three is vendored under
        /vendor/three/ (pinned 0.160.0) rather than pulled from a CDN
        so we have no supply-chain surface area and no SRI gap — an
@@ -86,11 +86,23 @@
       <button id="settings-btn" class="settings-btn" data-menu-label="Settings" title="Settings">⚙</button>
       <ftw-update-badge></ftw-update-badge>
       <span id="version" class="version" title="Click for version info" style="cursor:pointer">...</span>
+      <button id="signin-btn" class="icon-btn" data-menu-label="Sign in" title="Sign in with your passkey" hidden>&#128273;</button>
       <button id="signout-btn" class="icon-btn" data-menu-label="Sign out" title="Sign out" hidden>&#9211;</button>
       <span id="p2p-status" class="p2p-status" title="Transport — click to toggle direct P2P" hidden><span class="p2p-dot"></span><span class="p2p-label"></span></span>
       <span id="conn-status" class="conn-status connected" title="Connected">&#9679;</span>
     </div>
   </header>
+
+  <!-- Inline sign-in prompt: the dashboard IS the door. next-app.js (setupAuth)
+       reveals this when whoami reports the viewer isn't signed in on a remote
+       origin, and runs the passkey ceremony over the SAME strict P2P channel —
+       no redirect to /owner-access/login.html (which would spawn a fresh channel
+       with no session). Hidden on the LAN (bypass) and once signed in. -->
+  <div id="signin-banner" class="signin-banner" hidden>
+    <span class="signin-banner-text">Sign in with your passkey to see and control your home.</span>
+    <button id="signin-banner-btn" class="signin-banner-btn">Sign in</button>
+    <span id="signin-banner-msg" class="signin-banner-msg" role="status" aria-live="polite"></span>
+  </div>
 
   <!-- Settings Modal -->
   <div id="settings-modal" class="modal hidden">
@@ -676,7 +688,7 @@
   </ftw-modal>
 
   <script src="/p2p.js?v=p2p5"></script>
-  <script src="/next-app.js?v=next2"></script>
+  <script src="/next-app.js?v=next3"></script>
   <script src="/settings.js?v=diag1"></script>
   <script src="/settings/tabs/control.js?v=tabsplit1"></script>
   <script src="/settings/tabs/devices.js?v=tabsplit1"></script>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -3486,8 +3486,8 @@
   // explanation.)
   function setupP2PIndicator() {
     var el = document.getElementById("p2p-status");
-    if (!el || !window.ftwP2P) return;
-    var label = el.querySelector(".p2p-label");
+    if (!window.ftwP2P) return;
+    var label = el && el.querySelector(".p2p-label");
     var titles = {
       direct: "Direct & end-to-end encrypted between your browser and your Pi — the relay sees nothing.",
       relay: "Relayed via a blind TURN server — still end-to-end encrypted; the relay only forwards ciphertext.",
@@ -3495,14 +3495,37 @@
       off: "Direct channel unavailable.",
     };
     var text = { direct: "Direct", relay: "Relayed", connecting: "Connecting…", off: "" };
-    el.style.cursor = "default";
+    if (el) el.style.cursor = "default";
+
+    // The sign-in gate's trust line mirrors the same transport, so a visitor sees
+    // the security story BEFORE they're signed in. Direct = end-to-end to the Pi;
+    // Relayed = still E2E, relay forwards ciphertext only.
+    var trust = document.getElementById("signin-gate-trust");
+    var trustText = document.getElementById("signin-gate-trust-text");
+    var trustCopy = {
+      direct: "Direct & end-to-end encrypted to your Pi. The relay never sees your home.",
+      relay: "End-to-end encrypted. The relay only forwards ciphertext — it never sees your home.",
+      connecting: "Opening an encrypted channel to your Pi…",
+      off: "End-to-end encrypted to your Pi. The relay never sees your home.",
+    };
+
     window.ftwP2P.onState(function (s) {
-      if (s === "off") { el.hidden = true; return; }
-      el.hidden = false;
-      el.classList.remove("p2p-direct", "p2p-relay", "p2p-connecting");
-      el.classList.add("p2p-" + s);
-      if (label) label.textContent = text[s] || "";
-      el.title = titles[s] || "Transport";
+      if (el) {
+        if (s === "off") { el.hidden = true; }
+        else {
+          el.hidden = false;
+          el.classList.remove("p2p-direct", "p2p-relay", "p2p-connecting");
+          el.classList.add("p2p-" + s);
+          if (label) label.textContent = text[s] || "";
+          el.title = titles[s] || "Transport";
+        }
+      }
+      if (trust) {
+        trust.classList.remove("is-relay", "is-connecting");
+        if (s === "relay") trust.classList.add("is-relay");
+        else if (s === "connecting") trust.classList.add("is-connecting");
+        if (trustText && trustCopy[s]) trustText.textContent = trustCopy[s];
+      }
     });
   }
 
@@ -3572,15 +3595,93 @@
     ownerNotAuthed = false;
   }
 
-  // runSignIn: the passkey login ceremony, over the dashboard's strict P2P
-  // transport. On success the Pi sets the owner session cookie (captured
-  // in-process by the channel Bridge) — we just refresh the data in place.
+  // ---- C3: silent device-key sign-in (no passkey) ---------------------------
+  // A device that was set up on the LAN (C4) holds a NON-EXTRACTABLE key the Pi
+  // pinned. Once the channel is open we can prove that key to the Pi to mint the
+  // owner session SILENTLY — no Face ID. Flow:
+  //   GET  /api/owner-access/device-challenge -> {challenge, exp_ms}
+  //   sign "ftw-device-pop:v1:<site>:<challenge>" with the device key
+  //   POST /api/owner-access/device-pop {device_pubkey, challenge, sig}
+  // All over ownerFetch (strict P2P), so the proof never crosses the relay in
+  // cleartext. Resolves true iff the session was minted. Resolves false (never
+  // throws) for "no device key", "no site", or any PoP failure — the caller then
+  // falls back to the passkey ceremony.
+  var devicePoPBusy = false;
+  function runDevicePoP() {
+    if (devicePoPBusy) return Promise.resolve(false);
+    // Need both the device-key store and the pinned site (for the signing string).
+    if (!window.ftwDeviceKey || typeof window.ftwDeviceKey.hasDeviceKey !== "function") {
+      return Promise.resolve(false);
+    }
+    if (!window.ftwP2P || typeof window.ftwP2P.site !== "function") {
+      return Promise.resolve(false);
+    }
+    devicePoPBusy = true;
+    return window.ftwDeviceKey.hasDeviceKey()
+      .then(function (has) {
+        if (!has) return false; // never enrolled on this device → passkey path
+        return Promise.all([window.ftwDeviceKey.getOrCreate(), window.ftwP2P.site()])
+          .then(function (pair) {
+            var key = pair[0], site = pair[1];
+            if (!site) return false;
+            return ownerFetch("/api/owner-access/device-challenge", { credentials: "same-origin" })
+              .then(function (r) { return r.ok ? r.json() : null; })
+              .then(function (ch) {
+                if (!ch || !ch.challenge) return false;
+                var msg = "ftw-device-pop:v1:" + site + ":" + ch.challenge;
+                return key.sign(msg).then(function (sig) {
+                  return ownerFetch("/api/owner-access/device-pop", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ device_pubkey: key.pubHex, challenge: ch.challenge, sig: sig }),
+                    credentials: "same-origin",
+                  }).then(function (pop) { return !!(pop && pop.ok); });
+                });
+              });
+          });
+      })
+      .catch(function () { return false; })
+      .then(function (ok) { devicePoPBusy = false; return ok; });
+  }
+
+  // applySignedIn refreshes the dashboard in place once a session is minted
+  // (passkey OR silent device-PoP). Shared so both paths converge.
+  function applySignedIn() {
+    hideGate();
+    fetchStatus();
+    fetchLiveHistory(true);
+    loadHistory(chartRange);
+    setupAuth(); // reflect the signed-in state (signout button)
+  }
+
+  // runSignIn: sign in over the dashboard's strict P2P transport. Tries the SILENT
+  // device-key path FIRST (C3) — a returning device signs in with no Face ID — and
+  // only falls back to the passkey ceremony when there's no device key or the PoP
+  // fails. On success the Pi sets the owner session cookie (captured in-process by
+  // the channel Bridge); we just refresh the data in place.
   var signInBusy = false;
   function runSignIn() {
     if (signInBusy) return Promise.resolve(false);
     signInBusy = true;
     var msgEl = document.getElementById("signin-banner-msg");
     function say(t, cls) { if (msgEl) { msgEl.textContent = t || ""; msgEl.className = "signin-banner-msg" + (cls ? " " + cls : ""); } }
+    // Silent first: if this device is remembered, no passkey prompt at all.
+    say("Reaching your home…");
+    return runDevicePoP().then(function (silentOk) {
+      if (silentOk) {
+        signInBusy = false;
+        say("Signed in — this device is remembered.", "ok");
+        applySignedIn();
+        return true;
+      }
+      return runPasskeySignIn(say);
+    });
+  }
+
+  // runPasskeySignIn is the explicit passkey ceremony — the fallback when the
+  // silent device path isn't available. Kept as its own function so runSignIn can
+  // try silent first without duplicating the WebAuthn flow.
+  function runPasskeySignIn(say) {
     say("Waiting for your passkey…");
     return ownerFetch("/api/owner-access/login/start", { method: "POST" })
       .then(function (start) {
@@ -3611,13 +3712,7 @@
       })
       .then(function (ok) {
         signInBusy = false;
-        if (ok) {
-          hideGate();
-          fetchStatus();
-          fetchLiveHistory(true);
-          loadHistory(chartRange);
-          setupAuth(); // reflect the signed-in state (signout button)
-        }
+        if (ok) applySignedIn();
         return ok;
       });
   }
@@ -3643,15 +3738,47 @@
         if (me && me.can_sign_out) {            // signed-in remote session
           if (signoutBtn) signoutBtn.hidden = false;
           hideGate();
-        } else if (me && me.authenticated) {    // genuine-LAN bypass — full access
+          return;
+        }
+        if (me && me.authenticated) {           // genuine-LAN bypass — full access
           if (signoutBtn) signoutBtn.hidden = true;
           hideGate();
-        } else {                                // not signed in (remote) → show the gate
-          if (signoutBtn) signoutBtn.hidden = true;
-          showGate("signin");
+          return;
         }
+        // Not signed in (remote). Try the SILENT device-key path (C3) ONCE before
+        // showing the gate — a remembered device signs in with no Face ID. Only
+        // when there's no device key / PoP fails do we fall back to the passkey
+        // gate. silentAuthTried guards against re-running it on every channel
+        // reconnect.
+        if (signoutBtn) signoutBtn.hidden = true;
+        if (!silentAuthTried) {
+          silentAuthTried = true;
+          runDevicePoP().then(function (ok) {
+            if (ok) { applySignedIn(); return; }
+            showSignInGate();
+          });
+          return;
+        }
+        showSignInGate();
       })
       .catch(function () { /* channel down → leave the gate as-is (connecting) */ });
+  }
+
+  // silentAuthTried: the C3 silent device-PoP is attempted at most once per page
+  // load (it's idempotent but pointless to repeat on every reconnect).
+  var silentAuthTried = false;
+
+  // showSignInGate reveals the passkey gate, choosing the copy by whether this
+  // device is even capable of being remembered. If p2p.js reports the origin is
+  // UNENROLLED (no device key — never set up on the LAN), we surface the explicit
+  // "set up this device on your home network first" path (C2) instead of a passkey
+  // prompt the user can't satisfy here.
+  function showSignInGate() {
+    var unEnrolled = false;
+    try {
+      unEnrolled = !!(window.ftwP2P && window.ftwP2P.isUnenrolled && window.ftwP2P.isUnenrolled());
+    } catch (e) { /* default to the normal sign-in gate */ }
+    showGate(unEnrolled ? "setup" : "signin");
   }
 
   // ---- Init ----

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -3561,13 +3561,14 @@
   // also suppresses the "no devices configured" prompt for logged-out viewers.
   var ownerNotAuthed = false;
   function showGate(mode) {
+    document.documentElement.classList.add("ftw-gated"); // CSS shows the gate, hides nothing else needed (opaque overlay)
     var g = document.getElementById("signin-gate");
-    if (g) { g.hidden = false; g.setAttribute("data-mode", mode || "signin"); }
+    if (g) g.setAttribute("data-mode", mode || "signin");
     ownerNotAuthed = (mode !== "connecting");
     if (ownerNotAuthed && typeof hideSetupBanner === "function") { try { hideSetupBanner(); } catch (e) {} }
   }
   function hideGate() {
-    var g = document.getElementById("signin-gate"); if (g) g.hidden = true;
+    document.documentElement.classList.remove("ftw-gated");
     ownerNotAuthed = false;
   }
 

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2072,6 +2072,7 @@
   // ---- Setup banner (bootstrap mode — no config yet) ----
   function showSetupBanner() {
     if (setupBannerShown) return;
+    if (ownerNotAuthed) return; // a logged-out viewer's empty status ≠ "no devices"
     var banner = document.createElement("div");
     banner.id = "setup-banner";
     banner.className = "setup-banner";
@@ -2089,6 +2090,7 @@
   // ---- "Add a device" prompt when drivers object is empty ----
   function updateNoDevicesPrompt(drivers) {
     var existing = document.getElementById("no-devices-prompt");
+    if (ownerNotAuthed) { if (existing) existing.remove(); return; } // not our config to judge when logged out
     var hasDrivers = drivers && typeof drivers === "object" && Object.keys(drivers).length > 0;
     if (hasDrivers) {
       if (existing) existing.remove();
@@ -3476,19 +3478,24 @@
   }
 
   // ---- P2P transport indicator ----
-  // Reflects window.ftwP2P state (direct / relay / connecting); click toggles
-  // direct P2P on/off (persisted). Hidden only when WebRTC is unsupported.
+  // Reflects window.ftwP2P state (direct / relay / connecting). PURELY
+  // INFORMATIONAL — it explains how your browser is talking to your Pi; it is
+  // NOT a toggle. (The old click-to-toggle "disable direct P2P" made no sense on
+  // the P2P-only home route — there's no cleartext relay fallback for owner data,
+  // so disabling it just broke the channel. Tap/hover now only reveals the
+  // explanation.)
   function setupP2PIndicator() {
     var el = document.getElementById("p2p-status");
     if (!el || !window.ftwP2P) return;
     var label = el.querySelector(".p2p-label");
     var titles = {
-      direct: "Direct P2P — end-to-end encrypted, bypassing the relay",
-      relay: "Via relay — click to toggle direct P2P",
-      connecting: "Connecting direct P2P…",
-      off: "Direct P2P unavailable",
+      direct: "Direct & end-to-end encrypted between your browser and your Pi — the relay sees nothing.",
+      relay: "Relayed via a blind TURN server — still end-to-end encrypted; the relay only forwards ciphertext.",
+      connecting: "Opening a direct, encrypted channel to your Pi…",
+      off: "Direct channel unavailable.",
     };
-    var text = { direct: "Direct", relay: "Relay", connecting: "P2P…", off: "" };
+    var text = { direct: "Direct", relay: "Relayed", connecting: "Connecting…", off: "" };
+    el.style.cursor = "default";
     window.ftwP2P.onState(function (s) {
       if (s === "off") { el.hidden = true; return; }
       el.hidden = false;
@@ -3496,10 +3503,6 @@
       el.classList.add("p2p-" + s);
       if (label) label.textContent = text[s] || "";
       el.title = titles[s] || "Transport";
-    });
-    el.addEventListener("click", function () {
-      var disabled = localStorage.getItem("ftw.p2p") === "off";
-      window.ftwP2P.setEnabled(disabled); // toggle
     });
   }
 
@@ -3551,13 +3554,21 @@
     };
   }
 
-  function showSignIn() {
-    var b = document.getElementById("signin-banner"); if (b) b.hidden = false;
-    var k = document.getElementById("signin-btn"); if (k) k.hidden = false;
+  // The sign-in GATE replaces the dashboard when the viewer isn't signed in on a
+  // remote origin — so a logged-out visitor sees a clean "sign in to reach your
+  // home", never the empty dashboard chrome (which falsely reads as an
+  // unconfigured instance). On the LAN (bypass) the gate never shows. ownerNotAuthed
+  // also suppresses the "no devices configured" prompt for logged-out viewers.
+  var ownerNotAuthed = false;
+  function showGate(mode) {
+    var g = document.getElementById("signin-gate");
+    if (g) { g.hidden = false; g.setAttribute("data-mode", mode || "signin"); }
+    ownerNotAuthed = (mode !== "connecting");
+    if (ownerNotAuthed && typeof hideSetupBanner === "function") { try { hideSetupBanner(); } catch (e) {} }
   }
-  function hideSignIn() {
-    var b = document.getElementById("signin-banner"); if (b) b.hidden = true;
-    var k = document.getElementById("signin-btn"); if (k) k.hidden = true;
+  function hideGate() {
+    var g = document.getElementById("signin-gate"); if (g) g.hidden = true;
+    ownerNotAuthed = false;
   }
 
   // runSignIn: the passkey login ceremony, over the dashboard's strict P2P
@@ -3600,25 +3611,23 @@
       .then(function (ok) {
         signInBusy = false;
         if (ok) {
-          hideSignIn();
+          hideGate();
           fetchStatus();
           fetchLiveHistory(true);
           loadHistory(chartRange);
-          setupAuth(); // flip signin → signout
+          setupAuth(); // reflect the signed-in state (signout button)
         }
         return ok;
       });
   }
 
-  // setupAuth wires the buttons once, then reflects the current whoami state.
-  // Safe to call repeatedly (on load and whenever the P2P channel (re)connects),
-  // since whoami needs the channel up to answer on a remote origin.
+  // setupAuth wires the gate/signout buttons once, then reflects the current
+  // whoami state. Safe to call repeatedly (on load and whenever the P2P channel
+  // (re)connects), since whoami needs the channel up to answer on a remote origin.
   function setupAuth() {
     var signoutBtn = document.getElementById("signout-btn");
-    var signinBtn = document.getElementById("signin-btn");
-    var bannerBtn = document.getElementById("signin-banner-btn");
-    if (signinBtn && !signinBtn._wired) { signinBtn._wired = true; signinBtn.onclick = function () { runSignIn(); }; }
-    if (bannerBtn && !bannerBtn._wired) { bannerBtn._wired = true; bannerBtn.onclick = function () { runSignIn(); }; }
+    var gateBtn = document.getElementById("signin-gate-btn");
+    if (gateBtn && !gateBtn._wired) { gateBtn._wired = true; gateBtn.onclick = function () { runSignIn(); }; }
     if (signoutBtn && !signoutBtn._wired) {
       signoutBtn._wired = true;
       signoutBtn.onclick = function () {
@@ -3632,19 +3641,24 @@
       .then(function (me) {
         if (me && me.can_sign_out) {            // signed-in remote session
           if (signoutBtn) signoutBtn.hidden = false;
-          hideSignIn();
+          hideGate();
         } else if (me && me.authenticated) {    // genuine-LAN bypass — full access
           if (signoutBtn) signoutBtn.hidden = true;
-          hideSignIn();
-        } else {                                // not signed in (remote) → reveal sign-in
+          hideGate();
+        } else {                                // not signed in (remote) → show the gate
           if (signoutBtn) signoutBtn.hidden = true;
-          showSignIn();
+          showGate("signin");
         }
       })
-      .catch(function () { /* channel down → leave as-is; re-checked on reconnect */ });
+      .catch(function () { /* channel down → leave the gate as-is (connecting) */ });
   }
 
   // ---- Init ----
+  // On a remote/public origin, cover the dashboard with the gate ("connecting…")
+  // BEFORE any data fetch renders, so a logged-out visitor never sees the empty
+  // dashboard chrome. setupAuth() resolves it to the dashboard (signed in) or the
+  // sign-in card (not). On the LAN (bypass) the gate never shows.
+  if (typeof isLanFallbackOrigin === "function" && !isLanFallbackOrigin()) showGate("connecting");
   loadHistory(chartRange);
   fetchStatus();
   fetchLiveHistory();

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -3503,27 +3503,145 @@
     });
   }
 
-  // ---- Sign out (remote sessions only) ----
-  // whoami reports whether there's a real session to revoke; on the LAN
-  // (bypass) there's nothing to sign out of, so the button stays hidden.
-  function setupSignOut() {
-    var btn = document.getElementById("signout-btn");
-    if (!btn) return;
-    // whoami carries the owner session cookie and logout revokes it — both are
-    // owner/CONTROL calls, so route them strict (FIX-B): they must never traverse
-    // the relay on the public home route.
+  // ---- Owner auth: inline sign-in + sign-out (the dashboard IS the door) ----
+  // whoami reports whether the viewer is signed in (and whether there's a
+  // session to revoke). On the LAN (bypass) there's nothing to sign in/out of.
+  // Remotely, when NOT signed in, we reveal an inline passkey sign-in (a discreet
+  // banner + a header key) and run the ceremony over the SAME strict P2P channel —
+  // no redirect to /owner-access/login.html, which would spawn a fresh channel
+  // with no session. All three calls (whoami, login/*, logout) ride ownerFetch
+  // (strict / FIX-B) so they never traverse the relay in cleartext.
+
+  // Minimal WebAuthn codec — mirrors owner-access/webauthn.js. next-app.js is a
+  // classic script, so it can't `import` the module; these few helpers are tiny.
+  function b64urlToBuf(s) {
+    if (typeof s !== "string") return s;
+    var pad = "=".repeat((4 - (s.length % 4)) % 4);
+    var b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+    var bin = atob(b64), buf = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+    return buf.buffer;
+  }
+  function bufToB64url(buf) {
+    var bytes = new Uint8Array(buf), bin = "";
+    for (var i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+  function decodeAssertionOptions(opts) {
+    opts = JSON.parse(JSON.stringify(opts));
+    if (opts.publicKey) opts = opts.publicKey;
+    opts.challenge = b64urlToBuf(opts.challenge);
+    if (Array.isArray(opts.allowCredentials)) {
+      opts.allowCredentials = opts.allowCredentials.map(function (c) {
+        return Object.assign({}, c, { id: b64urlToBuf(c.id) });
+      });
+    }
+    return opts;
+  }
+  function encodeAssertionResult(cred) {
+    return {
+      id: cred.id, rawId: bufToB64url(cred.rawId), type: cred.type,
+      response: {
+        clientDataJSON: bufToB64url(cred.response.clientDataJSON),
+        authenticatorData: bufToB64url(cred.response.authenticatorData),
+        signature: bufToB64url(cred.response.signature),
+        userHandle: cred.response.userHandle ? bufToB64url(cred.response.userHandle) : null,
+      },
+      clientExtensionResults: cred.getClientExtensionResults ? cred.getClientExtensionResults() : {},
+    };
+  }
+
+  function showSignIn() {
+    var b = document.getElementById("signin-banner"); if (b) b.hidden = false;
+    var k = document.getElementById("signin-btn"); if (k) k.hidden = false;
+  }
+  function hideSignIn() {
+    var b = document.getElementById("signin-banner"); if (b) b.hidden = true;
+    var k = document.getElementById("signin-btn"); if (k) k.hidden = true;
+  }
+
+  // runSignIn: the passkey login ceremony, over the dashboard's strict P2P
+  // transport. On success the Pi sets the owner session cookie (captured
+  // in-process by the channel Bridge) — we just refresh the data in place.
+  var signInBusy = false;
+  function runSignIn() {
+    if (signInBusy) return Promise.resolve(false);
+    signInBusy = true;
+    var msgEl = document.getElementById("signin-banner-msg");
+    function say(t, cls) { if (msgEl) { msgEl.textContent = t || ""; msgEl.className = "signin-banner-msg" + (cls ? " " + cls : ""); } }
+    say("Waiting for your passkey…");
+    return ownerFetch("/api/owner-access/login/start", { method: "POST" })
+      .then(function (start) {
+        if (start.status === 404) { say("No passkey here yet — set up this device on your home network first.", "err"); return null; }
+        if (!start.ok) { say("Sign-in unavailable (" + start.status + ").", "err"); return null; }
+        return start.json();
+      })
+      .then(function (data) {
+        if (!data) return false;
+        return navigator.credentials.get({ publicKey: decodeAssertionOptions(data.options) }).then(function (cred) {
+          if (!cred) { say(""); return false; }
+          return ownerFetch("/api/owner-access/login/finish?ceremony_token=" + encodeURIComponent(data.ceremony_token), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(encodeAssertionResult(cred)),
+            credentials: "same-origin",
+          }).then(function (finish) {
+            if (!finish.ok) { say("Sign-in failed (" + finish.status + ").", "err"); return false; }
+            say("Signed in.", "ok");
+            return true;
+          });
+        });
+      })
+      .catch(function (e) {
+        if (e && e.name === "AbortError") { say(""); return false; }
+        say((e && e.message) || "Sign-in error.", "err");
+        return false;
+      })
+      .then(function (ok) {
+        signInBusy = false;
+        if (ok) {
+          hideSignIn();
+          fetchStatus();
+          fetchLiveHistory(true);
+          loadHistory(chartRange);
+          setupAuth(); // flip signin → signout
+        }
+        return ok;
+      });
+  }
+
+  // setupAuth wires the buttons once, then reflects the current whoami state.
+  // Safe to call repeatedly (on load and whenever the P2P channel (re)connects),
+  // since whoami needs the channel up to answer on a remote origin.
+  function setupAuth() {
+    var signoutBtn = document.getElementById("signout-btn");
+    var signinBtn = document.getElementById("signin-btn");
+    var bannerBtn = document.getElementById("signin-banner-btn");
+    if (signinBtn && !signinBtn._wired) { signinBtn._wired = true; signinBtn.onclick = function () { runSignIn(); }; }
+    if (bannerBtn && !bannerBtn._wired) { bannerBtn._wired = true; bannerBtn.onclick = function () { runSignIn(); }; }
+    if (signoutBtn && !signoutBtn._wired) {
+      signoutBtn._wired = true;
+      signoutBtn.onclick = function () {
+        ownerFetch("/api/owner-access/logout", { method: "POST", credentials: "same-origin" })
+          .catch(function () {})
+          .then(function () { location.reload(); });
+      };
+    }
     ownerFetch("/api/owner-access/whoami", { credentials: "same-origin" })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (me) {
-        if (!me || !me.can_sign_out) return; // LAN bypass / not signed in
-        btn.hidden = false;
-        btn.onclick = function () {
-          ownerFetch("/api/owner-access/logout", { method: "POST", credentials: "same-origin" })
-            .catch(function () {})
-            .then(function () { location.href = "/owner-access/"; });
-        };
+        if (me && me.can_sign_out) {            // signed-in remote session
+          if (signoutBtn) signoutBtn.hidden = false;
+          hideSignIn();
+        } else if (me && me.authenticated) {    // genuine-LAN bypass — full access
+          if (signoutBtn) signoutBtn.hidden = true;
+          hideSignIn();
+        } else {                                // not signed in (remote) → reveal sign-in
+          if (signoutBtn) signoutBtn.hidden = true;
+          showSignIn();
+        }
       })
-      .catch(function () { /* whoami failed → leave the button hidden */ });
+      .catch(function () { /* channel down → leave as-is; re-checked on reconnect */ });
   }
 
   // ---- Init ----
@@ -3531,7 +3649,12 @@
   fetchStatus();
   fetchLiveHistory();
   setupP2PIndicator();
-  setupSignOut();
+  setupAuth();
+  // whoami needs the P2P channel up to answer on a remote origin, so the load-time
+  // call may race the connection — re-check whenever the channel (re)connects.
+  if (window.ftwP2P && typeof window.ftwP2P.onState === "function") {
+    window.ftwP2P.onState(function (s) { if (s === "direct" || s === "relay") setupAuth(); });
+  }
   setInterval(fetchStatus, POLL_INTERVAL);
   setInterval(function () { fetchLiveHistory(true); }, 60_000); // 1-min refresh — always fresh
   window.addEventListener("resize", function () {

--- a/web/next.css
+++ b/web/next.css
@@ -258,12 +258,12 @@ body.ftw-next .signin-gate {
   position: fixed;
   inset: 0;
   z-index: 2000;
-  display: grid;
+  display: none;            /* shown via html.ftw-gated — set pre-paint (no flash) + by JS */
   place-items: center;
   background: var(--bg);
   font-family: var(--sans);
 }
-body.ftw-next .signin-gate[hidden] { display: none; }
+html.ftw-gated body.ftw-next .signin-gate { display: grid; }
 body.ftw-next .signin-gate-card {
   width: min(92vw, 380px);
   padding: 30px 28px;

--- a/web/next.css
+++ b/web/next.css
@@ -252,8 +252,11 @@ body.ftw-next .icon-btn[aria-pressed="true"]:hover {
 /* Sign-in GATE — a full-screen lock over the dashboard for logged-out remote
    visitors (the dashboard IS the door; locked, it shows only the door, never
    the empty dashboard chrome). setupAuth() reveals it; data-mode flips between
-   "connecting" and "signin". Single amber accent; on-accent text near-black per
-   DESIGN.md; tokens flip cleanly in the light theme. */
+   "connecting" (reaching home), "signin" (passkey / silent device key) and
+   "setup" (this device has no key — send the user to LAN enrollment). A trust
+   line conveys the direct, end-to-end, relay-blind transport. Single amber
+   accent; on-accent text near-black per DESIGN.md; tokens flip cleanly in the
+   light theme. */
 body.ftw-next .signin-gate {
   position: fixed;
   inset: 0;
@@ -293,11 +296,54 @@ body.ftw-next .signin-gate-btn {
 body.ftw-next .signin-gate-btn:hover { filter: brightness(1.05); }
 body.ftw-next .signin-gate-msg { color: var(--fg-dim); font-size: 12px; margin: 12px 0 0; min-height: 1em; }
 body.ftw-next .signin-gate-msg.err { color: var(--accent-e); }
+body.ftw-next .signin-gate-msg.ok { color: var(--green-e); }
 body.ftw-next .signin-gate-setup { color: var(--fg-dim); font-size: 12px; margin: 18px 0 0; }
 body.ftw-next .signin-gate-setup a { color: var(--accent-e); text-decoration: none; }
-/* Mode switch: "connecting" shows only the reaching-home line; "signin" the card. */
-body.ftw-next .signin-gate[data-mode="connecting"] .signin-gate-auth { display: none; }
-body.ftw-next .signin-gate[data-mode="signin"] .signin-gate-connecting { display: none; }
+/* setup mode — "set up this device first" (no device key on this origin). */
+body.ftw-next .signin-gate-sub { color: var(--fg-dim); font-size: 12.5px; line-height: 1.5; margin: 0 0 18px; }
+body.ftw-next a.signin-gate-btn { display: inline-block; text-decoration: none; }
+
+/* Trust line — direct & E2E-encrypted, relay-blind. Mono eyebrow + 6 px status
+   dot per DESIGN.md; the accent glow on the dot is the only sanctioned shadow.
+   It carries p2p-direct / p2p-relay / p2p-connecting classes from next-app.js
+   so the dot colour tracks the live transport (green = direct, amber = relay). */
+body.ftw-next .signin-gate-trust {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 22px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  text-align: left;
+}
+body.ftw-next .signin-gate-trust-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--green-e);
+  box-shadow: 0 0 10px var(--green-e);
+}
+body.ftw-next .signin-gate-trust.is-relay .signin-gate-trust-dot { background: var(--accent-e); box-shadow: none; }
+body.ftw-next .signin-gate-trust.is-connecting .signin-gate-trust-dot { background: var(--fg-muted); box-shadow: none; }
+body.ftw-next .signin-gate-trust-text {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  line-height: 1.5;
+  color: var(--fg-muted);
+}
+
+/* Mode switch: "connecting" shows only the reaching-home line; "signin" the
+   passkey card; "setup" the set-up-this-device card. */
+body.ftw-next .signin-gate-auth { display: none; }
+body.ftw-next .signin-gate-needs-setup { display: none; }
+body.ftw-next .signin-gate[data-mode="signin"] .signin-gate-auth { display: block; }
+body.ftw-next .signin-gate[data-mode="setup"] .signin-gate-needs-setup { display: block; }
+body.ftw-next .signin-gate[data-mode="signin"] .signin-gate-connecting,
+body.ftw-next .signin-gate[data-mode="setup"] .signin-gate-connecting { display: none; }
+/* The trust line is meaningless while still "connecting" — hide it there. */
+body.ftw-next .signin-gate[data-mode="connecting"] .signin-gate-trust { display: none; }
 
 /* Hamburger — hidden on desktop, visible under 720 px. Lives next to
    the header-right cluster so it's always reachable even when that

--- a/web/next.css
+++ b/web/next.css
@@ -249,36 +249,55 @@ body.ftw-next .icon-btn[aria-pressed="true"]:hover {
   background: color-mix(in oklab, var(--accent-e) 24%, transparent);
 }
 
-/* Inline sign-in prompt — setupAuth() reveals it when whoami reports the
-   viewer isn't signed in on a remote origin (the dashboard IS the door).
-   Discreet hairline bar, single amber accent on the action; on-accent text
-   is near-black per DESIGN.md. Tokens flip cleanly in the light theme. */
-body.ftw-next .signin-banner {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--line);
-  background: var(--ink-raised);
+/* Sign-in GATE — a full-screen lock over the dashboard for logged-out remote
+   visitors (the dashboard IS the door; locked, it shows only the door, never
+   the empty dashboard chrome). setupAuth() reveals it; data-mode flips between
+   "connecting" and "signin". Single amber accent; on-accent text near-black per
+   DESIGN.md; tokens flip cleanly in the light theme. */
+body.ftw-next .signin-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: grid;
+  place-items: center;
+  background: var(--bg);
   font-family: var(--sans);
-  font-size: 13px;
 }
-body.ftw-next .signin-banner[hidden] { display: none; }
-body.ftw-next .signin-banner-text { color: var(--fg); }
-body.ftw-next .signin-banner-btn {
+body.ftw-next .signin-gate[hidden] { display: none; }
+body.ftw-next .signin-gate-card {
+  width: min(92vw, 380px);
+  padding: 30px 28px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--ink-raised);
+}
+body.ftw-next .signin-gate-brand {
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+  color: var(--fg-dim);
+  margin-bottom: 20px;
+}
+body.ftw-next .signin-gate-lead { color: var(--fg); font-size: 15px; margin: 0 0 18px; }
+body.ftw-next .signin-gate-btn {
   font: inherit;
   font-weight: 600;
-  padding: 6px 16px;
+  padding: 10px 18px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--accent-e);
   background: var(--accent-e);
   color: #0a0a0a;
   cursor: pointer;
 }
-body.ftw-next .signin-banner-btn:hover { filter: brightness(1.05); }
-body.ftw-next .signin-banner-msg { color: var(--fg-dim); font-size: 12px; }
-body.ftw-next .signin-banner-msg.err { color: var(--accent-e); }
+body.ftw-next .signin-gate-btn:hover { filter: brightness(1.05); }
+body.ftw-next .signin-gate-msg { color: var(--fg-dim); font-size: 12px; margin: 12px 0 0; min-height: 1em; }
+body.ftw-next .signin-gate-msg.err { color: var(--accent-e); }
+body.ftw-next .signin-gate-setup { color: var(--fg-dim); font-size: 12px; margin: 18px 0 0; }
+body.ftw-next .signin-gate-setup a { color: var(--accent-e); text-decoration: none; }
+/* Mode switch: "connecting" shows only the reaching-home line; "signin" the card. */
+body.ftw-next .signin-gate[data-mode="connecting"] .signin-gate-auth { display: none; }
+body.ftw-next .signin-gate[data-mode="signin"] .signin-gate-connecting { display: none; }
 
 /* Hamburger — hidden on desktop, visible under 720 px. Lives next to
    the header-right cluster so it's always reachable even when that

--- a/web/next.css
+++ b/web/next.css
@@ -249,6 +249,37 @@ body.ftw-next .icon-btn[aria-pressed="true"]:hover {
   background: color-mix(in oklab, var(--accent-e) 24%, transparent);
 }
 
+/* Inline sign-in prompt — setupAuth() reveals it when whoami reports the
+   viewer isn't signed in on a remote origin (the dashboard IS the door).
+   Discreet hairline bar, single amber accent on the action; on-accent text
+   is near-black per DESIGN.md. Tokens flip cleanly in the light theme. */
+body.ftw-next .signin-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--ink-raised);
+  font-family: var(--sans);
+  font-size: 13px;
+}
+body.ftw-next .signin-banner[hidden] { display: none; }
+body.ftw-next .signin-banner-text { color: var(--fg); }
+body.ftw-next .signin-banner-btn {
+  font: inherit;
+  font-weight: 600;
+  padding: 6px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--accent-e);
+  background: var(--accent-e);
+  color: #0a0a0a;
+  cursor: pointer;
+}
+body.ftw-next .signin-banner-btn:hover { filter: brightness(1.05); }
+body.ftw-next .signin-banner-msg { color: var(--fg-dim); font-size: 12px; }
+body.ftw-next .signin-banner-msg.err { color: var(--accent-e); }
+
 /* Hamburger — hidden on desktop, visible under 720 px. Lives next to
    the header-right cluster so it's always reachable even when that
    cluster is collapsed into the drawer below. */

--- a/web/owner-access/device-key.js
+++ b/web/owner-access/device-key.js
@@ -1,0 +1,198 @@
+// device-key.js — silent device-key store for the home route (Phase 5).
+//
+// WHAT THIS IS
+// A per-device, NON-EXTRACTABLE ECDSA P-256 keypair minted at LAN enrollment,
+// persisted in IndexedDB keyed by ORIGIN, and used afterwards to:
+//   - prove this device to the RELAY before posting a WebRTC offer (C2), so the
+//     relay only ever wakes the Pi for a known device — never a stranger; and
+//   - prove the device to the PI over the open channel to mint the owner session
+//     SILENTLY (C3) — no Face ID for a returning device.
+//
+// WHY NON-EXTRACTABLE
+// The private key never leaves the browser's key store. A compromised page can
+// ask it to SIGN (the same trust boundary as a passkey) but can never exfiltrate
+// it — so a leaked key can't be replayed from another machine. The matching
+// public key is pinned on the Pi at LAN enrollment (C4) and published to the
+// relay by the Pi (C1); only those two parties accept this device's signatures.
+//
+// WIRE FORMATS (must match the relay + Pi byte-for-byte — see CONTRACTS):
+//   - pubHex: uncompressed P-256 public key as X||Y, 128 lowercase hex chars
+//     (same convention as the nova site pubkey). NO 0x04 prefix in the hex.
+//   - signatures: ECDSA P-256 over SHA-256, raw r||s (64 bytes), base64url, no
+//     padding. WebCrypto ECDSA 'P-256' already produces raw r||s, so we only
+//     base64url-encode it. Go verifies by splitting the 64 bytes into r,s.
+//
+// Importable as a module (ESM) AND usable as a classic script: when loaded via
+// <script src> it also assigns window.ftwDeviceKey = { getOrCreate, exportPubHex,
+// hasDeviceKey }. next-app.js (a classic IIFE) consumes the window global; the
+// owner-access ceremony pages (ESM) import it.
+
+import { bufToB64url } from "./webauthn.js";
+
+const DB_NAME = "ftw-device-key";
+const STORE = "keys";
+// Keyed by ORIGIN so a key minted on one home origin can't be used as another's.
+// location.origin already distinguishes scheme+host+port.
+function recordKey() {
+  try {
+    return "device-key:" + (location.origin || "");
+  } catch (_) {
+    return "device-key:";
+  }
+}
+
+// ---- IndexedDB plumbing (promise-wrapped) ---------------------------------
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    let req;
+    try {
+      req = indexedDB.open(DB_NAME, 1);
+    } catch (e) {
+      reject(e);
+      return;
+    }
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error || new Error("indexedDB open failed"));
+  });
+}
+
+function idbGet(key) {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, "readonly");
+        const req = tx.objectStore(STORE).get(key);
+        req.onsuccess = () => resolve(req.result || null);
+        req.onerror = () => reject(req.error || new Error("idb get failed"));
+      }),
+  );
+}
+
+function idbPut(key, value) {
+  return openDB().then(
+    (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE, "readwrite");
+        const req = tx.objectStore(STORE).put(value, key);
+        req.onsuccess = () => resolve(true);
+        req.onerror = () => reject(req.error || new Error("idb put failed"));
+      }),
+  );
+}
+
+// ---- key material ----------------------------------------------------------
+
+// rawXYToHex turns WebCrypto's "raw" EC public key (0x04 || X || Y, 65 bytes)
+// into the 128-hex X||Y the relay + Pi expect. Drops the 0x04 lead byte.
+function rawXYToHex(rawBuf) {
+  const b = new Uint8Array(rawBuf);
+  if (b.length !== 65 || b[0] !== 0x04) {
+    throw new Error("unexpected EC raw public key length/format");
+  }
+  let hex = "";
+  for (let i = 1; i < b.length; i++) hex += (b[i] + 0x100).toString(16).slice(1);
+  return hex; // 128 lowercase hex chars
+}
+
+// makeHandle wraps a stored {privateKey, publicKey, pubHex} into the public
+// surface getOrCreate() resolves to: pubHex + sign().
+function makeHandle(rec) {
+  return {
+    pubHex: rec.pubHex,
+    // sign(utf8string) -> base64url(r||s) over SHA-256, matching the Go verifier.
+    sign(message) {
+      const data =
+        typeof message === "string"
+          ? new TextEncoder().encode(message)
+          : new Uint8Array(message);
+      return crypto.subtle
+        .sign({ name: "ECDSA", hash: "SHA-256" }, rec.privateKey, data)
+        .then((sig) => {
+          // WebCrypto returns raw r||s (64 bytes for P-256) — base64url it.
+          if (sig.byteLength !== 64) {
+            // Defensive: a non-64 length means a non-raw encoding slipped in;
+            // never silently sign with an off-contract format.
+            throw new Error("unexpected ECDSA signature length " + sig.byteLength);
+          }
+          return bufToB64url(sig);
+        });
+    },
+  };
+}
+
+let _cache = null; // in-memory handle, deduped per page load
+
+// getOrCreate resolves to { pubHex, sign(utf8)->Promise<b64url> }. It reuses the
+// per-origin key from IndexedDB if present, else mints a fresh NON-EXTRACTABLE
+// keypair, persists the CryptoKey pair (browsers can structured-clone a
+// non-extractable CryptoKey into IndexedDB; the bytes still never leave the
+// store), and returns the handle. Throws only on a hard crypto/IndexedDB failure
+// — callers MUST surface a clear "set up this device first" state rather than
+// silently proceeding.
+export function getOrCreate() {
+  if (_cache) return Promise.resolve(_cache);
+  const key = recordKey();
+  return idbGet(key)
+    .then((stored) => {
+      if (stored && stored.privateKey && stored.publicKey && stored.pubHex) {
+        return makeHandle(stored);
+      }
+      // Mint a fresh non-extractable keypair. extractable=false → the private key
+      // can never be exported; only sign() works. ["sign"] usage on the pair; the
+      // public key is exported as "raw" for pubHex (a public key is exportable
+      // regardless of the private key's extractable flag).
+      return crypto.subtle
+        .generateKey({ name: "ECDSA", namedCurve: "P-256" }, false, ["sign", "verify"])
+        .then((kp) =>
+          crypto.subtle.exportKey("raw", kp.publicKey).then((raw) => {
+            const pubHex = rawXYToHex(raw);
+            const rec = { privateKey: kp.privateKey, publicKey: kp.publicKey, pubHex };
+            // Persist; if the put fails we still return a usable in-memory handle
+            // for this load, but log so a broken store is visible.
+            return idbPut(key, rec)
+              .catch((e) => {
+                try {
+                  console.warn("device-key: persist failed: " + (e && e.message));
+                } catch (_) {}
+              })
+              .then(() => makeHandle(rec));
+          }),
+        );
+    })
+    .then((handle) => {
+      _cache = handle;
+      return handle;
+    });
+}
+
+// exportPubHex resolves the 128-hex public key (minting the key if needed). This
+// is what enroll/finish posts as "device_pubkey" so the Pi can pin it (C4).
+export function exportPubHex() {
+  return getOrCreate().then((h) => h.pubHex);
+}
+
+// hasDeviceKey resolves true iff a key already exists for THIS origin WITHOUT
+// minting one. The sign-in gate (C2/C3) uses it to decide between the silent
+// device path and the "set up this device first" prompt — minting here would be
+// wrong (a never-enrolled device would look enrolled to the relay, which has not
+// pinned the freshly-minted key).
+export function hasDeviceKey() {
+  if (_cache) return Promise.resolve(true);
+  return idbGet(recordKey())
+    .then((stored) => !!(stored && stored.privateKey && stored.publicKey && stored.pubHex))
+    .catch(() => false);
+}
+
+// Classic-script bridge for next-app.js (a plain IIFE that can't `import`).
+try {
+  if (typeof window !== "undefined") {
+    window.ftwDeviceKey = { getOrCreate, exportPubHex, hasDeviceKey };
+  }
+} catch (_) {
+  /* non-browser (test harness) — ignore */
+}

--- a/web/owner-access/device-key.test.mjs
+++ b/web/owner-access/device-key.test.mjs
@@ -1,0 +1,150 @@
+// node --test web/owner-access/device-key.test.mjs
+//
+// device-key.js mints + persists a NON-EXTRACTABLE ECDSA P-256 keypair per origin
+// and exposes getOrCreate / exportPubHex / hasDeviceKey. These tests exercise the
+// REAL WebCrypto path (node's globalThis.crypto.subtle) against an in-memory
+// IndexedDB shim, and lock in the wire contract the relay + Pi verify against:
+//   - pubHex: uncompressed X||Y, 128 lowercase hex chars, NO 0x04 prefix.
+//   - sign(utf8) -> base64url(raw r||s, 64 bytes), no padding — verifiable as a
+//     standard ECDSA P-256/SHA-256 signature (which is exactly what Go's
+//     ecdsa.Verify over the split r||s checks).
+
+import { describe, it, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// --- minimal in-memory IndexedDB shim --------------------------------------
+// Just enough of the IndexedDB surface device-key.js uses: open(name) ->
+// request{onupgradeneeded,onsuccess,result}, db.transaction(store,mode),
+// store.get(key)/put(value,key) -> request{onsuccess,onerror,result}.
+function makeIndexedDBShim() {
+  const data = new Map(); // store-name -> Map(key->value)
+  function reqFire(req, fn) {
+    queueMicrotask(() => {
+      try {
+        req.result = fn();
+        if (req.onsuccess) req.onsuccess();
+      } catch (e) {
+        req.error = e;
+        if (req.onerror) req.onerror();
+      }
+    });
+  }
+  return {
+    _data: data,
+    open() {
+      const db = {
+        objectStoreNames: { contains: (n) => data.has(n) },
+        createObjectStore: (n) => { if (!data.has(n)) data.set(n, new Map()); },
+        transaction: (name) => ({
+          objectStore: (n) => ({
+            get(key) { const r = {}; reqFire(r, () => data.get(n)?.get(key) ?? undefined); return r; },
+            put(value, key) { const r = {}; reqFire(r, () => { if (!data.has(n)) data.set(n, new Map()); data.get(n).set(key, value); return true; }); return r; },
+          }),
+        }),
+      };
+      const req = { result: db };
+      queueMicrotask(() => {
+        // schema upgrade first (v1), then success
+        if (req.onupgradeneeded) req.onupgradeneeded();
+        if (req.onsuccess) req.onsuccess();
+      });
+      return req;
+    },
+  };
+}
+
+// base64url -> Uint8Array (mirror of webauthn.js b64urlToBuf, returns bytes)
+function b64urlToBytes(s) {
+  const pad = "=".repeat((4 - (s.length % 4)) % 4);
+  const b64 = (s + pad).replace(/-/g, "+").replace(/_/g, "/");
+  const bin = Buffer.from(b64, "base64");
+  return new Uint8Array(bin);
+}
+function hexToBytes(h) {
+  const a = new Uint8Array(h.length >> 1);
+  for (let i = 0; i < a.length; i++) a[i] = parseInt(h.substr(i * 2, 2), 16);
+  return a;
+}
+
+let deviceKey;
+
+before(async () => {
+  globalThis.location = { origin: "https://home.example.com", pathname: "/" };
+  globalThis.window = globalThis.window || {};
+  globalThis.indexedDB = makeIndexedDBShim();
+  deviceKey = await import("./device-key.js?fresh=" + Date.now());
+});
+
+describe("device-key store (C2/C3/C4 key material)", () => {
+  it("getOrCreate resolves a handle with a 128-hex pubHex and sign()", async () => {
+    const h = await deviceKey.getOrCreate();
+    assert.equal(typeof h.sign, "function");
+    assert.match(h.pubHex, /^[0-9a-f]{128}$/, "pubHex must be 128 lowercase hex chars (X||Y, no 0x04)");
+  });
+
+  it("exportPubHex matches getOrCreate().pubHex and is stable across calls", async () => {
+    const a = await deviceKey.exportPubHex();
+    const b = await deviceKey.exportPubHex();
+    const h = await deviceKey.getOrCreate();
+    assert.equal(a, b, "same key reused → same pubHex");
+    assert.equal(a, h.pubHex);
+  });
+
+  it("sign(utf8) returns base64url(raw r||s) of 64 bytes — the wire contract", async () => {
+    const h = await deviceKey.getOrCreate();
+    const sig = await h.sign("ftw-signal:v1:site:Home:abc123");
+    assert.match(sig, /^[A-Za-z0-9_-]+$/, "base64url, no padding (no '=', no '+', no '/')");
+    const raw = b64urlToBytes(sig);
+    assert.equal(raw.length, 64, "P-256 raw r||s is exactly 64 bytes");
+  });
+
+  it("the signature verifies as standard ECDSA P-256/SHA-256 (Go ecdsa.Verify compatible)", async () => {
+    const h = await deviceKey.getOrCreate();
+    const message = "ftw-device-pop:v1:site:Home:challengeXYZ";
+    const sig = b64urlToBytes(await h.sign(message));
+    // Re-import the public key from pubHex exactly as Go would (X||Y) and verify
+    // the raw r||s signature — proving the bytes are a real ECDSA signature, which
+    // is what the Pi/relay (Go: split 64 bytes into r,s, ecdsa.Verify) accept.
+    const xy = hexToBytes(h.pubHex);
+    const raw = new Uint8Array(65);
+    raw[0] = 0x04;
+    raw.set(xy, 1);
+    const pub = await crypto.subtle.importKey(
+      "raw", raw.buffer, { name: "ECDSA", namedCurve: "P-256" }, false, ["verify"],
+    );
+    const ok = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" }, pub, sig, new TextEncoder().encode(message),
+    );
+    assert.equal(ok, true, "signature must verify against the published pubHex");
+  });
+
+  it("hasDeviceKey reports true once a key exists, without re-minting a new one", async () => {
+    const before = await deviceKey.exportPubHex();
+    assert.equal(await deviceKey.hasDeviceKey(), true);
+    const after = await deviceKey.exportPubHex();
+    assert.equal(after, before, "hasDeviceKey must not rotate the key");
+  });
+
+  it("exposes window.ftwDeviceKey for the classic-script consumers (p2p.js/next-app.js)", () => {
+    assert.equal(typeof globalThis.window.ftwDeviceKey, "object");
+    assert.equal(typeof globalThis.window.ftwDeviceKey.getOrCreate, "function");
+    assert.equal(typeof globalThis.window.ftwDeviceKey.exportPubHex, "function");
+    assert.equal(typeof globalThis.window.ftwDeviceKey.hasDeviceKey, "function");
+  });
+});
+
+describe("hasDeviceKey on a FRESH origin does not mint (C2 unenrolled detection)", () => {
+  let fresh;
+  beforeEach(async () => {
+    // New origin + new IndexedDB → no stored key. hasDeviceKey() must stay false.
+    globalThis.location = { origin: "https://fresh.example.com", pathname: "/" };
+    globalThis.indexedDB = makeIndexedDBShim();
+    fresh = await import("./device-key.js?fresh2=" + Date.now());
+  });
+  it("returns false when nothing is stored (and persists nothing)", async () => {
+    assert.equal(await fresh.hasDeviceKey(), false, "a never-enrolled origin is unenrolled");
+    // Confirm the probe did NOT create a key store entry.
+    const store = globalThis.indexedDB._data.get("keys");
+    assert.ok(!store || store.size === 0, "hasDeviceKey must not write");
+  });
+});

--- a/web/owner-access/enroll.html
+++ b/web/owner-access/enroll.html
@@ -89,6 +89,7 @@
     import { decodeCreationOptions, encodeRegistrationResult } from "./webauthn.js";
     import { mountEnrollPin } from "./enroll-pin.js";
     import { ownerFetch } from "./owner-fetch.js";
+    import { exportPubHex } from "./device-key.js";
     const msg = document.getElementById("msg");
     const nameInput = document.getElementById("name");
     nameInput.focus();
@@ -129,13 +130,32 @@
         const credOpts = decodeCreationOptions(options);
         const cred = await navigator.credentials.create({ publicKey: credOpts });
 
-        // 3. Finish.
+        // 2b. Mint this device's silent-login key (C4). Enrollment is the ONLY
+        //     place it's created — it always runs on the LAN-trusted path (the
+        //     enroll ceremony rides strict P2P / genuine LAN), so the public key
+        //     we send here gets PINNED on the Pi's new credential. After this the
+        //     device can sign in over the relay with NO passkey (C2/C3). A failure
+        //     to mint must not silently drop the field — it would leave the device
+        //     un-rememberable without any signal — so we surface it.
+        let devicePubHex;
+        try {
+          devicePubHex = await exportPubHex();
+        } catch (e) {
+          msg.innerHTML = `<div class="err">Couldn't set up this device's silent-login key (${e.name}: ${e.message}). Your passkey still works; this device just won't be remembered.</div>`;
+          // Continue without the field rather than abort the passkey enrollment.
+          devicePubHex = null;
+        }
+
+        // 3. Finish. The device_pubkey rides INSIDE the WebAuthn registration JSON
+        //    body (C4): the Pi pins it on the NEW credential's trusted_devices row.
+        const finishBody = encodeRegistrationResult(cred);
+        if (devicePubHex) finishBody.device_pubkey = devicePubHex;
         const finish = await ownerFetch(
           "/api/owner-access/enroll/finish?ceremony_token=" + encodeURIComponent(ceremony_token) + "&name=" + encodeURIComponent(name),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(encodeRegistrationResult(cred)),
+            body: JSON.stringify(finishBody),
             credentials: "same-origin",
           }
         );

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -27,6 +27,10 @@
   var seq = 0;
   var listeners = [];
   var stateName = "off";             // off | connecting | direct | relay
+  var unenrolled = false;            // true once a connect() found NO device key
+                                     // for this origin (never LAN-enrolled). The
+                                     // sign-in gate reads this to prompt setup
+                                     // instead of looping on "connecting".
 
   // ---- base path: relay /me/<site> prefix, or "" for home-host / LAN ----
   function apiBase() {
@@ -100,6 +104,66 @@
     var s = "";
     for (var i = 0; i < b.length; i++) s += (b[i] + 0x100).toString(16).slice(1);
     return s;
+  }
+
+  // challengeURL is the relay's per-site device-proof challenge endpoint (C2). It
+  // lives at the relay ROOT alongside /signal/<site>/{offer,answer} and is keyed
+  // by site_id only — never under the /me/<site> tunnel prefix.
+  function challengeURL(site) {
+    return "/signal/" + encodeURIComponent(site) + "/challenge";
+  }
+
+  // ---- device-key proof for the relay (C2) ----------------------------------
+  // Before an offer ever reaches the Pi, the browser must prove it holds a key
+  // the Pi has published to the relay (C1). The relay refuses (403) — and the Pi
+  // is NEVER contacted — for any offer without a valid proof. We:
+  //   1. GET /signal/<site>/challenge  -> {nonce, exp_ms}
+  //   2. sign "ftw-signal:v1:<site>:<nonce>" with the device key
+  //   3. include {device_pubkey, nonce, sig} in the offer POST.
+  // If this device has no key (never enrolled on the LAN), there is nothing to
+  // prove with — we set the "unenrolled" state so the gate can tell the user to
+  // set up this device on their home network first, and abort the attempt rather
+  // than firing a doomed offer.
+  function deviceKeyHandle() {
+    // Use the same per-origin device-key store the ceremony pages mint into. It's
+    // attached to window by device-key.js (loaded as a classic script before this
+    // on the dashboard). hasDeviceKey() must NOT mint — a freshly-minted key the
+    // Pi hasn't pinned would look enrolled to the relay but be rejected by the Pi.
+    if (!window.ftwDeviceKey || typeof window.ftwDeviceKey.getOrCreate !== "function") {
+      var e = new Error("device-key store not loaded yet");
+      e.code = "store-pending"; // transient — module script hasn't run yet
+      return Promise.reject(e);
+    }
+    return window.ftwDeviceKey.hasDeviceKey().then(function (has) {
+      if (!has) {
+        var err = new Error("no device key for this origin — enroll on the LAN first");
+        err.code = "no-device-key";
+        return Promise.reject(err);
+      }
+      return window.ftwDeviceKey.getOrCreate();
+    });
+  }
+
+  // signalProof fetches a fresh challenge nonce and signs it, returning the
+  // {device_pubkey, nonce, sig} the offer POST attaches. Fails closed: any error
+  // (no key, challenge fetch failure, sign failure) rejects so the offer is never
+  // sent — the relay would reject it anyway, and an unenrolled device must not
+  // wake the Pi.
+  function signalProof(site) {
+    return deviceKeyHandle().then(function (key) {
+      return fetch(challengeURL(site), { method: "GET" })
+        .then(function (r) {
+          if (!r.ok) throw new Error("signal challenge http " + r.status);
+          return r.json();
+        })
+        .then(function (ch) {
+          if (!ch || !ch.nonce) throw new Error("signal challenge missing nonce");
+          var msg = "ftw-signal:v1:" + site + ":" + ch.nonce;
+          return key.sign(msg).then(function (sig) {
+            return { device_pubkey: key.pubHex, nonce: ch.nonce, sig: sig };
+          });
+        });
+    });
   }
 
   // ---- state broadcast (drives the dashboard transport indicator) ----
@@ -326,13 +390,17 @@
     connecting = new Promise(function (resolve) {
       var settled = false;
       var to;
-      function finish(ok) {
+      // finish(ok[, soft]): soft=true means "transient, retry soon" — used when the
+      // device-key store simply hasn't loaded yet at warm-up (a module-script load
+      // race), so we DON'T arm the long cooldown that would otherwise leave the page
+      // on the relay for 30 s for no reason.
+      function finish(ok, soft) {
         if (settled) return;
         settled = true;
         connecting = null;
         clearTimeout(to);
         if (!ok) {
-          nextRetryAt = Date.now() + RETRY_COOLDOWN_MS;
+          if (!soft) nextRetryAt = Date.now() + RETRY_COOLDOWN_MS;
           teardown();
           setState("relay");
         }
@@ -373,20 +441,36 @@
       pinnedIdentity()
         .then(function (pin) {
           var site = pin.site;
+          // C2: prove this device to the RELAY before the offer can reach the Pi.
+          // signalProof fetches a fresh challenge nonce and signs
+          // "ftw-signal:v1:<site>:<nonce>" with the device key. Done in parallel
+          // with the SDP/ICE work so it adds no latency on the happy path.
+          var proofP = signalProof(site);
           return pc.createOffer()
             .then(function (offer) { return pc.setLocalDescription(offer); })
             .then(function () { return waitIceComplete(pc); })
-            .then(function () {
+            .then(function () { return proofP; })
+            .then(function (proof) {
+              // The offer body is now a JSON envelope carrying the raw SDP PLUS the
+              // device-key proof (C2). The relay verifies {device_pubkey, nonce,
+              // sig} against the site's published key set + consumes the nonce, then
+              // parks the SDP for the Pi exactly as before. Field names are fixed by
+              // the contract — do not rename.
               return fetch(signalURL(site, "offer", nonce), {
                 method: "POST",
-                // The body is the raw SDP offer (the relay parks it verbatim and
-                // the Pi reads it raw); it is not a JSON envelope.
-                headers: { "Content-Type": "application/sdp" },
-                body: pc.localDescription.sdp
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  sdp: pc.localDescription.sdp,
+                  device_pubkey: proof.device_pubkey,
+                  nonce: proof.nonce,
+                  sig: proof.sig
+                })
               });
             })
             .then(function (r) {
-              // 204 = parked OK; anything else is a hard signaling error.
+              // 204 = parked OK; anything else is a hard signaling error. A 403
+              // means the relay rejected the device proof (unknown/again-used key);
+              // the Pi was NEVER contacted — fall back to the relay transport.
               if (r.status !== 204 && !r.ok) throw new Error("offer http " + r.status);
               return pollAnswer(site, nonce);
             })
@@ -402,7 +486,14 @@
         })
         .catch(function (e) {
           if (e && e.message) { try { console.warn("p2p: " + e.message); } catch (_) {} }
-          finish(false);
+          // No device key on this origin (never enrolled on the LAN): there is
+          // nothing to prove to the relay, so a direct channel can never open from
+          // here. Remember it so the sign-in gate shows "set up this device on your
+          // home network first" instead of a misleading endless "connecting".
+          if (e && e.code === "no-device-key") { unenrolled = true; }
+          // Soft-fail (store-pending): the device-key module hasn't run yet — retry
+          // soon instead of arming the long cooldown.
+          finish(false, e && e.code === "store-pending");
         });
     });
     return connecting;
@@ -553,6 +644,17 @@
     connect: connect,
     onState: function (fn) { listeners.push(fn); try { fn(stateName); } catch (e) {} },
     state: function () { return stateName; },
+    // isUnenrolled reports whether a connect() attempt found NO device key for this
+    // origin (this device was never set up on the LAN), so the relay can't be
+    // proven to and a direct channel can't open. The gate uses it to show the
+    // "set up this device on your home network first" path (C2) rather than a
+    // perpetual "connecting".
+    isUnenrolled: function () { return unenrolled; },
+    // site() resolves the pinned site_id (TOFU /api/identity, then localStorage).
+    // next-app.js needs it to build the C3 device-PoP signing string
+    // "ftw-device-pop:v1:<site>:<challenge>" — the SAME site p2p.js signs the
+    // signal proof over, so both ends agree.
+    site: function () { return pinnedIdentity().then(function (pin) { return pin.site; }); },
     setEnabled: function (on) {
       localStorage.setItem("ftw.p2p", on ? "on" : "off");
       if (!on) { teardown(); setState("relay"); }


### PR DESCRIPTION
## Summary
Closes the discoverability gap in the P2P-only home route: the dashboard now **is the door**. When you open `home.fortytwowatts.com` and aren't signed in, a discreet **"Sign in with your passkey"** banner (+ a header key) appears, and the passkey ceremony runs **in place** over the same strict P2P channel — no redirect to `/owner-access/login.html` (which would spawn a fresh channel with no session).

- `whoami`-driven: shown only when not signed in on a remote origin; hidden on the LAN bypass and once signed in. Re-checks when the P2P channel (re)connects (whoami needs the channel up to answer).
- Ceremony rides `ownerFetch` (strict / FIX-B) — login/start, login/finish, whoami, logout never traverse the relay in cleartext. The public-route fetch guard still passes.
- Styling uses DESIGN.md tokens (hairline, single amber accent, near-black on-accent text); flips cleanly in light theme.

Part of the #438 seamless-UX layer (the inline-login slice). Device-key silent re-auth + the discreet transport indicator are the remaining/already-shipped pieces.

## Verification
- Dev-deployed to the field Pi; confirmed in a browser on `home.fortytwowatts.com`: the banner + header key appear when unauthenticated, over a live `● DIRECT` channel (screenshot in chat).
- `node --test web/**` green incl. the public-route fetch guard; `next-app.js` parses.

## Test plan
- [ ] (owner) click **Sign in** on `home.*` off-WiFi → Face ID → dashboard populates with live data