### PR TITLE
docs(drivers): persistent ./data/drivers/ for custom drivers on Docker

### DIFF
--- a/docs/deploy-platforms.md
+++ b/docs/deploy-platforms.md
@@ -96,6 +96,14 @@ Open `http://<server-ip>:8080/` from another device on the LAN, or
   inverters falls back to `make:serial` (preferred, set by the driver)
   or `ep:<endpoint>`. See [device-identity.md](device-identity.md).
 
+- **Custom (unmerged) drivers go in `./data/drivers/`.** A driver you
+  wrote yourself — or a patched copy of a bundled one — belongs in the
+  persistent `./data/drivers/` directory, not `/app/drivers/` inside the
+  image. Files there survive image upgrades and reboots and shadow a
+  bundled driver of the same name; a `docker cp` into the running
+  container does **not** (it lands in the ephemeral container layer). See
+  [writing-a-driver.md §9](writing-a-driver.md#9-installing-a-custom-driver-on-a-docker-deploy).
+
 - **In-app updates work out of the box.** The `ftw-updater` sidecar in
   `docker-compose.yml` drives the web UI's Update / Restart buttons. See
   [self-update.md](self-update.md).

--- a/docs/writing-a-driver.md
+++ b/docs/writing-a-driver.md
@@ -405,3 +405,51 @@ DRIVER = {
 
 No function calls, no concatenation, no variables — the catalog loader
 reads the source as text.
+
+## 9. Installing a custom driver on a Docker deploy
+
+The Docker image ships the bundled drivers in `/app/drivers/`, which is
+part of the **immutable image layer** — replaced wholesale on every
+`docker compose pull`. A driver you wrote yourself, or a patched copy of
+a bundled one, lives nowhere in the image, so it needs a home that
+survives image upgrades. That home is the persistent `./data/drivers/`
+directory.
+
+`docker-compose.yml` bind-mounts `./data:/app/data`, and the container
+launches with `-user-drivers /app/data/drivers` (see the `CMD` in
+`Dockerfile`). At config-resolution time the EMS probes this directory
+**first** and only falls back to the bundled `/app/drivers/` when a file
+isn't found there (`go/internal/config/config.go`, `ResolveDriverPaths`).
+So a file in `./data/drivers/` is loaded, shadows any bundled driver of
+the same name, and persists across both image upgrades and power loss.
+Available since v0.100.0.
+
+To install one (the deploy directory is `~/forty-two-watts` after
+`scripts/install.sh`):
+
+```bash
+mkdir -p ~/forty-two-watts/data/drivers
+cp my-device.lua ~/forty-two-watts/data/drivers/
+
+# Linux only: the container runs as uid 100 / gid 101, so the file must
+# be readable by that user. (Docker Desktop on macOS maps ownership
+# transparently — skip this there.)
+sudo chown 100:101 ~/forty-two-watts/data/drivers/my-device.lua
+
+cd ~/forty-two-watts && sudo docker compose restart forty-two-watts
+```
+
+Reference it in `config.yaml` the normal way — `lua: drivers/my-device.lua`.
+The `drivers/` prefix resolves to the user directory first, so no
+absolute paths leak into the config and it stays portable.
+
+> **Don't `docker cp` into the running container.** Copying a driver to
+> `forty-two-watts:/app/drivers/` writes into the container's ephemeral
+> writable layer — not the image, not the volume. It works until the next
+> `docker compose pull && up -d` recreates the container and discards that
+> layer, and it can be lost on an unclean power-off. Use `./data/drivers/`
+> instead; that overlay exists precisely so you never have to.
+
+During a [pair session](ftw-pair.md) the friend's `deploy_driver` tool
+writes here automatically, so a driver added remotely is already
+persistent without any of the above.


### PR DESCRIPTION
## Why

A field tester running the Docker deploy on a Pi has to re-copy their custom `goodwe_et.lua` driver after **every image update** and **after a power outage**. Root cause: they're doing

```
sudo docker cp ~/goodwe_et.lua forty-two-watts:/app/drivers/
```

`/app/drivers/` is the **immutable image layer**, so `docker cp` lands in the container's ephemeral writable layer — discarded whenever the container is recreated (`docker compose pull && up -d`) and lost on an unclean power-off.

The fix already exists in code: the container launches with `-user-drivers /app/data/drivers` (shipped since **v0.100.0**, PR #311), and `ResolveDriverPaths` probes that persistent bind-mounted dir first. A driver dropped in `./data/drivers/` survives upgrades + reboots and shadows a bundled driver of the same name. It just wasn't documented anywhere outside the pair-flow (`docs/ftw-pair.md`).

## What

- **`docs/writing-a-driver.md`** — new "§9 Installing a custom driver on a Docker deploy": where `./data/drivers/` lives, why it persists, the install steps (incl. the `chown 100:101` for Linux), and an explicit "don't `docker cp`" callout.
- **`docs/deploy-platforms.md`** — cross-reference bullet in the Linux notes.

No code change — the mechanism already works; this closes the docs gap that sent operators reaching for `docker cp`.

Docs-only → changeset gate auto-exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)