### PR TITLE
feat(relay): writer-auth + route-gating for the wallet-blob endpoints

### DIFF
--- a/.changeset/wallet-blob-writer-auth.md
+++ b/.changeset/wallet-blob-writer-auth.md
@@ -1,0 +1,10 @@
+---
+"forty-two-watts": patch
+---
+
+Harden the (still dormant, behind `-multi-tenant`) relay wallet-blob endpoints.
+
+- **Writer authentication on `PUT /wallet/{user_handle}/blob`** (closes a Codex HIGH from the v0.118.0 foundation). Each PUT now carries an Ed25519 `write_pub` + `sig`; the relay TOFU-pins the write key on the first write and rejects any later write whose key differs or whose signature fails to verify over a canonical `handle|version|nonce|sha256(ciphertext)` message. A `userHandle`-knower without the owner's passkey-derived write key can no longer overwrite or take over a blob. Wallet blobs are no longer time-GC'd (eviction would drop the pin and reopen a squat window).
+- **Route gating:** the `/wallet/*` and `/signal/{site_id}/identity` routes are now registered ONLY in multi-tenant mode, and the single-tenant home-host catch-all reserves those paths (404) — so with the flag off the endpoints add no surface (a plain 404, not a 503 or a public-key answer).
+
+Still dormant: `-multi-tenant` defaults off and the production home route stays disabled. The remaining cutover blocker is the WebAuthn-PRF determinism device test. See `docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md`.

--- a/docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md
+++ b/docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md
@@ -265,15 +265,23 @@ until BOTH of these are closed. Until then the multi-tenant routes are not even
 registered, so the code is dormant.
 
 1. **PRF determinism spike** (above) — verify identical PRF output across a
-   synced passkey on real devices, or fall back to browser-carried-only.
-2. **Blob write authentication.** `PUT /wallet/{user_handle}/blob` is currently
-   NOT writer-authenticated: the ciphertext is useless without the owner's PRF
-   key and the version guard is bounded so a handle-knower cannot lock a wallet
-   out (`maxVersionJump`), but anyone who learns a `userHandle` could still
-   **overwrite or squat** a wallet's blob. Before cutover, gate the PUT with a
-   per-wallet write signature — a PRF-derived MAC over
-   `handle|version|nonce|ciphertext-hash`, verified against a write-verifier the
-   wallet registers at enrollment. (Codex review, 2026-06-05, HIGH.)
+   synced passkey on real devices, or fall back to browser-carried-only. **This is
+   the one remaining hard blocker.**
+2. ~~Blob write authentication.~~ **DONE (v0.119.0).** `PUT /wallet/{user_handle}/blob`
+   is now writer-authenticated: the client derives an **Ed25519 write key** from the
+   PRF secret (`HKDF(prf, info="ftw-blob-write:v1")` → seed), and each PUT carries
+   `write_pub` + an Ed25519 `sig` over `blobWriteMessage` =
+   `"ftw-blob:v1:" + handle + ":" + version + ":" + base64url(nonce) + ":" +
+   hex(sha256(ciphertext))`. The relay **TOFU-pins** `write_pub` on the first write
+   and rejects any later write whose key differs (constant-time) or whose signature
+   fails — so a `userHandle`-knower without the owner's passkey-derived write key
+   cannot overwrite or take over a blob. Wallet blobs are **not time-GC'd** (that
+   would drop the pin and reopen a squat window — Codex HIGH). Residual: a stranger
+   can still squat an **unused, high-entropy** handle before its first legitimate
+   write (TOFU), and an enrollment-capacity flood is bounded by the wallet-count cap;
+   a pin-preserving tombstone for abandoned-blob reclamation is a later refinement.
+   The web client (`instance-sync.js`, next slice) MUST construct `blobWriteMessage`
+   byte-identically.
 
 ## Honest residuals (documented, not over-built)
 

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -177,12 +177,16 @@ func (r *Relay) Handler() http.Handler {
 	mux.HandleFunc("POST /signal/{host_id}/answer", r.signalHostAnswer)
 
 	// Multi-tenant per-wallet ENCRYPTED directory blob (opaque ciphertext in/out,
-	// never parsed by the relay) + the per-site public-key cross-check read. Like
-	// the browser /signal/* routes, these are re-registered on the HomeHost mux
-	// below so they aren't shadowed by the home-host catch-all.
-	mux.HandleFunc("GET /wallet/{user_handle}/blob", r.walletBlobGet)
-	mux.HandleFunc("PUT /wallet/{user_handle}/blob", r.walletBlobPut)
-	mux.HandleFunc("GET /signal/{site_id}/identity", r.signalIdentity)
+	// never parsed by the relay) + the per-site public-key cross-check read. These
+	// are registered ONLY in multi-tenant mode so that with the flag off they are
+	// not even reachable (a 404, not a 503/public-key answer) — no extra surface
+	// when the feature is dormant. Re-registered on the HomeHost mux below so they
+	// aren't shadowed by the home-host catch-all.
+	if r.MultiTenant {
+		mux.HandleFunc("GET /wallet/{user_handle}/blob", r.walletBlobGet)
+		mux.HandleFunc("PUT /wallet/{user_handle}/blob", r.walletBlobPut)
+		mux.HandleFunc("GET /signal/{site_id}/identity", r.signalIdentity)
+	}
 
 	// Owner remote access registration (Phase 3). The Pi POSTs its ES256-signed
 	// /me/register on startup; the relay pins the key and returns the per-host
@@ -212,9 +216,13 @@ func (r *Relay) Handler() http.Handler {
 		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/challenge", r.signalChallenge)
 		mux.HandleFunc("POST "+r.HomeHost+"/signal/{site_id}/offer", r.signalBrowserOffer)
 		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/answer", r.signalBrowserAnswer)
-		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/identity", r.signalIdentity)
-		mux.HandleFunc("GET "+r.HomeHost+"/wallet/{user_handle}/blob", r.walletBlobGet)
-		mux.HandleFunc("PUT "+r.HomeHost+"/wallet/{user_handle}/blob", r.walletBlobPut)
+		// The wallet-blob + per-site identity routes are multi-tenant-only — never
+		// registered on the home host under a single-tenant pin.
+		if r.MultiTenant {
+			mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/identity", r.signalIdentity)
+			mux.HandleFunc("GET "+r.HomeHost+"/wallet/{user_handle}/blob", r.walletBlobGet)
+			mux.HandleFunc("PUT "+r.HomeHost+"/wallet/{user_handle}/blob", r.walletBlobPut)
+		}
 		mux.HandleFunc(r.HomeHost+"/", r.homeStaticForward)
 	}
 	return r.limitBody(mux)
@@ -255,6 +263,17 @@ func (r *Relay) homeStaticForward(w http.ResponseWriter, req *http.Request) {
 	// relay can never see (or be tricked into proxying) owner traffic.
 	if req.Method != http.MethodGet {
 		http.Error(w, "owner API is P2P-only; this relay serves static assets only", http.StatusMethodNotAllowed)
+		return
+	}
+	// Reserve the multi-tenant API-plane paths. Under -multi-tenant these are
+	// registered routes and never reach here; under a single-tenant pin they would
+	// otherwise be swallowed by this catch-all (served as SPA HTML, or — in an
+	// insecure TOFU-without-home-web config — forwarded to the Pi as an anonymous
+	// GET). 404 them so the wallet/identity surface is never reachable via the
+	// static path either (Codex 2026-06-05).
+	if strings.HasPrefix(req.URL.Path, "/wallet/") ||
+		(strings.HasPrefix(req.URL.Path, "/signal/") && strings.HasSuffix(req.URL.Path, "/identity")) {
+		http.NotFound(w, req)
 		return
 	}
 	// MULTI-TENANT: there is no single -home-site to resolve and the relay must
@@ -357,11 +376,16 @@ func (r *Relay) serveHomeIdentity(w http.ResponseWriter) {
 // relay treats ciphertext + nonce as OPAQUE standard-base64 strings — it never
 // decodes the plaintext (all crypto is client-side, derived from a WebAuthn-PRF
 // secret). version drives optimistic concurrency: a PUT whose version is <= the
-// stored one is a 409 (lost-update / rollback guard).
+// stored one is a 409 (lost-update / rollback guard). On PUT, write_pub + sig
+// authenticate the writer: write_pub is the wallet's Ed25519 write key (also
+// PRF-derived, TOFU-pinned by the relay) and sig is its signature over the
+// canonical message (see WalletBlobStore.blobWriteMessage). They are absent on GET.
 type walletBlobIO struct {
 	Ciphertext string `json:"ciphertext"`
 	Nonce      string `json:"nonce"`
 	Version    int    `json:"version"`
+	WritePub   string `json:"write_pub,omitempty"`
+	Sig        string `json:"sig,omitempty"`
 }
 
 // walletBlobGet serves a wallet's encrypted directory blob. Public + unauthenticated
@@ -393,23 +417,16 @@ func (r *Relay) walletBlobGet(w http.ResponseWriter, req *http.Request) {
 	})
 }
 
-// SECURITY — REQUIRED BEFORE THE MULTI-TENANT ROUTE GOES LIVE: this PUT is not
-// yet writer-authenticated. The blob ciphertext is useless without the owner's
-// PRF key, and the version guard is bounded so a handle-knower cannot lock a
-// wallet out (see WalletBlobStore.Put / maxVersionJump) — but anyone who learns a
-// userHandle can still OVERWRITE or squat a wallet's blob. Before -multi-tenant is
-// enabled in production, gate this with a per-wallet write signature (e.g. a
-// PRF-derived MAC over handle|version|nonce|ciphertext-hash verified against a
-// write-verifier the wallet registers at enrollment). This handler is unreachable
-// until -multi-tenant is passed (routes unregistered otherwise), so it is dormant
-// today; do NOT flip the flag until this is closed. See
-// docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md.
-//
 // walletBlobPut stores a wallet's encrypted directory blob under optimistic
-// concurrency. The body is JSON {ciphertext, nonce, version} with standard-base64
-// ciphertext/nonce the relay never decrypts. It validates the handle, the
-// transport encoding, and delegates the size + version checks to the store:
-//   - 400  invalid handle / malformed JSON / non-base64 ciphertext-or-nonce
+// concurrency, WRITER-AUTHENTICATED. The body is JSON {ciphertext, nonce,
+// version, write_pub, sig} — ciphertext/nonce are standard-base64 the relay never
+// decrypts; write_pub is the wallet's Ed25519 write key (base64) and sig (base64)
+// is its signature over the canonical message. The store TOFU-pins write_pub on
+// the first write and rejects any later write not signed by that key, so a
+// userHandle-knower WITHOUT the owner's passkey-derived write key cannot overwrite
+// or take over the blob. Statuses:
+//   - 400  invalid handle / malformed JSON / non-base64 field
+//   - 403  signature does not verify against the (pinned) write key
 //   - 409  version <= stored (lost-update / rollback)
 //   - 413  ciphertext over the per-blob byte cap
 //   - 503  too many distinct wallets (store cap)
@@ -440,8 +457,20 @@ func (r *Relay) walletBlobPut(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "nonce is not valid base64", http.StatusBadRequest)
 		return
 	}
-	if err := r.WalletBlobs.Put(handle, ct, nonce, in.Version); err != nil {
+	writePub, err := base64.StdEncoding.DecodeString(in.WritePub)
+	if err != nil {
+		http.Error(w, "write_pub is not valid base64", http.StatusBadRequest)
+		return
+	}
+	sig, err := base64.StdEncoding.DecodeString(in.Sig)
+	if err != nil {
+		http.Error(w, "sig is not valid base64", http.StatusBadRequest)
+		return
+	}
+	if err := r.WalletBlobs.Put(handle, ct, nonce, writePub, sig, in.Version); err != nil {
 		switch {
+		case errors.Is(err, ErrUnauthorizedWrite):
+			http.Error(w, "write not authorized", http.StatusForbidden)
 		case errors.Is(err, ErrVersionConflict):
 			http.Error(w, "stale version", http.StatusConflict)
 		case errors.Is(err, ErrBlobTooLarge):

--- a/go/cmd/ftw-relay/home_web_test.go
+++ b/go/cmd/ftw-relay/home_web_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -258,6 +261,42 @@ func TestMeRegister_DeviceKeysTamperRejected(t *testing.T) {
 	}
 }
 
+// Under a SINGLE-TENANT pin (multi-tenant off), the wallet/identity API paths are
+// not routes, but the home-host catch-all must still NOT serve or forward them:
+// they are reserved to 404, while ordinary SPA paths still serve the shell.
+func TestSingleTenantReservesWalletPaths(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<h1>SHELL</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	relay := &Relay{
+		Queue: tunnel.NewQueue(), Tokens: NewTokenRegistry(), Owners: NewOwnerRegistry(),
+		Polls: NewPollSecrets(), Signals: NewSignalMailbox(), Challenges: NewSignalChallenges(),
+		HomeHost: "home.test", HomeSite: "site:Home", HomeWeb: dir, // single-tenant, MultiTenant=false
+	}
+	srv := httptest.NewServer(relay.Handler())
+	defer srv.Close()
+	get := func(path string) int {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+		req.Host = "home.test"
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	if code := get("/wallet/" + testHandle + "/blob"); code != http.StatusNotFound {
+		t.Errorf("single-tenant /wallet = %d, want 404 (reserved, not SPA/forward)", code)
+	}
+	if code := get("/signal/site:Home/identity"); code != http.StatusNotFound {
+		t.Errorf("single-tenant /signal/.../identity = %d, want 404 (reserved)", code)
+	}
+	if code := get("/dashboard"); code != http.StatusOK {
+		t.Errorf("single-tenant ordinary SPA path = %d, want 200 (shell still served)", code)
+	}
+}
+
 // Under multi-tenant the browser reaches the relay AS the home host, so the
 // /wallet/* and /signal/{site}/identity routes must be re-registered on the
 // HomeHost mux (Go gives a host pattern precedence over a host-less one). This
@@ -288,8 +327,17 @@ func TestMultiTenantRoutesOnHomeHost(t *testing.T) {
 		t.Fatalf("home-host /signal/site:Bob/identity = %d, want 200 (route shadowed by catch-all?)", code)
 	}
 	// PUT /wallet/{handle}/blob resolves on the home host → 200 (not 405 from the
-	// GET-only static forwarder).
-	body, _ := json.Marshal(walletBlobIO{Ciphertext: "Y2lwaA==", Nonce: "bm9uYw==", Version: 1})
+	// GET-only static forwarder). Writer-authenticated: sign the canonical message.
+	wpub, wpriv, _ := ed25519.GenerateKey(rand.Reader)
+	ct, nonce := []byte("ciph"), []byte("nonc")
+	sig := ed25519.Sign(wpriv, blobWriteMessage(testHandle, 1, nonce, ct))
+	body, _ := json.Marshal(walletBlobIO{
+		Ciphertext: base64.StdEncoding.EncodeToString(ct),
+		Nonce:      base64.StdEncoding.EncodeToString(nonce),
+		Version:    1,
+		WritePub:   base64.StdEncoding.EncodeToString(wpub),
+		Sig:        base64.StdEncoding.EncodeToString(sig),
+	})
 	if code, b := doHost(http.MethodPut, "/wallet/"+testHandle+"/blob", body); code != http.StatusOK {
 		t.Fatalf("home-host PUT /wallet/.../blob = %d (%s), want 200", code, b)
 	}

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -78,7 +78,9 @@ func main() {
 			slog.Error("ftw-relay: -multi-tenant requires -wallet-blob-dir (the durable encrypted-blob store)")
 			os.Exit(1)
 		}
-		wb, err := NewWalletBlobStore(*walletBlobDir, *walletBlobMaxBytes, maxOwnerSites)
+		// maxBlobs 0 -> the store's generous default. Wallet blobs are not GC'd
+		// (see the janitor note), so the wallet-count cap is the sole bound.
+		wb, err := NewWalletBlobStore(*walletBlobDir, *walletBlobMaxBytes, 0)
 		if err != nil {
 			slog.Error("ftw-relay: wallet blob store", "err", err)
 			os.Exit(1)
@@ -164,14 +166,15 @@ func main() {
 						slog.Info("ftw-relay: offer-limit GC", "removed", n)
 					}
 				}
-				// Evict idle per-wallet encrypted blobs by last touch (same cadence
-				// as Owners/Polls), so an abandoned wallet directory doesn't pin
-				// durable relay state forever. A live wallet re-PUTs on every change.
-				if r.WalletBlobs != nil {
-					if n := r.WalletBlobs.GC(30 * time.Minute); n > 0 {
-						slog.Info("ftw-relay: wallet-blob GC", "removed", n)
-					}
-				}
+				// NB: wallet blobs are deliberately NOT time-GC'd. Unlike a site
+				// registration (which re-registers every ~60s, so staleness means
+				// "Pi gone"), a wallet directory is durable per-person and is only
+				// re-written when the owner changes it — which can be weeks apart.
+				// Evicting an idle blob would drop its TOFU-pinned write key, opening
+				// a squat window where an attacker who knows the userHandle pins THEIR
+				// key first and locks the owner out (Codex 2026-06-05, HIGH). The
+				// blob store is bounded by its wallet-count cap instead; abandoned-blob
+				// reclamation (a tombstone that keeps the pin) is a cutover concern.
 			}
 		}
 	}()

--- a/go/cmd/ftw-relay/walletblob.go
+++ b/go/cmd/ftw-relay/walletblob.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -43,6 +48,7 @@ type WalletBlobStore struct {
 type blobEntry struct {
 	ciphertext  []byte
 	nonce       []byte
+	writePub    []byte // Ed25519 public key (32 B) TOFU-pinned for this wallet's writes
 	version     int
 	updatedAtMs int64
 	touchedAt   time.Time
@@ -52,15 +58,20 @@ type blobEntry struct {
 type blobFile struct {
 	CiphertextB64 string `json:"ciphertext_b64"`
 	NonceB64      string `json:"nonce_b64"`
+	WritePubB64   string `json:"write_pub_b64"`
 	Version       int    `json:"version"`
 	UpdatedAtMs   int64  `json:"updated_at_ms"`
 }
 
 const (
 	// defaultMaxWalletBlobs bounds the number of distinct wallets the store holds,
-	// so a flood of PUTs for random userHandles can't grow disk/memory without
-	// limit. A real population of tenants is far below this.
-	defaultMaxWalletBlobs = 4096
+	// so a flood of (validly self-signed) PUTs for random userHandles can't grow
+	// disk/memory without limit. Wallet blobs are NOT time-GC'd (that would drop a
+	// TOFU-pinned write key — see the janitor note), so this count cap is the sole
+	// bound; it is generous because each entry is small and a real tenant
+	// population is well below it. The residual is an enrollment-capacity DoS
+	// (filling the cap blocks NEW wallets, never overwrites existing ones).
+	defaultMaxWalletBlobs = 65536
 	// blobFileSuffix is appended to the (validated, FS-safe) userHandle.
 	blobFileSuffix = ".blob"
 	// maxVersionJump bounds how far a single Put may advance the version. The raw
@@ -83,7 +94,26 @@ var (
 	ErrTooManyBlobs = errors.New("too many wallet blobs")
 	// ErrBadUserHandle is returned when the userHandle fails validation.
 	ErrBadUserHandle = errors.New("invalid user handle")
+	// ErrUnauthorizedWrite is returned when a Put's Ed25519 signature does not
+	// verify against the wallet's TOFU-pinned write key (or the supplied key
+	// differs from the pinned one). This is what stops a userHandle-knower who
+	// lacks the owner's passkey-derived write key from overwriting a blob.
+	ErrUnauthorizedWrite = errors.New("wallet blob write not authorized")
 )
+
+// blobWriteMessage is the canonical byte string a wallet's Ed25519 write key
+// signs for a PUT. Binding handle + version + nonce + a hash of the ciphertext
+// stops replay onto a different wallet/version and stops tampering with the
+// stored bytes. The web client (instance-sync.js) MUST construct this identically:
+//
+//	"ftw-blob:v1:" + handle + ":" + version + ":" + base64url(nonce) + ":" + hex(sha256(ciphertext))
+func blobWriteMessage(userHandle string, version int, nonce, ciphertext []byte) []byte {
+	sum := sha256.Sum256(ciphertext)
+	return []byte("ftw-blob:v1:" + userHandle + ":" +
+		strconv.Itoa(version) + ":" +
+		base64.RawURLEncoding.EncodeToString(nonce) + ":" +
+		hex.EncodeToString(sum[:]))
+}
 
 // validUserHandle reports whether s is a safe opaque WebAuthn userHandle: a
 // base64url token (RFC 4648 §5 alphabet, no padding) of bounded length. This is
@@ -165,15 +195,17 @@ func NewWalletBlobStore(dir string, maxBytes, maxBlobs int) (*WalletBlobStore, e
 		}
 		ct, e1 := base64.StdEncoding.DecodeString(bf.CiphertextB64)
 		nc, e2 := base64.StdEncoding.DecodeString(bf.NonceB64)
-		if e1 != nil || e2 != nil {
+		wp, e3 := base64.StdEncoding.DecodeString(bf.WritePubB64)
+		if e1 != nil || e2 != nil || e3 != nil {
 			continue
 		}
-		if (s.maxBytes > 0 && len(ct) > s.maxBytes) || bf.Version <= 0 {
-			continue // enforce the runtime invariants on reload too
+		if (s.maxBytes > 0 && len(ct) > s.maxBytes) || bf.Version <= 0 || len(wp) != ed25519.PublicKeySize {
+			continue // enforce the runtime invariants on reload too (incl. a pinned write key)
 		}
 		s.blobs[handle] = &blobEntry{
 			ciphertext:  ct,
 			nonce:       nc,
+			writePub:    wp,
 			version:     bf.Version,
 			updatedAtMs: bf.UpdatedAtMs,
 			touchedAt:   time.Now(),
@@ -207,7 +239,7 @@ func (s *WalletBlobStore) Get(userHandle string) (ciphertext, nonce []byte, vers
 // (ErrTooManyBlobs), strict version monotonicity (ErrVersionConflict), and
 // userHandle validity (ErrBadUserHandle). On success it persists the blob to
 // disk atomically (temp file + rename) so it survives a relay restart.
-func (s *WalletBlobStore) Put(userHandle string, ciphertext, nonce []byte, version int) error {
+func (s *WalletBlobStore) Put(userHandle string, ciphertext, nonce, writePub, sig []byte, version int) error {
 	if !validUserHandle(userHandle) {
 		return ErrBadUserHandle
 	}
@@ -217,26 +249,43 @@ func (s *WalletBlobStore) Put(userHandle string, ciphertext, nonce []byte, versi
 	if s.maxBytes > 0 && len(ciphertext) > s.maxBytes {
 		return ErrBlobTooLarge
 	}
+	if len(writePub) != ed25519.PublicKeySize || len(sig) != ed25519.SignatureSize {
+		return ErrUnauthorizedWrite
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if prev, present := s.blobs[userHandle]; present {
-		// Monotonic but bounded: must advance, but not jump far enough to lock the
-		// wallet out (see maxVersionJump). A legitimate client increments by 1.
+	prev, present := s.blobs[userHandle]
+	if present {
+		// The write key is TOFU-pinned at the first write and cannot change — a
+		// caller presenting a different key (even a validly self-signed one) can
+		// never take over an existing wallet's blob.
+		if subtle.ConstantTimeCompare(prev.writePub, writePub) != 1 {
+			return ErrUnauthorizedWrite
+		}
+	} else if len(s.blobs) >= s.maxBlobs {
+		return ErrTooManyBlobs
+	}
+	// Authenticate the writer: the Ed25519 signature must verify against the
+	// (pinned, or first-seen TOFU) write key over the canonical message. Without
+	// the owner's passkey-derived write key this cannot be produced, so a mere
+	// userHandle-knower cannot overwrite the blob.
+	if !ed25519.Verify(writePub, blobWriteMessage(userHandle, version, nonce, ciphertext), sig) {
+		return ErrUnauthorizedWrite
+	}
+	// Version monotonicity (bounded) — checked AFTER authentication so an
+	// unauthenticated caller learns nothing about the stored version.
+	if present {
 		if version <= prev.version || version > prev.version+maxVersionJump {
 			return ErrVersionConflict
 		}
-	} else {
-		if version > maxVersionJump {
-			return ErrVersionConflict
-		}
-		if len(s.blobs) >= s.maxBlobs {
-			return ErrTooManyBlobs
-		}
+	} else if version > maxVersionJump {
+		return ErrVersionConflict
 	}
 	now := time.Now()
 	e := &blobEntry{
 		ciphertext:  append([]byte(nil), ciphertext...),
 		nonce:       append([]byte(nil), nonce...),
+		writePub:    append([]byte(nil), writePub...),
 		version:     version,
 		updatedAtMs: now.UnixMilli(),
 		touchedAt:   now,
@@ -253,6 +302,7 @@ func (s *WalletBlobStore) persist(userHandle string, e *blobEntry) error {
 	bf := blobFile{
 		CiphertextB64: base64.StdEncoding.EncodeToString(e.ciphertext),
 		NonceB64:      base64.StdEncoding.EncodeToString(e.nonce),
+		WritePubB64:   base64.StdEncoding.EncodeToString(e.writePub),
 		Version:       e.version,
 		UpdatedAtMs:   e.updatedAtMs,
 	}
@@ -284,9 +334,15 @@ func (s *WalletBlobStore) persist(userHandle string, e *blobEntry) error {
 	return os.Rename(tmp, final)
 }
 
-// GC evicts wallets untouched for longer than idle (and removes their files),
-// so a churn of one-off userHandles can't grow the store without bound. Returns
-// how many were evicted. idle<=0 evicts nothing.
+// GC evicts wallets untouched for longer than idle (and removes their files).
+// Returns how many were evicted. idle<=0 evicts nothing.
+//
+// WARNING: evicting a wallet drops its TOFU-pinned write key, so a later attacker
+// PUT for the same userHandle would re-pin THEIR key and lock the owner out. This
+// must therefore NOT be run on a schedule for the multi-tenant route (the janitor
+// intentionally does not call it). It exists for tests and for an operator that
+// knows a handle is truly abandoned. Proper abandoned-blob reclamation keeps a
+// pin tombstone — a cutover concern.
 func (s *WalletBlobStore) GC(idle time.Duration) int {
 	if idle <= 0 {
 		return 0

--- a/go/cmd/ftw-relay/walletblob_http_test.go
+++ b/go/cmd/ftw-relay/walletblob_http_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -36,28 +38,43 @@ func newMultiTenantRelay(t *testing.T) *Relay {
 	}
 }
 
-// b64 standard-base64-encodes a string so a test can build the opaque
-// ciphertext/nonce wire fields the relay round-trips without parsing.
-func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+// b64 standard-base64-encodes bytes for the opaque wire fields.
+func b64b(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+func b64(s string) string  { return b64b([]byte(s)) }
+
+// signedBlobPut builds a writer-authenticated PUT body and sends it. The body's
+// write_pub/sig are produced from (pub, priv) over the canonical message, so the
+// relay's Ed25519 check passes when the key is the wallet's pinned one.
+func signedBlobPut(t *testing.T, url, handle string, ct, nonce []byte, version int, pub ed25519.PublicKey, priv ed25519.PrivateKey) (int, string) {
+	t.Helper()
+	sig := ed25519.Sign(priv, blobWriteMessage(handle, version, nonce, ct))
+	body, _ := json.Marshal(walletBlobIO{
+		Ciphertext: b64b(ct), Nonce: b64b(nonce), Version: version,
+		WritePub: b64b(pub), Sig: b64b(sig),
+	})
+	return rawBlobPut(t, url, handle, body)
+}
+
+func rawBlobPut(t *testing.T, url, handle string, body []byte) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPut, url+"/wallet/"+handle+"/blob", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode, string(b)
+}
 
 // PUT then GET round-trips the opaque ciphertext blob; version monotonicity is
 // enforced (a stale PUT is 409); a bad handle is 400; an unknown handle GET is 404.
 func TestWalletBlobPutGetHTTP(t *testing.T) {
 	srv := httptest.NewServer(newMultiTenantRelay(t).Handler())
 	defer srv.Close()
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
 
-	put := func(handle string, ct, nonce string, version int) (int, string) {
-		body, _ := json.Marshal(walletBlobIO{Ciphertext: ct, Nonce: nonce, Version: version})
-		req, _ := http.NewRequest(http.MethodPut, srv.URL+"/wallet/"+handle+"/blob", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		b, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		return resp.StatusCode, string(b)
-	}
 	get := func(handle string) (int, walletBlobIO) {
 		resp, err := http.Get(srv.URL + "/wallet/" + handle + "/blob")
 		if err != nil {
@@ -74,7 +91,7 @@ func TestWalletBlobPutGetHTTP(t *testing.T) {
 		t.Fatalf("GET unknown handle = %d, want 404", code)
 	}
 	// First PUT (version 1) → 200.
-	if code, body := put(testHandle, b64("cipher-1"), b64("nonce-1"), 1); code != http.StatusOK {
+	if code, body := signedBlobPut(t, srv.URL, testHandle, []byte("cipher-1"), []byte("nonce-1"), 1, pub, priv); code != http.StatusOK {
 		t.Fatalf("PUT v1 = %d (%s), want 200", code, body)
 	}
 	// GET returns it verbatim.
@@ -82,32 +99,80 @@ func TestWalletBlobPutGetHTTP(t *testing.T) {
 	if code != http.StatusOK || out.Ciphertext != b64("cipher-1") || out.Nonce != b64("nonce-1") || out.Version != 1 {
 		t.Fatalf("GET v1 = %d %+v, want 200 cipher-1/nonce-1/v1", code, out)
 	}
-	// PUT v2 advances.
-	if code, body := put(testHandle, b64("cipher-2"), b64("nonce-2"), 2); code != http.StatusOK {
+	// PUT v2 advances (same pinned key).
+	if code, body := signedBlobPut(t, srv.URL, testHandle, []byte("cipher-2"), []byte("nonce-2"), 2, pub, priv); code != http.StatusOK {
 		t.Fatalf("PUT v2 = %d (%s), want 200", code, body)
 	}
-	// A stale PUT (version <= stored) is rejected 409.
-	if code, _ := put(testHandle, b64("stale"), b64("stale"), 2); code != http.StatusConflict {
+	// A stale PUT (valid sig, version <= stored) is rejected 409.
+	if code, _ := signedBlobPut(t, srv.URL, testHandle, []byte("stale"), []byte("stale"), 2, pub, priv); code != http.StatusConflict {
 		t.Fatalf("PUT stale v2 = %d, want 409", code)
 	}
-	if code, _ := put(testHandle, b64("stale"), b64("stale"), 1); code != http.StatusConflict {
+	if code, _ := signedBlobPut(t, srv.URL, testHandle, []byte("stale"), []byte("stale"), 1, pub, priv); code != http.StatusConflict {
 		t.Fatalf("PUT rollback v1 = %d, want 409", code)
 	}
-	// A bad handle is 400 on both verbs.
+	// A bad handle is 400 on both verbs (checked before the body).
 	if code, _ := get("short"); code != http.StatusBadRequest {
 		t.Fatalf("GET bad handle = %d, want 400", code)
 	}
-	if code, _ := put("short", b64("x"), b64("y"), 1); code != http.StatusBadRequest {
+	if code, _ := signedBlobPut(t, srv.URL, "short", []byte("x"), []byte("y"), 1, pub, priv); code != http.StatusBadRequest {
 		t.Fatalf("PUT bad handle = %d, want 400", code)
 	}
-	// Non-base64 ciphertext is a 400 (the relay never parses plaintext, but it
-	// validates the transport encoding so a garbage body is caught here).
-	if code, _ := put(testHandle, "!!!not-base64!!!", b64("y"), 9); code != http.StatusBadRequest {
+	// Non-base64 ciphertext is a 400 (transport-encoding validation).
+	badBody, _ := json.Marshal(map[string]any{"ciphertext": "!!!not-base64!!!", "nonce": b64("y"), "version": 9, "write_pub": b64b(pub), "sig": b64("z")})
+	if code, _ := rawBlobPut(t, srv.URL, testHandle, badBody); code != http.StatusBadRequest {
 		t.Fatalf("PUT non-base64 ciphertext = %d, want 400", code)
 	}
 }
 
-// An over-max ciphertext is rejected with 413, never buffered into the store.
+// Writer authentication over HTTP: a PUT whose signature does not verify against
+// the wallet's pinned write key is 403 — a userHandle-knower cannot overwrite.
+func TestWalletBlobWriterAuthHTTP(t *testing.T) {
+	srv := httptest.NewServer(newMultiTenantRelay(t).Handler())
+	defer srv.Close()
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+
+	// Owner's first write pins the key.
+	if code, body := signedBlobPut(t, srv.URL, testHandle, []byte("ct"), []byte("nc"), 1, pub, priv); code != http.StatusOK {
+		t.Fatalf("owner PUT = %d (%s), want 200", code, body)
+	}
+	// An attacker who learned the handle but has a DIFFERENT key is 403.
+	apub, apriv, _ := ed25519.GenerateKey(rand.Reader)
+	if code, _ := signedBlobPut(t, srv.URL, testHandle, []byte("evil"), []byte("nc"), 2, apub, apriv); code != http.StatusForbidden {
+		t.Fatalf("attacker takeover = %d, want 403", code)
+	}
+	// A garbage signature with the owner's pubkey is also 403.
+	body, _ := json.Marshal(walletBlobIO{
+		Ciphertext: b64("x"), Nonce: b64("nc"), Version: 2,
+		WritePub: b64b(pub), Sig: b64b(make([]byte, 64)),
+	})
+	if code, _ := rawBlobPut(t, srv.URL, testHandle, body); code != http.StatusForbidden {
+		t.Fatalf("garbage sig = %d, want 403", code)
+	}
+}
+
+// With multi-tenant OFF the wallet-blob + per-site identity routes are NOT
+// registered at all — a request gets a plain 404 (no 503, no public-key answer),
+// so the dormant feature adds no surface.
+func TestWalletRoutesAbsentWhenFlagOff(t *testing.T) {
+	srv := httptest.NewServer(newTestRelay().Handler())
+	defer srv.Close()
+	for _, path := range []string{
+		"/wallet/" + testHandle + "/blob",
+		"/signal/site:whatever/identity",
+	} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s with multi-tenant off = %d, want 404 (route must not be registered)", path, resp.StatusCode)
+		}
+	}
+}
+
+// An over-max ciphertext is rejected with 413, never buffered into the store
+// (the size cap is enforced before the write-auth check).
 func TestWalletBlobPutTooLargeHTTP(t *testing.T) {
 	store, err := NewWalletBlobStore(t.TempDir(), 128, 1024) // tiny 128-byte cap
 	if err != nil {
@@ -119,7 +184,7 @@ func TestWalletBlobPutTooLargeHTTP(t *testing.T) {
 	defer srv.Close()
 
 	big := b64(strings.Repeat("x", 4096)) // base64 of 4 KiB, well over the 128-byte cap
-	body, _ := json.Marshal(walletBlobIO{Ciphertext: big, Nonce: b64("n"), Version: 1})
+	body, _ := json.Marshal(walletBlobIO{Ciphertext: big, Nonce: b64("n"), Version: 1, WritePub: b64("p"), Sig: b64("s")})
 	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/wallet/"+testHandle+"/blob", bytes.NewReader(body))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -132,12 +197,9 @@ func TestWalletBlobPutTooLargeHTTP(t *testing.T) {
 }
 
 // GET /signal/{site_id}/identity returns the PUBLIC key the relay holds for that
-// site (a convenience cross-check; the browser already pins from the Pi-signed
-// directory entry). A known site → 200 with the registered key; an unknown site
-// → 404; never a secret.
+// site. A known site → 200; an unknown site → 404; never a secret.
 func TestSignalIdentityHTTP(t *testing.T) {
 	relay := newMultiTenantRelay(t)
-	// TOFU-register a site so the relay holds its public key.
 	id := newTestIdentity(t)
 	if err := relay.Owners.Register("site:Alice", "host-alice", id.PublicKeyHex()); err != nil {
 		t.Fatalf("register: %v", err)
@@ -169,7 +231,6 @@ func TestSignalIdentityHTTP(t *testing.T) {
 		t.Fatalf("identity fields = %+v, want site:Alice/ES256/P-256", out)
 	}
 
-	// Unknown site → 404.
 	resp2, err := http.Get(srv.URL + "/signal/site:nobody/identity")
 	if err != nil {
 		t.Fatal(err)

--- a/go/cmd/ftw-relay/walletblob_test.go
+++ b/go/cmd/ftw-relay/walletblob_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"strings"
 	"testing"
 	"time"
@@ -18,11 +20,28 @@ func newTestBlobStore(t *testing.T) *WalletBlobStore {
 	return s
 }
 
+func newWriteKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+// putSigned signs the canonical write message with priv and Puts. Reuse the same
+// (pub, priv) across writes to one handle — the store TOFU-pins it.
+func putSigned(s *WalletBlobStore, pub ed25519.PublicKey, priv ed25519.PrivateKey, handle string, ct, nonce []byte, version int) error {
+	sig := ed25519.Sign(priv, blobWriteMessage(handle, version, nonce, ct))
+	return s.Put(handle, ct, nonce, pub, sig, version)
+}
+
 func TestWalletBlob_PutGetRoundTrip(t *testing.T) {
 	s := newTestBlobStore(t)
+	pub, priv := newWriteKey(t)
 	ct := []byte("opaque-ciphertext")
 	nc := []byte("twelvebytenon")
-	if err := s.Put(testHandle, ct, nc, 1); err != nil {
+	if err := putSigned(s, pub, priv, testHandle, ct, nc, 1); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 	gotCT, gotNC, ver, ok := s.Get(testHandle)
@@ -40,21 +59,81 @@ func TestWalletBlob_PutGetRoundTrip(t *testing.T) {
 	}
 }
 
+// Writer authentication: a forged signature, a missing key, or a DIFFERENT key on
+// an existing wallet are all rejected — only the holder of the TOFU-pinned write
+// key (the owner's passkey-derived key) can write.
+func TestWalletBlob_WriterAuth(t *testing.T) {
+	s := newTestBlobStore(t)
+	pub, priv := newWriteKey(t)
+	ct, nc := []byte("ct"), []byte("nc")
+
+	// Malformed key/sig lengths → unauthorized (never a panic).
+	if err := s.Put(testHandle, ct, nc, []byte("short"), make([]byte, 64), 1); err != ErrUnauthorizedWrite {
+		t.Fatalf("short pubkey: err=%v want ErrUnauthorizedWrite", err)
+	}
+	if err := s.Put(testHandle, ct, nc, pub, []byte("shortsig"), 1); err != ErrUnauthorizedWrite {
+		t.Fatalf("short sig: err=%v want ErrUnauthorizedWrite", err)
+	}
+	// A signature over the WRONG message (tampered ciphertext) does not verify.
+	badSig := ed25519.Sign(priv, blobWriteMessage(testHandle, 1, nc, []byte("other-ct")))
+	if err := s.Put(testHandle, ct, nc, pub, badSig, 1); err != ErrUnauthorizedWrite {
+		t.Fatalf("tampered sig: err=%v want ErrUnauthorizedWrite", err)
+	}
+	// A correct first write TOFU-pins the key.
+	if err := putSigned(s, pub, priv, testHandle, ct, nc, 1); err != nil {
+		t.Fatalf("authorized first write: %v", err)
+	}
+	// A DIFFERENT key — even with a valid self-signature — cannot take over.
+	pub2, priv2 := newWriteKey(t)
+	sig2 := ed25519.Sign(priv2, blobWriteMessage(testHandle, 2, nc, ct))
+	if err := s.Put(testHandle, ct, nc, pub2, sig2, 2); err != ErrUnauthorizedWrite {
+		t.Fatalf("takeover with new key: err=%v want ErrUnauthorizedWrite", err)
+	}
+	// The pinned key keeps working.
+	if err := putSigned(s, pub, priv, testHandle, ct, nc, 2); err != nil {
+		t.Fatalf("pinned key advance: %v", err)
+	}
+}
+
+func TestWalletBlob_VersionBounds(t *testing.T) {
+	s := newTestBlobStore(t)
+	pub, priv := newWriteKey(t)
+	// Non-positive versions are always rejected (before the wallet exists).
+	for _, v := range []int{0, -1, -1000} {
+		if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), v); err != ErrVersionConflict {
+			t.Fatalf("Put version=%d: err=%v want ErrVersionConflict", v, err)
+		}
+	}
+	// A first write that jumps past the bound (e.g. MaxInt to lock the wallet) is refused.
+	if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), maxVersionJump+1); err != ErrVersionConflict {
+		t.Fatalf("new-wallet over-jump: err=%v want ErrVersionConflict", err)
+	}
+	if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), 1); err != nil {
+		t.Fatalf("first write v1: %v", err)
+	}
+	// An advance that jumps past the bound (lock-out) is refused even though it is
+	// strictly greater than the stored version.
+	if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), 1+maxVersionJump+1); err != ErrVersionConflict {
+		t.Fatalf("advance over-jump: err=%v want ErrVersionConflict", err)
+	}
+	if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), 2); err != nil {
+		t.Fatalf("advance v2: %v", err)
+	}
+}
+
 func TestWalletBlob_VersionMonotonic(t *testing.T) {
 	s := newTestBlobStore(t)
-	if err := s.Put(testHandle, []byte("v2"), []byte("n"), 2); err != nil {
+	pub, priv := newWriteKey(t)
+	if err := putSigned(s, pub, priv, testHandle, []byte("v2"), []byte("n"), 2); err != nil {
 		t.Fatalf("first put: %v", err)
 	}
-	// Same version → conflict (lost-update guard).
-	if err := s.Put(testHandle, []byte("dupe"), []byte("n"), 2); err != ErrVersionConflict {
+	if err := putSigned(s, pub, priv, testHandle, []byte("dupe"), []byte("n"), 2); err != ErrVersionConflict {
 		t.Fatalf("equal version: err=%v want ErrVersionConflict", err)
 	}
-	// Lower version (rollback) → conflict.
-	if err := s.Put(testHandle, []byte("old"), []byte("n"), 1); err != ErrVersionConflict {
+	if err := putSigned(s, pub, priv, testHandle, []byte("old"), []byte("n"), 1); err != ErrVersionConflict {
 		t.Fatalf("lower version: err=%v want ErrVersionConflict", err)
 	}
-	// Strictly greater → accepted.
-	if err := s.Put(testHandle, []byte("v3"), []byte("n"), 3); err != nil {
+	if err := putSigned(s, pub, priv, testHandle, []byte("v3"), []byte("n"), 3); err != nil {
 		t.Fatalf("higher version: %v", err)
 	}
 	if _, _, ver, _ := s.Get(testHandle); ver != 3 {
@@ -62,40 +141,13 @@ func TestWalletBlob_VersionMonotonic(t *testing.T) {
 	}
 }
 
-func TestWalletBlob_VersionBounds(t *testing.T) {
-	s := newTestBlobStore(t)
-	// Non-positive versions are always rejected.
-	for _, v := range []int{0, -1, -1000} {
-		if err := s.Put(testHandle, []byte("x"), []byte("n"), v); err != ErrVersionConflict {
-			t.Fatalf("Put version=%d: err=%v want ErrVersionConflict", v, err)
-		}
-	}
-	// A first write that jumps past the bound (e.g. an attacker setting MaxInt to
-	// lock the wallet) is refused.
-	if err := s.Put(testHandle, []byte("x"), []byte("n"), maxVersionJump+1); err != ErrVersionConflict {
-		t.Fatalf("new-wallet over-jump: err=%v want ErrVersionConflict", err)
-	}
-	// A legitimate first write at 1 is fine.
-	if err := s.Put(testHandle, []byte("x"), []byte("n"), 1); err != nil {
-		t.Fatalf("first write v1: %v", err)
-	}
-	// An advance that jumps past the bound (MaxInt lock-out) is refused even though
-	// it is strictly greater than the stored version.
-	if err := s.Put(testHandle, []byte("x"), []byte("n"), 1+maxVersionJump+1); err != ErrVersionConflict {
-		t.Fatalf("advance over-jump (lock-out attempt): err=%v want ErrVersionConflict", err)
-	}
-	// A normal +1 advance still works.
-	if err := s.Put(testHandle, []byte("x"), []byte("n"), 2); err != nil {
-		t.Fatalf("advance v2: %v", err)
-	}
-}
-
 func TestWalletBlob_SizeCap(t *testing.T) {
 	s := newTestBlobStore(t) // maxBytes 4096
-	if err := s.Put(testHandle, make([]byte, 4097), []byte("n"), 1); err != ErrBlobTooLarge {
+	pub, priv := newWriteKey(t)
+	if err := putSigned(s, pub, priv, testHandle, make([]byte, 4097), []byte("n"), 1); err != ErrBlobTooLarge {
 		t.Fatalf("oversize: err=%v want ErrBlobTooLarge", err)
 	}
-	if err := s.Put(testHandle, make([]byte, 4096), []byte("n"), 1); err != nil {
+	if err := putSigned(s, pub, priv, testHandle, make([]byte, 4096), []byte("n"), 1); err != nil {
 		t.Fatalf("exactly at cap must succeed: %v", err)
 	}
 }
@@ -105,19 +157,20 @@ func TestWalletBlob_WalletCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
+	pub, priv := newWriteKey(t)
 	h := func(c byte) string { return strings.Repeat(string(c), 43) }
-	if err := s.Put(h('a'), []byte("x"), []byte("n"), 1); err != nil {
+	if err := putSigned(s, pub, priv, h('a'), []byte("x"), []byte("n"), 1); err != nil {
 		t.Fatalf("blob 1: %v", err)
 	}
-	if err := s.Put(h('b'), []byte("x"), []byte("n"), 1); err != nil {
+	if err := putSigned(s, pub, priv, h('b'), []byte("x"), []byte("n"), 1); err != nil {
 		t.Fatalf("blob 2: %v", err)
 	}
 	// A THIRD distinct wallet exceeds the cap.
-	if err := s.Put(h('c'), []byte("x"), []byte("n"), 1); err != ErrTooManyBlobs {
+	if err := putSigned(s, pub, priv, h('c'), []byte("x"), []byte("n"), 1); err != ErrTooManyBlobs {
 		t.Fatalf("over cap: err=%v want ErrTooManyBlobs", err)
 	}
-	// But UPDATING an existing wallet is always allowed (not a new wallet).
-	if err := s.Put(h('a'), []byte("y"), []byte("n"), 2); err != nil {
+	// Updating an existing wallet is always allowed (not a new wallet).
+	if err := putSigned(s, pub, priv, h('a'), []byte("y"), []byte("n"), 2); err != nil {
 		t.Fatalf("update existing at cap: %v", err)
 	}
 }
@@ -127,12 +180,13 @@ func TestWalletBlob_RejectsBadHandle(t *testing.T) {
 	for _, bad := range []string{
 		"short",
 		"../etc/passwd",
-		strings.Repeat("a", 42),  // one under min
-		strings.Repeat("a", 87),  // one over max
+		strings.Repeat("a", 42),
+		strings.Repeat("a", 87),
 		"has/slash" + strings.Repeat("a", 40),
 		"has.dot" + strings.Repeat("a", 40),
 	} {
-		if err := s.Put(bad, []byte("x"), []byte("n"), 1); err != ErrBadUserHandle {
+		// Bad handle is rejected before any signature check.
+		if err := s.Put(bad, []byte("x"), []byte("n"), make([]byte, 32), make([]byte, 64), 1); err != ErrBadUserHandle {
 			t.Errorf("Put(%q): err=%v want ErrBadUserHandle", bad, err)
 		}
 		if _, _, _, ok := s.Get(bad); ok {
@@ -147,10 +201,11 @@ func TestWalletBlob_PersistsAcrossReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open 1: %v", err)
 	}
-	if err := s1.Put(testHandle, []byte("durable-ct"), []byte("durable-nc"), 7); err != nil {
+	pub, priv := newWriteKey(t)
+	if err := putSigned(s1, pub, priv, testHandle, []byte("durable-ct"), []byte("durable-nc"), 7); err != nil {
 		t.Fatalf("put: %v", err)
 	}
-	// Reopen — the blob must load from disk.
+	// Reopen — the blob (and its pinned write key) must load from disk.
 	s2, err := NewWalletBlobStore(dir, 4096, 8)
 	if err != nil {
 		t.Fatalf("open 2: %v", err)
@@ -159,25 +214,32 @@ func TestWalletBlob_PersistsAcrossReopen(t *testing.T) {
 	if !ok || ver != 7 || string(ct) != "durable-ct" || string(nc) != "durable-nc" {
 		t.Fatalf("reloaded = %q,%q,%d,%v want durable v7", ct, nc, ver, ok)
 	}
+	// The pinned key still gates writes after reload: a stranger can't take over.
+	pub2, priv2 := newWriteKey(t)
+	sig2 := ed25519.Sign(priv2, blobWriteMessage(testHandle, 8, []byte("n"), []byte("x")))
+	if err := s2.Put(testHandle, []byte("x"), []byte("n"), pub2, sig2, 8); err != ErrUnauthorizedWrite {
+		t.Fatalf("takeover after reload: err=%v want ErrUnauthorizedWrite", err)
+	}
+	if err := putSigned(s2, pub, priv, testHandle, []byte("x"), []byte("n"), 8); err != nil {
+		t.Fatalf("pinned key after reload: %v", err)
+	}
 }
 
 func TestWalletBlob_GCEvictsIdle(t *testing.T) {
 	s := newTestBlobStore(t)
-	if err := s.Put(testHandle, []byte("x"), []byte("n"), 1); err != nil {
+	pub, priv := newWriteKey(t)
+	if err := putSigned(s, pub, priv, testHandle, []byte("x"), []byte("n"), 1); err != nil {
 		t.Fatalf("put: %v", err)
 	}
 	if n := s.GC(time.Hour); n != 0 {
 		t.Fatalf("fresh blob must survive GC(1h), evicted %d", n)
 	}
-	// idle 0 evicts nothing by contract.
 	if n := s.GC(0); n != 0 {
 		t.Fatalf("GC(0) must evict nothing, evicted %d", n)
 	}
-	// A negative-age sweep (everything older than "now") evicts it.
 	if n := s.GC(-time.Nanosecond); n != 0 {
 		t.Fatalf("GC(<=0) must evict nothing, evicted %d", n)
 	}
-	// Force staleness: backdate touchedAt, then a tiny idle window evicts.
 	s.mu.Lock()
 	s.blobs[testHandle].touchedAt = time.Now().Add(-time.Hour)
 	s.mu.Unlock()


### PR DESCRIPTION
## Summary
Hardens the **dormant** (`-multi-tenant`, default off) wallet-blob foundation from v0.118.0 and closes the two Codex findings on it. Still behind the flag — no production behaviour change.

### Closes Codex HIGH — writer authentication
`PUT /wallet/{user_handle}/blob` now carries an **Ed25519** `write_pub` + `sig` over a canonical `"ftw-blob:v1:"+handle+":"+version+":"+b64url(nonce)+":"+hex(sha256(ciphertext))`. The store **TOFU-pins** `write_pub` on the first write and rejects any later write with a different key (constant-time) or a failing signature. A `userHandle`-knower without the owner's passkey-derived write key can no longer overwrite or take over a blob.

Wallet blobs are **no longer time-GC'd** — eviction would drop the pin and reopen a squat window. Bounded by the (generous) wallet-count cap instead; abandoned-blob reclamation via a pin tombstone is a cutover concern.

### Closes Codex LOW — route gating
`/wallet/*` + `/signal/{site_id}/identity` register **only** under `-multi-tenant`, and the single-tenant home-host catch-all reserves those paths (404). With the flag off they add no surface (a plain 404, not a 503 or a public-key answer).

### Safety
- **Codex re-review: both fixes CLOSED, no new issues.** `make verify` green.
- The web client (`instance-sync.js`, next slice) must construct `blobWriteMessage` byte-identically — documented in the spec.
- Remaining cutover blocker: the WebAuthn-PRF determinism device test.

## Test plan
- [x] `make verify` (vet + test + build)
- [x] New: writer-auth (store + HTTP, 403 on wrong key/sig, TOFU continuity across reload), route-gating (404 with flag off; reserved under single-tenant)
- [x] Codex read-only security review (no blockers; both follow-ups CLOSED)
🤖 Generated with [Claude Code](https://claude.com/claude-code)