### PR TITLE
feat(home-route): multi-tenant web client + Pi instance descriptor

### DIFF
--- a/.changeset/multi-tenant-web-and-pi-descriptor.md
+++ b/.changeset/multi-tenant-web-and-pi-descriptor.md
@@ -1,0 +1,15 @@
+---
+"forty-two-watts": minor
+---
+
+Multi-tenant home-route client + Pi instance descriptor — still behind the relay's `-multi-tenant` flag (NOT yet live in production).
+
+Completes the browser + Pi half of the multi-tenant home route (the relay half shipped in v0.118.x):
+
+- **Web:** a PUBLIC landing for anonymous visitors (brand + passkey button only — no instance data); passkey sign-in that derives the directory key from the WebAuthn **PRF** extension, fetches + AES-GCM-decrypts the per-wallet directory blob from the relay, verifies each entry's Pi signature, and routes to the chosen instance's **own** Pi. Identity is pinned **first-key-wins** per `(origin, site_id)` and the relay's `/api/identity` is **never trusted on the public route** (anti-MITM); the Ed25519 directory write key is generated once and synced inside the encrypted blob.
+- **Pi:** `GET /api/owner-access/instance-descriptor` (owner-authed, served over the P2P channel) returns the Pi's signed `{site_id, pi_pubkey, label}` so the browser can build + verify its directory entry; first enrollment seeds the encrypted directory blob.
+- The single-tenant / LAN sign-in flow is **untouched** — the multi-tenant path is additive and only active on the public home route.
+
+Codex-reviewed: two anti-MITM findings (relay-identity TOFU on the public route; pin-overwrite) found and fixed. Cross-language interop is locked by tests: JS-signed blob PUTs verify in Go, and Go-signed descriptors verify in the browser.
+
+Cutover (flipping `-multi-tenant` on the relay + deploying this web bundle as `-home-web`) still needs the WebAuthn-PRF determinism device test on real synced devices + live browser validation. See `docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md`.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1526,7 +1526,11 @@ func main() {
 		TunnelMarker:         tunnelMarker,
 		SiteIdentityPubHex:   siteIdentityPubHex,
 		SiteID:               "site:" + cfg.Site.Name,
-		P2P:                  p2pMgr,
+		// InstanceSigner signs the owner-access instance descriptor with the same
+		// self-sovereign ES256 key. nil-safe: if identity load failed above,
+		// siteIdentity is nil and the descriptor endpoint returns 503.
+		InstanceSigner: instanceSignerOrNil(siteIdentity),
+		P2P:            p2pMgr,
 
 		Restart: func(reqCtx context.Context) error {
 			// Prefer the docker-compose sidecar path when wired up: the
@@ -2843,6 +2847,16 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// instanceSignerOrNil returns id as an api.InstanceSigner, or a genuine nil
+// interface when id is nil — so api's `InstanceSigner == nil` 503 guard fires
+// (a typed-nil *nova.Identity boxed into the interface would be non-nil).
+func instanceSignerOrNil(id *nova.Identity) api.InstanceSigner {
+	if id == nil {
+		return nil
+	}
+	return id
 }
 
 // envBool returns true iff the env var is set to a positive value

--- a/go/cmd/ftw-relay/walletblob_interop_test.go
+++ b/go/cmd/ftw-relay/walletblob_interop_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// TestWalletBlobInteropWithWebClient locks the JS<->Go interop of the blob
+// write-auth. The fixture below was produced by the BROWSER crypto in
+// web/owner-access/instance-sync.js (Ed25519 sign over the canonical
+// blobWriteMessage). If Go's blobWriteMessage ever drifts from the JS one — a
+// different field order, delimiter, encoding, or hash — this Ed25519 signature
+// stops verifying and the test fails. Regenerate the fixture from the web with the
+// one-liner in the commit message if the canonical message format is changed on
+// purpose.
+func TestWalletBlobInteropWithWebClient(t *testing.T) {
+	const (
+		fixtureW       = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO_-"
+		fixtureVersion = 1
+		ctB64          = "aW50ZXJvcC1jaXBoZXJ0ZXh0LWJsb2I="
+		nonceB64       = "AQIDBAUGBwgJCgsM"
+		pubB64         = "Gmr6dWWprzvyZ20EfEgYFoJJRHGNZRHeM3JFwAlOG8I="
+		sigB64         = "Caf5dYXL+GPxGH/Ap7B8ILdo67tf3IHIoKF8O+e90H3kZMsihlhDNJGgMotw/DYcXYGgezyakVm5u6+U3pOiDg=="
+	)
+	dec := func(s string) []byte {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			t.Fatalf("decode %q: %v", s, err)
+		}
+		return b
+	}
+	s := newTestBlobStore(t)
+	err := s.Put(fixtureW, dec(ctB64), dec(nonceB64), dec(pubB64), dec(sigB64), fixtureVersion)
+	if err != nil {
+		t.Fatalf("web-generated signed PUT rejected by the Go store: %v\n"+
+			"This means blobWriteMessage differs between web/owner-access/instance-sync.js and go/cmd/ftw-relay/walletblob.go.", err)
+	}
+}

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -53,6 +53,18 @@ const (
 	maskedPlaceholder = "••••••••"
 )
 
+// InstanceSigner signs the owner-access instance descriptor with the Pi's
+// self-sovereign ES256 identity. *nova.Identity satisfies it. PublicKeyHex
+// returns the uncompressed P-256 public key (X||Y, 128 lowercase hex chars);
+// SignRawHex returns the raw r||s 64-byte signature as a 128-char hex string
+// (the handler re-encodes it to base64url for the wire). Declared as an
+// interface here so internal/api does not import internal/nova (matches the
+// relaySigner pattern in cmd/forty-two-watts/owner_relay_register.go).
+type InstanceSigner interface {
+	PublicKeyHex() string
+	SignRawHex(msg string) (string, error)
+}
+
 // Deps is the full set of runtime dependencies the API handlers need.
 // One instance is shared across all handlers; mutations use the contained
 // mutexes from each package.
@@ -188,6 +200,13 @@ type Deps struct {
 	// /api/identity so the browser can pin it and rebuild the canonical DTLS
 	// fingerprint signing string (which binds the signature to this site).
 	SiteID string
+
+	// InstanceSigner is the Pi's self-sovereign ES256 identity used to sign the
+	// owner-access instance descriptor (GET /api/owner-access/instance-descriptor)
+	// over the P2P channel. Satisfied by *nova.Identity — the same key behind
+	// SiteIdentityPubHex. Nil when identity load failed on boot; the descriptor
+	// endpoint then returns 503.
+	InstanceSigner InstanceSigner
 
 	// P2P is the Pi-side WebRTC manager (Phase 5). It answers browser SDP
 	// offers (POST /api/p2p/offer) and serves the resulting direct DataChannel
@@ -365,6 +384,9 @@ func (s *Server) routes() {
 	// C3 — silent device-key PoP login over the P2P channel (open, pre-session).
 	s.handle("GET  /api/owner-access/device-challenge", s.handleOwnerDeviceChallenge)
 	s.handle("POST /api/owner-access/device-pop", s.handleOwnerDevicePoP)
+	// Multi-tenant home route: Pi-signed instance descriptor, owner-authed,
+	// served over the P2P channel (see api_owner_instance_descriptor.go).
+	s.handle("GET  /api/owner-access/instance-descriptor", s.handleOwnerInstanceDescriptor)
 
 	// ---- Self-sovereign site identity (Phase 2) ----
 	s.handle("GET  /api/identity", s.handleIdentity)

--- a/go/internal/api/api_owner_instance_descriptor.go
+++ b/go/internal/api/api_owner_instance_descriptor.go
@@ -1,0 +1,72 @@
+// api_owner_instance_descriptor.go
+//
+// GET /api/owner-access/instance-descriptor — the Pi-signed instance descriptor
+// the multi-tenant home route relies on. Served over the owner-authenticated P2P
+// (DTLS) channel; NOT an open path (deliberately absent from
+// isOwnerAccessOpenPath, so the global gate also refuses it without a session).
+// The browser stores the {site_id, pi_pubkey, label, sig} tuple inside its
+// encrypted directory blob and verifies sig against pi_pubkey
+// (web/owner-access/instance-sync.js verifyEntry) before trusting an entry — so
+// even a tampering relay that stores the blob cannot inject a fake instance. The
+// signing string is domain-separated ("ftw-instance:v1:") and bound to
+// site_id + pi_pubkey + label, so a signature minted here can never be replayed
+// for another purpose (cf. SignRawHex's domain-separation note in
+// internal/nova/identity.go).
+package api
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+)
+
+// instanceDescriptorSigningString is the canonical message the Pi signs for the
+// instance descriptor. Both ends (Pi here, browser in instance-sync.js
+// instanceMessage) MUST build it identically — pinning the format in one place
+// is the entire point.
+func instanceDescriptorSigningString(siteID, piPubkey, label string) string {
+	return "ftw-instance:v1:" + siteID + ":" + piPubkey + ":" + label
+}
+
+// handleOwnerInstanceDescriptor returns the Pi-signed instance descriptor. Owner
+// auth required (same posture as whoami): the descriptor is served only over the
+// already-owner-authenticated P2P channel, never anonymously over the relay.
+func (s *Server) handleOwnerInstanceDescriptor(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeOwner(r); !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.deps.InstanceSigner == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "site identity unavailable"})
+		return
+	}
+	piPubkey := s.deps.InstanceSigner.PublicKeyHex()
+	siteID := s.deps.SiteID
+	label := siteID
+	if s.deps.Cfg != nil && s.deps.Cfg.Site.Name != "" {
+		label = s.deps.Cfg.Site.Name
+	}
+	msg := instanceDescriptorSigningString(siteID, piPubkey, label)
+	sigHex, err := s.deps.InstanceSigner.SignRawHex(msg)
+	if err != nil {
+		slog.Error("instance-descriptor: sign failed", "site_id", siteID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "sign descriptor"})
+		return
+	}
+	// SignRawHex returns raw r||s as hex; the CONTRACT wire form is base64url
+	// (no padding) so the browser can verify with WebCrypto (P-256 native r||s).
+	// Re-encode.
+	sigBytes, err := hex.DecodeString(sigHex)
+	if err != nil {
+		slog.Error("instance-descriptor: malformed signature hex", "site_id", siteID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "encode descriptor"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"site_id":   siteID,
+		"pi_pubkey": piPubkey,
+		"label":     label,
+		"sig":       base64.RawURLEncoding.EncodeToString(sigBytes),
+	})
+}

--- a/go/internal/api/api_owner_instance_descriptor_test.go
+++ b/go/internal/api/api_owner_instance_descriptor_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeInstanceSigner is an in-test ES256 signer mirroring *nova.Identity's
+// SignRawHex/PublicKeyHex wire contract (raw r||s as 128-char hex; pubkey as
+// uncompressed X||Y, 128 lowercase hex chars). It lets the api package test the
+// descriptor handler without importing internal/nova (no cycle, matches the
+// relaySigner interface pattern in cmd/forty-two-watts/owner_relay_register.go).
+type fakeInstanceSigner struct{ priv *ecdsa.PrivateKey }
+
+func newFakeInstanceSigner(t *testing.T) *fakeInstanceSigner {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	return &fakeInstanceSigner{priv: priv}
+}
+
+func (f *fakeInstanceSigner) PublicKeyHex() string {
+	x := f.priv.PublicKey.X.Bytes()
+	y := f.priv.PublicKey.Y.Bytes()
+	buf := make([]byte, 64)
+	copy(buf[32-len(x):32], x)
+	copy(buf[64-len(y):64], y)
+	return hex.EncodeToString(buf)
+}
+
+func (f *fakeInstanceSigner) SignRawHex(msg string) (string, error) {
+	h := sha256.Sum256([]byte(msg))
+	r, s, err := ecdsa.Sign(rand.Reader, f.priv, h[:])
+	if err != nil {
+		return "", err
+	}
+	sig := make([]byte, 64)
+	rb, sb := r.Bytes(), s.Bytes()
+	copy(sig[32-len(rb):32], rb)
+	copy(sig[64-len(sb):64], sb)
+	return hex.EncodeToString(sig), nil
+}
+
+// verifyInstanceSig checks a base64url (no padding) raw r||s ECDSA-P256 sig of
+// msg against an uncompressed X||Y device public key (128 hex chars). Mirrors
+// the browser-side verifyEntry the directory blob relies on.
+func verifyInstanceSig(t *testing.T, pubKeyHex, msg, sigB64URL string) bool {
+	t.Helper()
+	pb, err := hex.DecodeString(pubKeyHex)
+	if err != nil || len(pb) != 64 {
+		return false
+	}
+	pub := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     new(big.Int).SetBytes(pb[:32]),
+		Y:     new(big.Int).SetBytes(pb[32:]),
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(sigB64URL)
+	if err != nil || len(sig) != 64 {
+		return false
+	}
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	h := sha256.Sum256([]byte(msg))
+	return ecdsa.Verify(pub, h[:], r, s)
+}
+
+// The descriptor is owner-authed and signs the EXACT CONTRACT string; the
+// signature must verify against pi_pubkey and the JSON fields must match.
+func TestInstanceDescriptorSignsContractString(t *testing.T) {
+	d := minDeps(t)
+	d.OwnerAccessLANBypass = true // gate inactive in minDeps (TunnelMarker empty), authorizeOwner returns lan-bypass
+	signer := newFakeInstanceSigner(t)
+	d.InstanceSigner = signer
+	d.SiteIdentityPubHex = signer.PublicKeyHex()
+	d.SiteID = "site:test-site"
+	d.Cfg.Site.Name = "test-site"
+	srv := New(d)
+
+	req := httptest.NewRequest("GET", "/api/owner-access/instance-descriptor", nil)
+	req.Host = "1.2.3.4"
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
+	}
+
+	var out struct {
+		SiteID   string `json:"site_id"`
+		PiPubkey string `json:"pi_pubkey"`
+		Label    string `json:"label"`
+		Sig      string `json:"sig"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v body=%q", err, rec.Body.String())
+	}
+	if out.SiteID != "site:test-site" {
+		t.Fatalf("site_id=%q want site:test-site", out.SiteID)
+	}
+	if out.PiPubkey != signer.PublicKeyHex() || len(out.PiPubkey) != 128 {
+		t.Fatalf("pi_pubkey=%q (len %d) want %q", out.PiPubkey, len(out.PiPubkey), signer.PublicKeyHex())
+	}
+	if out.Label != "test-site" {
+		t.Fatalf("label=%q want test-site", out.Label)
+	}
+
+	// The signed string MUST be byte-for-byte the CONTRACT format.
+	want := "ftw-instance:v1:" + out.SiteID + ":" + out.PiPubkey + ":" + out.Label
+	if !verifyInstanceSig(t, out.PiPubkey, want, out.Sig) {
+		t.Fatalf("signature does not verify over %q (sig=%q)", want, out.Sig)
+	}
+	// And sig is base64url (no padding) of a 64-byte raw r||s, never hex.
+	if _, err := base64.RawURLEncoding.DecodeString(out.Sig); err != nil {
+		t.Fatalf("sig not base64url-no-pad: %q (%v)", out.Sig, err)
+	}
+}
+
+// Without an owner session AND without LAN-bypass, a remote (tunnelled) caller
+// is refused — the descriptor carries the Pi pubkey + a signature and must not
+// be an anonymous read over the relay.
+func TestInstanceDescriptorRequiresOwner(t *testing.T) {
+	d := minDeps(t)
+	d.OwnerAccessLANBypass = false
+	d.TunnelMarker = "marker" // gate active
+	signer := newFakeInstanceSigner(t)
+	d.InstanceSigner = signer
+	d.SiteIdentityPubHex = signer.PublicKeyHex()
+	d.SiteID = "site:test-site"
+	srv := New(d)
+
+	req := httptest.NewRequest("GET", "/api/owner-access/instance-descriptor", nil)
+	req.Host = "127.0.0.1"
+	req.Header.Set("X-FTW-Tunnel", "marker") // tunnelled → no LAN bypass, no session → reject
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Fatalf("status=%d want 401 body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// When no identity/signer is wired (e.g. identity load failed on boot), the
+// endpoint reports 503 rather than serving an unsigned descriptor.
+func TestInstanceDescriptor503WhenNoSigner(t *testing.T) {
+	d := minDeps(t)
+	d.OwnerAccessLANBypass = true
+	d.InstanceSigner = nil
+	d.SiteIdentityPubHex = ""
+	srv := New(d)
+
+	req := httptest.NewRequest("GET", "/api/owner-access/instance-descriptor", nil)
+	req.Host = "1.2.3.4"
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Fatalf("status=%d want 503 body=%q", rec.Code, rec.Body.String())
+	}
+}

--- a/web/enroll-directory-seed.test.mjs
+++ b/web/enroll-directory-seed.test.mjs
@@ -1,0 +1,185 @@
+// node --test web/enroll-directory-seed.test.mjs
+//
+// First-enrollment directory seeding (Task Group 6, requirement 5) and the
+// gate-state routing DECISION given a mock directory (0 / 1 / >1 instances).
+//
+// Two layers:
+//  1. Behavioural — the enroll flow builds a 1-entry directory from the Pi-signed
+//     instance descriptor and writes it via instance-sync.saveDirectory. We
+//     exercise the REAL instance-sync.js against a fake relay + the Go-signed
+//     fixture, proving the entry shape the enroll page builds round-trips
+//     (saveDirectory → getCachedInstances → loadDirectory) and verifies.
+//  2. Pure decision — the route() contract from next-app.js
+//     openDirectoryAfterAssertion: 0 → guidance, 1 → auto-open, >1 → auto-open
+//     the first (picker TODO). Replicated here as a pure function so the
+//     0/1/>1 branch is asserted headless (next-app.js itself is a DOM-coupled
+//     IIFE the repo can't import — see web/setup.test.mjs).
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// ---- shared web-crypto + storage harness so instance-sync.js runs under node --
+import { webcrypto } from "node:crypto";
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+globalThis.btoa = (s) => Buffer.from(s, "binary").toString("base64");
+globalThis.atob = (s) => Buffer.from(s, "base64").toString("binary");
+
+// Minimal localStorage so getCachedInstances/cacheInstances work.
+function installLocalStorage() {
+  const store = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  };
+  return store;
+}
+
+// Fake relay: a single in-memory wallet blob behind /wallet/<W>/blob.
+function installFakeRelay() {
+  const blobs = new Map(); // W -> { ciphertext, nonce, version, write_pub }
+  globalThis.fetch = async (url, init = {}) => {
+    const m = /\/wallet\/([^/]+)\/blob$/.exec(String(url));
+    if (!m) throw new Error("unexpected fetch " + url);
+    const W = m[1];
+    if (!init.method || init.method === "GET") {
+      const b = blobs.get(W);
+      if (!b) return { status: 404, ok: false, json: async () => null };
+      return { status: 200, ok: true, json: async () => b };
+    }
+    if (init.method === "PUT") {
+      const body = JSON.parse(init.body);
+      blobs.set(W, { ciphertext: body.ciphertext, nonce: body.nonce, version: body.version, write_pub: body.write_pub });
+      return { status: 200, ok: true };
+    }
+    throw new Error("unexpected method " + init.method);
+  };
+  return blobs;
+}
+
+// The Go(Pi)-signed instance descriptor fixture (same as instance-interop.test.mjs):
+// exactly what GET /api/owner-access/instance-descriptor returns and what the
+// enroll page wraps into the 1-entry directory.
+const DESC = {
+  site_id: "site:Home",
+  label: "Home",
+  pi_pubkey:
+    "f0298dc888bb1d4c2d5708ae5072d6c4ae282d00fd705c42534ab2864bdc6e81e914516a4452b431ae6eb138afaeb8ad68300c61829530a6106622cb6c8858d2",
+  sig: "8nDdyLDhqHIug9__TseI7bUeFI8IsfyWKPi_ND62-iMAKqmZnmEtOet_QbEF3G1DKj1E7b2ngNpUpXwvHnCA5Q",
+};
+
+describe("first-enrollment directory seed (instance-sync round-trip)", () => {
+  let store, blobs, sync, prf;
+  beforeEach(async () => {
+    store = installLocalStorage();
+    blobs = installFakeRelay();
+    sync = await import("./owner-access/instance-sync.js?seed=" + Math.random());
+    prf = await import("./owner-access/prf.js?seed=" + Math.random());
+  });
+
+  it("the descriptor verifies as an instance entry (verifyEntry over the Pi sig)", async () => {
+    assert.ok(await sync.verifyEntry(DESC), "Pi-signed descriptor must verify");
+  });
+
+  it("saveDirectory writes a 1-entry directory; getCachedInstances reads it back", async () => {
+    const W = "dGVzdC13YWxsZXQ"; // base64url(user.id), opaque
+    const encKey = await prf.deriveEncKey(new Uint8Array(32).fill(7).buffer);
+    const entry = { ...DESC, added_ms: Date.now() };
+    const out = await sync.saveDirectory(W, encKey, "https://relay.example", {
+      instances: [entry], version: 0, writeKey: null,
+    });
+    assert.equal(out.putStatus, 200, "relay PUT must succeed");
+    const cached = sync.getCachedInstances();
+    assert.equal(cached.length, 1, "browser-carried copy holds the single home");
+    assert.equal(cached[0].site_id, "site:Home");
+    assert.equal(cached[0].pi_pubkey, DESC.pi_pubkey);
+    assert.ok(blobs.has(W), "an encrypted blob was written to the relay");
+  });
+
+  it("a FRESH device with the same passkey (encKey) loads the seeded home from the relay", async () => {
+    const W = "dGVzdC13YWxsZXQ";
+    const encKey = await prf.deriveEncKey(new Uint8Array(32).fill(7).buffer);
+    await sync.saveDirectory(W, encKey, "https://relay.example", {
+      instances: [{ ...DESC, added_ms: Date.now() }], version: 0, writeKey: null,
+    });
+    // Simulate a fresh device: wipe the browser-carried copy, keep the relay blob.
+    store.delete("ftw.directory");
+    assert.equal(sync.getCachedInstances().length, 0, "fresh device starts with no cache");
+    const dir = await sync.loadDirectory(W, encKey, "https://relay.example");
+    assert.ok(dir, "directory loads from the relay blob");
+    assert.equal(dir.instances.length, 1, "the seeded home is discovered remotely");
+    assert.equal(dir.instances[0].site_id, "site:Home");
+  });
+
+  it("without PRF (encKey=null) saveDirectory still caches locally but writes NO relay blob", async () => {
+    const W = "dGVzdC13YWxsZXQ";
+    const entry = { ...DESC, added_ms: Date.now() };
+    const out = await sync.saveDirectory(W, null, "https://relay.example", {
+      instances: [entry], version: 0, writeKey: null,
+    });
+    assert.equal(sync.getCachedInstances().length, 1, "browser-carried copy still works with no PRF");
+    assert.equal(blobs.has(W), false, "no encrypted blob without a key (carry-local only)");
+    assert.equal(out.putStatus, undefined, "no relay PUT attempted without encKey");
+  });
+});
+
+// route() is the exact decision the next-app.js openDirectoryAfterAssertion makes
+// after loadDirectory resolves. Replicated as a pure function so the 0/1/>1
+// branch is covered headless. Returns the routing verdict as a tag.
+function route(instances) {
+  const list = instances || [];
+  if (list.length === 1) return "auto-open";
+  if (list.length > 1) return "auto-open-first"; // picker TODO
+  return "needs-setup-guidance"; // 0 entries — not an error
+}
+
+describe("gate-state decision: 0 / 1 / >1 instances", () => {
+  it("0 instances → finish-setup guidance (no error, no open)", () => {
+    assert.equal(route([]), "needs-setup-guidance");
+  });
+  it("exactly 1 instance → auto-open", () => {
+    assert.equal(route([{ site_id: "site:Home" }]), "auto-open");
+  });
+  it(">1 instances → auto-open the first (picker deferred)", () => {
+    assert.equal(route([{ site_id: "site:Home" }, { site_id: "site:Cabin" }]), "auto-open-first");
+  });
+});
+
+// ---- static wiring guards: enroll.html + login.html consume the real contract --
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(join(__dirname, p), "utf8");
+
+describe("enroll.html seeds the directory on first enrollment", () => {
+  const ENROLL = read("owner-access/enroll.html");
+  it("requests the PRF extension on navigator.credentials.create", () => {
+    assert.match(ENROLL, /extensionInput\(\)/);
+    assert.match(ENROLL, /credOpts\.extensions\s*=/);
+  });
+  it("fetches the Pi-signed instance descriptor over the owner channel", () => {
+    assert.match(ENROLL, /ownerFetch\("\/api\/owner-access\/instance-descriptor"/);
+  });
+  it("verifies the entry, then saveDirectory with a 1-entry list (version 0, writeKey null)", () => {
+    assert.match(ENROLL, /verifyEntry\(entry\)/);
+    assert.match(ENROLL, /saveDirectory\(/);
+    assert.match(ENROLL, /instances:\s*\[entry\],\s*version:\s*0,\s*writeKey:\s*null/);
+  });
+  it("derives the key from the create assertion's PRF output (null fallback)", () => {
+    assert.match(ENROLL, /outputFrom\(cred\)/);
+    assert.match(ENROLL, /prfOut\s*\?\s*await\s+deriveEncKey\(prfOut\)\s*:\s*null/);
+  });
+});
+
+describe("login.html requests PRF and seeds the routing directory", () => {
+  const LOGIN = read("owner-access/login.html");
+  it("requests the PRF extension on the assertion", () => {
+    assert.match(LOGIN, /extensionInput\(\)/);
+    assert.match(LOGIN, /credOpts\.extensions\s*=/);
+  });
+  it("loads the directory from THIS assertion's PRF output after sign-in", () => {
+    assert.match(LOGIN, /outputFrom\(cred\)/);
+    assert.match(LOGIN, /loadDirectory\(/);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -119,6 +119,21 @@
        served unauthenticated — the gate is purely the lock's UI. -->
   <div id="signin-gate" class="signin-gate" data-mode="connecting">
     <div class="signin-gate-card">
+      <!-- PUBLIC landing: shown to an anonymous visitor with no decryptable
+           directory. Brand + one passkey button + a discreet "Learn more" link
+           ONLY. Per the multi-tenant spec it reveals NOTHING about any home
+           (no count, label, site_id, or Pi key) before the user authenticates —
+           home.fortytwowatts.com is a public front door for everyone. -->
+      <div class="signin-gate-landing">
+        <div class="signin-gate-brand">&#9889; forty-two watts</div>
+        <p class="signin-gate-lead">This is your forty-two-watts home. Sign in with your passkey to reach it.</p>
+        <button id="signin-landing-btn" class="signin-gate-btn">Sign in with your passkey</button>
+        <p class="signin-gate-msg" id="signin-landing-msg" role="status" aria-live="polite"></p>
+        <p class="signin-gate-learn-row">Don&rsquo;t have a 42W yet?
+          <a class="signin-gate-learn" href="https://fortytwowatts.com" rel="noopener">Learn more &rarr;</a></p>
+      </div>
+      <!-- /signin-gate-landing -->
+
       <div class="signin-gate-brand">&#9889; forty-two watts</div>
       <p class="signin-gate-lead signin-gate-connecting">Reaching your home&hellip;</p>
 
@@ -738,8 +753,19 @@
        (C3). A module, so it's deferred — p2p.js's warm-up connect soft-fails once
        if it races ahead and retries promptly once the global is present. -->
   <script type="module" src="/owner-access/device-key.js?v=devkey1"></script>
-  <script src="/p2p.js?v=p2p5"></script>
-  <script src="/next-app.js?v=next6"></script>
+  <!-- Multi-tenant home route (ADDITIVE — only active on the public home host).
+       prf.js derives the per-wallet directory ENCRYPTION key from the passkey's
+       PRF output; instance-sync.js manages the encrypted per-wallet directory of
+       42W homes against the relay. Both are ES modules that ALSO attach
+       window.ftwPrf / window.ftwInstanceSync for the classic scripts (p2p.js,
+       next-app.js) to consume. Deferred like device-key.js: every consumer reads
+       the globals from inside async handlers (whoami / sign-in / connect), never
+       at top-level, so the module-load race is harmless — an anonymous visitor
+       with no directory simply gets the public landing until they sign in. -->
+  <script type="module" src="/owner-access/prf.js?v=prf1"></script>
+  <script type="module" src="/owner-access/instance-sync.js?v=isync1"></script>
+  <script src="/p2p.js?v=p2p6"></script>
+  <script src="/next-app.js?v=next7"></script>
   <script src="/settings.js?v=diag1"></script>
   <script src="/settings/tabs/control.js?v=tabsplit1"></script>
   <script src="/settings/tabs/devices.js?v=tabsplit1"></script>

--- a/web/landing-gate.test.mjs
+++ b/web/landing-gate.test.mjs
@@ -1,0 +1,96 @@
+// node --test web/landing-gate.test.mjs
+//
+// Gate routing (Task Group 6): next-app.js must show the PUBLIC landing when
+// there's no decryptable directory (anonymous), wire the landing button to the
+// same runSignIn ceremony, AUTO-OPEN when the decrypted directory has exactly 1
+// entry (no picker in v1), and request the PRF extension on the assertion. These
+// static guards lock the exact branch shape against the prf.js / instance-sync.js
+// contract (window.ftwPrf, window.ftwInstanceSync) so the modules stay aligned.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(join(__dirname, p), "utf8");
+const APP = read("next-app.js");
+const INDEX = read("index.html");
+
+describe("next-app.js — public landing for the anonymous visitor", () => {
+  it("shows the public-landing gate mode when no directory is decryptable", () => {
+    assert.match(APP, /showGate\("public-landing"\)/,
+      "an anonymous / no-directory visitor must land on data-mode=public-landing");
+  });
+
+  it("reads the cached directory via instance-sync (getCachedInstances)", () => {
+    assert.match(APP, /getCachedInstances\(\)/,
+      "the gate must consult the decrypted directory, not invent its own store");
+  });
+
+  it("wires the landing button to the SAME runSignIn ceremony as the gate button", () => {
+    assert.match(APP, /getElementById\("signin-landing-btn"\)/);
+    assert.match(APP, /landingBtn[\s\S]{0,120}runSignIn\(\)/,
+      "the landing button must call runSignIn() — one ceremony, not a fork");
+  });
+});
+
+describe("next-app.js — PRF extension on the sign-in assertion (prf.js contract)", () => {
+  it("requests the prf extension via extensionInput() on navigator.credentials.get", () => {
+    assert.match(APP, /extensionInput\(\)/,
+      "the assertion must carry prf.extensionInput() so PRF is evaluated");
+    assert.match(APP, /publicKey\.extensions\s*=/,
+      "navigator.credentials.get publicKey must set an extensions field for PRF");
+  });
+
+  it("derives the directory key from the assertion via outputFrom + deriveEncKey", () => {
+    assert.match(APP, /outputFrom\(/,
+      "must read the PRF output from the assertion (prf.outputFrom)");
+    assert.match(APP, /deriveEncKey\(/,
+      "must HKDF the PRF output into the AES key (prf.deriveEncKey)");
+  });
+
+  it("uses the base64url userHandle as the wallet handle W", () => {
+    assert.match(APP, /userHandle/,
+      "W = base64url(assertion.response.userHandle) keys the relay blob");
+  });
+
+  it("loads the directory via instance-sync.loadDirectory(W, encKey, origin)", () => {
+    assert.match(APP, /loadDirectory\(/,
+      "must call instanceSync.loadDirectory to fetch+decrypt the relay blob");
+    assert.match(APP, /location\.origin/,
+      "loadDirectory's relayBase is location.origin on the public home route");
+  });
+
+  it("falls back to loadDirectory(W, null, origin) when PRF is unavailable", () => {
+    assert.match(APP, /loadDirectory\([^)]*,\s*null\s*,/,
+      "no PRF → browser-carried copy via loadDirectory(W, null, origin)");
+  });
+});
+
+describe("next-app.js — auto-open on exactly 1 entry (no picker in v1)", () => {
+  it("auto-opens when the directory has exactly one entry", () => {
+    assert.match(APP, /length\s*===\s*1/,
+      "exactly-1-entry must short-circuit straight through (no picker)");
+  });
+
+  it("auto-opens the FIRST entry when there is more than one (picker TODO)", () => {
+    assert.match(APP, /TODO[\s\S]{0,120}picker/i,
+      "the >1 case auto-opens the first and leaves a clearly-marked picker TODO");
+  });
+
+  it("does NOT render a picker UI in v1", () => {
+    assert.doesNotMatch(APP, /pickInstance|instance-picker|chooseInstance/i,
+      "v1 routes the single home automatically; the picker is deferred");
+  });
+});
+
+describe("index.html loads the multi-tenant crypto modules (prf + instance-sync)", () => {
+  it("loads prf.js and instance-sync.js so window.ftwPrf / window.ftwInstanceSync exist", () => {
+    assert.match(INDEX, /owner-access\/prf\.js/,
+      "prf.js must be loaded for the PRF-derived directory key");
+    assert.match(INDEX, /owner-access\/instance-sync\.js/,
+      "instance-sync.js must be loaded for loadDirectory/saveDirectory/getCachedInstances");
+  });
+});

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -3577,6 +3577,19 @@
     };
   }
 
+  // hasDecryptableDirectory reports whether instance-sync has a usable directory
+  // cached (the user already authenticated + PRF-decrypted this session, or a
+  // migrated single-home record seeded the browser-carried copy). When false the
+  // visitor is anonymous and gets the PUBLIC landing — never any instance data.
+  function hasDecryptableDirectory() {
+    try {
+      var sync = window.ftwInstanceSync;
+      if (!sync || typeof sync.getCachedInstances !== "function") return false;
+      var list = sync.getCachedInstances() || [];
+      return list.length >= 1;
+    } catch (e) { return false; }
+  }
+
   // The sign-in GATE replaces the dashboard when the viewer isn't signed in on a
   // remote origin — so a logged-out visitor sees a clean "sign in to reach your
   // home", never the empty dashboard chrome (which falsely reads as an
@@ -3663,8 +3676,19 @@
   function runSignIn() {
     if (signInBusy) return Promise.resolve(false);
     signInBusy = true;
-    var msgEl = document.getElementById("signin-banner-msg");
-    function say(t, cls) { if (msgEl) { msgEl.textContent = t || ""; msgEl.className = "signin-banner-msg" + (cls ? " " + cls : ""); } }
+    // say updates whichever message line is on screen. The same ceremony runs
+    // from both the returning-visitor gate (#signin-banner-msg) and the public
+    // landing (#signin-landing-msg); writing both keeps feedback visible without
+    // forking the flow.
+    var msgEls = ["signin-banner-msg", "signin-landing-msg"]
+      .map(function (id) { return document.getElementById(id); })
+      .filter(function (el) { return !!el; });
+    function say(t, cls) {
+      for (var i = 0; i < msgEls.length; i++) {
+        msgEls[i].textContent = t || "";
+        msgEls[i].className = "signin-gate-msg" + (cls ? " " + cls : "");
+      }
+    }
     // Silent first: if this device is remembered, no passkey prompt at all.
     say("Reaching your home…");
     return runDevicePoP().then(function (silentOk) {
@@ -3678,9 +3702,69 @@
     });
   }
 
+  // openDirectoryAfterAssertion derives the directory ENCRYPTION key from THIS
+  // login assertion's PRF output (prf.js: outputFrom → deriveEncKey), loads +
+  // decrypts the relay directory blob (instance-sync.js: loadDirectory), and
+  // routes. v1 contract: the directory is a LIST. Exactly 1 entry → auto-open
+  // (no picker). >1 → auto-open the FIRST and leave a clearly-marked picker TODO.
+  // 0 → "finish setup on your home network" guidance (no error). When the PRF
+  // output is absent (Firefox, or a passkey enrolled without prf), we fall back to
+  // loadDirectory(W, null, origin) — the browser-carried copy — and surface that
+  // encrypted home sync is unavailable here. A PRF/decrypt failure is NEVER fatal:
+  // the dashboard still opens; instance-sync's local cache is the source of truth.
+  function openDirectoryAfterAssertion(cred, say) {
+    var prf = window.ftwPrf, sync = window.ftwInstanceSync;
+    if (!prf || typeof prf.outputFrom !== "function" || typeof prf.deriveEncKey !== "function" ||
+        !sync || typeof sync.loadDirectory !== "function") {
+      return Promise.resolve(); // crypto modules absent → carry-local only
+    }
+    // W = base64url(assertion.response.userHandle) — the opaque wallet handle the
+    // relay keys the encrypted blob on.
+    var W = null;
+    try {
+      var uh = cred && cred.response ? cred.response.userHandle : null;
+      if (uh) W = bufToB64url(uh);
+    } catch (e) {}
+    if (!W) return Promise.resolve(); // no wallet handle → nothing to fetch
+    var origin = location.origin;
+    function route(dir) {
+      var list = (dir && dir.instances) || [];
+      if (list.length === 1) {
+        // Exactly one home — auto-open. The pin re-resolves from the freshly
+        // cached directory entry (p2p.js::pinnedIdentity), so the next owner
+        // fetch connects to the right site with no relay round-trip.
+        return;
+      }
+      if (list.length > 1) {
+        // TODO(multi-instance picker): v1 has no picker, so auto-open the FIRST
+        // entry. instance-sync's getCachedInstances()[0] is what p2p.js pins, so
+        // "the first" is already the chosen one. Replace this with a picker UI
+        // when multi-home support lands.
+        try { console.log("ftw: " + list.length + " homes in directory; auto-opening the first (picker TODO)"); } catch (e) {}
+        return;
+      }
+      // 0 entries — the wallet has no home registered yet. This isn't an error;
+      // the user just hasn't finished setup on their home network.
+      say("Finish setting up 42W on your home network, then return here.", "ok");
+    }
+    var prfOut = null;
+    try { prfOut = prf.outputFrom(cred); } catch (e) { prfOut = null; }
+    if (!prfOut) {
+      // No PRF on this browser/passkey — fall back to the browser-carried copy.
+      say("Signed in. (Encrypted home sync isn’t available on this browser.)", "ok");
+      return sync.loadDirectory(W, null, origin).then(route).catch(function () {});
+    }
+    return prf.deriveEncKey(prfOut)
+      .then(function (encKey) { return sync.loadDirectory(W, encKey, origin); })
+      .then(route)
+      .catch(function () { /* PRF/decrypt failure → carry-local; never blocks login */ });
+  }
+
   // runPasskeySignIn is the explicit passkey ceremony — the fallback when the
   // silent device path isn't available. Kept as its own function so runSignIn can
-  // try silent first without duplicating the WebAuthn flow.
+  // try silent first without duplicating the WebAuthn flow. The assertion requests
+  // the PRF extension (prf.extensionInput): the same passkey tap yields the
+  // directory-decryption key, so after finish we load + route the directory.
   function runPasskeySignIn(say) {
     say("Waiting for your passkey…");
     return ownerFetch("/api/owner-access/login/start", { method: "POST" })
@@ -3691,7 +3775,18 @@
       })
       .then(function (data) {
         if (!data) return false;
-        return navigator.credentials.get({ publicKey: decodeAssertionOptions(data.options) }).then(function (cred) {
+        var getOpts = { publicKey: decodeAssertionOptions(data.options) };
+        // Request the PRF extension so the authenticator evaluates the per-wallet
+        // secret we HKDF into the directory key (prf.js). Harmless on browsers /
+        // authenticators that don't support it — they simply return no prf result
+        // and we fall back to the browser-carried directory copy.
+        try {
+          if (window.ftwPrf && typeof window.ftwPrf.extensionInput === "function") {
+            getOpts.publicKey.extensions = Object.assign(
+              {}, getOpts.publicKey.extensions, window.ftwPrf.extensionInput());
+          }
+        } catch (e) {}
+        return navigator.credentials.get(getOpts).then(function (cred) {
           if (!cred) { say(""); return false; }
           return ownerFetch("/api/owner-access/login/finish?ceremony_token=" + encodeURIComponent(data.ceremony_token), {
             method: "POST",
@@ -3700,8 +3795,14 @@
             credentials: "same-origin",
           }).then(function (finish) {
             if (!finish.ok) { say("Sign-in failed (" + finish.status + ").", "err"); return false; }
-            say("Signed in.", "ok");
-            return true;
+            // Session minted. Now derive the directory key from this SAME
+            // assertion's PRF output, load + decrypt the relay directory, and
+            // route (auto-open on exactly 1). Non-fatal: a PRF/decrypt failure
+            // still signs the user in against the browser-carried copy.
+            return openDirectoryAfterAssertion(cred, say).then(function () {
+              say("Signed in.", "ok");
+              return true;
+            });
           });
         });
       })
@@ -3724,6 +3825,11 @@
     var signoutBtn = document.getElementById("signout-btn");
     var gateBtn = document.getElementById("signin-gate-btn");
     if (gateBtn && !gateBtn._wired) { gateBtn._wired = true; gateBtn.onclick = function () { runSignIn(); }; }
+    // The public-landing button runs the SAME ceremony as the gate button — one
+    // runSignIn(), not a fork — so the landing and the returning-visitor card
+    // converge on the identical passkey + PRF + directory flow.
+    var landingBtn = document.getElementById("signin-landing-btn");
+    if (landingBtn && !landingBtn._wired) { landingBtn._wired = true; landingBtn.onclick = function () { runSignIn(); }; }
     if (signoutBtn && !signoutBtn._wired) {
       signoutBtn._wired = true;
       signoutBtn.onclick = function () {
@@ -3768,12 +3874,16 @@
   // load (it's idempotent but pointless to repeat on every reconnect).
   var silentAuthTried = false;
 
-  // showSignInGate reveals the passkey gate, choosing the copy by whether this
-  // device is even capable of being remembered. If p2p.js reports the origin is
-  // UNENROLLED (no device key — never set up on the LAN), we surface the explicit
-  // "set up this device on your home network first" path (C2) instead of a passkey
-  // prompt the user can't satisfy here.
+  // showSignInGate routes the gate. The multi-tenant PUBLIC home route is purely
+  // ADDITIVE: a visitor with NO decryptable directory (anonymous, fresh browser)
+  // gets the public landing — brand + passkey + Learn more, and NO instance data.
+  // Once a directory is cached (this session's PRF decrypt, or a migrated
+  // single-home record) the existing single-tenant copy applies: the normal
+  // "signin" card, or the "setup" card when p2p.js reports this origin is
+  // UNENROLLED (no device key — never set up on the LAN). On the LAN the gate
+  // never shows at all, so the existing flow there is untouched.
   function showSignInGate() {
+    if (!hasDecryptableDirectory()) { showGate("public-landing"); return; }
     var unEnrolled = false;
     try {
       unEnrolled = !!(window.ftwP2P && window.ftwP2P.isUnenrolled && window.ftwP2P.isUnenrolled());

--- a/web/next.css
+++ b/web/next.css
@@ -345,6 +345,27 @@ body.ftw-next .signin-gate[data-mode="setup"] .signin-gate-connecting { display:
 /* The trust line is meaningless while still "connecting" — hide it there. */
 body.ftw-next .signin-gate[data-mode="connecting"] .signin-gate-trust { display: none; }
 
+/* Public landing (multi-tenant): the anonymous front door. Brand + passkey +
+   a discreet "Learn more" — no instance data pre-auth. Shown ONLY in
+   data-mode="public-landing"; it suppresses the "reaching your home" line, the
+   single-tenant auth/setup panels, and the trust line (no home reached yet).
+   Reuses the existing gate tokens — single amber accent, near-black on-accent
+   text, mono eyebrow — so light theme flips cleanly. No hard-coded hex. */
+body.ftw-next .signin-gate-landing { display: none; }
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-landing { display: block; }
+/* No "reaching your home" line on the public front door — the visitor hasn't
+   chosen a home yet. */
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-connecting { display: none; }
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-auth,
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-needs-setup,
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-trust { display: none; }
+/* The landing carries its OWN brand inside .signin-gate-landing; hide the
+   card-level brand (a direct child of the card, not the landing's nested one)
+   so the public front door shows a single masthead, not a doubled one. */
+body.ftw-next .signin-gate[data-mode="public-landing"] .signin-gate-card > .signin-gate-brand { display: none; }
+body.ftw-next .signin-gate-learn-row { color: var(--fg-dim); font-size: 12px; margin: 18px 0 0; }
+body.ftw-next .signin-gate-learn { color: var(--accent-e); text-decoration: none; }
+
 /* Hamburger — hidden on desktop, visible under 720 px. Lives next to
    the header-right cluster so it's always reachable even when that
    cluster is collapsed into the drawer below. */

--- a/web/owner-access/enroll.html
+++ b/web/owner-access/enroll.html
@@ -86,10 +86,12 @@
        window.p2pFetch when a channel is up. -->
   <script src="/p2p.js?v=p2p1"></script>
   <script type="module">
-    import { decodeCreationOptions, encodeRegistrationResult } from "./webauthn.js";
+    import { decodeCreationOptions, encodeRegistrationResult, bufToB64url } from "./webauthn.js";
     import { mountEnrollPin } from "./enroll-pin.js";
     import { ownerFetch } from "./owner-fetch.js";
     import { exportPubHex } from "./device-key.js";
+    import { extensionInput, outputFrom, deriveEncKey } from "./prf.js";
+    import { saveDirectory, verifyEntry } from "./instance-sync.js";
     const msg = document.getElementById("msg");
     const nameInput = document.getElementById("name");
     nameInput.focus();
@@ -126,8 +128,13 @@
         }
         const { ceremony_token, options } = await start.json();
 
-        // 2. Browser ceremony.
+        // 2. Browser ceremony. Request the PRF extension so THIS credential can
+        //    later derive the per-wallet directory ENCRYPTION key (prf.js): the
+        //    same passkey the owner taps to sign in yields the key that decrypts
+        //    their list of 42W homes from the relay, with no LAN visit. Harmless
+        //    on authenticators without PRF — they just return no prf result.
         const credOpts = decodeCreationOptions(options);
+        credOpts.extensions = Object.assign({}, credOpts.extensions, extensionInput());
         const cred = await navigator.credentials.create({ publicKey: credOpts });
 
         // 2b. Mint this device's silent-login key (C4). Enrollment is the ONLY
@@ -166,6 +173,40 @@
         }
         const out = await finish.json();
         msg.innerHTML = '<div class="ok">Enrolled <span class="code">' + (out.friendly_name || name) + '</span>. Redirecting…</div>';
+
+        // 4. FIRST ENROLLMENT — seed the per-wallet directory. Now that a passkey
+        //    exists, fetch the Pi-signed instance descriptor over the owner channel
+        //    and write a 1-entry directory (browser-carried copy + the relay's
+        //    encrypted blob) so a FRESH device with the synced passkey can discover
+        //    this home remotely. Best-effort: a failure here never blocks the
+        //    enrollment that already succeeded — the directory also self-heals from
+        //    the legacy single-home pin on first sign-in (p2p.js migration).
+        try {
+          // W = base64url(user.id) — the opaque wallet handle the relay keys the
+          // encrypted blob on. On a create ceremony the handle is the user.id we
+          // were given in the options (the assertion's userHandle echoes it later).
+          const W = credOpts.user && credOpts.user.id ? bufToB64url(credOpts.user.id) : null;
+          const prfOut = outputFrom(cred); // null on authenticators without PRF
+          const desc = await ownerFetch("/api/owner-access/instance-descriptor", { credentials: "same-origin" });
+          if (W && desc.ok) {
+            const entry = await desc.json(); // { site_id, pi_pubkey, label, sig }
+            if (await verifyEntry(entry)) {
+              entry.added_ms = Date.now();
+              // encKey = PRF-derived when available; null falls back to the
+              // browser-carried copy only (no relay blob written, but the home is
+              // still cached locally so this device routes correctly).
+              const encKey = prfOut ? await deriveEncKey(prfOut) : null;
+              await saveDirectory(W, encKey, location.origin, {
+                instances: [entry], version: 0, writeKey: null,
+              });
+            }
+          }
+        } catch (e) {
+          // Non-fatal: log only. The passkey is enrolled; directory seeding can
+          // retry on the next sign-in.
+          try { console.warn("instance directory seed failed: " + (e && e.message)); } catch (_) {}
+        }
+
         setTimeout(() => location.href = "./", 1500);
       } catch (e) {
         msg.innerHTML = `<div class="err">${e.name}: ${e.message}</div>`;

--- a/web/owner-access/instance-interop.test.mjs
+++ b/web/owner-access/instance-interop.test.mjs
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { verifyEntry } from "./instance-sync.js";
+
+// Locks the Pi(Go) -> browser(JS) interop of the instance descriptor signature.
+// The fixture below was produced by the SAME ES256 signing the Pi performs in
+// go/internal/api/api_owner_instance_descriptor.go: an ECDSA P-256 / SHA-256
+// signature, raw r||s, base64url-no-pad, over the exact UTF-8 string
+//   "ftw-instance:v1:" + site_id + ":" + pi_pubkey + ":" + label
+// If Go's instanceDescriptorSigningString or its encoding ever drifts from the
+// browser's instanceMessage()/verifyEntry(), this stops verifying.
+const fixture = {
+  site_id: "site:Home",
+  label: "Home",
+  pi_pubkey:
+    "f0298dc888bb1d4c2d5708ae5072d6c4ae282d00fd705c42534ab2864bdc6e81e914516a4452b431ae6eb138afaeb8ad68300c61829530a6106622cb6c8858d2",
+  sig: "8nDdyLDhqHIug9__TseI7bUeFI8IsfyWKPi_ND62-iMAKqmZnmEtOet_QbEF3G1DKj1E7b2ngNpUpXwvHnCA5Q",
+};
+
+test("browser verifyEntry accepts a Pi(Go)-signed instance descriptor", async () => {
+  assert.ok(
+    await verifyEntry(fixture),
+    "Go-signed descriptor rejected by the browser — instance message/encoding drift between go/internal/api and web/owner-access/instance-sync.js",
+  );
+});
+
+test("tampering with the signed-over fields breaks verification", async () => {
+  assert.equal(await verifyEntry({ ...fixture, site_id: "site:Other" }), false);
+  assert.equal(await verifyEntry({ ...fixture, label: "Cabin" }), false);
+});

--- a/web/owner-access/instance-sync.js
+++ b/web/owner-access/instance-sync.js
@@ -1,0 +1,263 @@
+// instance-sync.js — the per-wallet DIRECTORY manager for the multi-tenant home
+// route. The directory is the list of a wallet's 42W instances
+// [{site_id, pi_pubkey, label}], each entry SIGNED by its Pi. It lives in two
+// places, by design (the "hybrid" binding):
+//
+//   1. Browser-carried copy (localStorage) — the SOURCE OF TRUTH for routing +
+//      display. Works with no network and no PRF.
+//   2. Relay-held CIPHERTEXT blob — the same list AES-GCM-encrypted under the
+//      PRF-derived key (prf.js), keyed by the opaque WebAuthn userHandle. Lets a
+//      FRESH device with the synced passkey fetch + decrypt its homes remotely.
+//
+// The relay never decrypts the blob. Writes are authenticated by an Ed25519 WRITE
+// KEY that is generated once, kept INSIDE the encrypted blob (so it syncs to the
+// owner's other devices), and whose public half the relay TOFU-pins — so a
+// userHandle-knower who cannot decrypt the blob cannot forge a write. The signed
+// PUT message is byte-identical to the relay's Go blobWriteMessage.
+//
+// ES module exports below; via <script src> it also sets window.ftwInstanceSync.
+
+const subtle = globalThis.crypto.subtle;
+const LS_DIR = "ftw.directory"; // browser-carried instances cache (no secrets)
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+// ---- encoding helpers ----
+function bytesToB64std(b) {
+  let s = "";
+  const u = b instanceof Uint8Array ? b : new Uint8Array(b);
+  for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]);
+  return btoa(s);
+}
+function b64stdToBytes(s) {
+  const bin = atob(s);
+  const u = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+  return u;
+}
+function bytesToB64url(b) {
+  return bytesToB64std(b).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function b64urlToBytes(s) {
+  return b64stdToBytes(s.replace(/-/g, "+").replace(/_/g, "/"));
+}
+function toHex(b) {
+  const u = b instanceof Uint8Array ? b : new Uint8Array(b);
+  let s = "";
+  for (let i = 0; i < u.length; i++) s += u[i].toString(16).padStart(2, "0");
+  return s;
+}
+function hexToBytes(h) {
+  const u = new Uint8Array(h.length / 2);
+  for (let i = 0; i < u.length; i++) u[i] = parseInt(h.substr(i * 2, 2), 16);
+  return u;
+}
+
+// ---- relay wire ----
+function walletBlobURL(relayBase, userHandleB64u) {
+  return `${relayBase.replace(/\/$/, "")}/wallet/${userHandleB64u}/blob`;
+}
+async function fetchBlob(relayBase, W) {
+  const r = await fetch(walletBlobURL(relayBase, W), { cache: "no-store" });
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error("wallet blob GET " + r.status);
+  return r.json(); // { ciphertext, nonce, version }
+}
+async function putBlob(relayBase, W, body) {
+  const r = await fetch(walletBlobURL(relayBase, W), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return r.status; // 200 | 409 | 403 | 413 | 400 | 503
+}
+
+// ---- blob crypto ----
+async function decryptBlob(encKey, blob) {
+  const nonce = b64stdToBytes(blob.nonce);
+  const ct = b64stdToBytes(blob.ciphertext);
+  const pt = await subtle.decrypt({ name: "AES-GCM", iv: nonce }, encKey, ct);
+  return JSON.parse(dec.decode(pt));
+}
+async function encryptDir(encKey, plaintextObj) {
+  const nonce = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const data = enc.encode(JSON.stringify(plaintextObj));
+  const ct = new Uint8Array(await subtle.encrypt({ name: "AES-GCM", iv: nonce }, encKey, data));
+  return { nonce, ciphertext: ct };
+}
+
+// blobWriteMessage MUST match the relay's Go implementation byte-for-byte:
+//   "ftw-blob:v1:" + handle + ":" + version + ":" + base64url(nonce) + ":" + hex(sha256(ciphertext))
+async function blobWriteMessage(W, version, nonce, ciphertext) {
+  const hash = new Uint8Array(await subtle.digest("SHA-256", ciphertext));
+  return enc.encode(
+    "ftw-blob:v1:" + W + ":" + version + ":" + bytesToB64url(nonce) + ":" + toHex(hash),
+  );
+}
+
+// ---- write key (Ed25519, generated once, stored in the encrypted blob) ----
+async function genWriteKey() {
+  const kp = await subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  return {
+    priv: kp.privateKey,
+    pubRaw: new Uint8Array(await subtle.exportKey("raw", kp.publicKey)),
+    privPkcs8: new Uint8Array(await subtle.exportKey("pkcs8", kp.privateKey)),
+  };
+}
+async function importWriteKey(privPkcs8, pubRaw) {
+  return {
+    priv: await subtle.importKey("pkcs8", privPkcs8, { name: "Ed25519" }, true, ["sign"]),
+    pubRaw,
+    privPkcs8,
+  };
+}
+async function signWrite(writeKey, message) {
+  return new Uint8Array(await subtle.sign({ name: "Ed25519" }, writeKey.priv, message));
+}
+
+// ---- per-entry Pi signature verification ----
+// importP256Pub imports a Pi identity public key given as hex X||Y (128 chars).
+async function importP256Pub(piPubHex) {
+  const raw = new Uint8Array(65);
+  raw[0] = 0x04; // uncompressed point
+  raw.set(hexToBytes(piPubHex), 1);
+  return subtle.importKey("raw", raw, { name: "ECDSA", namedCurve: "P-256" }, false, ["verify"]);
+}
+function instanceMessage(e) {
+  return enc.encode("ftw-instance:v1:" + e.site_id + ":" + e.pi_pubkey + ":" + e.label);
+}
+// verifyEntry checks the Pi's ES256 signature over the instance descriptor, so a
+// tampering relay cannot inject a fake instance even though it stores the blob.
+export async function verifyEntry(e) {
+  try {
+    if (!e || !e.site_id || !e.pi_pubkey || !e.sig || e.pi_pubkey.length !== 128) return false;
+    const pub = await importP256Pub(e.pi_pubkey);
+    const sig = b64urlToBytes(e.sig);
+    if (sig.length !== 64) return false;
+    return subtle.verify({ name: "ECDSA", hash: "SHA-256" }, pub, sig, instanceMessage(e));
+  } catch {
+    return false;
+  }
+}
+
+// ---- browser-carried cache ----
+export function getCachedInstances() {
+  try {
+    const raw = globalThis.localStorage ? localStorage.getItem(LS_DIR) : null;
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+function cacheInstances(instances) {
+  try {
+    if (globalThis.localStorage) localStorage.setItem(LS_DIR, JSON.stringify(instances));
+  } catch {
+    /* private mode / quota — non-fatal */
+  }
+}
+function mergeUnion(a, b) {
+  const bySite = new Map();
+  for (const e of [...(a || []), ...(b || [])]) {
+    if (!e || !e.site_id) continue;
+    const prev = bySite.get(e.site_id);
+    if (!prev || (e.added_ms || 0) >= (prev.added_ms || 0)) bySite.set(e.site_id, e);
+  }
+  return [...bySite.values()];
+}
+
+// loadDirectory fetches + decrypts + verifies the wallet's directory from the
+// relay, merges it with the browser-carried copy, and returns
+// { instances, version, writeKey } — or null when there is no blob and no cache.
+// encKey comes from prf.deriveEncKey(); pass null when PRF is unavailable to fall
+// back to the browser-carried copy only.
+export async function loadDirectory(userHandleB64u, encKey, relayBase) {
+  const cached = getCachedInstances();
+  if (!encKey) {
+    return cached.length ? { instances: cached, version: 0, writeKey: null } : null;
+  }
+  let blob = null;
+  try {
+    blob = await fetchBlob(relayBase, userHandleB64u);
+  } catch {
+    blob = null; // network/relay error → fall back to cache
+  }
+  if (!blob) {
+    return cached.length ? { instances: cached, version: 0, writeKey: null } : null;
+  }
+  let pt;
+  try {
+    pt = await decryptBlob(encKey, blob);
+  } catch {
+    // Decrypt failed (PRF mismatch across sync, or wrong/garbage blob). Degrade to
+    // the browser-carried copy rather than losing the homes.
+    return cached.length ? { instances: cached, version: 0, writeKey: null } : null;
+  }
+  const verified = [];
+  for (const e of pt.instances || []) {
+    if (await verifyEntry(e)) verified.push(e);
+  }
+  const instances = mergeUnion(cached, verified);
+  cacheInstances(instances);
+  let writeKey = null;
+  if (pt.write_priv && pt.write_pub) {
+    try {
+      writeKey = await importWriteKey(b64urlToBytes(pt.write_priv), b64urlToBytes(pt.write_pub));
+    } catch {
+      writeKey = null;
+    }
+  }
+  return { instances, version: blob.version | 0, writeKey };
+}
+
+// saveDirectory re-encrypts the directory and writes it to the relay, writer-
+// authenticated. `dir` is the object from loadDirectory (or {instances:[],
+// version:0, writeKey:null} for a brand-new wallet). It updates the browser copy
+// regardless, then attempts the relay PUT when encKey is available; on a 409 it
+// re-reads, merges, and retries once. Returns the updated dir.
+export async function saveDirectory(userHandleB64u, encKey, relayBase, dir) {
+  const instances = dir.instances || [];
+  cacheInstances(instances); // browser-carried copy is the source of truth
+  if (!encKey) return { ...dir, instances };
+
+  let writeKey = dir.writeKey || (await genWriteKey());
+  let version = (dir.version | 0) + 1;
+
+  const attempt = async () => {
+    const plaintext = {
+      v: 1,
+      write_priv: bytesToB64url(writeKey.privPkcs8),
+      write_pub: bytesToB64url(writeKey.pubRaw),
+      instances,
+    };
+    const { nonce, ciphertext } = await encryptDir(encKey, plaintext);
+    const msg = await blobWriteMessage(userHandleB64u, version, nonce, ciphertext);
+    const sig = await signWrite(writeKey, msg);
+    return putBlob(relayBase, userHandleB64u, {
+      ciphertext: bytesToB64std(ciphertext),
+      nonce: bytesToB64std(nonce),
+      version,
+      write_pub: bytesToB64std(writeKey.pubRaw),
+      sig: bytesToB64std(sig),
+    });
+  };
+
+  let status = await attempt();
+  if (status === 409) {
+    // Lost-update: re-read the latest, merge, bump past it, retry once.
+    const latest = await loadDirectory(userHandleB64u, encKey, relayBase);
+    if (latest) {
+      version = (latest.version | 0) + 1;
+      if (latest.writeKey) writeKey = latest.writeKey; // keep the pinned key
+      // instances already merged via cache by loadDirectory
+    }
+    status = await attempt();
+  }
+  return { instances, version, writeKey, putStatus: status };
+}
+
+if (typeof window !== "undefined") {
+  window.ftwInstanceSync = { loadDirectory, saveDirectory, verifyEntry, getCachedInstances };
+}

--- a/web/owner-access/instance-sync.test.mjs
+++ b/web/owner-access/instance-sync.test.mjs
@@ -1,0 +1,139 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const subtle = globalThis.crypto.subtle;
+const enc = new TextEncoder();
+
+// ---- minimal localStorage + a FAITHFUL in-JS relay that mirrors the Go
+// WalletBlobStore write-auth (Ed25519 verify over the canonical message +
+// TOFU-pinned write_pub + bounded version monotonicity). ----
+globalThis.localStorage = (() => {
+  const m = new Map();
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+  };
+})();
+
+function b64stdToBytes(s) {
+  const bin = atob(s);
+  const u = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+  return u;
+}
+function bytesToB64url(b) {
+  let s = "";
+  const u = new Uint8Array(b);
+  for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function toHex(b) {
+  const u = new Uint8Array(b);
+  let s = "";
+  for (let i = 0; i < u.length; i++) s += u[i].toString(16).padStart(2, "0");
+  return s;
+}
+
+const relay = { blobs: new Map() }; // W -> { ct, nonce, version, pubRaw }
+
+async function relayVerify(W, version, nonceB64, ctB64, pubB64, sigB64) {
+  const nonce = b64stdToBytes(nonceB64);
+  const ct = b64stdToBytes(ctB64);
+  const pubRaw = b64stdToBytes(pubB64);
+  const sig = b64stdToBytes(sigB64);
+  const hash = new Uint8Array(await subtle.digest("SHA-256", ct));
+  const msg = enc.encode(
+    "ftw-blob:v1:" + W + ":" + version + ":" + bytesToB64url(nonce) + ":" + toHex(hash),
+  );
+  const pub = await subtle.importKey("raw", pubRaw, { name: "Ed25519" }, false, ["verify"]);
+  return { ok: await subtle.verify({ name: "Ed25519" }, pub, sig, msg), pubRaw, sig };
+}
+
+globalThis.fetch = async (url, opts = {}) => {
+  const m = String(url).match(/\/wallet\/([^/]+)\/blob$/);
+  const W = m ? m[1] : "";
+  if (!opts.method || opts.method === "GET") {
+    const b = relay.blobs.get(W);
+    if (!b) return { status: 404, ok: false, json: async () => ({}) };
+    return { status: 200, ok: true, json: async () => ({ ciphertext: b.ct, nonce: b.nonce, version: b.version }) };
+  }
+  // PUT
+  const body = JSON.parse(opts.body);
+  const v = await relayVerify(W, body.version, body.nonce, body.ciphertext, body.write_pub, body.sig);
+  if (!v.ok) return { status: 403, ok: false, json: async () => ({}) };
+  const prev = relay.blobs.get(W);
+  if (prev) {
+    if (toHex(prev.pubRaw) !== toHex(v.pubRaw)) return { status: 403, ok: false, json: async () => ({}) }; // TOFU pin
+    if (body.version <= prev.version) return { status: 409, ok: false, json: async () => ({}) };
+  } else if (body.version <= 0) {
+    return { status: 409, ok: false, json: async () => ({}) };
+  }
+  relay.blobs.set(W, { ct: body.ciphertext, nonce: body.nonce, version: body.version, pubRaw: v.pubRaw });
+  return { status: 200, ok: true, json: async () => ({}) };
+};
+
+const { loadDirectory, saveDirectory, verifyEntry, getCachedInstances } = await import("./instance-sync.js");
+const { deriveEncKey } = await import("./prf.js");
+
+const W = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"; // 43-char base64url
+const encKey = await deriveEncKey(new Uint8Array(32).fill(0x11).buffer);
+
+// Build a Pi-signed instance descriptor (ES256 over the canonical message).
+async function signedInstance(label) {
+  const kp = await subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+  const rawPub = new Uint8Array(await subtle.exportKey("raw", kp.publicKey)); // 0x04||X||Y
+  const piPubHex = toHex(rawPub.slice(1));
+  const site_id = "site:" + label;
+  const msg = enc.encode("ftw-instance:v1:" + site_id + ":" + piPubHex + ":" + label);
+  const sig = new Uint8Array(await subtle.sign({ name: "ECDSA", hash: "SHA-256" }, kp.privateKey, msg));
+  return { site_id, pi_pubkey: piPubHex, label, sig: bytesToB64url(sig), added_ms: 1 };
+}
+
+test("verifyEntry accepts a Pi-signed descriptor and rejects tampering", async () => {
+  const e = await signedInstance("Home");
+  assert.ok(await verifyEntry(e));
+  assert.equal(await verifyEntry({ ...e, label: "Evil" }), false); // label not signed-over
+  assert.equal(await verifyEntry({ ...e, sig: bytesToB64url(new Uint8Array(64)) }), false);
+});
+
+test("save then load round-trips the directory through the relay (writer-authed)", async () => {
+  relay.blobs.clear();
+  const home = await signedInstance("Home");
+  // First write: brand-new wallet, generates the Ed25519 write key, stores it in the blob.
+  const saved = await saveDirectory(W, encKey, "https://relay.test", { instances: [home], version: 0, writeKey: null });
+  assert.equal(saved.putStatus, 200, "first PUT must be accepted by the relay");
+
+  // A FRESH "device": clear the browser-carried cache, then load purely from the relay blob.
+  localStorage.removeItem("ftw.directory");
+  const loaded = await loadDirectory(W, encKey, "https://relay.test");
+  assert.ok(loaded, "fresh device must recover the directory from the relay");
+  assert.equal(loaded.instances.length, 1);
+  assert.equal(loaded.instances[0].site_id, "site:Home");
+  assert.ok(loaded.writeKey, "fresh device must recover the write key from the blob");
+
+  // Update from the fresh device using the recovered write key.
+  const lab = await signedInstance("Cabin");
+  const merged = { instances: [...loaded.instances, lab], version: loaded.version, writeKey: loaded.writeKey };
+  const saved2 = await saveDirectory(W, encKey, "https://relay.test", merged);
+  assert.equal(saved2.putStatus, 200, "update with the pinned key must be accepted");
+  assert.equal(getCachedInstances().length, 2);
+});
+
+test("a wrong PRF key cannot decrypt the blob and degrades to the cache", async () => {
+  const wrong = await deriveEncKey(new Uint8Array(32).fill(0x99).buffer);
+  localStorage.removeItem("ftw.directory"); // no cache
+  const loaded = await loadDirectory(W, wrong, "https://relay.test");
+  assert.equal(loaded, null, "undecryptable blob + empty cache → null (no homes leaked)");
+});
+
+test("a stranger with a different write key is rejected (403) — no takeover", async () => {
+  // The relay already pinned the owner's key in the round-trip test above. A
+  // brand-new writeKey for the same W must be refused.
+  relay.blobs.clear();
+  const home = await signedInstance("Home");
+  await saveDirectory(W, encKey, "https://relay.test", { instances: [home], version: 0, writeKey: null });
+  const attacker = await saveDirectory(W, encKey, "https://relay.test", { instances: [home], version: 0, writeKey: null });
+  // attacker passes writeKey:null → genWriteKey() → different pub → relay 403 (and 409 retry also 403)
+  assert.equal(attacker.putStatus, 403, "a different write key must be refused by the TOFU pin");
+});

--- a/web/owner-access/login.html
+++ b/web/owner-access/login.html
@@ -36,8 +36,10 @@
        cookie is minted INSIDE DTLS and never crosses the relay. -->
   <script src="/p2p.js?v=p2p1"></script>
   <script type="module">
-    import { apiBase, decodeAssertionOptions, encodeAssertionResult } from "./webauthn.js";
+    import { apiBase, decodeAssertionOptions, encodeAssertionResult, bufToB64url } from "./webauthn.js";
     import { ownerFetch } from "./owner-fetch.js";
+    import { extensionInput, outputFrom, deriveEncKey } from "./prf.js";
+    import { loadDirectory } from "./instance-sync.js";
     const base = apiBase();
     const msg = document.getElementById("msg");
 
@@ -73,6 +75,11 @@
         }
         const { ceremony_token, options } = await start.json();
         const credOpts = decodeAssertionOptions(options);
+        // Request the PRF extension so this assertion also yields the per-wallet
+        // directory ENCRYPTION key (prf.js) — the same passkey tap that signs in
+        // can decrypt the owner's list of 42W homes from the relay. Harmless where
+        // unsupported (no prf result → browser-carried directory only).
+        credOpts.extensions = Object.assign({}, credOpts.extensions, extensionInput());
         const getOpts = { publicKey: credOpts, signal: abort.signal };
         if (mediation) getOpts.mediation = mediation;
         const cred = await navigator.credentials.get(getOpts);
@@ -91,6 +98,21 @@
           return;
         }
         msg.innerHTML = '<div class="ok">Signed in. Redirecting…</div>';
+
+        // Seed the browser-carried directory from THIS assertion's PRF output so
+        // the dashboard (next-app.js) routes to the right home after the redirect.
+        // Best-effort: a PRF/decrypt/network failure never blocks the redirect —
+        // the dashboard re-derives the directory on its own sign-in path too.
+        try {
+          const uh = cred.response && cred.response.userHandle ? cred.response.userHandle : null;
+          const W = uh ? bufToB64url(uh) : null;
+          if (W) {
+            const prfOut = outputFrom(cred);
+            const encKey = prfOut ? await deriveEncKey(prfOut) : null;
+            await loadDirectory(W, encKey, location.origin); // caches instances for routing
+          }
+        } catch (e) { /* non-fatal — directory self-heals on the dashboard */ }
+
         setTimeout(() => location.href = base + "/", 800);
       } catch (e) {
         if (e.name === "AbortError") return; // cancelled / superseded — silent

--- a/web/owner-access/prf.js
+++ b/web/owner-access/prf.js
@@ -1,0 +1,80 @@
+// prf.js — derive the per-wallet directory ENCRYPTION key from a WebAuthn passkey
+// via the PRF extension, for the multi-tenant home route.
+//
+// The same passkey the owner taps to sign in also yields, through the WebAuthn
+// `prf` extension, a high-entropy secret that is STABLE for that credential. We
+// HKDF it into a non-extractable AES-GCM-256 key and use that to encrypt/decrypt
+// the wallet's directory blob (the list of the owner's 42W instances) that the
+// relay stores opaquely. Because the key derives from the passkey — not from any
+// device-local secret — a FRESH device with the SYNCED passkey derives the SAME
+// key and can decrypt the blob it fetches from the relay, with no LAN visit.
+//
+// HONEST RESIDUAL: PRF output determinism across iCloud Keychain / Google Password
+// Manager passkey SYNC is undocumented and must be verified on real devices before
+// the relay blob is relied on for fresh-device bootstrap. Firefox ships no PRF at
+// all. When PRF is unavailable, callers fall back to the browser-carried directory
+// copy (instance-sync.js) and lose only remote fresh-device discovery.
+//
+// As an ES module it exports the functions below; loaded via a classic <script src>
+// it also assigns window.ftwPrf = { extensionInput, outputFrom, supported, deriveEncKey }.
+
+// FIXED_SALT_32 is the fixed 32-byte PRF eval input + HKDF salt. It is a public
+// domain-separation constant (NOT a secret) — it only ensures this app's PRF
+// evaluation and key derivation are distinct from any other use of the credential.
+export const FIXED_SALT_32 = new Uint8Array([
+  0x66, 0x74, 0x77, 0x2d, 0x68, 0x6f, 0x6d, 0x65, // "ftw-home"
+  0x2d, 0x70, 0x72, 0x66, 0x2d, 0x76, 0x31, 0x2e, // "-prf-v1."
+  0x9a, 0x3c, 0x71, 0xe5, 0x4d, 0x88, 0x0b, 0x12, // random tail
+  0xf6, 0x27, 0x90, 0xab, 0x5e, 0xd4, 0x33, 0x7c,
+]);
+
+const HKDF_INFO = new TextEncoder().encode("ftw-instance-blob:aes-gcm:v1");
+
+// extensionInput returns the `extensions` object to pass to
+// navigator.credentials.get({ publicKey: { ..., extensions: extensionInput() } }).
+// Requesting prf.eval.first makes the authenticator evaluate the PRF at our salt.
+export function extensionInput() {
+  return { prf: { eval: { first: FIXED_SALT_32.buffer.slice(0) } } };
+}
+
+// outputFrom extracts the raw PRF secret (ArrayBuffer, 32 bytes) from a completed
+// assertion, or null when the authenticator/browser did not return one (no PRF
+// support, or the credential was created without the prf extension enabled).
+export function outputFrom(assertion) {
+  try {
+    const ext = assertion && assertion.getClientExtensionResults
+      ? assertion.getClientExtensionResults()
+      : null;
+    const first = ext && ext.prf && ext.prf.results ? ext.prf.results.first : null;
+    if (!first) return null;
+    const buf = first instanceof ArrayBuffer ? first : (first.buffer || null);
+    if (!buf || buf.byteLength < 32) return null;
+    return buf.slice(0, 32);
+  } catch {
+    return null;
+  }
+}
+
+// supported reports whether an assertion carried a usable PRF output.
+export function supported(assertion) {
+  return outputFrom(assertion) !== null;
+}
+
+// deriveEncKey HKDFs a PRF output into a NON-EXTRACTABLE AES-GCM-256 key bound to
+// this app's domain (salt + info). The same prfOutput always yields the same key,
+// so any device with the synced passkey can decrypt the directory blob.
+export async function deriveEncKey(prfOutput) {
+  const subtle = globalThis.crypto.subtle;
+  const base = await subtle.importKey("raw", prfOutput, "HKDF", false, ["deriveKey"]);
+  return subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt: FIXED_SALT_32, info: HKDF_INFO },
+    base,
+    { name: "AES-GCM", length: 256 },
+    false, // non-extractable
+    ["encrypt", "decrypt"],
+  );
+}
+
+if (typeof window !== "undefined") {
+  window.ftwPrf = { extensionInput, outputFrom, supported, deriveEncKey, FIXED_SALT_32 };
+}

--- a/web/owner-access/prf.test.mjs
+++ b/web/owner-access/prf.test.mjs
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FIXED_SALT_32, extensionInput, outputFrom, supported, deriveEncKey } from "./prf.js";
+
+const subtle = globalThis.crypto.subtle;
+
+test("FIXED_SALT_32 is a stable 32-byte public constant", () => {
+  assert.equal(FIXED_SALT_32.length, 32);
+});
+
+test("extensionInput requests prf.eval.first with the salt", () => {
+  const ext = extensionInput();
+  assert.ok(ext.prf && ext.prf.eval && ext.prf.eval.first);
+  assert.equal(new Uint8Array(ext.prf.eval.first).length, 32);
+});
+
+test("outputFrom extracts a 32-byte PRF secret, or null when absent", () => {
+  const prf = new Uint8Array(32).fill(7).buffer;
+  const withPrf = { getClientExtensionResults: () => ({ prf: { results: { first: prf } } }) };
+  assert.equal(outputFrom(withPrf).byteLength, 32);
+  assert.ok(supported(withPrf));
+
+  const noPrf = { getClientExtensionResults: () => ({}) };
+  assert.equal(outputFrom(noPrf), null);
+  assert.equal(supported(noPrf), false);
+  // A short/garbage result is rejected (treated as unsupported).
+  const shortPrf = { getClientExtensionResults: () => ({ prf: { results: { first: new Uint8Array(8).buffer } } }) };
+  assert.equal(outputFrom(shortPrf), null);
+});
+
+test("deriveEncKey is deterministic and round-trips AES-GCM", async () => {
+  const prf = new Uint8Array(32).fill(0x42).buffer;
+  const k1 = await deriveEncKey(prf);
+  const k2 = await deriveEncKey(prf.slice(0)); // same secret, different buffer
+  const nonce = new Uint8Array(12).fill(1);
+  const msg = new TextEncoder().encode("hello directory");
+  const ct = await subtle.encrypt({ name: "AES-GCM", iv: nonce }, k1, msg);
+  const pt = await subtle.decrypt({ name: "AES-GCM", iv: nonce }, k2, ct);
+  assert.equal(new TextDecoder().decode(pt), "hello directory");
+});
+
+test("a different PRF secret yields a key that cannot decrypt", async () => {
+  const a = await deriveEncKey(new Uint8Array(32).fill(1).buffer);
+  const b = await deriveEncKey(new Uint8Array(32).fill(2).buffer);
+  const nonce = new Uint8Array(12).fill(9);
+  const ct = await subtle.encrypt({ name: "AES-GCM", iv: nonce }, a, new TextEncoder().encode("secret"));
+  await assert.rejects(() => subtle.decrypt({ name: "AES-GCM", iv: nonce }, b, ct));
+});
+
+test("the derived key is non-extractable", async () => {
+  const k = await deriveEncKey(new Uint8Array(32).fill(3).buffer);
+  await assert.rejects(() => subtle.exportKey("raw", k));
+});

--- a/web/p2p-identity-pin.test.mjs
+++ b/web/p2p-identity-pin.test.mjs
@@ -1,0 +1,190 @@
+// node --test web/p2p-identity-pin.test.mjs
+//
+// Multi-tenant pin (Task Group 6): pinnedIdentity()/site() must key the pin per
+// (origin, site_id) at localStorage "ftw.identity:<apiBase>:<site_id>", taking the
+// site_id + pi_pubkey from the decrypted instance directory (window.ftwInstanceSync)
+// with NO relay /api/identity round-trip. A pre-existing single-home user is
+// migrated: the legacy "ftw.identity:<apiBase>" record seeds the first per-site key.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const P2P_SRC = readFileSync(join(__dirname, "p2p.js"), "utf8");
+
+// A 128-hex (X||Y) public key whose value is irrelevant to the pin-keying logic:
+// importP256Pub() is stubbed in the sandbox so we never run real WebCrypto here.
+const PUB_A = "a".repeat(128);
+const PUB_LEGACY = "b".repeat(128);
+
+// loadP2P evaluates p2p.js inside a vm sandbox. fetchCalls records every fetched
+// URL so a test can assert the relay /api/identity endpoint was (not) hit.
+function loadP2P({
+  pathname = "/",
+  hostname = "home.fortytwowatts.com",
+  seedStore = {},
+  instances = [],
+} = {}) {
+  const store = new Map(Object.entries(seedStore));
+  const fetchCalls = [];
+  const win = {
+    localStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+    },
+    ftwInstanceSync: {
+      getCachedInstances: () => instances,
+    },
+  };
+  const sandbox = {
+    window: win,
+    location: { pathname, hostname },
+    localStorage: win.localStorage,
+    crypto: {
+      getRandomValues: (a) => a,
+      // subtle.importKey is hit by the real importP256Pub() in p2p.js. We stub
+      // it to resolve a fake "key" so the pin logic runs without WebCrypto.
+      subtle: { importKey: () => Promise.resolve({ __fakeKey: true }) },
+    },
+    Headers: class {},
+    fetch: (url) => {
+      fetchCalls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ public_key_hex: PUB_LEGACY, site_id: "site:Relay" }),
+      });
+    },
+    setTimeout: () => 0,
+    clearTimeout: () => {},
+    console: { warn() {}, log() {} },
+    btoa: (s) => Buffer.from(s, "binary").toString("base64"),
+    atob: (s) => Buffer.from(s, "base64").toString("binary"),
+    TextEncoder,
+    TextDecoder,
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(P2P_SRC, sandbox, { filename: "p2p.js" });
+  return { win, store, fetchCalls };
+}
+
+describe("p2p.js per-(origin, site_id) pin from the directory", () => {
+  let h;
+  beforeEach(() => {
+    h = loadP2P({
+      instances: [{ site_id: "site:Home", pi_pubkey: PUB_A, label: "Home" }],
+    });
+  });
+  afterEach(() => {
+    h = null;
+  });
+
+  it("site() resolves the directory entry's site_id with no relay round-trip", async () => {
+    const site = await h.win.ftwP2P.site();
+    assert.equal(site, "site:Home");
+    assert.equal(
+      h.fetchCalls.filter((u) => u.indexOf("/api/identity") !== -1).length,
+      0,
+      "the directory carries the Pi pubkey + site_id; /api/identity must NOT be fetched",
+    );
+  });
+
+  it("pins per (origin, site_id) at ftw.identity:<apiBase>:<site_id>", async () => {
+    await h.win.ftwP2P.site(); // triggers pinnedIdentity()
+    assert.ok(
+      h.store.has("ftw.identity::site:Home"),
+      "pin key must be ftw.identity:<apiBase>:<site_id> (apiBase is '' on the bare home host)",
+    );
+    const rec = JSON.parse(h.store.get("ftw.identity::site:Home"));
+    assert.equal(rec.pub, PUB_A);
+    assert.equal(rec.site, "site:Home");
+  });
+});
+
+describe("p2p.js legacy single-home migration", () => {
+  it("seeds the first per-site pin from the legacy ftw.identity:<apiBase> record", async () => {
+    // Existing single-home user: legacy record present, NO directory yet (the
+    // directory is empty because instance-sync hasn't decrypted anything this
+    // session). The per-site key is migrated from the legacy record WITHOUT a
+    // relay fetch.
+    const h = loadP2P({
+      seedStore: {
+        "ftw.identity:": JSON.stringify({ pub: PUB_LEGACY, site: "site:Home" }),
+      },
+      instances: [],
+    });
+    const site = await h.win.ftwP2P.site();
+    assert.equal(site, "site:Home");
+    const rec = JSON.parse(h.store.get("ftw.identity::site:Home"));
+    assert.equal(rec.pub, PUB_LEGACY, "migrated pubkey matches the legacy record");
+    assert.equal(
+      h.fetchCalls.filter((u) => u.indexOf("/api/identity") !== -1).length,
+      0,
+      "migration must not re-TOFU against the relay",
+    );
+  });
+
+  it("PUBLIC route: fails closed when nothing is pinned — NEVER trusts relay /api/identity", async () => {
+    // home.fortytwowatts.com is a public (relay) origin. With no directory and no
+    // legacy pin, the relay's /api/identity must NOT be trusted (it could be a MITM)
+    // — pinnedIdentity rejects and the endpoint is never even fetched.
+    const h = loadP2P({ hostname: "home.fortytwowatts.com", instances: [] });
+    await assert.rejects(() => h.win.ftwP2P.site(), /sign in with your passkey/);
+    assert.equal(
+      h.fetchCalls.filter((u) => u.indexOf("/api/identity") !== -1).length,
+      0,
+      "the public route must never fetch (let alone trust) relay /api/identity",
+    );
+  });
+
+  it("LAN origin: /api/identity TOFU is the safe last resort (the Pi serves it directly)", async () => {
+    const h = loadP2P({ hostname: "192.168.1.50", instances: [] });
+    const site = await h.win.ftwP2P.site();
+    assert.equal(site, "site:Relay", "on the LAN the Pi answers /api/identity directly — TOFU is safe");
+    assert.equal(
+      h.fetchCalls.filter((u) => u.indexOf("/api/identity") !== -1).length,
+      1,
+    );
+  });
+});
+
+describe("p2p.js first-key-wins pin", () => {
+  it("a directory entry with a DIFFERENT key than the existing pin hard-fails (identity change)", async () => {
+    const h = loadP2P({
+      hostname: "home.fortytwowatts.com",
+      seedStore: { "ftw.identity::site:Home": JSON.stringify({ pub: PUB_A, site: "site:Home" }) },
+      instances: [{ site_id: "site:Home", pi_pubkey: PUB_LEGACY, label: "Home" }], // different key
+    });
+    await assert.rejects(() => h.win.ftwP2P.site(), /identity for site:Home changed/);
+    // The known-good pin is NOT overwritten.
+    assert.equal(JSON.parse(h.store.get("ftw.identity::site:Home")).pub, PUB_A);
+  });
+
+  it("a LEGACY pin can't be silently replaced by a directory entry with a different key", async () => {
+    // Existing single-home user with only the legacy ftw.identity:<apiBase> pin
+    // (no per-site key yet). A directory entry for the same site but a DIFFERENT
+    // key must hard-fail — first-key-wins spans the migration.
+    const h = loadP2P({
+      hostname: "home.fortytwowatts.com",
+      seedStore: { "ftw.identity:": JSON.stringify({ pub: PUB_A, site: "site:Home" }) },
+      instances: [{ site_id: "site:Home", pi_pubkey: PUB_LEGACY, label: "Home" }],
+    });
+    await assert.rejects(() => h.win.ftwP2P.site(), /identity for site:Home changed/);
+  });
+
+  it("an identical directory key reuses the pin without error", async () => {
+    const h = loadP2P({
+      hostname: "home.fortytwowatts.com",
+      seedStore: { "ftw.identity::site:Home": JSON.stringify({ pub: PUB_A, site: "site:Home" }) },
+      instances: [{ site_id: "site:Home", pi_pubkey: PUB_A, label: "Home" }],
+    });
+    assert.equal(await h.win.ftwP2P.site(), "site:Home");
+  });
+});

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -225,30 +225,118 @@
   }
 
   var _pinPromise = null;
-  // pinnedIdentity TOFU-fetches + pins {pubkey, site_id} from /api/identity on
-  // first connect (keyed per home origin / me-prefix), then reuses it. The first
-  // fetch trusts the path once (SSH known-hosts model); every later answer is
-  // verified against the pinned key, so the relay can't MITM after that.
+
+  // directoryEntry returns the chosen instance from the decrypted directory
+  // (window.ftwInstanceSync, attached by instance-sync.js). v1: the directory is
+  // a 1-entry list, so we take the first. Returns null when no directory exists
+  // yet (anonymous, pre-decrypt, or a not-yet-migrated single-home user). The
+  // directory's pi_pubkey is Pi-signed (instance-sync verifyEntry), so trusting
+  // it needs NO relay /api/identity round-trip.
+  function directoryEntry() {
+    try {
+      var sync = window.ftwInstanceSync;
+      if (!sync || typeof sync.getCachedInstances !== "function") return null;
+      var list = sync.getCachedInstances() || [];
+      var e = list[0];
+      if (e && e.site_id && e.pi_pubkey) return { pub: e.pi_pubkey, site: e.site_id };
+    } catch (_) {}
+    return null;
+  }
+
+  // legacyRecord reads the pre-multi-tenant single pin written at
+  // "ftw.identity:<apiBase>" ({pub, site}). Used once to seed the first per-site
+  // record so an existing single-home user doesn't re-TOFU.
+  function legacyRecord() {
+    try {
+      var raw = localStorage.getItem("ftw.identity:" + apiBase());
+      var rec = raw ? JSON.parse(raw) : null;
+      if (rec && rec.pub && rec.site) return rec;
+    } catch (_) {}
+    return null;
+  }
+
+  // pinKey is the per-(origin, site_id) localStorage key. The site_id is part of
+  // the key so two tenants reached through the same origin pin independently and
+  // can never clobber each other's Pi identity.
+  function pinKey(site) { return "ftw.identity:" + apiBase() + ":" + site; }
+
+  // persistPin enforces FIRST-KEY-WINS per (origin, site_id): the first Pi key
+  // pinned for a site is authoritative; a later DIFFERENT key is a hard error (an
+  // identity change / possible relay MITM), NEVER a silent overwrite — even when
+  // it arrives in a validly Pi-signed directory entry (a signature proves the key
+  // signed that descriptor, not that it may replace the known-good pin). Returns
+  // the record to use (the existing pin if present, else the freshly written one).
+  function persistPin(site, pub) {
+    var existing = null;
+    try { existing = JSON.parse(localStorage.getItem(pinKey(site)) || "null"); } catch (e) {}
+    if (!existing || !existing.pub) {
+      // No per-site pin yet — but a LEGACY single-home pin (ftw.identity:<apiBase>,
+      // no site suffix) for the SAME site is equally authoritative. First-key-wins
+      // must span the migration, or a directory entry could silently replace the
+      // identity an existing user already trusts before it was migrated.
+      var legacy = legacyRecord();
+      if (legacy && legacy.site === site && legacy.pub) existing = legacy;
+    }
+    if (existing && existing.pub) {
+      if (existing.pub !== pub) {
+        throw new Error("home identity for " + site + " changed — refusing to connect (re-pair on your home network if this was intentional)");
+      }
+      // Persist/refresh the per-site record (also migrates a legacy pin forward).
+      var kept = { pub: existing.pub, site: site };
+      try { localStorage.setItem(pinKey(site), JSON.stringify(kept)); } catch (e) {}
+      return kept;
+    }
+    var rec = { pub: pub, site: site };
+    try { localStorage.setItem(pinKey(site), JSON.stringify(rec)); } catch (e) {}
+    return rec;
+  }
+
+  // pinnedIdentity resolves {key, site} for the chosen instance, pinning per
+  // (origin, site_id). Source priority — NO relay round-trip until the last:
+  //   1. the decrypted directory entry (Pi pubkey is Pi-signed there);
+  //   2. the legacy single-pin record (migrate it into a per-site record);
+  //   3. relay /api/identity TOFU (only when nothing is cached at all).
+  // Every later answer is verified against the pinned key, so the relay can't
+  // MITM after that. The pubkey is imported once and the promise cached.
   function pinnedIdentity() {
     if (_pinPromise) return _pinPromise;
-    var p = (function () {
-      var storeKey = "ftw.identity:" + apiBase();
-      var stored = null;
-      try { stored = JSON.parse(localStorage.getItem(storeKey) || "null"); } catch (e) {}
-      var got = stored
-        ? Promise.resolve(stored)
-        : fetch(relayURL("/api/identity"), { credentials: "same-origin" })
-            .then(function (r) { if (!r.ok) throw new Error("/api/identity " + r.status); return r.json(); })
-            .then(function (id) {
-              if (!id.public_key_hex || !id.site_id) throw new Error("identity response missing fields");
-              var rec = { pub: id.public_key_hex, site: id.site_id };
-              try { localStorage.setItem(storeKey, JSON.stringify(rec)); } catch (e) {}
-              return rec;
-            });
-      return got.then(function (rec) {
+    var p;
+    try {
+      p = (function () {
+      // 1. The decrypted directory entry (its Pi pubkey is Pi-signed) — first-key-wins.
+      var dir = directoryEntry();
+      if (dir) {
+        var rec = persistPin(dir.site, dir.pub);
         return importP256Pub(rec.pub).then(function (key) { return { key: key, site: rec.site }; });
-      });
-    })();
+      }
+      // 2. The legacy single-home pin, migrated into a per-site record (first-key-wins).
+      var legacy = legacyRecord();
+      if (legacy) {
+        var rec2 = persistPin(legacy.site, legacy.pub);
+        return importP256Pub(rec2.pub).then(function (key) { return { key: key, site: rec2.site }; });
+      }
+      // 3. No directory and no legacy pin. On a GENUINE LAN origin the Pi serves
+      // /api/identity ITSELF (no relay in the path), so a one-time TOFU there is the
+      // SSH-known-hosts model and safe. On the PUBLIC relay route, trusting
+      // /api/identity would mean trusting a RELAY-supplied identity — a MITM vector
+      // — so we FAIL CLOSED: the user must sign in, which loads the Pi-signed
+      // directory, before any channel is verified. (Codex 2026-06-05, BLOCKER.)
+      if (!isLanOrigin()) {
+        return Promise.reject(new Error("no pinned home identity yet — sign in with your passkey first (the relay's /api/identity is never trusted on the public route)"));
+      }
+      return fetch(relayURL("/api/identity"), { credentials: "same-origin" })
+        .then(function (r) { if (!r.ok) throw new Error("/api/identity " + r.status); return r.json(); })
+        .then(function (id) {
+          if (!id.public_key_hex || !id.site_id) throw new Error("identity response missing fields");
+          var rec3 = persistPin(id.site_id, id.public_key_hex);
+          return importP256Pub(rec3.pub).then(function (key) { return { key: key, site: rec3.site }; });
+        });
+      })();
+    } catch (e) {
+      // A synchronous throw (e.g. a first-key-wins identity change) becomes a
+      // rejection so callers fail closed via .catch rather than crashing.
+      p = Promise.reject(e);
+    }
     // Cache only on success — a transient fetch failure must not poison later
     // verifications (the pinned record persists in localStorage regardless).
     p.catch(function () { if (_pinPromise === p) _pinPromise = null; });
@@ -650,7 +738,8 @@
     // "set up this device on your home network first" path (C2) rather than a
     // perpetual "connecting".
     isUnenrolled: function () { return unenrolled; },
-    // site() resolves the pinned site_id (TOFU /api/identity, then localStorage).
+    // site() resolves the pinned site_id (directory entry, then the migrated
+    // legacy record, then last-resort TOFU /api/identity — see pinnedIdentity).
     // next-app.js needs it to build the C3 device-PoP signing string
     // "ftw-device-pop:v1:<site>:<challenge>" — the SAME site p2p.js signs the
     // signal proof over, so both ends agree.

--- a/web/public-landing.test.mjs
+++ b/web/public-landing.test.mjs
@@ -1,0 +1,57 @@
+// node --test web/public-landing.test.mjs
+//
+// Public landing (Task Group 6): an anonymous visitor with no decryptable
+// directory sees brand + a passkey button + a discreet "Learn more" link, and
+// NOTHING about any instance (no count, label, site_id, or Pi key) pre-auth.
+// Static markup/CSS guards — the gate logic is covered in landing-gate.test.mjs.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(join(__dirname, p), "utf8");
+const INDEX = read("index.html");
+const CSS = read("next.css");
+
+describe("index.html public landing panel", () => {
+  it("has a public-landing panel inside the sign-in gate", () => {
+    assert.match(INDEX, /signin-gate-landing/,
+      "a .signin-gate-landing panel must exist for the anonymous visitor");
+  });
+
+  it("offers a passkey/sign-in button on the landing", () => {
+    assert.match(INDEX, /id="signin-landing-btn"/,
+      "the landing must carry its own passkey button");
+  });
+
+  it("offers a discreet 'Learn more' link", () => {
+    assert.match(INDEX, /class="signin-gate-learn"/);
+    assert.match(INDEX, /Learn more/i);
+  });
+
+  it("leaks NO instance data pre-auth (no site_id/pi_pubkey/label/count tokens)", () => {
+    // Slice just the landing panel so we only assert about THIS markup.
+    const m = /<div class="signin-gate-landing">([\s\S]*?)<\/div>\s*<!-- \/signin-gate-landing -->/.exec(INDEX);
+    assert.ok(m, "landing panel must be delimited by the closing comment for this guard");
+    const panel = m[1];
+    assert.doesNotMatch(panel, /site:/i, "no site_id in the landing markup");
+    assert.doesNotMatch(panel, /pi_pubkey|pubkey/i, "no Pi key in the landing markup");
+    assert.doesNotMatch(panel, /instance|tenant/i, "no instance/tenant wording pre-auth");
+  });
+});
+
+describe("next.css drives the public-landing mode", () => {
+  it("shows .signin-gate-landing only in data-mode=public-landing", () => {
+    assert.match(CSS, /\.signin-gate-landing\s*\{[^}]*display:\s*none/,
+      "landing panel hidden by default");
+    assert.match(CSS, /\[data-mode="public-landing"\]\s*\.signin-gate-landing\s*\{[^}]*display:\s*block/,
+      "shown only when data-mode is public-landing");
+  });
+
+  it("hides the connecting line in public-landing mode (no 'reaching your home')", () => {
+    assert.match(CSS, /\[data-mode="public-landing"\]\s*\.signin-gate-connecting\s*\{[^}]*display:\s*none/);
+  });
+});


### PR DESCRIPTION
## Summary
Completes the **browser + Pi half** of the multi-tenant home route (the relay half shipped in v0.118.x). **Still behind the relay's `-multi-tenant` flag** — the single-tenant / LAN flow is untouched; the multi-tenant path is additive and only active on the public home route.

### Web
- **Public landing** for anonymous visitors — brand + passkey button only, NO instance data.
- Passkey sign-in derives the directory key from the WebAuthn **PRF** extension → fetches + AES-GCM-decrypts the per-wallet directory blob → verifies each **Pi-signed** entry → routes to the chosen instance's **own** Pi.
- Identity pinned **first-key-wins** per `(origin, site_id)`; the relay's `/api/identity` is **never trusted on the public route** (anti-MITM). The Ed25519 directory write key is generated once and synced inside the encrypted blob.

### Pi
- `GET /api/owner-access/instance-descriptor` (owner-authed, over the P2P channel) → the Pi's signed `{site_id, pi_pubkey, label}`. First enrollment seeds the encrypted directory blob.

### Safety
- **Codex-reviewed: two anti-MITM findings found + fixed** (relay-identity TOFU on the public route → fail-closed off-LAN; pin-overwrite → first-key-wins spanning legacy + per-site pins).
- **Cross-language interop locked by tests:** JS-signed blob PUTs verify in Go (`walletblob_interop_test.go`); Go-signed descriptors verify in the browser (`instance-interop.test.mjs`).
- 148 web tests + `make verify` green.

### Not in this PR (cutover, needs @frahlg)
Flipping `-multi-tenant` on the relay + deploying this bundle as `-home-web` still needs: the WebAuthn-PRF determinism device test on real synced devices, live browser validation, and device-key enrollment under the forced C2 gate. Spec: `docs/superpowers/specs/2026-06-05-multi-tenant-home-route-design.md`.

## Test plan
- [x] `make verify` (vet + test + build)
- [x] 148 web node tests incl. the two interop locks + the anti-MITM regression tests
- [x] Codex security review (both findings closed)
🤖 Generated with [Claude Code](https://claude.com/claude-code)