### PR TITLE
fix(release): stabilize RPi image apt sources

### DIFF
--- a/.changeset/rpi-image-docker-source.md
+++ b/.changeset/rpi-image-docker-source.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Fix the Raspberry Pi SD-card image release build so pi-gen does not OOM on Docker's apt repository during export.

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
@@ -26,6 +26,11 @@ DEBIAN_FRONTEND=noninteractive apt-get -y -qq install --no-install-recommends \
 systemctl enable docker.service
 systemctl enable avahi-daemon.service
 systemctl enable NetworkManager.service
+# pi-gen's export-image stage runs another apt update under qemu. Leaving
+# Docker's third-party apt source enabled has repeatedly OOMed that step on
+# GitHub hosted runners after Docker is already installed. App updates pull
+# containers from GHCR, so the image build does not need this repo afterward.
+rm -f /etc/apt/sources.list.d/docker.list
 # /etc/hosts entry prevents sudo's "unable to resolve host 42w"
 # warning on first boot. pi-gen writes /etc/hostname from
 # TARGET_HOSTNAME but leaves /etc/hosts at the stock Raspberry Pi


### PR DESCRIPTION
## Summary
- remove Docker's third-party apt source from the Pi image after Docker is installed
- prevents pi-gen export-image apt update from OOMing on GitHub hosted runners
- add a patch changeset for the release asset fix

## Verification
- bash -n deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
- make verify (pre-commit)
- make verify-all (pre-push)