### PR TITLE
fix(ha): advertise planner modes in MQTT discovery select

### DIFF
--- a/.changeset/ha-mode-options-planner-modes.md
+++ b/.changeset/ha-mode-options-planner-modes.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": patch
+---
+
+Fix Home Assistant logging "Invalid option for select.forty_two_watts_mode"
+for the planner modes. The MQTT discovery for the Mode `select` only
+advertised six modes, but the bridge publishes the live mode as state — and
+the default UI choices (`planner_passive_arbitrage` / `planner_arbitrage`)
+weren't in the advertised list, so HA rejected them every cycle. The discovery
+options and the API mode validator now both derive from a single
+`control.AllModes` source of truth, so all ten modes are advertised and the
+two lists can't drift again.

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -1174,52 +1174,50 @@ func (s *Server) handleSetMode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	m := control.Mode(req.Mode)
-	// Validate mode string
-	switch m {
-	case control.ModeIdle, control.ModeSelfConsumption, control.ModePeakShaving,
-		control.ModeCharge, control.ModePriority, control.ModeWeighted,
-		control.ModePlannerSelf, control.ModePlannerCheap,
-		control.ModePlannerPassiveArbitrage, control.ModePlannerArbitrage:
-		s.deps.CtrlMu.Lock()
-		s.deps.Ctrl.Mode = m
-		// An explicit mode change is a reset signal: drop any active
-		// battery manual hold so the new mode takes effect on the very
-		// next dispatch tick. Mirrors the loadpoint manual_hold UX.
-		s.deps.Ctrl.ClearBatteryManualHold()
-		// Reset the PI integrator. The integral accumulated under the
-		// previous mode's error signal is meaningless to the new mode
-		// — keeping it caused integrator windup → wrong-direction stuck
-		// output across the 2026-05-24 evening mode switch (live
-		// regression: discharged the fleet to 7 % overnight while the
-		// PI integral was pinned in the wrong direction). Mode change
-		// is a discrete event; start the new regime from a clean PI.
-		if s.deps.Ctrl.PI != nil {
-			s.deps.Ctrl.PI.Reset()
-		}
-		s.deps.CtrlMu.Unlock()
-		if err := s.deps.State.SaveConfig("mode", req.Mode); err != nil {
-			slog.Warn("failed to persist mode", "err", err)
-		}
-		// Propagate to MPC if switching to a planner mode. Map
-		// control.ModePlanner* → mpc.Mode and force an immediate replan.
-		if m.IsPlannerMode() && s.deps.MPC != nil {
-			var mm mpc.Mode
-			switch m {
-			case control.ModePlannerSelf:
-				mm = mpc.ModeSelfConsumption
-			case control.ModePlannerCheap:
-				mm = mpc.ModeCheapCharge
-			case control.ModePlannerPassiveArbitrage:
-				mm = mpc.ModePassiveArbitrage
-			case control.ModePlannerArbitrage:
-				mm = mpc.ModeArbitrage
-			}
-			s.deps.MPC.SetMode(r.Context(), mm)
-		}
-		writeJSON(w, 200, map[string]string{"status": "ok", "mode": req.Mode})
-	default:
+	// Validate against the canonical mode list. control.AllModes is the
+	// single source of truth — the same list the HA discovery `select`
+	// options derive from — so the validator and the HA bridge can't drift.
+	if !control.IsValidMode(m) {
 		writeJSON(w, 400, map[string]string{"error": "unknown mode: " + req.Mode})
+		return
 	}
+	s.deps.CtrlMu.Lock()
+	s.deps.Ctrl.Mode = m
+	// An explicit mode change is a reset signal: drop any active
+	// battery manual hold so the new mode takes effect on the very
+	// next dispatch tick. Mirrors the loadpoint manual_hold UX.
+	s.deps.Ctrl.ClearBatteryManualHold()
+	// Reset the PI integrator. The integral accumulated under the
+	// previous mode's error signal is meaningless to the new mode
+	// — keeping it caused integrator windup → wrong-direction stuck
+	// output across the 2026-05-24 evening mode switch (live
+	// regression: discharged the fleet to 7 % overnight while the
+	// PI integral was pinned in the wrong direction). Mode change
+	// is a discrete event; start the new regime from a clean PI.
+	if s.deps.Ctrl.PI != nil {
+		s.deps.Ctrl.PI.Reset()
+	}
+	s.deps.CtrlMu.Unlock()
+	if err := s.deps.State.SaveConfig("mode", req.Mode); err != nil {
+		slog.Warn("failed to persist mode", "err", err)
+	}
+	// Propagate to MPC if switching to a planner mode. Map
+	// control.ModePlanner* → mpc.Mode and force an immediate replan.
+	if m.IsPlannerMode() && s.deps.MPC != nil {
+		var mm mpc.Mode
+		switch m {
+		case control.ModePlannerSelf:
+			mm = mpc.ModeSelfConsumption
+		case control.ModePlannerCheap:
+			mm = mpc.ModeCheapCharge
+		case control.ModePlannerPassiveArbitrage:
+			mm = mpc.ModePassiveArbitrage
+		case control.ModePlannerArbitrage:
+			mm = mpc.ModeArbitrage
+		}
+		s.deps.MPC.SetMode(r.Context(), mm)
+	}
+	writeJSON(w, 200, map[string]string{"status": "ok", "mode": req.Mode})
 }
 
 // ---- /api/target ----

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -41,6 +41,31 @@ const (
 	ModePlannerArbitrage        Mode = "planner_arbitrage"
 )
 
+// AllModes is the canonical, ordered list of every operator-selectable
+// Mode. It is the single source of truth: the API mode validator and the
+// Home Assistant discovery `select` options both derive from it, so a new
+// mode can't be added to the enum without automatically appearing in both
+// places. Order is operator-facing (simple → advanced → planner), so it's
+// also a safe order to render in a UI dropdown.
+func AllModes() []Mode {
+	return []Mode{
+		ModeIdle, ModeSelfConsumption, ModePeakShaving,
+		ModeCharge, ModePriority, ModeWeighted,
+		ModePlannerSelf, ModePlannerCheap,
+		ModePlannerPassiveArbitrage, ModePlannerArbitrage,
+	}
+}
+
+// IsValidMode reports whether s names a known Mode.
+func IsValidMode(m Mode) bool {
+	for _, valid := range AllModes() {
+		if m == valid {
+			return true
+		}
+	}
+	return false
+}
+
 // IsPlannerMode reports whether the mode is one of the planner modes.
 func (m Mode) IsPlannerMode() bool {
 	return m == ModePlannerSelf ||

--- a/go/internal/control/modes_test.go
+++ b/go/internal/control/modes_test.go
@@ -1,0 +1,54 @@
+package control
+
+import "testing"
+
+// TestAllModesCoversPlannerModes is the regression guard for the Home
+// Assistant "Invalid option for select" bug: the mode state topic can emit
+// any planner_* mode (they are the default UI choice), and the HA discovery
+// `select` options derive from AllModes. If a planner mode ever drops out of
+// AllModes, HA rejects the published state again. See go/internal/ha/bridge.go.
+func TestAllModesCoversPlannerModes(t *testing.T) {
+	want := []Mode{
+		ModeIdle, ModeSelfConsumption, ModePeakShaving,
+		ModeCharge, ModePriority, ModeWeighted,
+		ModePlannerSelf, ModePlannerCheap,
+		ModePlannerPassiveArbitrage, ModePlannerArbitrage,
+	}
+	got := AllModes()
+	if len(got) != len(want) {
+		t.Fatalf("AllModes() returned %d modes, want %d: %v", len(got), len(want), got)
+	}
+	for i, m := range want {
+		if got[i] != m {
+			t.Errorf("AllModes()[%d] = %q, want %q", i, got[i], m)
+		}
+	}
+}
+
+// TestIsValidModeAgreesWithAllModes locks the validator to the canonical
+// list so the API mode setter and the HA bridge can't drift from each other.
+func TestIsValidModeAgreesWithAllModes(t *testing.T) {
+	for _, m := range AllModes() {
+		if !IsValidMode(m) {
+			t.Errorf("IsValidMode(%q) = false, want true (mode is in AllModes)", m)
+		}
+	}
+	for _, bad := range []Mode{"", "planner", "self", "arbitrage", "PLANNER_ARBITRAGE"} {
+		if IsValidMode(bad) {
+			t.Errorf("IsValidMode(%q) = true, want false", bad)
+		}
+	}
+}
+
+// TestEveryPlannerModeIsValid guards the specific failure from the field
+// report: planner_arbitrage published as state must be a recognized mode.
+func TestEveryPlannerModeIsValid(t *testing.T) {
+	for _, m := range AllModes() {
+		if !m.IsPlannerMode() {
+			continue
+		}
+		if !IsValidMode(m) {
+			t.Errorf("planner mode %q is not valid per IsValidMode", m)
+		}
+	}
+}

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -26,11 +26,11 @@ import (
 // CommandCallbacks is how the bridge hands received commands back to the
 // control loop. Caller provides these at construction time.
 type CommandCallbacks struct {
-	SetMode             func(string) error
-	SetGridTarget       func(float64) error
-	SetPeakLimit        func(float64) error
-	SetEVCharging       func(float64, bool) error
-	SetBatteryCoversEV  func(bool) error
+	SetMode            func(string) error
+	SetGridTarget      func(float64) error
+	SetPeakLimit       func(float64) error
+	SetEVCharging      func(float64, bool) error
+	SetBatteryCoversEV func(bool) error
 }
 
 // Bridge is an instance of the HA MQTT bridge.
@@ -321,13 +321,22 @@ func (b *Bridge) publishDiscovery() {
 	}
 
 	// ---- Mode as HA select ----
+	// Options MUST cover every value publishState can emit on the mode
+	// state topic, otherwise HA logs "Invalid option for select" the moment
+	// the active mode falls outside the list (e.g. any planner_* mode, which
+	// is the default UI choice). Derive from control.AllModes so the enum is
+	// the single source of truth and the two lists can't drift again.
+	modeOpts := make([]string, len(control.AllModes()))
+	for i, m := range control.AllModes() {
+		modeOpts[i] = string(m)
+	}
 	modeMsg := map[string]any{
-		"name":             "Mode",
-		"unique_id":        b.deviceID + "_mode",
-		"state_topic":      b.stateTopic("mode"),
-		"command_topic":    b.cmdTopic("mode"),
-		"options":          []string{"idle", "self_consumption", "peak_shaving", "charge", "priority", "weighted"},
-		"device":           dev,
+		"name":          "Mode",
+		"unique_id":     b.deviceID + "_mode",
+		"state_topic":   b.stateTopic("mode"),
+		"command_topic": b.cmdTopic("mode"),
+		"options":       modeOpts,
+		"device":        dev,
 	}
 	data, _ := json.Marshal(modeMsg)
 	b.publish(fmt.Sprintf("%s/select/%s/mode/config", b.discoPrefix, b.deviceID), data, true)
@@ -405,21 +414,27 @@ func (b *Bridge) subscribeCommands() {
 	})
 	b.client.Subscribe(b.cmdTopic("grid_target_w"), 0, func(_ paho.Client, m paho.Message) {
 		f, err := strconv.ParseFloat(string(m.Payload()), 64)
-		if err != nil { return }
+		if err != nil {
+			return
+		}
 		if b.cb.SetGridTarget != nil {
 			_ = b.cb.SetGridTarget(f)
 		}
 	})
 	b.client.Subscribe(b.cmdTopic("peak_limit_w"), 0, func(_ paho.Client, m paho.Message) {
 		f, err := strconv.ParseFloat(string(m.Payload()), 64)
-		if err != nil { return }
+		if err != nil {
+			return
+		}
 		if b.cb.SetPeakLimit != nil {
 			_ = b.cb.SetPeakLimit(f)
 		}
 	})
 	b.client.Subscribe(b.cmdTopic("ev_charging_w"), 0, func(_ paho.Client, m paho.Message) {
 		f, err := strconv.ParseFloat(string(m.Payload()), 64)
-		if err != nil { return }
+		if err != nil {
+			return
+		}
 		if b.cb.SetEVCharging != nil {
 			_ = b.cb.SetEVCharging(f, f > 0)
 		}
@@ -437,7 +452,9 @@ func (b *Bridge) subscribeCommands() {
 func (b *Bridge) publishLoop() {
 	defer close(b.done)
 	interval := time.Duration(b.cfg.PublishIntervalS) * time.Second
-	if interval <= 0 { interval = 5 * time.Second }
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
@@ -470,7 +487,9 @@ func (b *Bridge) publishState() {
 	}
 	var pvW, batW, sumSoC float64
 	var socCount int
-	for _, r := range b.tel.ReadingsByType(telemetry.DerPV) { pvW += r.SmoothedW }
+	for _, r := range b.tel.ReadingsByType(telemetry.DerPV) {
+		pvW += r.SmoothedW
+	}
 	for _, r := range b.tel.ReadingsByType(telemetry.DerBattery) {
 		batW += r.SmoothedW
 		if r.SoC != nil {
@@ -479,9 +498,13 @@ func (b *Bridge) publishState() {
 		}
 	}
 	avgSoC := 0.0
-	if socCount > 0 { avgSoC = sumSoC / float64(socCount) }
+	if socCount > 0 {
+		avgSoC = sumSoC / float64(socCount)
+	}
 	loadW := gridW - batW - pvW
-	if loadW < 0 { loadW = 0 }
+	if loadW < 0 {
+		loadW = 0
+	}
 
 	b.publishValue("grid_w", gridW)
 	b.publishValue("pv_w", pvW)


### PR DESCRIPTION
## Problem

Field report from Göran Andersson:

> Home Assistant mqtt gillar inte planner_arbitrage: `ERROR ... Invalid option for select.forty_two_watts_mode: 'planner_arbitrage' (valid options: ['idle', 'self_consumption', 'peak_shaving', 'charge', 'priority', 'weighted'])`

Göran's diagnosis was correct: the bug is in forty-two-watts, not Home Assistant. The HA bridge published two lists of modes that had drifted apart:

- **Discovery `select` options** — hardcoded to **6** modes (`go/internal/ha/bridge.go`).
- **Mode state topic** — publishes `string(b.ctrl.Mode)`, any of the **10** canonical `control.Mode` constants.

When the active mode is a `planner_*` mode, the state topic emits e.g. `planner_arbitrage`, which HA's `select` (only told about 6 options) rejects every publish cycle.

This bites essentially every default install: the **primary** (non-advanced) UI mode buttons are *only* planner modes (`planner_passive_arbitrage`, `planner_arbitrage` — `web/index.html`). The 6 advertised modes are all under advanced-only.

## Fix

Introduce `control.AllModes()` (and `control.IsValidMode`) as the single source of truth for the canonical, ordered mode list. Both consumers now derive from it:

- `go/internal/ha/bridge.go` — discovery `options` are built from `control.AllModes()`, so all 10 modes are advertised.
- `go/internal/api/api.go` — the `/api/mode` validator switch is replaced with `control.IsValidMode`, so the validator and the HA bridge can no longer drift.

The mode list had been duplicated in three places (the enum, the API switch, the bridge literal); now it lives in one.

## Tests

`go/internal/control/modes_test.go` adds regression guards:
- `AllModes()` covers every mode incl. all four planner modes (the ones that were missing).
- `IsValidMode` agrees with `AllModes` and rejects bogus values.
- every planner mode is valid (guards the exact field failure).

## Verification

```
gofmt -l   # clean
go build ./...   # ok
go vet ./internal/control/ ./internal/ha/ ./internal/api/   # ok
go test ./internal/control/ ./internal/ha/ ./internal/api/   # all pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)