### PR TITLE
fix: treat Tailscale/zerotier CGNAT (100.64/10) as genuine LAN (client + Pi gate)

### DIFF
--- a/.changeset/tailscale-cgnat-lan-detection.md
+++ b/.changeset/tailscale-cgnat-lan-detection.md
@@ -1,0 +1,13 @@
+---
+"forty-two-watts": patch
+---
+
+Reaching your dashboard over Tailscale no longer shows the passkey sign-in
+gate. The browser's LAN-origin detection treated Tailscale's CGNAT addresses
+(100.64.0.0/10, RFC 6598) as a public/relay origin, so it waited for a P2P
+channel that a direct connection never opens and fell back to the sign-in gate
+— while the same Pi reached over zerotier (192.168.0.0/16) sailed straight
+through. The CGNAT range is now recognised as a direct-LAN origin in all three
+copies of the check (`p2p.js`, `next-app.js`, `owner-access/owner-fetch.js`),
+matching `p2p.js`'s own `isDirectLAN`. Direct IP access — LAN, zerotier, or
+Tailscale — reaches the dashboard without a passkey prompt.

--- a/.changeset/tailscale-cgnat-lan-detection.md
+++ b/.changeset/tailscale-cgnat-lan-detection.md
@@ -11,3 +11,11 @@ through. The CGNAT range is now recognised as a direct-LAN origin in all three
 copies of the check (`p2p.js`, `next-app.js`, `owner-access/owner-fetch.js`),
 matching `p2p.js`'s own `isDirectLAN`. Direct IP access — LAN, zerotier, or
 Tailscale — reaches the dashboard without a passkey prompt.
+
+The Pi-side LAN-presence check (`isLANClientSource`) now recognises the same
+CGNAT range, so owner-admin actions (manage passkeys, mint the setup PIN,
+bootstrap the first passkey) work over Tailscale exactly as over an RFC1918 LAN.
+An overlay you joined to your Pi is an explicit, authenticated owner decision —
+genuine LAN presence — while the relay path stays excluded by the X-FTW-Tunnel
+marker and the loopback check, so the friend pair-flow still cannot reach
+owner-admin.

--- a/go/internal/api/api_owner_access.go
+++ b/go/internal/api/api_owner_access.go
@@ -524,7 +524,23 @@ func isLANClientSource(r *http.Request) bool {
 	if ip == nil || ip.IsLoopback() {
 		return false
 	}
-	return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast() || isCGNAT(ip)
+}
+
+// isCGNAT reports whether ip is in RFC 6598 shared address space
+// (100.64.0.0/10) — the range Tailscale and zerotier hand out for their
+// overlays. Go's net.IP.IsPrivate covers RFC1918 + IPv6 ULA (so a Tailscale
+// IPv6 fd7a:… address already reads as private) but NOT the IPv4 CGNAT block,
+// so it is checked here. A source in this range reached the Pi over an overlay
+// the owner explicitly joined to the machine — an authenticated, encrypted path
+// with the relay NOT in it — so it counts as genuine LAN presence, exactly like
+// an RFC1918 client. Mirrors isPrivateIPv4 / isDirectLAN in web/p2p.js.
+func isCGNAT(ip net.IP) bool {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	return ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127
 }
 
 // isTunneled reports whether the request arrived via the relay long-poll

--- a/go/internal/api/api_owner_access_source_test.go
+++ b/go/internal/api/api_owner_access_source_test.go
@@ -8,8 +8,9 @@ import (
 // isLANClientSource / isLoopbackSource are the fail-closed second line of
 // defence behind the X-FTW-Tunnel marker (see authorizeOwner). They classify
 // the request's SOURCE address (RemoteAddr), so this table pins the exact
-// trust boundary: private-range = LAN client, everything else (public, CGNAT,
-// loopback) = not a LAN client.
+// trust boundary: private-range AND the 100.64/10 CGNAT overlay range
+// (Tailscale / zerotier — an overlay the owner explicitly joined to the Pi) =
+// LAN client; public internet space and loopback = not a LAN client.
 func TestIsLANClientSource(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -29,7 +30,10 @@ func TestIsLANClientSource(t *testing.T) {
 		{"loopback v6 is NOT a LAN client", "[::1]:9", false, true},
 		{"public ipv4", "8.8.8.8:9", false, false},
 		{"public ipv6", "[2606:4700:4700::1111]:9", false, false},
-		{"CGNAT 100.64/10 is NOT private", "100.64.0.1:9", false, false},
+		{"CGNAT 100.64/10 (Tailscale/zerotier overlay) is LAN", "100.64.0.1:9", true, false},
+		{"CGNAT top of /10 is LAN", "100.127.255.255:9", true, false},
+		{"100.63/8 just below CGNAT is public", "100.63.255.255:9", false, false},
+		{"100.128/9 just above CGNAT is public", "100.128.0.1:9", false, false},
 		{"garbage", "not-an-ip", false, false},
 	}
 	for _, tc := range cases {

--- a/go/internal/api/api_owner_access_test.go
+++ b/go/internal/api/api_owner_access_test.go
@@ -696,6 +696,45 @@ func TestFriendLoopbackCannotManageOwner(t *testing.T) {
 	}
 }
 
+// TestTailscaleCGNATCountsAsLAN: an overlay (Tailscale/zerotier) you joined to
+// your Pi is genuine LAN presence — the owner explicitly, authenticatedly opted
+// in — so owner-manage actions must work over it, exactly like RFC1918. Tailscale
+// (and zerotier) hand out 100.64.0.0/10 (RFC 6598 CGNAT); only that /10, never
+// all of 100.0.0.0/8, is the overlay range. The relay path stays excluded by the
+// X-FTW-Tunnel marker + loopback check, untouched by this.
+func TestTailscaleCGNATCountsAsLAN(t *testing.T) {
+	d := minDeps(t)
+	d.OwnerAccessLANBypass = true
+	d.TunnelMarker = "marker"
+	if err := d.State.SaveTrustedDevice(state.TrustedDevice{
+		CredentialID: []byte("owner-cred"), PublicKey: []byte("k"),
+		FriendlyName: "owner phone", CreatedAtMs: time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("seed owner device: %v", err)
+	}
+	srv := New(d)
+	get := func(remoteAddr string) int {
+		req := httptest.NewRequest("GET", "/api/owner-access/devices", nil)
+		req.Host = "127.0.0.1:8080"
+		req.RemoteAddr = remoteAddr // direct overlay source, no X-FTW-Tunnel marker
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		return rec.Code
+	}
+	// CGNAT (Tailscale) source manages like LAN.
+	for _, addr := range []string{"100.64.0.1:1234", "100.97.0.112:1234", "100.127.255.255:1234"} {
+		if code := get(addr); code != 200 {
+			t.Errorf("CGNAT owner %s devices list: got %d, want 200", addr, code)
+		}
+	}
+	// Public 100.x outside the /10 is ordinary internet space — stays blocked.
+	for _, addr := range []string{"100.63.255.255:1234", "100.128.0.1:1234"} {
+		if code := get(addr); code != 401 {
+			t.Errorf("public %s devices list: got %d, want 401 (not LAN)", addr, code)
+		}
+	}
+}
+
 func contains(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
 }

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -64,7 +64,8 @@
     if (h === "localhost" || h === "::1" || h === "[::1]") return true;
     if (h.slice(-6) === ".local" || h.indexOf(".") === -1) return true; // *.local / single-label
     if (/^10\./.test(h) || /^127\./.test(h) || /^192\.168\./.test(h) ||
-        /^169\.254\./.test(h) || /^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+        /^169\.254\./.test(h) || /^172\.(1[6-9]|2\d|3[01])\./.test(h) ||
+        /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./.test(h)) return true; // 100.64/10 CGNAT (Tailscale)
     var hv6 = h.replace(/^\[|\]$/g, "");
     if (/^f[cd][0-9a-f]{2}:/.test(hv6) || /^fe[89ab][0-9a-f]:/.test(hv6)) return true;
     return false; // dotted public host → NOT LAN → fail closed

--- a/web/owner-access/owner-fetch.js
+++ b/web/owner-access/owner-fetch.js
@@ -26,6 +26,7 @@ function isPrivateIPv4(h) {
   if (a === 192 && b === 168) return true;          // 192.168.0.0/16
   if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
   if (a === 169 && b === 254) return true;          // link-local
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT (Tailscale / RFC 6598)
   return false;
 }
 

--- a/web/owner-access/owner-fetch.test.mjs
+++ b/web/owner-access/owner-fetch.test.mjs
@@ -93,6 +93,27 @@ describe("ownerFetch — transport selection (FIX-B)", () => {
     globalThis.window.ftwP2P = { isLanOrigin: () => true }; // p2p.js says LAN
     assert.equal(isLanOrigin(), true, "must defer to p2p.js's isLanOrigin");
   });
+
+  it("treats a Tailscale CGNAT 100.64/10 host as LAN (direct, relay not in path)", async () => {
+    // Tailscale assigns every node a 100.64.0.0/10 (RFC 6598) address. Reaching
+    // the Pi on one is a direct WireGuard connection — the relay is NOT in the
+    // path — so it must read as LAN, exactly like zerotier's 192.168/16. The bug:
+    // isPrivateIPv4 omitted CGNAT, so Tailscale users got the passkey sign-in gate
+    // while zerotier users sailed through.
+    for (const ip of ["100.64.0.0", "100.97.0.112", "100.120.141.49", "100.127.255.255"]) {
+      setOrigin("/", ip);
+      assert.equal(isLanOrigin(), true, `${ip} (CGNAT) must read as LAN`);
+    }
+  });
+
+  it("does NOT treat non-CGNAT 100.x hosts as LAN (boundary)", async () => {
+    // 100.0.0.0/10 below and 100.128.0.0 above the CGNAT block are ordinary
+    // public space and must still fail closed.
+    for (const ip of ["100.63.255.255", "100.128.0.0", "100.0.0.1"]) {
+      setOrigin("/", ip);
+      assert.equal(isLanOrigin(), false, `${ip} is public, must NOT read as LAN`);
+    }
+  });
 });
 
 // --- source hygiene: no owner/control call may regress to a bare fetch ------
@@ -131,6 +152,26 @@ describe("ceremony pages route owner calls through the shared strict ownerFetch"
     assert.match(INDEX, /MANUAL_SIGNOUT_KEY\s*=\s*"ftw\.owner\.manual_signout\.v1"/);
     assert.match(INDEX, /function markManualSignout\(\)[\s\S]*localStorage\.setItem\(MANUAL_SIGNOUT_KEY,\s*"1"\)/);
     assert.match(INDEX, /document\.getElementById\("signout"\)\.onclick[\s\S]*markManualSignout\(\)[\s\S]*ownerFetch\("\/api\/owner-access\/logout"/);
+  });
+});
+
+// --- CGNAT/Tailscale LAN detection must agree across all three copies --------
+// p2p.js's isDirectLAN already recognised 100.64/10, but the parallel
+// isPrivateIPv4 (used by isLanOrigin) and next-app.js's isLanFallbackOrigin did
+// not — so a Tailscale-reached dashboard saw the sign-in gate while the same Pi
+// over zerotier (192.168/16) did not. These guard the three copies in lockstep.
+describe("CGNAT (Tailscale 100.64/10) is recognised as LAN in every copy", () => {
+  const P2P = readFileSync(join(__dirname, "..", "p2p.js"), "utf8");
+  const APP = readFileSync(join(__dirname, "..", "next-app.js"), "utf8");
+
+  it("p2p.js isPrivateIPv4 (the isLanOrigin helper) handles 100.64/10", () => {
+    assert.match(P2P, /a === 100 && b >= 64 && b <= 127/,
+      "p2p.js isPrivateIPv4 must recognise the CGNAT block, matching its own isDirectLAN");
+  });
+
+  it("next-app.js isLanFallbackOrigin handles 100.64/10", () => {
+    assert.match(APP, /\^100\\\.\(6\[4-9\]\|\[7-9\]\[0-9\]\|1\[01\]\[0-9\]\|12\[0-7\]\)\\\./,
+      "next-app.js inline LAN fallback must recognise the CGNAT block");
   });
 });
 

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -56,6 +56,7 @@
     if (a === 192 && b === 168) return true;         // 192.168.0.0/16
     if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
     if (a === 169 && b === 254) return true;         // link-local
+    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT (Tailscale / RFC 6598) — matches isDirectLAN
     return false;
   }
   function isLanOrigin() {


### PR DESCRIPTION
## Symptom

Field testers (and I) hit the passkey **sign-in gate** when opening the dashboard over a **Tailscale** IP (`100.x:8080`). The *same Pi* over **zerotier** (`192.168.x`) loads straight away. "Tailscale should count as LAN — that's the whole point: you explicitly, authenticatedly joined that (virtual) network to your Pi."

## Root cause

The browser carried **two** host classifiers that disagreed. `p2p.js` `isDirectLAN()` already knew **`100.64.0.0/10`** (RFC 6598 CGNAT — Tailscale's range) is a *direct* connection, so it disabled P2P. But the parallel `isPrivateIPv4()` (used by `isLanOrigin()`) and `next-app.js`'s `isLanFallbackOrigin()` **omitted** it. So over Tailscale the page judged itself **remote** while P2P was **off** — it waited for a direct channel that never opens, timed out, and fell back to the sign-in gate. zerotier's `192.168/16` is plain RFC1918, so it was recognised.

`curl` over Tailscale always returned `200` + the dashboard — the **server never gated direct requests**. The whole gate lives in browser JS, which `curl` doesn't run. (The Pi side keys off the `X-FTW-Tunnel` relay marker, not source IP.)

## Fix

**Client (the gate):** add `100.64.0.0/10` to all three copies so they agree with `isDirectLAN` — `web/p2p.js` `isPrivateIPv4`, `web/owner-access/owner-fetch.js`, `web/next-app.js` `isLanFallbackOrigin`. Direct IP access (LAN / zerotier / Tailscale) now reaches the dashboard with no passkey prompt.

**Pi gate (`isLANClientSource`):** Go's `ip.IsPrivate()` covers RFC1918 + IPv6 ULA (so Tailscale **IPv6** `fd7a:…` already worked) but not the IPv4 CGNAT block, so owner-**admin** actions (manage passkeys, mint the setup PIN, bootstrap the first passkey) returned 401 over Tailscale. Add `isCGNAT(100.64/10)`. An overlay you joined to your Pi is an explicit, authenticated owner decision — genuine LAN presence.

**Invariant preserved:** the relay path stays excluded by the `X-FTW-Tunnel` marker + the loopback check (a relay/friend reverse-proxy connects from loopback, never a LAN client), so the friend pair-flow still cannot reach owner-admin. `TestFriendLoopbackCannotManageOwner` stays green. This deliberately flips the prior `TestIsLANClientSource` stance that pinned CGNAT as not-LAN, per the decision that overlays count as LAN; the boundary is now pinned at the `/10` edges (`100.63`/`100.128` stay public).

## Evidence

- `curl` over Tailscale (`100.97.0.112:8080`): `/` → 200 dashboard, `/api/owner-access/whoami` → `{"authenticated":true}`, but `/api/owner-access/devices` → **401** (admin blocked) — exactly the asymmetry the fix closes.
- `isLanOrigin` now `true` for the testers' real IPs (`100.97.0.112`, `100.120.141.49`).

## Tests

- `owner-fetch.test.mjs`: CGNAT bounds → LAN, non-CGNAT `100.x` → fail closed; source-hygiene guards the block in `p2p.js` + `next-app.js`.
- `api_owner_access_test.go` `TestTailscaleCGNATCountsAsLAN`: CGNAT source manages (200), public `100.x` blocked (401), through the real `Handler()`.
- `TestIsLANClientSource` updated; `TestFriendLoopbackCannotManageOwner` unchanged + green.
- Full JS suite (209/209) + `make verify` (go vet + test + build, incl. e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)