### PR TITLE
[codex] Add global troubleshooting mode

### DIFF
--- a/.changeset/pixii-troubleshooting-mode.md
+++ b/.changeset/pixii-troubleshooting-mode.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Add a UI-controlled global troubleshooting mode for incident diagnostics. It exposes its state in `/api/status`, logs dispatch-decision snapshots without changing control behavior, and passes a reserved troubleshooting flag into Lua drivers. Pixii now uses that flag to emit calibration/control status and setpoint readback metrics, while still supporting its legacy per-driver troubleshooting flag. Invalid Pixii SoC values now omit `soc` from the battery emit instead of dropping the whole battery reading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,17 @@ self-consumption around the site meter. `slew_rate_w` is a soft per-cycle
 ramp ceiling; per-driver power caps and the fuse guard remain the hard
 dispatch constraints.
 
+### Global Troubleshooting Mode
+
+Use **Settings → Control → Troubleshooting mode** when diagnosing a live
+system issue. It does not change planner, dispatch, clamp, or driver command
+behavior. It adds dispatch-decision log lines, exposes the active flag in
+`/api/status`, and passes a reserved `_troubleshooting_mode` flag to Lua
+drivers so driver-specific diagnostics can emit richer status/readback data.
+
+Turn it off in Settings after the incident; logs and long-format metrics are
+noisier while it is enabled.
+
 ## `fuse`
 
 ```yaml
@@ -130,6 +141,14 @@ drivers:
 Driver-specific fields are parsed by the Lua driver, not by the generic
 config schema. See the driver source and
 [`docs/driver-catalog.md`](driver-catalog.md) for expected keys.
+
+### Pixii Diagnostics
+
+When Troubleshooting mode is enabled from Settings, the Pixii driver emits
+extra SunSpec battery diagnostics: charge status, control mode, battery state,
+vendor state, event bits, and setpoint readback. `charge_status=testing` is
+the useful signal for suspected Pixii calibration/testing sessions that may
+ignore external setpoints.
 
 ## `api`
 

--- a/drivers/pixii.lua
+++ b/drivers/pixii.lua
@@ -53,7 +53,23 @@ local REG_HEARTBEAT   = 39903  -- uint16, 0..100, must tick >= 1/min
 local REG_SETPOINT_HI = 39905  -- int32 MSB (big-endian, paired with 39906)
 local REG_SETPOINT_LO = 39906  -- int32 LSB
 
+-- SunSpec model 802 battery status points. Pixii's SoC is already read
+-- from this block at 40132, so these adjacent points are cheap diagnostics.
+local REG_BATTERY_SOC = 40132
+local REG_BATTERY_CHARGE_STATUS = 40137 -- ChaSt: OFF/EMPTY/DISCHARGING/...
+local REG_BATTERY_CONTROL_MODE = 40138 -- LocRemCtl: REMOTE/LOCAL
+local REG_BATTERY_STATE = 40143 -- State: CONNECTED/STANDBY/FAULT/...
+local REG_BATTERY_STATE_VENDOR = 40144 -- StateVnd: Pixii-specific
+local REG_BATTERY_EVT1 = 40147 -- Evt1 bitfield32
+
 local sn_read = false
+local troubleshooting = false
+local last_status_key = nil
+local last_command_ems_w = nil
+local last_command_pixii_w = nil
+local last_command_ms = nil
+local last_command_ok = nil
+
 -- Handshake counter, bumped every poll so the Pixii never times out to idle.
 -- Any change is sufficient; we just walk 0..99 and wrap.
 local hb_tick = 0
@@ -89,12 +105,135 @@ local function decode_ascii(regs, count)
     return s
 end
 
+local function config_bool(config, key)
+    if config == nil then return false end
+    local v = config[key]
+    return v == true or v == 1 or v == "1" or v == "true" or v == "yes" or v == "on"
+end
+
+local function read_u16(addr)
+    local ok, regs = pcall(host.modbus_read, addr, 1, "holding")
+    if ok and regs and regs[1] ~= nil then return regs[1] end
+    return nil
+end
+
+local function read_u32_be(addr)
+    local ok, regs = pcall(host.modbus_read, addr, 2, "holding")
+    if ok and regs and regs[1] ~= nil and regs[2] ~= nil then
+        return host.decode_u32_be(regs[1], regs[2])
+    end
+    return nil
+end
+
+local function read_i32_be(addr)
+    local ok, regs = pcall(host.modbus_read, addr, 2, "holding")
+    if ok and regs and regs[1] ~= nil and regs[2] ~= nil then
+        return host.decode_i32_be(regs[1], regs[2])
+    end
+    return nil
+end
+
+local charge_status_labels = {
+    [1] = "off",
+    [2] = "empty",
+    [3] = "discharging",
+    [4] = "charging",
+    [5] = "full",
+    [6] = "holding",
+    [7] = "testing",
+}
+
+local control_mode_labels = {
+    [0] = "remote",
+    [1] = "local",
+}
+
+local battery_state_labels = {
+    [1] = "disconnected",
+    [2] = "initializing",
+    [3] = "connected",
+    [4] = "standby",
+    [5] = "soc_protection",
+    [6] = "suspending",
+    [99] = "fault",
+}
+
+local function label_for(labels, value)
+    if value == nil then return "unknown" end
+    return labels[value] or ("unknown_" .. tostring(value))
+end
+
+local function read_battery_status()
+    local charge_status = read_u16(REG_BATTERY_CHARGE_STATUS)
+    local control_mode = read_u16(REG_BATTERY_CONTROL_MODE)
+    local battery_state = read_u16(REG_BATTERY_STATE)
+    local vendor_state = read_u16(REG_BATTERY_STATE_VENDOR)
+    local event1 = read_u32_be(REG_BATTERY_EVT1)
+
+    if charge_status ~= nil then host.emit_metric("battery_charge_status_code", charge_status) end
+    if control_mode ~= nil then host.emit_metric("battery_control_mode_code", control_mode) end
+    if battery_state ~= nil then host.emit_metric("battery_state_code", battery_state) end
+    if vendor_state ~= nil then host.emit_metric("battery_vendor_state_code", vendor_state) end
+    if event1 ~= nil then host.emit_metric("battery_event1_bits", event1) end
+
+    local charge_label = label_for(charge_status_labels, charge_status)
+    local control_label = label_for(control_mode_labels, control_mode)
+    local state_label = label_for(battery_state_labels, battery_state)
+    local key = charge_label .. "/" .. control_label .. "/" .. state_label .. "/" .. tostring(vendor_state) .. "/" .. tostring(event1)
+    if key ~= last_status_key then
+        host.log("info", "Pixii: status charge=" .. charge_label
+            .. " control=" .. control_label
+            .. " state=" .. state_label
+            .. " vendor_state=" .. tostring(vendor_state)
+            .. " event1=" .. tostring(event1))
+        if charge_status == 7 then
+            host.log("warn", "Pixii: charge status is TESTING; Pixii may be calibrating/testing and may ignore external setpoints")
+        end
+        last_status_key = key
+    end
+
+    return {
+        charge_status = charge_status,
+        charge_status_label = charge_label,
+        control_mode = control_mode,
+        control_mode_label = control_label,
+        battery_state = battery_state,
+        battery_state_label = state_label,
+        vendor_state = vendor_state,
+        event1 = event1,
+    }
+end
+
+local function emit_troubleshooting_metrics()
+    host.emit_metric("pixii_heartbeat_counter", hb_tick)
+    local setpoint_pixii_w = read_i32_be(REG_SETPOINT_HI)
+    if setpoint_pixii_w ~= nil then
+        host.emit_metric("pixii_setpoint_native_w", setpoint_pixii_w)
+        host.emit_metric("pixii_setpoint_ems_w", -setpoint_pixii_w)
+    end
+    if last_command_ems_w ~= nil then
+        host.emit_metric("pixii_last_command_ems_w", last_command_ems_w)
+        host.emit_metric("pixii_last_command_native_w", last_command_pixii_w)
+        host.emit_metric("pixii_last_command_ok", last_command_ok or 0)
+        if last_command_ms ~= nil then
+            host.emit_metric("pixii_last_command_age_s", (host.millis() - last_command_ms) / 1000)
+        end
+    end
+end
+
 ----------------------------------------------------------------------------
 -- Initialization
 ----------------------------------------------------------------------------
 
 function driver_init(config)
     host.set_make("Pixii")
+    troubleshooting = config_bool(config, "_troubleshooting_mode")
+        or config_bool(config, "troubleshooting_mode")
+        or config_bool(config, "troubleshooting")
+        or config_bool(config, "debug")
+    if troubleshooting then
+        host.log("info", "Pixii: troubleshooting mode enabled")
+    end
 
     -- Verify SunSpec signature at 40000 ("SunS") as a sanity check.
     local ok, sig = pcall(host.modbus_read, 40000, 2, "holding")
@@ -172,11 +311,27 @@ function driver_poll()
         temp_c = scale(host.decode_i16(temp_regs[1]), temp_sf)
     end
 
-    -- Battery SoC: 40132, U16 (percent → fraction 0..1)
-    local ok_soc, soc_regs = pcall(host.modbus_read, 40132, 1, "holding")
-    local bat_soc = 0
-    if ok_soc and soc_regs then
-        bat_soc = scale(soc_regs[1], soc_sf) / 100
+    -- Battery SoC: 40132, U16 (percent → fraction 0..1).
+    -- If Pixii returns a sentinel or otherwise impossible value, omit SoC
+    -- from the emit rather than invalidating the whole battery reading.
+    local ok_soc, soc_regs = pcall(host.modbus_read, REG_BATTERY_SOC, 1, "holding")
+    local bat_soc = nil
+    local bat_soc_pct = nil
+    if ok_soc and soc_regs and soc_regs[1] ~= nil then
+        bat_soc_pct = scale(soc_regs[1], soc_sf)
+        local candidate = bat_soc_pct / 100
+        if candidate >= 0 and candidate <= 1 then
+            bat_soc = candidate
+        else
+            host.log("warn", "Pixii: ignoring invalid battery SoC percent=" .. tostring(bat_soc_pct)
+                .. " raw=" .. tostring(soc_regs[1]) .. " sf=" .. tostring(soc_sf))
+        end
+    elseif troubleshooting then
+        host.log("warn", "Pixii: SoC read failed")
+    end
+    if bat_soc_pct ~= nil then
+        host.emit_metric("battery_soc_pct_raw", bat_soc_pct)
+        host.emit_metric("battery_soc_valid", bat_soc ~= nil and 1 or 0)
     end
 
     -- Battery voltage: 40155, I16
@@ -208,15 +363,26 @@ function driver_poll()
         bat_discharge_wh = host.decode_i32_be(cab_regs[3], cab_regs[4]) * 1000
     end
 
-    host.emit("battery", {
-        w            = bat_w,
-        v            = bat_v,
-        a            = bat_a,
-        soc          = bat_soc,
-        temp_c       = temp_c,
-        charge_wh    = bat_charge_wh,
-        discharge_wh = bat_discharge_wh,
-    })
+    local status = read_battery_status()
+    if troubleshooting then
+        emit_troubleshooting_metrics()
+    end
+
+    local battery = {
+        w                    = bat_w,
+        v                    = bat_v,
+        a                    = bat_a,
+        temp_c               = temp_c,
+        charge_wh            = bat_charge_wh,
+        discharge_wh         = bat_discharge_wh,
+        charge_status        = status.charge_status_label,
+        control_mode         = status.control_mode_label,
+        battery_state        = status.battery_state_label,
+        battery_vendor_state = status.vendor_state,
+        battery_event1       = status.event1,
+    }
+    if bat_soc ~= nil then battery.soc = bat_soc end
+    host.emit("battery", battery)
     -- Diagnostics: long-format TS DB
     host.emit_metric("battery_dc_v",      bat_v)
     host.emit_metric("battery_dc_a",      bat_a)
@@ -406,6 +572,17 @@ local function write_setpoint_w(pixii_w)
     if hb_err ~= nil and hb_err ~= "" then
         host.log("warn", "Pixii: heartbeat write failed: " .. tostring(hb_err))
     end
+    if troubleshooting then
+        local actual_pixii_w = read_i32_be(REG_SETPOINT_HI)
+        if actual_pixii_w ~= nil then
+            host.emit_metric("pixii_setpoint_native_w", actual_pixii_w)
+            host.emit_metric("pixii_setpoint_ems_w", -actual_pixii_w)
+            host.log("info", "Pixii: setpoint readback pixii_w=" .. tostring(actual_pixii_w)
+                .. " ems_w=" .. tostring(-actual_pixii_w))
+        else
+            host.log("warn", "Pixii: setpoint readback failed")
+        end
+    end
     return true
 end
 
@@ -414,7 +591,12 @@ local function set_battery_power(power_w)
     local pixii_w = -power_w
     host.log("info", "Pixii: setpoint ems_w=" .. tostring(power_w)
         .. " pixii_w=" .. tostring(pixii_w))
-    return write_setpoint_w(pixii_w)
+    last_command_ems_w = power_w
+    last_command_pixii_w = pixii_w
+    last_command_ms = host.millis()
+    local ok = write_setpoint_w(pixii_w)
+    last_command_ok = ok and 1 or 0
+    return ok
 end
 
 function driver_command(action, power_w, cmd)

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -262,6 +262,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	reg := drivers.NewRegistry(tel)
+	reg.SetTroubleshootingMode(cfg.Site.TroubleshootingMode)
 	reg.MQTTFactory = func(name string, c *config.MQTTConfig) (drivers.MQTTCap, error) {
 		return mqttcli.Dial(c.Host, c.Port, c.Username, c.Password, "ftw-"+name)
 	}
@@ -434,7 +435,7 @@ func main() {
 			}
 			// Driver paths are already resolved by config.Load; no extra
 			// work needed here.
-			reg.Reload(ctx, newCfg.Drivers)
+			reg.Reload(ctx, newCfg.Drivers, newCfg.Site.TroubleshootingMode)
 			// Refresh capacities — mutate the existing map in place so
 			// Deps.Capacities (a map header captured at init) sees the
 			// update. Rebinding the local variable would orphan the
@@ -1892,6 +1893,9 @@ func main() {
 			if watchdogTimeout <= 0 {
 				watchdogTimeout = 60 * time.Second
 			}
+			cfgMu.RLock()
+			troubleshootingMode := cfg.Site.TroubleshootingMode
+			cfgMu.RUnlock()
 			for _, tr := range tel.WatchdogScan(watchdogTimeout) {
 				if !tr.Online {
 					slog.Warn("driver telemetry stale — marking offline + reverting to autonomous",
@@ -1940,6 +1944,10 @@ func main() {
 			if siteMeterStale {
 				slog.Warn("site meter telemetry stale — idling batteries this cycle",
 					"driver", ctrl.SiteMeterDriver)
+				if troubleshootingMode {
+					slog.Info("troubleshooting: site meter stale, dispatch skipped",
+						"site_meter", siteMeterDriver, "timeout", watchdogTimeout)
+				}
 				for _, n := range driversToDefaultOnSiteMeterStale(reg.Names(), ctrl.SiteMeterDriver) {
 					sendDriverDefault(ctx, reg, n, "site_meter_stale")
 				}
@@ -2006,15 +2014,41 @@ func main() {
 
 			// ---- Self-tune override: force commanded battery, hold others at 0 ----
 			finalTargets := targets
-			if name, cmd, active := selfTune.CurrentCommand(); active {
+			selfTuneName, selfTuneCmd, selfTuneActive := selfTune.CurrentCommand()
+			if selfTuneActive {
 				finalTargets = make([]control.DispatchTarget, 0, len(reg.Names()))
 				for _, n := range reg.Names() {
-					if n == name {
-						finalTargets = append(finalTargets, control.DispatchTarget{Driver: n, TargetW: cmd})
+					if n == selfTuneName {
+						finalTargets = append(finalTargets, control.DispatchTarget{Driver: n, TargetW: selfTuneCmd})
 					} else {
 						finalTargets = append(finalTargets, control.DispatchTarget{Driver: n, TargetW: 0})
 					}
 				}
+			}
+			if troubleshootingMode {
+				gridW, haveGrid := troubleshootingGridW(tel, siteMeterDriver)
+				pvW := troubleshootingSumOnlineW(tel, telemetry.DerPV)
+				batW := troubleshootingSumOnlineW(tel, telemetry.DerBattery)
+				evW := tel.SumOnlineEVW()
+				attrs := []any{
+					"mode", ctrl.Mode,
+					"plan_stale", planMissingNow,
+					"site_meter", siteMeterDriver,
+					"grid_known", haveGrid,
+					"grid_w", gridW,
+					"pv_w", pvW,
+					"bat_w", batW,
+					"ev_w", evW,
+					"self_tune_active", selfTuneActive,
+					"self_tune_driver", selfTuneName,
+					"self_tune_command_w", selfTuneCmd,
+					"targets", targets,
+					"final_targets", finalTargets,
+				}
+				if haveGrid {
+					attrs = append(attrs, "load_w", gridW-batW-pvW-evW)
+				}
+				slog.Info("troubleshooting: dispatch decision", attrs...)
 			}
 
 			// ---- Dispatch to drivers ----
@@ -2882,6 +2916,29 @@ func instanceSignerOrNil(id *nova.Identity) api.InstanceSigner {
 		return nil
 	}
 	return id
+}
+
+func troubleshootingGridW(tel *telemetry.Store, siteMeterDriver string) (float64, bool) {
+	if siteMeterDriver == "" {
+		return 0, false
+	}
+	r := tel.Get(siteMeterDriver, telemetry.DerMeter)
+	if r == nil {
+		return 0, false
+	}
+	return r.SmoothedW, true
+}
+
+func troubleshootingSumOnlineW(tel *telemetry.Store, typ telemetry.DerType) float64 {
+	var sum float64
+	for _, r := range tel.ReadingsByType(typ) {
+		h := tel.DriverHealth(r.Driver)
+		if h == nil || !h.IsOnline() {
+			continue
+		}
+		sum += r.SmoothedW
+	}
+	return sum
 }
 
 // envBool returns true iff the env var is set to a positive value

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -781,6 +781,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	// doesn't need a second /api/config fetch, and pull per-phase readings
 	// from the site meter driver's raw emit payload.
 	s.deps.CfgMu.RLock()
+	troubleshootingMode := s.deps.Cfg.Site.TroubleshootingMode
 	fuseCfg := map[string]any{
 		"max_amps": s.deps.Cfg.Fuse.MaxAmps,
 		"phases":   s.deps.Cfg.Fuse.Phases,
@@ -793,6 +794,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"version":               s.deps.Version,
 		"mode":                  ctrl.Mode,
+		"troubleshooting_mode":  troubleshootingMode,
 		"plan_stale":            ctrl.PlanStale,
 		"grid_w":                gridW,
 		"pv_w":                  pvW,
@@ -1142,6 +1144,9 @@ func (s *Server) handlePostConfig(w http.ResponseWriter, r *http.Request) {
 	s.deps.Ctrl.PVSurplusAbsorbSoCCapPct = newCfg.Site.PVSurplusAbsorbSoCCapPct
 	s.deps.Ctrl.PVSurplusAbsorbThresholdW = newCfg.Site.PVSurplusAbsorbThresholdW
 	s.deps.CtrlMu.Unlock()
+	if s.deps.Registry != nil {
+		s.deps.Registry.Reload(r.Context(), newCfg.Drivers, newCfg.Site.TroubleshootingMode)
+	}
 	// Update shared cfg pointer
 	s.deps.CfgMu.Lock()
 	*s.deps.Cfg = newCfg
@@ -1440,7 +1445,7 @@ func (s *Server) setDriverDisabled(w http.ResponseWriter, r *http.Request, disab
 	}
 	// Apply immediately via Reload — it filters disabled drivers and
 	// stops running ones, or re-adds the newly-enabled one.
-	s.deps.Registry.Reload(r.Context(), cfgCopy.Drivers)
+	s.deps.Registry.Reload(r.Context(), cfgCopy.Drivers, cfgCopy.Site.TroubleshootingMode)
 
 	action := "disabled"
 	if !disabled {

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -96,9 +96,9 @@ type NtfyConfig struct {
 
 // NotificationRule is one event type the operator can toggle.
 type NotificationRule struct {
-	Type          string `yaml:"type" json:"type"`
-	Enabled       bool   `yaml:"enabled" json:"enabled"`
-	ThresholdS    int    `yaml:"threshold_s,omitempty" json:"threshold_s,omitempty"`
+	Type       string `yaml:"type" json:"type"`
+	Enabled    bool   `yaml:"enabled" json:"enabled"`
+	ThresholdS int    `yaml:"threshold_s,omitempty" json:"threshold_s,omitempty"`
 	// ThresholdN is a count-based threshold used by event types that
 	// aggregate across drivers (concurrent_drivers_offline). Ignored
 	// by per-driver events. Default behaviour per event documented
@@ -122,12 +122,12 @@ type NotificationRule struct {
 //
 // SchemaMode controls the wire format sent to Nova:
 //   - "legacy"  (default): translate forty-two-watts' native clean payload
-//                to the current Nova wire shape (battery sign flip,
-//                PascalCase fields, pv→solar, ev→ev_port). The translation
-//                layer is in internal/nova and is designed to be deleted
-//                once Nova adopts the unified schema.
+//     to the current Nova wire shape (battery sign flip,
+//     PascalCase fields, pv→solar, ev→ev_port). The translation
+//     layer is in internal/nova and is designed to be deleted
+//     once Nova adopts the unified schema.
 //   - "unified": publish forty-two-watts' clean payload directly. Enable
-//                once the Nova schema-alignment PR lands.
+//     once the Nova schema-alignment PR lands.
 type Nova struct {
 	Enabled            bool   `yaml:"enabled" json:"enabled"`
 	URL                string `yaml:"url" json:"url"`
@@ -282,13 +282,13 @@ func (e *EVCharger) Validate() error {
 // Planner configures the MPC scheduler (optional — disabled if omitted).
 // Mode: "self_consumption" (default) | "cheap_charge" | "arbitrage".
 type Planner struct {
-	Enabled             bool    `yaml:"enabled" json:"enabled"`
-	Mode                string  `yaml:"mode,omitempty" json:"mode,omitempty"`
-	BaseLoadW           float64 `yaml:"base_load_w,omitempty" json:"base_load_w,omitempty"`
-	HorizonHours        int     `yaml:"horizon_hours,omitempty" json:"horizon_hours,omitempty"`
-	IntervalMin         int     `yaml:"interval_min,omitempty" json:"interval_min,omitempty"`
-	SoCMinPct           float64 `yaml:"soc_min_pct,omitempty" json:"soc_min_pct,omitempty"`
-	SoCMaxPct           float64 `yaml:"soc_max_pct,omitempty" json:"soc_max_pct,omitempty"`
+	Enabled      bool    `yaml:"enabled" json:"enabled"`
+	Mode         string  `yaml:"mode,omitempty" json:"mode,omitempty"`
+	BaseLoadW    float64 `yaml:"base_load_w,omitempty" json:"base_load_w,omitempty"`
+	HorizonHours int     `yaml:"horizon_hours,omitempty" json:"horizon_hours,omitempty"`
+	IntervalMin  int     `yaml:"interval_min,omitempty" json:"interval_min,omitempty"`
+	SoCMinPct    float64 `yaml:"soc_min_pct,omitempty" json:"soc_min_pct,omitempty"`
+	SoCMaxPct    float64 `yaml:"soc_max_pct,omitempty" json:"soc_max_pct,omitempty"`
 
 	// Deprecated: SoCSafetyFloorPct / SafetyFloorPenaltyOreKwhHour. The
 	// SoC-percentage safety floor was replaced by downside-PV planning
@@ -363,6 +363,7 @@ func (p *Planner) PVSafetyK() float64 {
 
 // Site is the top-level control loop config.
 type Site struct {
+	TroubleshootingMode  bool    `yaml:"troubleshooting_mode,omitempty" json:"troubleshooting_mode,omitempty"`
 	Name                 string  `yaml:"name" json:"name"`
 	ControlIntervalS     int     `yaml:"control_interval_s" json:"control_interval_s"`
 	GridTargetW          float64 `yaml:"grid_target_w" json:"grid_target_w"`
@@ -481,10 +482,10 @@ func (f Fuse) EffectiveSafetyMarginA() float64 {
 // Driver is one driver entry. Each driver is a Lua script loaded by
 // the driver host at startup (or on hot-reload via the file watcher).
 type Driver struct {
-	Name               string  `yaml:"name" json:"name"`
-	Lua                string  `yaml:"lua,omitempty" json:"lua,omitempty"` // path to .lua file
-	IsSiteMeter        bool    `yaml:"is_site_meter,omitempty" json:"is_site_meter,omitempty"`
-	BatteryCapacityWh  float64 `yaml:"battery_capacity_wh,omitempty" json:"battery_capacity_wh,omitempty"`
+	Name              string  `yaml:"name" json:"name"`
+	Lua               string  `yaml:"lua,omitempty" json:"lua,omitempty"` // path to .lua file
+	IsSiteMeter       bool    `yaml:"is_site_meter,omitempty" json:"is_site_meter,omitempty"`
+	BatteryCapacityWh float64 `yaml:"battery_capacity_wh,omitempty" json:"battery_capacity_wh,omitempty"`
 	// MaxChargeW + MaxDischargeW set this driver's per-command power
 	// ceiling (site-signed +/-). Both optional; zero = fall through to
 	// the global MaxCommandW = 5 kW default the dispatcher has shipped
@@ -539,11 +540,11 @@ type Driver struct {
 
 // Capabilities explicitly scope what host resources a driver can access.
 type Capabilities struct {
-	MQTT      *MQTTConfig      `yaml:"mqtt,omitempty" json:"mqtt,omitempty"`
-	Modbus    *ModbusConfig    `yaml:"modbus,omitempty" json:"modbus,omitempty"`
-	HTTP      *HTTPCapability  `yaml:"http,omitempty" json:"http,omitempty"`
-	WebSocket *WSCapability    `yaml:"websocket,omitempty" json:"websocket,omitempty"`
-	TCP       *TCPCapability   `yaml:"tcp,omitempty" json:"tcp,omitempty"`
+	MQTT      *MQTTConfig     `yaml:"mqtt,omitempty" json:"mqtt,omitempty"`
+	Modbus    *ModbusConfig   `yaml:"modbus,omitempty" json:"modbus,omitempty"`
+	HTTP      *HTTPCapability `yaml:"http,omitempty" json:"http,omitempty"`
+	WebSocket *WSCapability   `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+	TCP       *TCPCapability  `yaml:"tcp,omitempty" json:"tcp,omitempty"`
 }
 
 // MQTTConfig grants access to one MQTT broker.
@@ -557,7 +558,7 @@ type MQTTConfig struct {
 // ModbusConfig grants access to one Modbus TCP endpoint.
 type ModbusConfig struct {
 	Host   string `yaml:"host" json:"host"`
-	Port   int    `yaml:"port,omitempty" json:"port,omitempty"`   // default 502
+	Port   int    `yaml:"port,omitempty" json:"port,omitempty"`       // default 502
 	UnitID int    `yaml:"unit_id,omitempty" json:"unit_id,omitempty"` // default 1
 }
 
@@ -1030,15 +1031,23 @@ func applyDefaults(c *Config) {
 			cap.Port = 1883
 		}
 		if cap := d.Capabilities.Modbus; cap != nil {
-			if cap.Port == 0 { cap.Port = 502 }
-			if cap.UnitID == 0 { cap.UnitID = 1 }
+			if cap.Port == 0 {
+				cap.Port = 502
+			}
+			if cap.UnitID == 0 {
+				cap.UnitID = 1
+			}
 		}
 		if cap := d.MQTT; cap != nil && cap.Port == 0 {
 			cap.Port = 1883
 		}
 		if cap := d.Modbus; cap != nil {
-			if cap.Port == 0 { cap.Port = 502 }
-			if cap.UnitID == 0 { cap.UnitID = 1 }
+			if cap.Port == 0 {
+				cap.Port = 502
+			}
+			if cap.UnitID == 0 {
+				cap.UnitID = 1
+			}
 		}
 	}
 	if c.HomeAssistant != nil {

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -123,6 +123,17 @@ func TestLoadMinimalYAML(t *testing.T) {
 // opt-in / default-off. A config with no remote_access block must NOT dial out
 // (a Pi that merely inherits FTW_RELAY_URL stays local); only an explicit
 // enabled:true opts in. The blind TURN knob must parse while staying off.
+func TestSiteTroubleshootingModeParses(t *testing.T) {
+	raw := strings.Replace(minimalYAML, "name: Test", "name: Test\n  troubleshooting_mode: true", 1)
+	c, err := Parse([]byte(raw), "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Site.TroubleshootingMode {
+		t.Fatal("expected troubleshooting_mode=true")
+	}
+}
+
 func TestRemoteAccessOptInDefaultsOff(t *testing.T) {
 	off, err := Parse([]byte(minimalYAML), "/tmp")
 	if err != nil {

--- a/go/internal/drivers/pixii_driver_test.go
+++ b/go/internal/drivers/pixii_driver_test.go
@@ -1,0 +1,134 @@
+package drivers
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+type pixiiTestModbus struct {
+	regs        map[uint16]uint16
+	writeSingle []struct {
+		addr  uint16
+		value uint16
+	}
+	writeMulti []struct {
+		addr   uint16
+		values []uint16
+	}
+}
+
+func newPixiiTestModbus() *pixiiTestModbus {
+	return &pixiiTestModbus{regs: map[uint16]uint16{
+		40000: 0x5375, // "Su"
+		40001: 0x6e53, // "nS"
+		40132: 94,     // SoC %
+		40137: 7,      // SunSpec 802 ChaSt TESTING
+		40138: 0,      // remote control
+		40143: 2,      // initializing
+		40144: 42,     // vendor state, opaque
+		40147: 0,
+		40148: 1, // event bitfield
+	}}
+}
+
+func (m *pixiiTestModbus) Read(addr, count uint16, kind int32) ([]uint16, error) {
+	out := make([]uint16, count)
+	for i := range out {
+		out[i] = m.regs[addr+uint16(i)]
+	}
+	return out, nil
+}
+
+func (m *pixiiTestModbus) WriteSingle(addr, value uint16) error {
+	m.writeSingle = append(m.writeSingle, struct {
+		addr  uint16
+		value uint16
+	}{addr: addr, value: value})
+	m.regs[addr] = value
+	return nil
+}
+
+func (m *pixiiTestModbus) WriteMulti(addr uint16, values []uint16) error {
+	cp := append([]uint16(nil), values...)
+	m.writeMulti = append(m.writeMulti, struct {
+		addr   uint16
+		values []uint16
+	}{addr: addr, values: cp})
+	for i, value := range values {
+		m.regs[addr+uint16(i)] = value
+	}
+	return nil
+}
+
+func (m *pixiiTestModbus) Close() error { return nil }
+
+func TestPixiiTroubleshootingStatusAndSetpoint(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "drivers", "pixii.lua")
+	tel := telemetry.NewStore()
+	modbus := newPixiiTestModbus()
+	env := NewHostEnv("pixii", tel).WithModbus(modbus)
+	env.BatteryCapacityWh = 10000
+
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load pixii driver: %v", err)
+	}
+	defer d.Cleanup()
+
+	if err := d.Init(context.Background(), map[string]any{"troubleshooting_mode": true}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	got := tel.Get("pixii", telemetry.DerBattery)
+	if got == nil {
+		t.Fatal("expected battery reading")
+	}
+	if got.SoC == nil || *got.SoC != 0.94 {
+		t.Fatalf("SoC = %v, want 0.94", got.SoC)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(got.Data, &data); err != nil {
+		t.Fatalf("decode battery data: %v", err)
+	}
+	if data["charge_status"] != "testing" {
+		t.Fatalf("charge_status = %v, want testing", data["charge_status"])
+	}
+	if data["control_mode"] != "remote" {
+		t.Fatalf("control_mode = %v, want remote", data["control_mode"])
+	}
+
+	if err := d.Command(context.Background(), []byte(`{"action":"battery","power_w":-1000}`)); err != nil {
+		t.Fatalf("command: %v", err)
+	}
+	if len(modbus.writeMulti) == 0 {
+		t.Fatal("expected setpoint write")
+	}
+	last := modbus.writeMulti[len(modbus.writeMulti)-1]
+	if last.addr != 39905 || len(last.values) != 2 || last.values[0] != 0 || last.values[1] != 1000 {
+		t.Fatalf("setpoint write = addr %d values %v, want addr 39905 [0 1000]", last.addr, last.values)
+	}
+
+	samples := tel.FlushSamples()
+	var sawStatus, sawSetpoint bool
+	for _, sample := range samples {
+		if sample.Driver == "pixii" && sample.Metric == "battery_charge_status_code" && sample.Value == 7 {
+			sawStatus = true
+		}
+		if sample.Driver == "pixii" && sample.Metric == "pixii_setpoint_ems_w" && sample.Value == -1000 {
+			sawSetpoint = true
+		}
+	}
+	if !sawStatus {
+		t.Fatal("expected battery_charge_status_code=7 metric")
+	}
+	if !sawSetpoint {
+		t.Fatal("expected pixii_setpoint_ems_w=-1000 metric")
+	}
+}

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -18,7 +18,8 @@ import (
 // Registry manages running Lua driver instances — spawn, poll, command, stop.
 // Thread-safe.
 type Registry struct {
-	tel *telemetry.Store
+	tel                 *telemetry.Store
+	troubleshootingMode bool
 
 	// MQTTFactory creates an MQTT capability for a driver given its config.
 	// Called on Add; the returned MQTTCap belongs to that driver alone.
@@ -39,6 +40,14 @@ func NewRegistry(tel *telemetry.Store) *Registry {
 		tel: tel,
 		rec: map[string]*runningDriver{},
 	}
+}
+
+// SetTroubleshootingMode updates the global incident-diagnostics flag used for
+// subsequently started drivers. Use Reload to restart already-running drivers.
+func (r *Registry) SetTroubleshootingMode(enabled bool) {
+	r.mu.Lock()
+	r.troubleshootingMode = enabled
+	r.mu.Unlock()
 }
 
 // driverRuntime abstracts the Lua driver lifecycle so the registry's
@@ -67,6 +76,21 @@ func (l *luaRuntime) Init(ctx context.Context, cfg []byte) error {
 func (l *luaRuntime) DefaultMode(ctx context.Context) error { return l.LuaDriver.DefaultMode() }
 func (l *luaRuntime) Cleanup(ctx context.Context) error     { l.LuaDriver.Cleanup(); return nil }
 func (l *luaRuntime) Env() *HostEnv                         { return l.LuaDriver.Env }
+
+func driverInitConfigJSON(cfg config.Driver, troubleshootingMode bool) []byte {
+	if len(cfg.Config) == 0 && !troubleshootingMode {
+		return nil
+	}
+	m := make(map[string]any, len(cfg.Config)+1)
+	for k, v := range cfg.Config {
+		m[k] = v
+	}
+	if troubleshootingMode {
+		m["_troubleshooting_mode"] = true
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
 
 type runningDriver struct {
 	driver driverRuntime
@@ -111,7 +135,9 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 		// Best-effort MAC resolution. Cross-VLAN devices return ""; that's
 		// fine — device_id falls back to the endpoint.
 		if r.ARPLookup != nil {
-			if mac, ok := r.ARPLookup(mq.Host); ok { env.SetMAC(mac) }
+			if mac, ok := r.ARPLookup(mq.Host); ok {
+				env.SetMAC(mac)
+			}
 		}
 	}
 	if mb := cfg.EffectiveModbus(); mb != nil && r.ModbusFactory != nil {
@@ -122,7 +148,9 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 		env.WithModbus(cap)
 		env.SetEndpoint(fmt.Sprintf("modbus://%s:%d", mb.Host, mb.Port))
 		if r.ARPLookup != nil {
-			if mac, ok := r.ARPLookup(mb.Host); ok { env.SetMAC(mac) }
+			if mac, ok := r.ARPLookup(mb.Host); ok {
+				env.SetMAC(mac)
+			}
 		}
 	}
 	if cfg.Capabilities.HTTP != nil {
@@ -159,11 +187,13 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	}
 	var drv driverRuntime = &luaRuntime{LuaDriver: luaDrv}
 
-	// Pass the driver's config map as JSON to driver_init.
-	var initCfg []byte
-	if cfg.Config != nil {
-		initCfg, _ = json.Marshal(cfg.Config)
-	}
+	r.mu.Lock()
+	troubleshootingMode := r.troubleshootingMode
+	r.mu.Unlock()
+
+	// Pass the driver's config map as JSON to driver_init, with reserved
+	// host-level keys injected only at runtime.
+	initCfg := driverInitConfigJSON(cfg, troubleshootingMode)
 	if err := drv.Init(ctx, initCfg); err != nil {
 		drv.Cleanup(ctx)
 		return fmt.Errorf("driver_init: %w", err)
@@ -353,7 +383,9 @@ func (r *Registry) Env(name string) *HostEnv {
 	r.mu.Lock()
 	rd, ok := r.rec[name]
 	r.mu.Unlock()
-	if !ok { return nil }
+	if !ok {
+		return nil
+	}
 	return rd.env
 }
 
@@ -361,7 +393,9 @@ func (r *Registry) Names() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]string, 0, len(r.rec))
-	for n := range r.rec { out = append(out, n) }
+	for n := range r.rec {
+		out = append(out, n)
+	}
 	return out
 }
 
@@ -369,7 +403,9 @@ func (r *Registry) Names() []string {
 func (r *Registry) ShutdownAll() {
 	r.mu.Lock()
 	names := make([]string, 0, len(r.rec))
-	for n := range r.rec { names = append(names, n) }
+	for n := range r.rec {
+		names = append(names, n)
+	}
 	r.mu.Unlock()
 	for _, n := range names {
 		r.Remove(n)
@@ -380,7 +416,7 @@ func (r *Registry) ShutdownAll() {
 // remove/restart. Drivers with changed lua path, capabilities, or config
 // map are restarted. Drivers marked Disabled are treated as "not in the
 // new list" — running ones get stopped, missing ones are not added.
-func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
+func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver, troubleshootingMode bool) {
 	// Filter out disabled drivers — they behave like removed from the
 	// registry's perspective but remain in config.yaml for re-enable.
 	active := make([]config.Driver, 0, len(newDrivers))
@@ -392,6 +428,8 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 	}
 
 	r.mu.Lock()
+	troubleshootingChanged := r.troubleshootingMode != troubleshootingMode
+	r.troubleshootingMode = troubleshootingMode
 	oldNames := make(map[string]bool, len(r.rec))
 	oldCfgs := make(map[string]config.Driver, len(r.rec))
 	for n, rd := range r.rec {
@@ -401,12 +439,17 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 	r.mu.Unlock()
 
 	newNames := make(map[string]bool, len(active))
-	for _, d := range active { newNames[d.Name] = true }
+	for _, d := range active {
+		newNames[d.Name] = true
+	}
 
 	// Remove or restart
 	for n, old := range oldCfgs {
 		newCfg, stillThere := findDriver(active, n)
 		if !stillThere {
+			r.Remove(n)
+		} else if troubleshootingChanged {
+			slog.Info("driver troubleshooting mode changed, restarting", "name", n, "enabled", troubleshootingMode)
 			r.Remove(n)
 		} else if !sameDriverConfig(old, newCfg) {
 			slog.Info("driver config changed, restarting", "name", n)
@@ -418,7 +461,9 @@ func (r *Registry) Reload(ctx context.Context, newDrivers []config.Driver) {
 		r.mu.Lock()
 		_, exists := r.rec[d.Name]
 		r.mu.Unlock()
-		if exists { continue }
+		if exists {
+			continue
+		}
 		if err := r.Add(ctx, d); err != nil {
 			slog.Warn("add driver failed", "name", d.Name, "err", err)
 		}
@@ -532,7 +577,9 @@ func mergeAllowedHosts(explicit []string, drvCfg map[string]any) []string {
 
 func findDriver(list []config.Driver, name string) (config.Driver, bool) {
 	for _, d := range list {
-		if d.Name == name { return d, true }
+		if d.Name == name {
+			return d, true
+		}
 	}
 	return config.Driver{}, false
 }
@@ -545,18 +592,24 @@ func sameDriverConfig(a, b config.Driver) bool {
 		return false
 	}
 	aMq, bMq := a.EffectiveMQTT(), b.EffectiveMQTT()
-	if (aMq == nil) != (bMq == nil) { return false }
+	if (aMq == nil) != (bMq == nil) {
+		return false
+	}
 	if aMq != nil && (aMq.Host != bMq.Host || aMq.Port != bMq.Port ||
 		aMq.Username != bMq.Username || aMq.Password != bMq.Password) {
 		return false
 	}
 	aMb, bMb := a.EffectiveModbus(), b.EffectiveModbus()
-	if (aMb == nil) != (bMb == nil) { return false }
+	if (aMb == nil) != (bMb == nil) {
+		return false
+	}
 	if aMb != nil && (aMb.Host != bMb.Host || aMb.Port != bMb.Port || aMb.UnitID != bMb.UnitID) {
 		return false
 	}
 	aTCP, bTCP := a.Capabilities.TCP, b.Capabilities.TCP
-	if (aTCP == nil) != (bTCP == nil) { return false }
+	if (aTCP == nil) != (bTCP == nil) {
+		return false
+	}
 	if aTCP != nil && !reflect.DeepEqual(aTCP.AllowedHosts, bTCP.AllowedHosts) {
 		return false
 	}

--- a/go/internal/drivers/registry_restart_test.go
+++ b/go/internal/drivers/registry_restart_test.go
@@ -137,8 +137,29 @@ func writeTestDriver(t *testing.T, src string) string {
 	return path
 }
 
+func sawMetricValue(samples []telemetry.MetricSample, driver, metric string, value float64) bool {
+	for _, sample := range samples {
+		if sample.Driver == driver && sample.Metric == metric && sample.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
 const registryRestartTestDriver = `
 function driver_init(config) end
+function driver_poll() return 1000 end
+function driver_command(action, w, cmd) end
+`
+
+const registryTroubleshootingTestDriver = `
+function driver_init(config)
+  local enabled = 0
+  if config ~= nil and config._troubleshooting_mode == true then
+    enabled = 1
+  end
+  host.emit_metric("troubleshooting_mode_enabled", enabled)
+end
 function driver_poll() return 1000 end
 function driver_command(action, w, cmd) end
 `
@@ -273,6 +294,44 @@ func TestAddCreatesHealthRecordImmediately(t *testing.T) {
 	all := r.tel.AllHealth()
 	if _, ok := all["d1"]; !ok {
 		t.Errorf("driver missing from AllHealth: %+v", all)
+	}
+}
+
+func TestAddInjectsGlobalTroubleshootingMode(t *testing.T) {
+	r := NewRegistry(telemetry.NewStore())
+	r.SetTroubleshootingMode(true)
+	path := writeTestDriver(t, registryTroubleshootingTestDriver)
+	cfg := config.Driver{
+		Name:   "d1",
+		Lua:    path,
+		Config: map[string]any{"local": true},
+	}
+	if err := r.Add(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	defer r.ShutdownAll()
+	if _, ok := cfg.Config["_troubleshooting_mode"]; ok {
+		t.Fatal("global troubleshooting key leaked into driver config map")
+	}
+	if !sawMetricValue(r.tel.FlushSamples(), "d1", "troubleshooting_mode_enabled", 1) {
+		t.Fatal("expected troubleshooting_mode_enabled=1 metric")
+	}
+}
+
+func TestReloadRestartsDriversWhenTroubleshootingModeChanges(t *testing.T) {
+	r := NewRegistry(telemetry.NewStore())
+	path := writeTestDriver(t, registryTroubleshootingTestDriver)
+	cfg := config.Driver{Name: "d1", Lua: path}
+	if err := r.Add(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	defer r.ShutdownAll()
+	if !sawMetricValue(r.tel.FlushSamples(), "d1", "troubleshooting_mode_enabled", 0) {
+		t.Fatal("expected initial troubleshooting_mode_enabled=0 metric")
+	}
+	r.Reload(context.Background(), []config.Driver{cfg}, true)
+	if !sawMetricValue(r.tel.FlushSamples(), "d1", "troubleshooting_mode_enabled", 1) {
+		t.Fatal("expected reload troubleshooting_mode_enabled=1 metric")
 	}
 }
 

--- a/web/settings.js
+++ b/web/settings.js
@@ -218,6 +218,9 @@
       if (input.type === "password" && val === "" && getByPath(currentConfig, path, "")) return;
       setByPath(currentConfig, path, val);
     });
+    bodyEl.querySelectorAll("[data-checkbox-path]").forEach(function (input) {
+      setByPath(currentConfig, input.dataset.checkboxPath, input.checked);
+    });
   }
 
   function setByPath(obj, path, val) {

--- a/web/settings/tabs/control.js
+++ b/web/settings/tabs/control.js
@@ -27,6 +27,11 @@
         '</div><div>' +
         field("Min dispatch interval (s)", "site.min_dispatch_interval_s", "number", 5) +
         '</div></div>' +
+        '<label class="checkbox-row"><input type="checkbox" data-checkbox-path="site.troubleshooting_mode"' +
+          (getByPath(config, "site.troubleshooting_mode", false) ? ' checked' : '') +
+          '> Troubleshooting mode ' +
+          help("Incident diagnostics only. Adds dispatch-decision logs and driver readback metrics without changing control behavior.") +
+        '</label>' +
         '<div class="field-row"><div>' +
         field("Smoothing alpha", "site.smoothing_alpha", "number", 0.3,
           "EMA smoothing factor for the grid reading (0-1). Lower = smoother but slower response.") +

--- a/web/style.css
+++ b/web/style.css
@@ -1222,6 +1222,18 @@ footer {
   color: var(--text-dim);
 }
 
+.modal-body label.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+  color: var(--text);
+}
+
+.modal-body label.checkbox-row input[type="checkbox"] {
+  width: auto;
+}
+
 .modal-body input[type="text"],
 .modal-body input[type="number"],
 .modal-body input[type="password"],


### PR DESCRIPTION
## What changed

- Added a global troubleshooting mode controlled from Settings -> Control, not by editing YAML.
- Exposed `troubleshooting_mode` in `/api/status` and applied `POST /api/config` driver reloads immediately when the flag changes.
- Passed a reserved `_troubleshooting_mode` flag into Lua driver init config and restart active drivers when the global flag toggles.
- Added dispatch-decision troubleshooting log snapshots without changing planner, dispatch, clamp, or command behavior.
- Added Pixii troubleshooting diagnostics for calibration/control/status and setpoint readback, plus safer handling for invalid Pixii SoC values.

## Why

When an operator says "my system is behaving strangely", support needs a UI-first switch that makes the running system explain what it thinks is happening without changing control behavior. Pixii also needs enough readback to surface states like calibration/testing that can make manual commands appear ignored.

## Validation

- `go test ./internal/api ./internal/config ./internal/drivers ./cmd/forty-two-watts -count=1`
- `go test ./... -count=1`
- `node --check web/settings.js`
- `node --check web/settings/tabs/control.js`
- `git diff --cached --check`
- pre-commit hook: `make verify` (`go vet ./...`, `go test ./...`, `go build ./...`)
- pre-push hook: `make verify-all`