### PR TITLE
[codex] Fix surplus-only EV battery feed

### DIFF
--- a/.changeset/surplus-ev-battery-block.md
+++ b/.changeset/surplus-ev-battery-block.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Prevent surplus-only EV loadpoints from using home battery discharge as synthetic PV surplus, even when "Let battery cover EV" is enabled, and surface the policy in planner diagnostics.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -980,14 +980,15 @@ func main() {
 				return control.SlotDirective{}, false
 			}
 			return control.SlotDirective{
-				SlotStart:       d.SlotStart,
-				SlotEnd:         d.SlotEnd,
-				BatteryEnergyWh: d.BatteryEnergyWh,
-				SoCTargetPct:    d.SoCTargetPct,
-				Strategy:        string(d.Strategy),
-				PVLimitW:        d.PVLimitW,
-				PlannedGridW:    d.GridW,
-				HasPlannedGridW: true,
+				SlotStart:         d.SlotStart,
+				SlotEnd:           d.SlotEnd,
+				BatteryEnergyWh:   d.BatteryEnergyWh,
+				SoCTargetPct:      d.SoCTargetPct,
+				Strategy:          string(d.Strategy),
+				PVLimitW:          d.PVLimitW,
+				PlannedGridW:      d.GridW,
+				HasPlannedGridW:   true,
+				LoadpointEnergyWh: d.LoadpointEnergyWh,
 			}, true
 		}
 		// Default to the energy-allocation path. The plan is a

--- a/go/internal/control/control_test.go
+++ b/go/internal/control/control_test.go
@@ -1034,6 +1034,40 @@ func TestSurplusOnlyEVDoesNotAutoEnableBatteryCoversEV(t *testing.T) {
 	}
 }
 
+func TestSurplusOnlyEVPlanBlocksBatteryToEVEvenWhenCoverEVEnabled(t *testing.T) {
+	now := time.Now()
+	dir := SlotDirective{
+		SlotStart:         now,
+		SlotEnd:           now.Add(15 * time.Minute),
+		BatteryEnergyWh:   -1250, // stale/pre-fix plan: discharge ~5 kW this slot.
+		Strategy:          "arbitrage",
+		LoadpointEnergyWh: map[string]float64{"garage": 1250},
+	}
+	store := seedStore(0, []struct {
+		name          string
+		currentW, soc float64
+	}{
+		{"ferroamp", 0, 0.7},
+	})
+	st := NewState(0, 50, "ferroamp")
+	st.Mode = ModePlannerArbitrage
+	st.UseEnergyDispatch = true
+	st.BatteryCoversEV = true
+	st.EVSurplusOnlyReserveW = 5000
+	st.SlewRateW = 100000
+	st.MinDispatchIntervalS = 0
+	st.SlotDirective = func(time.Time) (SlotDirective, bool) { return dir, true }
+
+	targets := ComputeDispatch(store, st, caps(map[string]float64{"ferroamp": 15200}), 11040)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0].TargetW < -50 {
+		t.Errorf("surplus_only planned EV must block battery-to-EV discharge even with BatteryCoversEV=true, got %.0f W",
+			targets[0].TargetW)
+	}
+}
+
 // TestBatteryCoversEV_OnIncludesEVInPeakShaving covers the opt-in scenario
 // outside self-consumption: peak-shaving may discharge to protect an import
 // ceiling, and BatteryCoversEV=true means the full EV draw participates.

--- a/go/internal/control/dispatch.go
+++ b/go/internal/control/dispatch.go
@@ -150,6 +150,11 @@ type SlotDirective struct {
 	// has HasPlannedGridW=false → cap opts out by default.
 	PlannedGridW    float64
 	HasPlannedGridW bool
+
+	// LoadpointEnergyWh is the current slot's planned EV charging budget.
+	// Runtime uses planned EV energy to keep surplus-only EV from being
+	// satisfied by home-battery discharge if a stale plan tries.
+	LoadpointEnergyWh map[string]float64
 }
 
 // SlotDirectiveFunc returns the plan's energy-allocation directive for
@@ -1550,7 +1555,14 @@ func ComputeDispatch(
 		// predicate into a small helper consumed by both this clamp
 		// and the DP rule, so a future change to the accounting can't
 		// drift between plan and runtime.
-		if !state.BatteryCoversEV && evActive && targetTotalW < 0 {
+		var plannedLoadpointEnergyWh float64
+		for _, wh := range currentDirective.LoadpointEnergyWh {
+			if wh > 0 {
+				plannedLoadpointEnergyWh += wh
+			}
+		}
+		surplusOnlyPlannedEV := state.EVSurplusOnlyReserveW > 0 && plannedLoadpointEnergyWh > 0
+		if ((!state.BatteryCoversEV && evActive) || surplusOnlyPlannedEV) && targetTotalW < 0 {
 			houseGridW := rawGridW - state.EVChargingW
 			reactiveTotal := currentTotal - houseGridW
 			if targetTotalW < reactiveTotal {

--- a/go/internal/mpc/diagnose.go
+++ b/go/internal/mpc/diagnose.go
@@ -47,10 +47,10 @@ type DiagnosticSlot struct {
 type DiagnosticParams struct {
 	Mode                Mode     `json:"mode"`
 	InitialSoCPct       float64  `json:"initial_soc_pct"`
-	SoCMinPct                    float64 `json:"soc_min_pct"`
-	SoCMaxPct                    float64 `json:"soc_max_pct"`
-	PVChargeBonusOreKwh          float64 `json:"pv_charge_bonus_ore_kwh,omitempty"`
-	SoCLevels                    int     `json:"soc_levels"`
+	SoCMinPct           float64  `json:"soc_min_pct"`
+	SoCMaxPct           float64  `json:"soc_max_pct"`
+	PVChargeBonusOreKwh float64  `json:"pv_charge_bonus_ore_kwh,omitempty"`
+	SoCLevels           int      `json:"soc_levels"`
 	ActionLevels        int      `json:"action_levels"`
 	MaxChargeW          float64  `json:"max_charge_w"`
 	MaxDischargeW       float64  `json:"max_discharge_w"`
@@ -61,6 +61,10 @@ type DiagnosticParams struct {
 	ExportBonusOreKwh   float64  `json:"export_bonus_ore_kwh"`
 	ExportFeeOreKwh     float64  `json:"export_fee_ore_kwh"`
 	ExportFloorOreKwh   *float64 `json:"export_floor_ore_kwh,omitempty"`
+
+	LoadpointSurplusOnly       bool `json:"loadpoint_surplus_only"`
+	LoadpointNoBatteryToEV     bool `json:"loadpoint_no_battery_to_ev"`
+	LoadpointBlocksBatteryToEV bool `json:"loadpoint_blocks_battery_to_ev"`
 }
 
 // Diagnostic is the full post-mortem of the most recent Optimize call.
@@ -149,22 +153,25 @@ func buildDiagnostic(plan *Plan, slots []Slot, p Params, zone string,
 		Horizon:      plan.HorizonSlots,
 		TotalCostOre: plan.TotalCostOre,
 		Params: DiagnosticParams{
-			Mode:                         p.Mode,
-			InitialSoCPct:                p.InitialSoCPct,
-			SoCMinPct:                    p.SoCMinPct,
-			SoCMaxPct:                    p.SoCMaxPct,
-			PVChargeBonusOreKwh:          p.PVChargeBonusOreKwh,
-			SoCLevels:                    p.SoCLevels,
-			ActionLevels:                 p.ActionLevels,
-			MaxChargeW:                   p.MaxChargeW,
-			MaxDischargeW:                p.MaxDischargeW,
-			ChargeEfficiency:             p.ChargeEfficiency,
-			DischargeEfficiency:          p.DischargeEfficiency,
-			CapacityWh:                   p.CapacityWh,
-			TerminalSoCPrice:             p.TerminalSoCPrice,
-			ExportBonusOreKwh:            p.ExportBonusOreKwh,
-			ExportFeeOreKwh:              p.ExportFeeOreKwh,
-			ExportFloorOreKwh:            p.ExportFloorOreKwh,
+			Mode:                       p.Mode,
+			InitialSoCPct:              p.InitialSoCPct,
+			SoCMinPct:                  p.SoCMinPct,
+			SoCMaxPct:                  p.SoCMaxPct,
+			PVChargeBonusOreKwh:        p.PVChargeBonusOreKwh,
+			SoCLevels:                  p.SoCLevels,
+			ActionLevels:               p.ActionLevels,
+			MaxChargeW:                 p.MaxChargeW,
+			MaxDischargeW:              p.MaxDischargeW,
+			ChargeEfficiency:           p.ChargeEfficiency,
+			DischargeEfficiency:        p.DischargeEfficiency,
+			CapacityWh:                 p.CapacityWh,
+			TerminalSoCPrice:           p.TerminalSoCPrice,
+			ExportBonusOreKwh:          p.ExportBonusOreKwh,
+			ExportFeeOreKwh:            p.ExportFeeOreKwh,
+			ExportFloorOreKwh:          p.ExportFloorOreKwh,
+			LoadpointSurplusOnly:       p.Loadpoint != nil && p.Loadpoint.SurplusOnly,
+			LoadpointNoBatteryToEV:     p.Loadpoint != nil && p.Loadpoint.NoBatteryToEV,
+			LoadpointBlocksBatteryToEV: p.Loadpoint != nil && p.Loadpoint.blocksBatteryToEV(),
 		},
 		LoadpointID:    loadpointID,
 		Slots:          out,
@@ -252,22 +259,22 @@ func planFromDiagnostic(d *Diagnostic) (*Plan, []Slot, Params, time.Time, bool) 
 		replanAtMs = generatedAtMs
 	}
 	params := Params{
-		Mode:                         d.Params.Mode,
-		InitialSoCPct:                d.Params.InitialSoCPct,
-		SoCMinPct:                    d.Params.SoCMinPct,
-		SoCMaxPct:                    d.Params.SoCMaxPct,
-		PVChargeBonusOreKwh:          d.Params.PVChargeBonusOreKwh,
-		SoCLevels:                    d.Params.SoCLevels,
-		ActionLevels:                 d.Params.ActionLevels,
-		MaxChargeW:                   d.Params.MaxChargeW,
-		MaxDischargeW:                d.Params.MaxDischargeW,
-		ChargeEfficiency:             d.Params.ChargeEfficiency,
-		DischargeEfficiency:          d.Params.DischargeEfficiency,
-		CapacityWh:                   d.Params.CapacityWh,
-		TerminalSoCPrice:             d.Params.TerminalSoCPrice,
-		ExportBonusOreKwh:            d.Params.ExportBonusOreKwh,
-		ExportFeeOreKwh:              d.Params.ExportFeeOreKwh,
-		ExportFloorOreKwh:            d.Params.ExportFloorOreKwh,
+		Mode:                d.Params.Mode,
+		InitialSoCPct:       d.Params.InitialSoCPct,
+		SoCMinPct:           d.Params.SoCMinPct,
+		SoCMaxPct:           d.Params.SoCMaxPct,
+		PVChargeBonusOreKwh: d.Params.PVChargeBonusOreKwh,
+		SoCLevels:           d.Params.SoCLevels,
+		ActionLevels:        d.Params.ActionLevels,
+		MaxChargeW:          d.Params.MaxChargeW,
+		MaxDischargeW:       d.Params.MaxDischargeW,
+		ChargeEfficiency:    d.Params.ChargeEfficiency,
+		DischargeEfficiency: d.Params.DischargeEfficiency,
+		CapacityWh:          d.Params.CapacityWh,
+		TerminalSoCPrice:    d.Params.TerminalSoCPrice,
+		ExportBonusOreKwh:   d.Params.ExportBonusOreKwh,
+		ExportFeeOreKwh:     d.Params.ExportFeeOreKwh,
+		ExportFloorOreKwh:   d.Params.ExportFloorOreKwh,
 	}
 	if params.Mode == "" {
 		params.Mode = ModeSelfConsumption

--- a/go/internal/mpc/loadpoint_service_test.go
+++ b/go/internal/mpc/loadpoint_service_test.go
@@ -211,3 +211,69 @@ func TestNoBatteryToEVForbidsBatteryFeedingEV(t *testing.T) {
 		}
 	}
 }
+
+func TestSurplusOnlyForbidsBatteryFeedingEVEvenWhenCoverEVEnabled(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	start := now.Truncate(15 * time.Minute)
+
+	slots := []Slot{
+		{
+			StartMs:    start.UnixMilli(),
+			LenMin:     60,
+			PriceOre:   500,
+			SpotOre:    500,
+			LoadW:      1000,
+			PVW:        -1000,
+			Confidence: 1.0,
+		},
+		{
+			StartMs:    start.Add(time.Hour).UnixMilli(),
+			LenMin:     60,
+			PriceOre:   500,
+			SpotOre:    500,
+			LoadW:      1000,
+			PVW:        -1000,
+			Confidence: 1.0,
+		},
+	}
+
+	plan := Optimize(slots, Params{
+		Mode:                ModeArbitrage,
+		SoCLevels:           11,
+		CapacityWh:          20000,
+		SoCMinPct:           10,
+		SoCMaxPct:           95,
+		InitialSoCPct:       90,
+		ActionLevels:        11,
+		MaxChargeW:          5000,
+		MaxDischargeW:       5000,
+		ChargeEfficiency:    0.95,
+		DischargeEfficiency: 0.95,
+		TerminalSoCPrice:    400,
+		Loadpoint: &LoadpointSpec{
+			ID:               "garage",
+			CapacityWh:       10000,
+			Levels:           11,
+			InitialSoCPct:    20,
+			PluggedIn:        true,
+			TargetSoCPct:     70,
+			TargetSlotIdx:    1,
+			MaxChargeW:       5000,
+			AllowedStepsW:    []float64{0, 5000},
+			ChargeEfficiency: 1.0,
+			SurplusOnly:      true,
+			NoBatteryToEV:    false, // mirrors BatteryCoversEV=true.
+		},
+	})
+
+	for i, a := range plan.Actions {
+		houseResidualW := slots[i].LoadW + slots[i].PVW
+		if houseResidualW < 0 {
+			houseResidualW = 0
+		}
+		if a.LoadpointW > 100 && a.BatteryW < -(houseResidualW+50) {
+			t.Errorf("slot %d: surplus_only used battery as EV surplus — battW=%.0f loadpointW=%.0f gridW=%.0f",
+				i, a.BatteryW, a.LoadpointW, a.GridW)
+		}
+	}
+}

--- a/go/internal/mpc/loadpoint_spec.go
+++ b/go/internal/mpc/loadpoint_spec.go
@@ -31,9 +31,9 @@ type LoadpointSpec struct {
 
 	// SoC grid. Coarser than battery (11 is typical — EV loads are
 	// lumpy anyway).
-	Levels  int
-	MinPct  float64 // usually 0
-	MaxPct  float64 // usually 100
+	Levels int
+	MinPct float64 // usually 0
+	MaxPct float64 // usually 100
 
 	// Plan-start conditions.
 	InitialSoCPct float64 // EV SoC at the first slot
@@ -41,29 +41,24 @@ type LoadpointSpec struct {
 
 	// User intent. Zero target (< 1%) = no deadline — charge
 	// opportunistically based on price/PV surplus only.
-	TargetSoCPct    float64
-	TargetSlotIdx   int // slot index by which target must be met; 0 or negative = no deadline
+	TargetSoCPct  float64
+	TargetSlotIdx int // slot index by which target must be met; 0 or negative = no deadline
 
 	// Electrical constraints. AllowedStepsW MUST include 0 (off) and
 	// should enumerate the discrete charger power levels. If empty,
 	// defaults to {0, MaxChargeW}.
-	MaxChargeW      float64
-	AllowedStepsW   []float64
+	MaxChargeW    float64
+	AllowedStepsW []float64
 
 	// Charge-side efficiency (AC → battery). Typical 0.90 for a
 	// modern 3-phase EV charger. 0 defaults to 0.90.
 	ChargeEfficiency float64
 
-	// SurplusOnly forbids EV actions that would turn the site into a
-	// net importer. Hard constraint in the DP feasibility loop: any
-	// (battW, evW) combination with gridW > 50 AND evW > 0 is rejected
-	// (mpc.go:474). The 50 W epsilon absorbs grid-discretisation and
-	// FP dither so we don't reject solutions that are zero-import in
-	// every operationally meaningful sense. evW = 0 is always
-	// feasible, so the DP degrades gracefully when no PV surplus
-	// exists — the deadline shortfall penalty handles the
-	// lexicographic "miss target rather than break constraint"
-	// preference.
+	// SurplusOnly forbids EV actions that need grid import or home-battery
+	// discharge. The loadpoint may use real site surplus only: PV already
+	// covering house load, or PV left after the battery's own planned charge.
+	// It must not treat battery discharge as synthetic PV surplus, even when
+	// the global BatteryCoversEV opt-in is enabled.
 	SurplusOnly bool
 
 	// NoBatteryToEV mirrors ctrl.State.BatteryCoversEV inverted: when
@@ -83,6 +78,10 @@ type LoadpointSpec struct {
 	// shared houseResidualW + feasibility predicate into a helper so
 	// the two sites can't drift.
 	NoBatteryToEV bool
+}
+
+func (l *LoadpointSpec) blocksBatteryToEV() bool {
+	return l != nil && (l.NoBatteryToEV || l.SurplusOnly)
 }
 
 // normalizedSteps returns a non-nil, 0-included, dedup'd + sorted

--- a/go/internal/mpc/mpc.go
+++ b/go/internal/mpc/mpc.go
@@ -616,9 +616,10 @@ func Optimize(slots []Slot, p Params) Plan {
 							continue
 						}
 
-						// NoBatteryToEV: operator has BatteryCoversEV=false
-						// (the default), meaning the home battery's energy
-						// is allowed to cover house load but never the EV.
+						// Battery-to-EV block: operator has BatteryCoversEV=false
+						// (the default), or this loadpoint is surplus-only. In
+						// both cases, the home battery's energy may cover house
+						// load but must not become synthetic EV surplus.
 						// Reject any allocation where the battery's
 						// discharge exceeds the PV-residual house demand
 						// — i.e. where, by conservation, some of the
@@ -636,7 +637,7 @@ func Optimize(slots []Slot, p Params) Plan {
 						// constraints. TODO(refactor): the
 						// houseResidualW math + feasibility predicate
 						// is duplicated; extract a shared helper.
-						if evActive && lp.NoBatteryToEV && evW > 0 && battW < 0 {
+						if evActive && lp.blocksBatteryToEV() && evW > 0 && battW < 0 {
 							houseResidualW := slot.LoadW + slot.PVW // PVW is negative
 							if houseResidualW < 0 {
 								houseResidualW = 0

--- a/web/app.js
+++ b/web/app.js
@@ -1535,14 +1535,14 @@
     var cb = document.createElement("input");
     cb.type = "checkbox";
     cb.checked = !!lp.surplus_only;
-    cb.title = "Charge only when PV exports exceed local load. No deadline planning, no grid import. Add a schedule below to also catch up via grid when prices are cheap.";
+    cb.title = "Charge only from real PV surplus. No grid import and no home-battery discharge. Add a schedule below to also catch up via grid when prices are cheap.";
     var text = document.createElement("span");
-    text.textContent = "Surplus only (PV exports only — never imports grid)";
+    text.textContent = "Surplus only (PV only — no grid or battery)";
     var hint = document.createElement("div");
     hint.style.fontSize = "0.72rem";
     hint.style.color = "var(--text-dim)";
     hint.style.marginLeft = "1.4rem";
-    hint.textContent = "Charges only when PV exports exceed your load. No deadline planning — no grid import. Optional: add a schedule below to also catch up via grid when cheap.";
+    hint.textContent = "Charges only from real PV surplus. No deadline planning, no grid import, and no home-battery discharge. Optional: add a schedule below to also catch up via grid when cheap.";
     cb.addEventListener("change", function () {
       cb.disabled = true;
       var body = { surplus_only: cb.checked };

--- a/web/diagnose.js
+++ b/web/diagnose.js
@@ -201,6 +201,13 @@
     // would never see the SoC trajectory.
     const lpActive = d.slots && d.slots.some(x =>
       x.loadpoint_w || x.loadpoint_soc_pct);
+    const lpBadges = lpActive ? [
+      '<span class="diag-pill diag-ev">EV in plan</span>',
+      params.loadpoint_surplus_only ? '<span class="diag-pill diag-lp-policy">surplus only</span>' : '',
+      params.loadpoint_blocks_battery_to_ev
+        ? '<span class="diag-pill diag-lp-policy" title="Home battery discharge cannot satisfy planned EV charging in this plan.">battery to EV blocked</span>'
+        : '<span class="diag-pill diag-lp-warn" title="This plan may let home battery discharge satisfy EV charging.">battery may cover EV</span>'
+    ].join('') : '';
     const header = `
       <div class="diagnose-detail-header">
         <div>
@@ -217,7 +224,7 @@
           <span title="Mode"><b>${escapeHtml(params.mode || '—')}</b></span>
           <span title="Initial SoC">SoC start ${params.initial_soc_pct != null ? params.initial_soc_pct.toFixed(1) : '—'}%</span>
           <span title="Battery capacity">${params.capacity_wh ? (params.capacity_wh/1000).toFixed(1)+' kWh' : ''}</span>
-          ${lpActive ? '<span class="diag-pill diag-ev">EV in plan</span>' : ''}
+          ${lpBadges}
         </div>
       </div>
       <div class="diagnose-chart-wrap">

--- a/web/index.html
+++ b/web/index.html
@@ -703,7 +703,10 @@
         <span class="ftw-toggle-slider"></span>
         <span class="ftw-toggle-label" id="battery-covers-ev-label">Off</span>
       </label>
-      <div class="card-sub card-hint">On = home battery discharges into the EV. Off = battery stays out of EV charging.</div>
+      <div class="card-sub card-hint">Default off. On lets the home battery discharge into EV charging. Surplus-only loadpoints still use real PV surplus only.</div>
+      <div class="ev-cover-info" id="battery-covers-ev-info" hidden>
+        This can drain the home battery into the car. Use it only when EV charging should be part of the site battery plan.
+      </div>
     </div>
     <div slot="footer" style="display:flex;gap:0.5rem;width:100%">
       <button class="btn-add" id="ev-btn-start" style="flex:1">Start</button>

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -345,6 +345,7 @@
   const evSend = $("ev-send");
   const bceToggle = $("battery-covers-ev-toggle");
   const bceLabel = $("battery-covers-ev-label");
+  const bceInfo = $("battery-covers-ev-info");
   const fuseUse = $("fuse-use");
   const fuseFill = $("fuse-fill");
   const fusePhases = $("fuse-phases");
@@ -931,6 +932,7 @@
     if (bceToggle && document.activeElement !== bceToggle && data.battery_covers_ev != null) {
       bceToggle.checked = !!data.battery_covers_ev;
       if (bceLabel) bceLabel.textContent = data.battery_covers_ev ? "On" : "Off";
+      if (bceInfo) bceInfo.hidden = !data.battery_covers_ev;
     }
 
     // Energy today
@@ -2321,6 +2323,7 @@
   if (bceToggle) {
     bceToggle.addEventListener("change", function () {
       if (bceLabel) bceLabel.textContent = bceToggle.checked ? "On" : "Off";
+      if (bceInfo) bceInfo.hidden = !bceToggle.checked;
       setBatteryCoversEV(bceToggle.checked);
     });
   }
@@ -2585,7 +2588,7 @@
     soCb.checked = !!(lp && lp.surplus_only);
     soCb.style.accentColor = "var(--accent-e)";
     var soText = document.createElement("span");
-    soText.textContent = "Surplus only (PV exports only — never imports grid)";
+    soText.textContent = "Surplus only (PV only — no grid or battery)";
     soWrap.appendChild(soCb);
     soWrap.appendChild(soText);
 
@@ -2676,7 +2679,7 @@
     // above, so toggling it gives instant feedback without waiting on
     // the network save round-trip.
     var surplusBestEffortHint = document.createElement("div");
-    surplusBestEffortHint.textContent = "Surplus only is on — the deadline becomes best-effort from PV only. Turn it off to let the planner grid-charge if PV can't cover.";
+    surplusBestEffortHint.textContent = "Surplus only is on — the deadline becomes best-effort from real PV surplus only. Turn it off to let the planner grid-charge if PV can't cover.";
     surplusBestEffortHint.style.fontSize = "0.72rem";
     surplusBestEffortHint.style.color = "var(--fg)";
     surplusBestEffortHint.style.fontStyle = "italic";

--- a/web/next.css
+++ b/web/next.css
@@ -1341,6 +1341,16 @@ body.ftw-next .modal-close {
 body.ftw-next .modal-close:hover {
   color: var(--fg);
 }
+body.ftw-next .ev-cover-info {
+  background: rgba(251,191,36,0.10);
+  border: 1px solid rgba(251,191,36,0.22);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  margin-top: 10px;
+  padding: 8px 10px;
+}
 body.ftw-next .modal-tabs {
   gap: 0;
   padding: 8px 16px 0;

--- a/web/style.css
+++ b/web/style.css
@@ -212,6 +212,8 @@ header h1 {
   margin-right: 0.4rem;
 }
 .diag-ev { background: rgba(6,182,212,0.18); color: #67e8f9; }
+.diag-lp-policy { background: rgba(34,197,94,0.16); color: #86efac; }
+.diag-lp-warn { background: rgba(251,191,36,0.18); color: #fde68a; }
 
 /* Detail pane — single scroll container so the chart can roll out
    of view on short viewports (small laptops); the sticky thead still


### PR DESCRIPTION
## What changed

- Treat EV loadpoints in `surplus_only` mode the same as `no_battery_to_ev` for MPC battery-to-EV planning.
- Carry planned loadpoint energy into runtime dispatch so surplus-only EV charging cannot drain the home battery even when `battery_covers_ev` is enabled.
- Make the EV battery-cover setting default off in the UI, add clearer warning/help copy, and surface EV battery-blocking in Diagnose planner rows.
- Add focused MPC/control tests and a patch changeset.

## Why

The planner could allocate battery discharge to a loadpoint that was configured for PV surplus charging. In practice this made the plan look like the EV would consume the surplus/battery energy, while the charger was not actually taking that energy. The result was exported PV at bad prices and a planner that preserved too little battery for household load later.

## Impact

For normal EV surplus charging, the home battery is now protected by default. Users can still opt into battery-backed EV charging, but the UI makes the tradeoff explicit.

## Checks

- `go test ./internal/mpc ./internal/control`
- `npm test -- --runInBand`
- `make test`
- `make verify`
- `make verify-all`
- `node --check web/diagnose.js && node --check web/app.js && node --check web/next-app.js`
- `git diff --check`