### PR TITLE
feat(ha): richer MQTT bridge — LWT, per-driver health, emit_metric, MPC plan, price, EV/vehicle, phase sensors, today's energy

### DIFF
--- a/.changeset/ha-driver-health-plan-metrics.md
+++ b/.changeset/ha-driver-health-plan-metrics.md
@@ -1,0 +1,11 @@
+---
+"forty-two-watts": minor
+---
+
+Home Assistant integration: LWT availability, per-driver health sensors, peak/EV entities, emit_metric sensors, MPC plan sensor
+
+- **Availability topic (LWT)**: HA entities now show as "Unavailable" when the EMS goes offline. The paho Last Will Testament publishes `offline` to `forty-two-watts/status` on unclean disconnect; a clean shutdown publishes it synchronously before disconnect.
+- **Per-driver binary_sensor**: One `<driver>_online` entity per driver so HA dashboards can alert on a stale driver (e.g. stuck Modbus device).
+- **`peak_limit_w` and `ev_charging_w`**: Both control setpoints are now published as `number` entities and writable from HA.
+- **`emit_metric` sensors**: Any scalar diagnostic emitted by a Lua driver via `host.emit_metric(name, value)` is automatically discovered as a HA sensor with the unit and device_class inferred from the name suffix (`_w` → W/power, `_c` → °C/temperature, `_v` → V/voltage, `_a` → A/current, `_hz` → Hz/frequency, `_soc` → %/battery, `_wh` → Wh/energy).
+- **MPC plan sensor**: A `plan_action` text sensor shows the current slot's action (charge / discharge / idle), with JSON attributes containing `battery_w`, `grid_w`, `soc_pct`, slot start/end times, and a full 24 h schedule array — so you can see what the EMS plans to do throughout the day directly in HA.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -547,7 +547,7 @@ func main() {
 				deps.HA = nil
 				slog.Info("HA bridge stopped (disabled in config)")
 			case haBridge == nil && haEnabled:
-				if bridge, err := ha.Start(newCfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc)); err != nil {
+				if bridge, err := ha.Start(newCfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc), haEnergySource(st)); err != nil {
 					slog.Warn("HA bridge start failed", "err", err)
 				} else {
 					haBridge = bridge
@@ -1724,7 +1724,7 @@ func main() {
 
 	// ---- HA MQTT bridge (optional) ----
 	if cfg.HomeAssistant != nil && cfg.HomeAssistant.Enabled {
-		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc))
+		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc), haEnergySource(st))
 		if err != nil {
 			slog.Warn("HA MQTT bridge failed to start", "err", err)
 		} else {
@@ -2929,6 +2929,33 @@ func mpcPlanSource(svc *mpc.Service) ha.PlanSource {
 		return nil
 	}
 	return mpcPlanBridge{svc: svc}
+}
+
+// stateEnergyBridge adapts *state.Store to ha.EnergySource.
+type stateEnergyBridge struct{ st *state.Store }
+
+func (b stateEnergyBridge) TodayEnergy() (ha.TodayEnergySnapshot, bool) {
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	d, err := b.st.DailyEnergy(midnight.UnixMilli(), now.UnixMilli())
+	if err != nil {
+		return ha.TodayEnergySnapshot{}, false
+	}
+	return ha.TodayEnergySnapshot{
+		ImportWh:        d.ImportWh,
+		ExportWh:        d.ExportWh,
+		PVWh:            d.PVWh,
+		BatChargedWh:    d.BatChargedWh,
+		BatDischargedWh: d.BatDischargedWh,
+		LoadWh:          d.LoadWh,
+	}, true
+}
+
+func haEnergySource(st *state.Store) ha.EnergySource {
+	if st == nil {
+		return nil
+	}
+	return stateEnergyBridge{st: st}
 }
 
 func envOr(key, def string) string {

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -2911,6 +2911,14 @@ func (b mpcPlanBridge) LatestActions() []ha.PlanAction {
 			BatteryW:    a.BatteryW,
 			GridW:       a.GridW,
 			SoCPct:      a.SoCPct,
+			PriceOre:    a.PriceOre,
+			SpotOre:     a.SpotOre,
+			CostOre:     a.CostOre,
+			Confidence:  a.Confidence,
+			Reason:      a.Reason,
+			EMSMode:     a.EMSMode,
+			PVW:         a.PVW,
+			LoadW:       a.LoadW,
 		}
 	}
 	return out

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -547,7 +547,7 @@ func main() {
 				deps.HA = nil
 				slog.Info("HA bridge stopped (disabled in config)")
 			case haBridge == nil && haEnabled:
-				if bridge, err := ha.Start(newCfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc)); err != nil {
+				if bridge, err := ha.Start(newCfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc)); err != nil {
 					slog.Warn("HA bridge start failed", "err", err)
 				} else {
 					haBridge = bridge
@@ -1724,7 +1724,7 @@ func main() {
 
 	// ---- HA MQTT bridge (optional) ----
 	if cfg.HomeAssistant != nil && cfg.HomeAssistant.Enabled {
-		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc))
+		bridge, err := ha.Start(cfg.HomeAssistant, tel, ctrl, ctrlMu, reg.Names(), haCallbacks(ctx, ctrl, ctrlMu, st, mpcSvc), mpcPlanSource(mpcSvc))
 		if err != nil {
 			slog.Warn("HA MQTT bridge failed to start", "err", err)
 		} else {
@@ -2889,6 +2889,38 @@ func haCallbacks(ctx context.Context, ctrl *control.State, ctrlMu *sync.Mutex, s
 			return st.SaveConfig("battery_covers_ev", val)
 		},
 	}
+}
+
+// mpcPlanBridge adapts *mpc.Service to ha.PlanSource without creating an
+// import cycle between ha and mpc.
+type mpcPlanBridge struct{ svc *mpc.Service }
+
+func (b mpcPlanBridge) LatestActions() []ha.PlanAction {
+	if b.svc == nil {
+		return nil
+	}
+	plan := b.svc.Latest()
+	if plan == nil {
+		return nil
+	}
+	out := make([]ha.PlanAction, len(plan.Actions))
+	for i, a := range plan.Actions {
+		out[i] = ha.PlanAction{
+			SlotStartMs: a.SlotStartMs,
+			SlotLenMin:  a.SlotLenMin,
+			BatteryW:    a.BatteryW,
+			GridW:       a.GridW,
+			SoCPct:      a.SoCPct,
+		}
+	}
+	return out
+}
+
+func mpcPlanSource(svc *mpc.Service) ha.PlanSource {
+	if svc == nil {
+		return nil
+	}
+	return mpcPlanBridge{svc: svc}
 }
 
 func envOr(key, def string) string {

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -48,6 +48,14 @@ type PlanAction struct {
 	BatteryW    float64
 	GridW       float64
 	SoCPct      float64
+	PriceOre    float64 // total consumer price (öre/kWh)
+	SpotOre     float64 // raw wholesale spot price (öre/kWh)
+	CostOre     float64 // expected cost this slot (öre, negative = revenue)
+	Confidence  float64 // forecast confidence 0–1
+	Reason      string  // human-readable DP reason
+	EMSMode     string  // effective EMS mode the planner chose
+	PVW         float64 // planned PV output (site-sign, ≤ 0)
+	LoadW       float64 // planned load (site-sign, ≥ 0)
 }
 
 // Bridge is an instance of the HA MQTT bridge.
@@ -84,10 +92,13 @@ type Bridge struct {
 	sensorsAnnounced int
 	stopped          bool
 
-	// announcedMetrics tracks emit_metric sensors already registered with HA
-	// so we only publish discovery once per metric, not every publish tick.
+	// announcedMetrics tracks emit_metric sensors already registered with HA.
 	// Keys are "driverName:metricName". Reset on Reload so reconnect re-announces.
 	announcedMetrics map[string]struct{}
+	// announcedEVDrivers / announcedVehicleDrivers track lazily-discovered
+	// EV charger and vehicle readers. Keys are driver names.
+	announcedEVDrivers      map[string]struct{}
+	announcedVehicleDrivers map[string]struct{}
 
 	// connectTimeout is the WaitTimeout passed to paho's Connect token.
 	// 0 means "use defaultConnectTimeout"; tests override to keep the
@@ -162,15 +173,17 @@ func Start(
 	plan PlanSource,
 ) (*Bridge, error) {
 	b := &Bridge{
-		tel:              tel,
-		ctrl:             ctrl,
-		ctrlMu:           ctrlMu,
-		cb:               cb,
-		plan:             plan,
-		topicPrefix:      "forty-two-watts",
-		discoPrefix:      "homeassistant",
-		deviceID:         "forty_two_watts",
-		announcedMetrics: make(map[string]struct{}),
+		tel:                     tel,
+		ctrl:                    ctrl,
+		ctrlMu:                  ctrlMu,
+		cb:                      cb,
+		plan:                    plan,
+		topicPrefix:             "forty-two-watts",
+		discoPrefix:             "homeassistant",
+		deviceID:                "forty_two_watts",
+		announcedMetrics:        make(map[string]struct{}),
+		announcedEVDrivers:      make(map[string]struct{}),
+		announcedVehicleDrivers: make(map[string]struct{}),
 	}
 	if err := b.connectAndStart(cfg, driverNames); err != nil {
 		return nil, err
@@ -193,6 +206,8 @@ func (b *Bridge) Reload(newCfg *config.HomeAssistant, driverNames []string) erro
 	}
 	b.mu.Lock()
 	b.announcedMetrics = make(map[string]struct{})
+	b.announcedEVDrivers = make(map[string]struct{})
+	b.announcedVehicleDrivers = make(map[string]struct{})
 	b.mu.Unlock()
 	b.teardown()
 	return b.connectAndStart(newCfg, driverNames)
@@ -472,21 +487,50 @@ func (b *Bridge) publishDiscovery() {
 	b.publish(fmt.Sprintf("%s/switch/%s/battery_covers_ev/config", b.discoPrefix, b.deviceID), data, true)
 	total++
 
-	// ---- MPC plan sensor ----
-	// State topic carries the current slot's action string ("charge" / "discharge" / "idle").
-	// JSON-attributes topic carries the full day schedule so HA automations and
-	// template sensors can inspect upcoming slots.
+	// ---- MPC plan + price + plan-stale sensors (only when planner is wired) ----
 	if b.plan != nil {
+		// Plan action sensor: state = "charge"/"discharge"/"idle", attrs = full 24h schedule.
 		planMsg := b.withAvail(map[string]any{
-			"name":                   "Plan",
-			"unique_id":              b.deviceID + "_plan",
-			"state_topic":            b.stateTopic("plan_action"),
-			"json_attributes_topic":  b.stateTopic("plan_json"),
-			"icon":                   "mdi:calendar-clock",
-			"device":                 dev,
+			"name":                  "Plan",
+			"unique_id":             b.deviceID + "_plan",
+			"state_topic":           b.stateTopic("plan_action"),
+			"json_attributes_topic": b.stateTopic("plan_json"),
+			"icon":                  "mdi:calendar-clock",
+			"device":                dev,
 		})
 		data, _ = json.Marshal(planMsg)
 		b.publish(fmt.Sprintf("%s/sensor/%s/plan/config", b.discoPrefix, b.deviceID), data, true)
+		total++
+
+		// Current electricity price sensor: state = total consumer price (öre/kWh),
+		// attrs = spot_ore, cost_ore, confidence, reason, ems_mode.
+		priceMsg := b.withAvail(map[string]any{
+			"name":                  "Electricity Price",
+			"unique_id":             b.deviceID + "_price_ore",
+			"state_topic":           b.stateTopic("price_ore"),
+			"json_attributes_topic": b.stateTopic("price_json"),
+			"unit_of_measurement":   "öre/kWh",
+			"icon":                  "mdi:cash-multiple",
+			"device":                dev,
+		})
+		data, _ = json.Marshal(priceMsg)
+		b.publish(fmt.Sprintf("%s/sensor/%s/price/config", b.discoPrefix, b.deviceID), data, true)
+		total++
+
+		// Plan-stale binary_sensor: "on" = planner fell back to self_consumption
+		// because the plan was missing or older than 30 min.
+		staleMsg := b.withAvail(map[string]any{
+			"name":         "Plan Stale",
+			"unique_id":    b.deviceID + "_plan_stale",
+			"state_topic":  b.stateTopic("plan_stale"),
+			"payload_on":   "true",
+			"payload_off":  "false",
+			"device_class": "problem",
+			"icon":         "mdi:calendar-alert",
+			"device":       dev,
+		})
+		data, _ = json.Marshal(staleMsg)
+		b.publish(fmt.Sprintf("%s/binary_sensor/%s/plan_stale/config", b.discoPrefix, b.deviceID), data, true)
 		total++
 	}
 
@@ -495,6 +539,14 @@ func (b *Bridge) publishDiscovery() {
 	knownMetrics := make(map[string]struct{}, len(b.announcedMetrics))
 	for k, v := range b.announcedMetrics {
 		knownMetrics[k] = v
+	}
+	knownEVs := make(map[string]struct{}, len(b.announcedEVDrivers))
+	for k, v := range b.announcedEVDrivers {
+		knownEVs[k] = v
+	}
+	knownVehicles := make(map[string]struct{}, len(b.announcedVehicleDrivers))
+	for k, v := range b.announcedVehicleDrivers {
+		knownVehicles[k] = v
 	}
 	b.mu.Unlock()
 
@@ -520,16 +572,17 @@ func (b *Bridge) publishDiscovery() {
 		}
 		total += 4
 
-		// Health binary_sensor: online/offline.
+		// Health binary_sensor: online/offline with JSON attributes for rich diagnostics.
 		healthMsg := b.withAvail(map[string]any{
-			"name":         name + " Online",
-			"unique_id":    b.deviceID + "_" + name + "_online",
-			"state_topic":  b.driverTopic(name, "online"),
-			"payload_on":   "true",
-			"payload_off":  "false",
-			"device_class": "connectivity",
-			"icon":         "mdi:lan-connect",
-			"device":       dev,
+			"name":                  name + " Online",
+			"unique_id":             b.deviceID + "_" + name + "_online",
+			"state_topic":           b.driverTopic(name, "online"),
+			"json_attributes_topic": b.driverTopic(name, "health_json"),
+			"payload_on":            "true",
+			"payload_off":           "false",
+			"device_class":          "connectivity",
+			"icon":                  "mdi:lan-connect",
+			"device":                dev,
 		})
 		d, _ := json.Marshal(healthMsg)
 		b.publish(fmt.Sprintf("%s/binary_sensor/%s/%s_online/config", b.discoPrefix, b.deviceID, name), d, true)
@@ -545,6 +598,16 @@ func (b *Bridge) publishDiscovery() {
 			b.announceMetric(dev, name, metricName)
 			total++
 		}
+	}
+
+	// Re-announce EV charger and vehicle sensors lazily discovered before reconnect.
+	for name := range knownEVs {
+		b.announceEVDriver(dev, name)
+		total++
+	}
+	for name := range knownVehicles {
+		b.announceVehicleDriver(dev, name)
+		total++
 	}
 
 	b.mu.Lock()
@@ -678,6 +741,7 @@ func (b *Bridge) publishState() {
 	peakLimit := b.ctrl.PeakLimitW
 	evCharging := b.ctrl.EVChargingW
 	batteryCoversEV := b.ctrl.BatteryCoversEV
+	planStale := b.ctrl.PlanStale
 	b.ctrlMu.Unlock()
 
 	gridW := 0.0
@@ -720,8 +784,9 @@ func (b *Bridge) publishState() {
 	}
 	b.publishString("battery_covers_ev", bceState)
 
-	// ---- MPC plan ----
+	// ---- MPC plan + price + plan-stale ----
 	if b.plan != nil {
+		b.publish(b.stateTopic("plan_stale"), []byte(strconv.FormatBool(planStale)), false)
 		b.publishPlan()
 	}
 
@@ -741,10 +806,22 @@ func (b *Bridge) publishState() {
 			}
 		}
 
-		// Health
+		// Health: boolean state + rich JSON attributes.
 		online := false
 		if h := b.tel.DriverHealth(name); h != nil {
 			online = h.IsOnline()
+			attrs := map[string]any{
+				"status":             h.Status.String(),
+				"consecutive_errors": h.ConsecutiveErrors,
+				"last_error":         h.LastError,
+				"tick_count":         h.TickCount,
+			}
+			if h.LastSuccess != nil {
+				attrs["last_seen"] = h.LastSuccess.UTC().Format(time.RFC3339)
+			}
+			if d, err := json.Marshal(attrs); err == nil {
+				b.publish(b.driverTopic(name, "health_json"), d, false)
+			}
 		}
 		b.publish(b.driverTopic(name, "online"), []byte(strconv.FormatBool(online)), false)
 
@@ -763,32 +840,144 @@ func (b *Bridge) publishState() {
 			b.publishDriver(name, snap.Name, snap.Value)
 		}
 	}
+
+	// ---- EV charger readings (DerEV) ----
+	// Lazily discovered: on first sighting of a driver we register it with HA.
+	for _, r := range b.tel.ReadingsByType(telemetry.DerEV) {
+		name := r.Driver
+		b.mu.Lock()
+		_, known := b.announcedEVDrivers[name]
+		if !known {
+			b.announcedEVDrivers[name] = struct{}{}
+		}
+		b.mu.Unlock()
+		if !known {
+			b.announceEVDriver(dev, name)
+		}
+		b.publishDriver(name, "ev_w", r.SmoothedW)
+		// Publish raw Data as JSON attributes so HA can surface charging_state,
+		// charge_limit_pct, and any other fields the driver emits.
+		attrs := map[string]any{
+			"power_w":    r.SmoothedW,
+			"updated_at": r.UpdatedAt.UTC().Format(time.RFC3339),
+		}
+		if len(r.Data) > 0 {
+			var extra map[string]any
+			if json.Unmarshal(r.Data, &extra) == nil {
+				for k, v := range extra {
+					attrs[k] = v
+				}
+			}
+		}
+		if d, err := json.Marshal(attrs); err == nil {
+			b.publish(b.driverTopic(name, "ev_json"), d, false)
+		}
+	}
+
+	// ---- Vehicle readings (DerVehicle) ----
+	// Vehicle SoC + charging metadata from the vehicle itself (e.g. Tesla BLE).
+	for _, r := range b.tel.ReadingsByType(telemetry.DerVehicle) {
+		name := r.Driver
+		b.mu.Lock()
+		_, known := b.announcedVehicleDrivers[name]
+		if !known {
+			b.announcedVehicleDrivers[name] = struct{}{}
+		}
+		b.mu.Unlock()
+		if !known {
+			b.announceVehicleDriver(dev, name)
+		}
+		if r.SoC != nil {
+			b.publishDriver(name, "vehicle_soc_pct", *r.SoC*100)
+		}
+		attrs := map[string]any{
+			"updated_at": r.UpdatedAt.UTC().Format(time.RFC3339),
+		}
+		if r.SoC != nil {
+			attrs["soc_pct"] = *r.SoC * 100
+		}
+		if len(r.Data) > 0 {
+			var extra map[string]any
+			if json.Unmarshal(r.Data, &extra) == nil {
+				for k, v := range extra {
+					attrs[k] = v
+				}
+			}
+		}
+		if d, err := json.Marshal(attrs); err == nil {
+			b.publish(b.driverTopic(name, "vehicle_json"), d, false)
+		}
+	}
 }
 
-// publishPlan reads the current MPC plan and publishes the current-slot
-// action string plus a JSON-attributes payload with the day schedule.
+// announceEVDriver publishes HA discovery for an EV charger reader.
+func (b *Bridge) announceEVDriver(dev map[string]any, driver string) {
+	msg := b.withAvail(map[string]any{
+		"name":                  driver + " EV Power",
+		"unique_id":             b.deviceID + "_" + driver + "_ev_w",
+		"state_topic":           b.driverTopic(driver, "ev_w"),
+		"json_attributes_topic": b.driverTopic(driver, "ev_json"),
+		"unit_of_measurement":   "W",
+		"device_class":          "power",
+		"icon":                  "mdi:car-electric",
+		"device":                dev,
+	})
+	d, _ := json.Marshal(msg)
+	b.publish(fmt.Sprintf("%s/sensor/%s/%s_ev_w/config", b.discoPrefix, b.deviceID, driver), d, true)
+}
+
+// announceVehicleDriver publishes HA discovery for a vehicle SoC reader.
+func (b *Bridge) announceVehicleDriver(dev map[string]any, driver string) {
+	msg := b.withAvail(map[string]any{
+		"name":                  driver + " Vehicle SoC",
+		"unique_id":             b.deviceID + "_" + driver + "_vehicle_soc",
+		"state_topic":           b.driverTopic(driver, "vehicle_soc_pct"),
+		"json_attributes_topic": b.driverTopic(driver, "vehicle_json"),
+		"unit_of_measurement":   "%",
+		"device_class":          "battery",
+		"icon":                  "mdi:car-electric",
+		"device":                dev,
+	})
+	d, _ := json.Marshal(msg)
+	b.publish(fmt.Sprintf("%s/sensor/%s/%s_vehicle_soc/config", b.discoPrefix, b.deviceID, driver), d, true)
+}
+
+// publishPlan reads the current MPC plan and publishes:
+//   - plan_action: current slot action string (charge/discharge/idle)
+//   - plan_json: full attributes including 24 h schedule with price/cost data
+//   - price_ore: current consumer electricity price (öre/kWh)
+//   - price_json: price attributes (spot_ore, cost_ore, confidence, reason, ems_mode)
 func (b *Bridge) publishPlan() {
 	actions := b.plan.LatestActions()
 	now := time.Now()
 	nowMs := now.UnixMilli()
 
 	type slotJSON struct {
-		Start    string  `json:"start"`
-		End      string  `json:"end"`
-		Action   string  `json:"action"`
-		BatteryW float64 `json:"battery_w"`
-		GridW    float64 `json:"grid_w"`
-		SoCPct   float64 `json:"soc_pct"`
+		Start      string  `json:"start"`
+		End        string  `json:"end"`
+		Action     string  `json:"action"`
+		BatteryW   float64 `json:"battery_w"`
+		GridW      float64 `json:"grid_w"`
+		SoCPct     float64 `json:"soc_pct"`
+		PVW        float64 `json:"pv_w,omitempty"`
+		LoadW      float64 `json:"load_w,omitempty"`
+		PriceOre   float64 `json:"price_ore,omitempty"`
+		SpotOre    float64 `json:"spot_ore,omitempty"`
+		CostOre    float64 `json:"cost_ore,omitempty"`
+		Confidence float64 `json:"confidence,omitempty"`
+		Reason     string  `json:"reason,omitempty"`
+		EMSMode    string  `json:"ems_mode,omitempty"`
 	}
 
 	currentAction := "unavailable"
-	var currentBatteryW, currentGridW, currentSoCPct float64
-	var currentStart, currentEnd string
+	var curBatW, curGridW, curSoCPct float64
+	var curStart, curEnd string
+	var curPriceOre, curSpotOre, curCostOre, curConfidence float64
+	var curReason, curEMSMode string
 
 	var schedule []slotJSON
 	horizon := nowMs + 24*60*60*1000 // 24 h ahead
 
-	// Sort by start time for deterministic output.
 	sort.Slice(actions, func(i, j int) bool {
 		return actions[i].SlotStartMs < actions[j].SlotStartMs
 	})
@@ -807,37 +996,70 @@ func (b *Bridge) publishPlan() {
 		end := time.UnixMilli(endMs).UTC().Format(time.RFC3339)
 
 		if a.SlotStartMs <= nowMs && nowMs < endMs {
-			// This is the current slot.
 			currentAction = label
-			currentBatteryW = a.BatteryW
-			currentGridW = a.GridW
-			currentSoCPct = a.SoCPct
-			currentStart = start
-			currentEnd = end
+			curBatW = a.BatteryW
+			curGridW = a.GridW
+			curSoCPct = a.SoCPct
+			curStart = start
+			curEnd = end
+			curPriceOre = a.PriceOre
+			curSpotOre = a.SpotOre
+			curCostOre = a.CostOre
+			curConfidence = a.Confidence
+			curReason = a.Reason
+			curEMSMode = a.EMSMode
 		}
 		schedule = append(schedule, slotJSON{
-			Start:    start,
-			End:      end,
-			Action:   label,
-			BatteryW: a.BatteryW,
-			GridW:    a.GridW,
-			SoCPct:   a.SoCPct,
+			Start:      start,
+			End:        end,
+			Action:     label,
+			BatteryW:   a.BatteryW,
+			GridW:      a.GridW,
+			SoCPct:     a.SoCPct,
+			PVW:        a.PVW,
+			LoadW:      a.LoadW,
+			PriceOre:   a.PriceOre,
+			SpotOre:    a.SpotOre,
+			CostOre:    a.CostOre,
+			Confidence: a.Confidence,
+			Reason:     a.Reason,
+			EMSMode:    a.EMSMode,
 		})
 	}
 
 	b.publishString("plan_action", currentAction)
 
-	attrPayload := map[string]any{
-		"action":    currentAction,
-		"battery_w": currentBatteryW,
-		"grid_w":    currentGridW,
-		"soc_pct":   currentSoCPct,
-		"slot_start": currentStart,
-		"slot_end":   currentEnd,
-		"schedule":  schedule,
+	planAttrs := map[string]any{
+		"action":     currentAction,
+		"battery_w":  curBatW,
+		"grid_w":     curGridW,
+		"soc_pct":    curSoCPct,
+		"slot_start": curStart,
+		"slot_end":   curEnd,
+		"price_ore":  curPriceOre,
+		"spot_ore":   curSpotOre,
+		"cost_ore":   curCostOre,
+		"confidence": curConfidence,
+		"reason":     curReason,
+		"ems_mode":   curEMSMode,
+		"schedule":   schedule,
 	}
-	if d, err := json.Marshal(attrPayload); err == nil {
+	if d, err := json.Marshal(planAttrs); err == nil {
 		b.publish(b.stateTopic("plan_json"), d, false)
+	}
+
+	// Price sensor: standalone value + rich attributes for HA energy dashboard.
+	b.publishValue("price_ore", curPriceOre)
+	priceAttrs := map[string]any{
+		"price_ore":  curPriceOre,
+		"spot_ore":   curSpotOre,
+		"cost_ore":   curCostOre,
+		"confidence": curConfidence,
+		"reason":     curReason,
+		"ems_mode":   curEMSMode,
+	}
+	if d, err := json.Marshal(priceAttrs); err == nil {
+		b.publish(b.stateTopic("price_json"), d, false)
 	}
 }
 

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -12,7 +12,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +35,21 @@ type CommandCallbacks struct {
 	SetBatteryCoversEV func(bool) error
 }
 
+// PlanSource is the minimal interface the bridge needs to read the MPC plan.
+// Pass an adapter wrapping *mpc.Service at construction; nil disables plan sensors.
+type PlanSource interface {
+	LatestActions() []PlanAction
+}
+
+// PlanAction is one slot in the MPC plan as seen by the HA bridge.
+type PlanAction struct {
+	SlotStartMs int64
+	SlotLenMin  int
+	BatteryW    float64
+	GridW       float64
+	SoCPct      float64
+}
+
 // Bridge is an instance of the HA MQTT bridge.
 //
 // Lifecycle invariants:
@@ -49,6 +66,7 @@ type Bridge struct {
 	ctrl   *control.State
 	ctrlMu *sync.Mutex
 	cb     CommandCallbacks
+	plan   PlanSource // nil when MPC is not configured
 
 	topicPrefix string // e.g. "forty-two-watts"
 	discoPrefix string // e.g. "homeassistant"
@@ -65,6 +83,11 @@ type Bridge struct {
 	lastPublishMs    int64
 	sensorsAnnounced int
 	stopped          bool
+
+	// announcedMetrics tracks emit_metric sensors already registered with HA
+	// so we only publish discovery once per metric, not every publish tick.
+	// Keys are "driverName:metricName". Reset on Reload so reconnect re-announces.
+	announcedMetrics map[string]struct{}
 
 	// connectTimeout is the WaitTimeout passed to paho's Connect token.
 	// 0 means "use defaultConnectTimeout"; tests override to keep the
@@ -127,21 +150,27 @@ func (b *Bridge) SensorsAnnounced() int {
 // Start connects to the HA broker, publishes autodiscovery, and begins
 // periodic state publishes. Returns immediately; the goroutine runs until
 // Stop() is called.
+//
+// plan may be nil when the MPC planner is not configured; plan sensors
+// are skipped in that case.
 func Start(
 	cfg *config.HomeAssistant,
 	tel *telemetry.Store,
 	ctrl *control.State, ctrlMu *sync.Mutex,
 	driverNames []string,
 	cb CommandCallbacks,
+	plan PlanSource,
 ) (*Bridge, error) {
 	b := &Bridge{
-		tel:         tel,
-		ctrl:        ctrl,
-		ctrlMu:      ctrlMu,
-		cb:          cb,
-		topicPrefix: "forty-two-watts",
-		discoPrefix: "homeassistant",
-		deviceID:    "forty_two_watts",
+		tel:              tel,
+		ctrl:             ctrl,
+		ctrlMu:           ctrlMu,
+		cb:               cb,
+		plan:             plan,
+		topicPrefix:      "forty-two-watts",
+		discoPrefix:      "homeassistant",
+		deviceID:         "forty_two_watts",
+		announcedMetrics: make(map[string]struct{}),
 	}
 	if err := b.connectAndStart(cfg, driverNames); err != nil {
 		return nil, err
@@ -153,14 +182,8 @@ func Start(
 // requiring a process restart. The current MQTT client is disconnected,
 // the publish loop drained, then a fresh paho client is built from
 // newCfg and a new loop is started. Diagnostic counters reset because
-// the new connection is its own thing — operators reading
-// LastPublishMs / SensorsAnnounced after a reload should see "fresh
-// connection" semantics, not stale figures from the previous broker.
-//
-// driverNames is the current driver registry as of reload time. The
-// applier in cmd/forty-two-watts/main.go passes in reg.Names() so a
-// driver added or removed in the same config-reload tick is reflected
-// in HA discovery without a second round-trip.
+// the new connection is its own thing. announcedMetrics is also reset
+// so dynamic emit_metric sensors are re-announced on the new connection.
 func (b *Bridge) Reload(newCfg *config.HomeAssistant, driverNames []string) error {
 	b.lifecycleMu.Lock()
 	defer b.lifecycleMu.Unlock()
@@ -168,6 +191,9 @@ func (b *Bridge) Reload(newCfg *config.HomeAssistant, driverNames []string) erro
 	if b.stopped {
 		return fmt.Errorf("ha: bridge stopped, cannot reload")
 	}
+	b.mu.Lock()
+	b.announcedMetrics = make(map[string]struct{})
+	b.mu.Unlock()
 	b.teardown()
 	return b.connectAndStart(newCfg, driverNames)
 }
@@ -177,10 +203,6 @@ func (b *Bridge) Reload(newCfg *config.HomeAssistant, driverNames []string) erro
 // and Reload (after a teardown). Caller is responsible for serializing
 // access via lifecycleMu.
 func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string) error {
-	// Swap data fields BEFORE Connect: paho fires OnConnectHandler from
-	// inside Connect() and that handler calls publishDiscovery, which
-	// reads b.driverNames. Updating after Connect would publish discovery
-	// for the previous driver list.
 	b.mu.Lock()
 	b.cfg = cfg
 	b.driverNames = driverNames
@@ -196,8 +218,14 @@ func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string
 		SetAutoReconnect(true).
 		SetConnectRetry(true).
 		SetConnectRetryInterval(10 * time.Second).
+		// LWT: broker publishes "offline" if the EMS vanishes without a clean disconnect.
+		// QoS 1 + retained so HA sees it immediately after reconnecting to the broker.
+		SetWill(b.availTopic(), "offline", 1, true).
 		SetOnConnectHandler(func(_ paho.Client) {
 			slog.Info("HA MQTT connected", "broker", cfg.Broker)
+			// Mark EMS as online before discovery so HA doesn't briefly
+			// show entities as unavailable on the same connect.
+			b.publish(b.availTopic(), []byte("online"), true)
 			b.publishDiscovery()
 			b.subscribeCommands()
 		})
@@ -213,8 +241,6 @@ func (b *Bridge) connectAndStart(cfg *config.HomeAssistant, driverNames []string
 	b.client = cli
 	b.mu.Unlock()
 
-	// We own b.done until publishLoop takes over — close it on any
-	// early return so the next teardown() doesn't block on <-doneCh.
 	started := false
 	defer func() {
 		if !started {
@@ -258,6 +284,15 @@ func (b *Bridge) teardown() {
 		<-doneCh
 	}
 	if cli != nil {
+		// Publish "offline" synchronously before disconnecting so HA
+		// sees the EMS go away cleanly (e.g. on a planned restart).
+		// Use IsConnectionOpen (not IsConnected): with ConnectRetry=true,
+		// IsConnected() returns true even while retrying, so Publish would
+		// block for WaitTimeout. Only publish "offline" when the TCP link
+		// is actually up.
+		if cli.IsConnectionOpen() {
+			cli.Publish(b.availTopic(), 1, true, []byte("offline")).WaitTimeout(2 * time.Second)
+		}
 		cli.Disconnect(500)
 	}
 }
@@ -274,6 +309,15 @@ func (b *Bridge) Stop() {
 	}
 	b.teardown()
 	b.stopped = true
+}
+
+// ---- Topic helpers ----
+
+func (b *Bridge) availTopic() string  { return b.topicPrefix + "/status" }
+func (b *Bridge) stateTopic(name string) string { return b.topicPrefix + "/state/" + name }
+func (b *Bridge) cmdTopic(name string) string   { return b.topicPrefix + "/cmd/" + name }
+func (b *Bridge) driverTopic(driver, field string) string {
+	return fmt.Sprintf("%s/driver/%s/%s", b.topicPrefix, driver, field)
 }
 
 // ---- Autodiscovery ----
@@ -305,15 +349,24 @@ func modeSelectOptions() []string {
 	return opts
 }
 
+// withAvail adds the availability topic keys to a discovery message map.
+func (b *Bridge) withAvail(m map[string]any) map[string]any {
+	m["availability_topic"] = b.availTopic()
+	m["payload_available"] = "online"
+	m["payload_not_available"] = "offline"
+	return m
+}
+
 // publishDiscovery registers all sensors and controls with HA. Called on
 // every reconnect — HA de-dupes by unique_id so it's safe to re-publish.
 func (b *Bridge) publishDiscovery() {
 	dev := b.discoveryDevice()
+	total := 0
 
-	// ---- Sensors (site level) ----
+	// ---- Site-level sensors ----
 	sensors := []struct {
 		id, name, unit, devClass string
-		state                    string // the topic to read from
+		state                    string
 	}{
 		{"grid_power", "Grid Power", "W", "power", b.stateTopic("grid_w")},
 		{"pv_power", "PV Power", "W", "power", b.stateTopic("pv_w")},
@@ -321,35 +374,39 @@ func (b *Bridge) publishDiscovery() {
 		{"load_power", "Load Power", "W", "power", b.stateTopic("load_w")},
 		{"battery_soc", "Battery SoC", "%", "battery", b.stateTopic("bat_soc_pct")},
 		{"grid_target", "Grid Target", "W", "power", b.stateTopic("grid_target_w")},
+		{"peak_limit", "Peak Limit", "W", "power", b.stateTopic("peak_limit_w")},
+		{"ev_charging", "EV Charging Power", "W", "power", b.stateTopic("ev_charging_w")},
 	}
 	for _, s := range sensors {
-		msg := map[string]any{
+		msg := b.withAvail(map[string]any{
 			"name":                s.name,
 			"unique_id":           b.deviceID + "_" + s.id,
 			"state_topic":         s.state,
 			"unit_of_measurement": s.unit,
 			"device_class":        s.devClass,
 			"device":              dev,
-		}
+		})
 		data, _ := json.Marshal(msg)
 		topic := fmt.Sprintf("%s/sensor/%s/%s/config", b.discoPrefix, b.deviceID, s.id)
-		b.publish(topic, data, true) // retained
+		b.publish(topic, data, true)
 	}
+	total += len(sensors)
 
 	// ---- Mode as HA select ----
-	modeMsg := map[string]any{
+	modeMsg := b.withAvail(map[string]any{
 		"name":          "Mode",
 		"unique_id":     b.deviceID + "_mode",
 		"state_topic":   b.stateTopic("mode"),
 		"command_topic": b.cmdTopic("mode"),
 		"options":       modeSelectOptions(),
 		"device":        dev,
-	}
+	})
 	data, _ := json.Marshal(modeMsg)
 	b.publish(fmt.Sprintf("%s/select/%s/mode/config", b.discoPrefix, b.deviceID), data, true)
+	total++
 
 	// ---- Grid target as HA number ----
-	targetMsg := map[string]any{
+	targetMsg := b.withAvail(map[string]any{
 		"name":                "Grid Target",
 		"unique_id":           b.deviceID + "_grid_target_cmd",
 		"state_topic":         b.stateTopic("grid_target_w"),
@@ -359,14 +416,47 @@ func (b *Bridge) publishDiscovery() {
 		"step":                50,
 		"unit_of_measurement": "W",
 		"device":              dev,
-	}
+	})
 	data, _ = json.Marshal(targetMsg)
 	b.publish(fmt.Sprintf("%s/number/%s/grid_target/config", b.discoPrefix, b.deviceID), data, true)
+	total++
+
+	// ---- Peak limit as HA number ----
+	peakMsg := b.withAvail(map[string]any{
+		"name":                "Peak Limit",
+		"unique_id":           b.deviceID + "_peak_limit_cmd",
+		"state_topic":         b.stateTopic("peak_limit_w"),
+		"command_topic":       b.cmdTopic("peak_limit_w"),
+		"min":                 0,
+		"max":                 25000,
+		"step":                100,
+		"unit_of_measurement": "W",
+		"icon":                "mdi:gauge",
+		"device":              dev,
+	})
+	data, _ = json.Marshal(peakMsg)
+	b.publish(fmt.Sprintf("%s/number/%s/peak_limit/config", b.discoPrefix, b.deviceID), data, true)
+	total++
+
+	// ---- EV charging target as HA number ----
+	evMsg := b.withAvail(map[string]any{
+		"name":                "EV Charging Power",
+		"unique_id":           b.deviceID + "_ev_charging_cmd",
+		"state_topic":         b.stateTopic("ev_charging_w"),
+		"command_topic":       b.cmdTopic("ev_charging_w"),
+		"min":                 0,
+		"max":                 22000,
+		"step":                100,
+		"unit_of_measurement": "W",
+		"icon":                "mdi:car-electric",
+		"device":              dev,
+	})
+	data, _ = json.Marshal(evMsg)
+	b.publish(fmt.Sprintf("%s/number/%s/ev_charging/config", b.discoPrefix, b.deviceID), data, true)
+	total++
 
 	// ---- Battery-covers-EV as HA switch ----
-	// Operator-facing override: when ON, the control loop lets the battery
-	// discharge into the EV (price-arbitrage scenarios). Default OFF.
-	bceMsg := map[string]any{
+	bceMsg := b.withAvail(map[string]any{
 		"name":          "Battery Covers EV",
 		"unique_id":     b.deviceID + "_battery_covers_ev_cmd",
 		"state_topic":   b.stateTopic("battery_covers_ev"),
@@ -377,35 +467,135 @@ func (b *Bridge) publishDiscovery() {
 		"state_off":     "OFF",
 		"icon":          "mdi:car-battery",
 		"device":        dev,
-	}
+	})
 	data, _ = json.Marshal(bceMsg)
 	b.publish(fmt.Sprintf("%s/switch/%s/battery_covers_ev/config", b.discoPrefix, b.deviceID), data, true)
+	total++
 
-	// ---- Per-driver sensors ----
+	// ---- MPC plan sensor ----
+	// State topic carries the current slot's action string ("charge" / "discharge" / "idle").
+	// JSON-attributes topic carries the full day schedule so HA automations and
+	// template sensors can inspect upcoming slots.
+	if b.plan != nil {
+		planMsg := b.withAvail(map[string]any{
+			"name":                   "Plan",
+			"unique_id":              b.deviceID + "_plan",
+			"state_topic":            b.stateTopic("plan_action"),
+			"json_attributes_topic":  b.stateTopic("plan_json"),
+			"icon":                   "mdi:calendar-clock",
+			"device":                 dev,
+		})
+		data, _ = json.Marshal(planMsg)
+		b.publish(fmt.Sprintf("%s/sensor/%s/plan/config", b.discoPrefix, b.deviceID), data, true)
+		total++
+	}
+
+	// ---- Per-driver sensors + health ----
+	b.mu.Lock()
+	knownMetrics := make(map[string]struct{}, len(b.announcedMetrics))
+	for k, v := range b.announcedMetrics {
+		knownMetrics[k] = v
+	}
+	b.mu.Unlock()
+
 	for _, name := range b.driverNames {
+		// Data sensors
 		for _, s := range []struct{ id, label, unit, class string }{
-			{"_meter_w", " Meter Power", "W", "power"},
-			{"_pv_w", " PV Power", "W", "power"},
-			{"_bat_w", " Battery Power", "W", "power"},
-			{"_bat_soc_pct", " Battery SoC", "%", "battery"},
+			{"meter_w", " Meter Power", "W", "power"},
+			{"pv_w", " PV Power", "W", "power"},
+			{"bat_w", " Battery Power", "W", "power"},
+			{"bat_soc_pct", " Battery SoC", "%", "battery"},
 		} {
-			msg := map[string]any{
+			msg := b.withAvail(map[string]any{
 				"name":                name + s.label,
 				"unique_id":           b.deviceID + "_" + name + s.id,
-				"state_topic":         b.driverTopic(name, s.id[1:]),
+				"state_topic":         b.driverTopic(name, s.id),
 				"unit_of_measurement": s.unit,
 				"device_class":        s.class,
 				"device":              dev,
+			})
+			d, _ := json.Marshal(msg)
+			topic := fmt.Sprintf("%s/sensor/%s/%s_%s/config", b.discoPrefix, b.deviceID, name, s.id)
+			b.publish(topic, d, true)
+		}
+		total += 4
+
+		// Health binary_sensor: online/offline.
+		healthMsg := b.withAvail(map[string]any{
+			"name":         name + " Online",
+			"unique_id":    b.deviceID + "_" + name + "_online",
+			"state_topic":  b.driverTopic(name, "online"),
+			"payload_on":   "true",
+			"payload_off":  "false",
+			"device_class": "connectivity",
+			"icon":         "mdi:lan-connect",
+			"device":       dev,
+		})
+		d, _ := json.Marshal(healthMsg)
+		b.publish(fmt.Sprintf("%s/binary_sensor/%s/%s_online/config", b.discoPrefix, b.deviceID, name), d, true)
+		total++
+
+		// Re-announce any emit_metric sensors already known from a previous cycle.
+		for key := range knownMetrics {
+			prefix := name + ":"
+			if !strings.HasPrefix(key, prefix) {
+				continue
 			}
-			data, _ := json.Marshal(msg)
-			topic := fmt.Sprintf("%s/sensor/%s/%s%s/config", b.discoPrefix, b.deviceID, name, s.id)
-			b.publish(topic, data, true)
+			metricName := key[len(prefix):]
+			b.announceMetric(dev, name, metricName)
+			total++
 		}
 	}
-	// Count total sensors announced (site + per-driver).
+
 	b.mu.Lock()
-	b.sensorsAnnounced = len(sensors) + len(b.driverNames)*5 // 5 per driver
+	b.sensorsAnnounced = total
 	b.mu.Unlock()
+}
+
+// announceMetric publishes a single HA discovery message for a driver emit_metric.
+// Called when a metric is seen for the first time and on every reconnect.
+func (b *Bridge) announceMetric(dev map[string]any, driver, metricName string) {
+	unit, devClass := metricUnitAndClass(metricName)
+	uid := b.deviceID + "_" + driver + "_" + metricName
+	msg := b.withAvail(map[string]any{
+		"name":      driver + " " + strings.ReplaceAll(metricName, "_", " "),
+		"unique_id": uid,
+		"state_topic": b.driverTopic(driver, metricName),
+		"device":    dev,
+	})
+	if unit != "" {
+		msg["unit_of_measurement"] = unit
+	}
+	if devClass != "" {
+		msg["device_class"] = devClass
+	}
+	d, _ := json.Marshal(msg)
+	topic := fmt.Sprintf("%s/sensor/%s/%s_%s/config", b.discoPrefix, b.deviceID, driver, metricName)
+	b.publish(topic, d, true)
+}
+
+// metricUnitAndClass infers HA unit and device_class from an emit_metric name suffix.
+func metricUnitAndClass(name string) (unit, devClass string) {
+	switch {
+	case strings.HasSuffix(name, "_w"):
+		return "W", "power"
+	case strings.HasSuffix(name, "_wh"):
+		return "Wh", "energy"
+	case strings.HasSuffix(name, "_c"):
+		return "°C", "temperature"
+	case strings.HasSuffix(name, "_soc_pct"), strings.HasSuffix(name, "_soc"):
+		return "%", "battery"
+	case strings.HasSuffix(name, "_pct"):
+		return "%", ""
+	case strings.HasSuffix(name, "_v"):
+		return "V", "voltage"
+	case strings.HasSuffix(name, "_a"):
+		return "A", "current"
+	case strings.HasSuffix(name, "_hz"):
+		return "Hz", "frequency"
+	default:
+		return "", ""
+	}
 }
 
 // ---- Command subscriber ----
@@ -476,15 +666,17 @@ func (b *Bridge) publishLoop() {
 }
 
 func (b *Bridge) publishState() {
-	// Record the publish tick so /api/ha/status can show liveness.
 	b.mu.Lock()
 	b.lastPublishMs = time.Now().UnixMilli()
 	b.mu.Unlock()
-	// Site-level aggregates
+
+	// ---- Site-level aggregates ----
 	b.ctrlMu.Lock()
 	siteMeter := b.ctrl.SiteMeterDriver
 	mode := string(b.ctrl.Mode)
 	gridTarget := b.ctrl.GridTargetW
+	peakLimit := b.ctrl.PeakLimitW
+	evCharging := b.ctrl.EVChargingW
 	batteryCoversEV := b.ctrl.BatteryCoversEV
 	b.ctrlMu.Unlock()
 
@@ -519,6 +711,8 @@ func (b *Bridge) publishState() {
 	b.publishValue("load_w", loadW)
 	b.publishValue("bat_soc_pct", avgSoC*100)
 	b.publishValue("grid_target_w", gridTarget)
+	b.publishValue("peak_limit_w", peakLimit)
+	b.publishValue("ev_charging_w", evCharging)
 	b.publishString("mode", mode)
 	bceState := "OFF"
 	if batteryCoversEV {
@@ -526,7 +720,13 @@ func (b *Bridge) publishState() {
 	}
 	b.publishString("battery_covers_ev", bceState)
 
-	// Per-driver
+	// ---- MPC plan ----
+	if b.plan != nil {
+		b.publishPlan()
+	}
+
+	// ---- Per-driver ----
+	dev := b.discoveryDevice()
 	for _, name := range b.driverNames {
 		if r := b.tel.Get(name, telemetry.DerMeter); r != nil {
 			b.publishDriver(name, "meter_w", r.SmoothedW)
@@ -540,16 +740,120 @@ func (b *Bridge) publishState() {
 				b.publishDriver(name, "bat_soc_pct", *r.SoC*100)
 			}
 		}
+
+		// Health
+		online := false
+		if h := b.tel.DriverHealth(name); h != nil {
+			online = h.IsOnline()
+		}
+		b.publish(b.driverTopic(name, "online"), []byte(strconv.FormatBool(online)), false)
+
+		// Emit_metric sensors — discover new ones, publish all.
+		for _, snap := range b.tel.LatestMetricsByDriver(name) {
+			key := name + ":" + snap.Name
+			b.mu.Lock()
+			_, known := b.announcedMetrics[key]
+			if !known {
+				b.announcedMetrics[key] = struct{}{}
+			}
+			b.mu.Unlock()
+			if !known {
+				b.announceMetric(dev, name, snap.Name)
+			}
+			b.publishDriver(name, snap.Name, snap.Value)
+		}
 	}
 }
 
-// ---- Helpers ----
+// publishPlan reads the current MPC plan and publishes the current-slot
+// action string plus a JSON-attributes payload with the day schedule.
+func (b *Bridge) publishPlan() {
+	actions := b.plan.LatestActions()
+	now := time.Now()
+	nowMs := now.UnixMilli()
 
-func (b *Bridge) stateTopic(name string) string { return b.topicPrefix + "/state/" + name }
-func (b *Bridge) cmdTopic(name string) string   { return b.topicPrefix + "/cmd/" + name }
-func (b *Bridge) driverTopic(driver, field string) string {
-	return fmt.Sprintf("%s/driver/%s/%s", b.topicPrefix, driver, field)
+	type slotJSON struct {
+		Start    string  `json:"start"`
+		End      string  `json:"end"`
+		Action   string  `json:"action"`
+		BatteryW float64 `json:"battery_w"`
+		GridW    float64 `json:"grid_w"`
+		SoCPct   float64 `json:"soc_pct"`
+	}
+
+	currentAction := "unavailable"
+	var currentBatteryW, currentGridW, currentSoCPct float64
+	var currentStart, currentEnd string
+
+	var schedule []slotJSON
+	horizon := nowMs + 24*60*60*1000 // 24 h ahead
+
+	// Sort by start time for deterministic output.
+	sort.Slice(actions, func(i, j int) bool {
+		return actions[i].SlotStartMs < actions[j].SlotStartMs
+	})
+
+	for _, a := range actions {
+		endMs := a.SlotStartMs + int64(a.SlotLenMin)*60*1000
+		if endMs <= nowMs {
+			continue // past slot
+		}
+		if a.SlotStartMs > horizon {
+			break // beyond 24 h
+		}
+
+		label := planActionLabel(a.BatteryW)
+		start := time.UnixMilli(a.SlotStartMs).UTC().Format(time.RFC3339)
+		end := time.UnixMilli(endMs).UTC().Format(time.RFC3339)
+
+		if a.SlotStartMs <= nowMs && nowMs < endMs {
+			// This is the current slot.
+			currentAction = label
+			currentBatteryW = a.BatteryW
+			currentGridW = a.GridW
+			currentSoCPct = a.SoCPct
+			currentStart = start
+			currentEnd = end
+		}
+		schedule = append(schedule, slotJSON{
+			Start:    start,
+			End:      end,
+			Action:   label,
+			BatteryW: a.BatteryW,
+			GridW:    a.GridW,
+			SoCPct:   a.SoCPct,
+		})
+	}
+
+	b.publishString("plan_action", currentAction)
+
+	attrPayload := map[string]any{
+		"action":    currentAction,
+		"battery_w": currentBatteryW,
+		"grid_w":    currentGridW,
+		"soc_pct":   currentSoCPct,
+		"slot_start": currentStart,
+		"slot_end":   currentEnd,
+		"schedule":  schedule,
+	}
+	if d, err := json.Marshal(attrPayload); err == nil {
+		b.publish(b.stateTopic("plan_json"), d, false)
+	}
 }
+
+// planActionLabel converts a signed battery power to a human-readable label.
+// Mirrors the logic in mpc.Service.SlotAt.
+func planActionLabel(batteryW float64) string {
+	if batteryW > 100 {
+		return "charge"
+	}
+	if batteryW < -100 {
+		return "discharge"
+	}
+	return "idle"
+}
+
+// ---- Publish helpers ----
 
 func (b *Bridge) publishValue(name string, v float64) {
 	b.publish(b.stateTopic(name), []byte(strconv.FormatFloat(v, 'f', 2, 64)), false)

--- a/go/internal/ha/bridge.go
+++ b/go/internal/ha/bridge.go
@@ -41,6 +41,23 @@ type PlanSource interface {
 	LatestActions() []PlanAction
 }
 
+// EnergySource is the minimal interface for today's running Wh totals.
+// Pass an adapter wrapping *state.Store at construction; nil disables energy sensors.
+type EnergySource interface {
+	TodayEnergy() (TodayEnergySnapshot, bool)
+}
+
+// TodayEnergySnapshot is today's accumulated energy since midnight (local time).
+// All values are in Wh, site convention (ExportWh and PVWh are positive magnitudes).
+type TodayEnergySnapshot struct {
+	ImportWh        float64
+	ExportWh        float64
+	PVWh            float64
+	BatChargedWh    float64
+	BatDischargedWh float64
+	LoadWh          float64
+}
+
 // PlanAction is one slot in the MPC plan as seen by the HA bridge.
 type PlanAction struct {
 	SlotStartMs int64
@@ -74,7 +91,8 @@ type Bridge struct {
 	ctrl   *control.State
 	ctrlMu *sync.Mutex
 	cb     CommandCallbacks
-	plan   PlanSource // nil when MPC is not configured
+	plan   PlanSource   // nil when MPC is not configured
+	energy EnergySource // nil when state.Store is not available
 
 	topicPrefix string // e.g. "forty-two-watts"
 	discoPrefix string // e.g. "homeassistant"
@@ -171,6 +189,7 @@ func Start(
 	driverNames []string,
 	cb CommandCallbacks,
 	plan PlanSource,
+	energy EnergySource,
 ) (*Bridge, error) {
 	b := &Bridge{
 		tel:                     tel,
@@ -178,6 +197,7 @@ func Start(
 		ctrlMu:                  ctrlMu,
 		cb:                      cb,
 		plan:                    plan,
+		energy:                  energy,
 		topicPrefix:             "forty-two-watts",
 		discoPrefix:             "homeassistant",
 		deviceID:                "forty_two_watts",
@@ -380,17 +400,38 @@ func (b *Bridge) publishDiscovery() {
 
 	// ---- Site-level sensors ----
 	sensors := []struct {
-		id, name, unit, devClass string
-		state                    string
+		id, name, unit, devClass, stateClass string
+		state                                string
 	}{
-		{"grid_power", "Grid Power", "W", "power", b.stateTopic("grid_w")},
-		{"pv_power", "PV Power", "W", "power", b.stateTopic("pv_w")},
-		{"battery_power", "Battery Power", "W", "power", b.stateTopic("bat_w")},
-		{"load_power", "Load Power", "W", "power", b.stateTopic("load_w")},
-		{"battery_soc", "Battery SoC", "%", "battery", b.stateTopic("bat_soc_pct")},
-		{"grid_target", "Grid Target", "W", "power", b.stateTopic("grid_target_w")},
-		{"peak_limit", "Peak Limit", "W", "power", b.stateTopic("peak_limit_w")},
-		{"ev_charging", "EV Charging Power", "W", "power", b.stateTopic("ev_charging_w")},
+		// Real-time power flow
+		{"grid_power", "Grid Power", "W", "power", "measurement", b.stateTopic("grid_w")},
+		{"pv_power", "PV Power", "W", "power", "measurement", b.stateTopic("pv_w")},
+		{"battery_power", "Battery Power", "W", "power", "measurement", b.stateTopic("bat_w")},
+		{"load_power", "Load Power", "W", "power", "measurement", b.stateTopic("load_w")},
+		{"battery_soc", "Battery SoC", "%", "battery", "measurement", b.stateTopic("bat_soc_pct")},
+		// Control setpoints
+		{"grid_target", "Grid Target", "W", "power", "", b.stateTopic("grid_target_w")},
+		{"peak_limit", "Peak Limit", "W", "power", "", b.stateTopic("peak_limit_w")},
+		{"peak_import_ceiling", "Peak Import Ceiling", "W", "power", "", b.stateTopic("peak_import_ceiling_w")},
+		{"ev_charging", "EV Charging Power", "W", "power", "", b.stateTopic("ev_charging_w")},
+		// Forecast from current MPC slot (only populated when plan is wired)
+		{"pv_predicted", "PV Power Predicted", "W", "power", "measurement", b.stateTopic("pv_w_predicted")},
+		{"load_predicted", "Load Power Predicted", "W", "power", "measurement", b.stateTopic("load_w_predicted")},
+		// Per-phase power (site meter, available when driver emits l1_w/l2_w/l3_w)
+		{"phase_1_power", "Phase L1 Power", "W", "power", "measurement", b.stateTopic("phase_1_w")},
+		{"phase_2_power", "Phase L2 Power", "W", "power", "measurement", b.stateTopic("phase_2_w")},
+		{"phase_3_power", "Phase L3 Power", "W", "power", "measurement", b.stateTopic("phase_3_w")},
+		// Per-phase current (site meter, available when driver emits l1_a/l2_a/l3_a)
+		{"phase_1_current", "Phase L1 Current", "A", "current", "measurement", b.stateTopic("phase_1_a")},
+		{"phase_2_current", "Phase L2 Current", "A", "current", "measurement", b.stateTopic("phase_2_a")},
+		{"phase_3_current", "Phase L3 Current", "A", "current", "measurement", b.stateTopic("phase_3_a")},
+		// Today's energy totals (accumulated since midnight, reset daily)
+		{"today_import", "Today Grid Import", "Wh", "energy", "measurement", b.stateTopic("today_import_wh")},
+		{"today_export", "Today Grid Export", "Wh", "energy", "measurement", b.stateTopic("today_export_wh")},
+		{"today_pv", "Today PV Generation", "Wh", "energy", "measurement", b.stateTopic("today_pv_wh")},
+		{"today_bat_charged", "Today Battery Charged", "Wh", "energy", "measurement", b.stateTopic("today_bat_charged_wh")},
+		{"today_bat_discharged", "Today Battery Discharged", "Wh", "energy", "measurement", b.stateTopic("today_bat_discharged_wh")},
+		{"today_load", "Today Load", "Wh", "energy", "measurement", b.stateTopic("today_load_wh")},
 	}
 	for _, s := range sensors {
 		msg := b.withAvail(map[string]any{
@@ -401,6 +442,9 @@ func (b *Bridge) publishDiscovery() {
 			"device_class":        s.devClass,
 			"device":              dev,
 		})
+		if s.stateClass != "" {
+			msg["state_class"] = s.stateClass
+		}
 		data, _ := json.Marshal(msg)
 		topic := fmt.Sprintf("%s/sensor/%s/%s/config", b.discoPrefix, b.deviceID, s.id)
 		b.publish(topic, data, true)
@@ -739,6 +783,7 @@ func (b *Bridge) publishState() {
 	mode := string(b.ctrl.Mode)
 	gridTarget := b.ctrl.GridTargetW
 	peakLimit := b.ctrl.PeakLimitW
+	peakCeiling := b.ctrl.PeakImportCeilingW
 	evCharging := b.ctrl.EVChargingW
 	batteryCoversEV := b.ctrl.BatteryCoversEV
 	planStale := b.ctrl.PlanStale
@@ -776,6 +821,7 @@ func (b *Bridge) publishState() {
 	b.publishValue("bat_soc_pct", avgSoC*100)
 	b.publishValue("grid_target_w", gridTarget)
 	b.publishValue("peak_limit_w", peakLimit)
+	b.publishValue("peak_import_ceiling_w", peakCeiling)
 	b.publishValue("ev_charging_w", evCharging)
 	b.publishString("mode", mode)
 	bceState := "OFF"
@@ -783,6 +829,50 @@ func (b *Bridge) publishState() {
 		bceState = "ON"
 	}
 	b.publishString("battery_covers_ev", bceState)
+
+	// ---- Per-phase power + current (from site meter DerReading.Data) ----
+	if r := b.tel.Get(siteMeter, telemetry.DerMeter); r != nil && len(r.Data) > 0 {
+		var phase struct {
+			L1W *float64 `json:"l1_w"`
+			L2W *float64 `json:"l2_w"`
+			L3W *float64 `json:"l3_w"`
+			L1A *float64 `json:"l1_a"`
+			L2A *float64 `json:"l2_a"`
+			L3A *float64 `json:"l3_a"`
+		}
+		if json.Unmarshal(r.Data, &phase) == nil {
+			if phase.L1W != nil {
+				b.publishValue("phase_1_w", *phase.L1W)
+			}
+			if phase.L2W != nil {
+				b.publishValue("phase_2_w", *phase.L2W)
+			}
+			if phase.L3W != nil {
+				b.publishValue("phase_3_w", *phase.L3W)
+			}
+			if phase.L1A != nil {
+				b.publishValue("phase_1_a", *phase.L1A)
+			}
+			if phase.L2A != nil {
+				b.publishValue("phase_2_a", *phase.L2A)
+			}
+			if phase.L3A != nil {
+				b.publishValue("phase_3_a", *phase.L3A)
+			}
+		}
+	}
+
+	// ---- Today's energy totals (since midnight local time) ----
+	if b.energy != nil {
+		if snap, ok := b.energy.TodayEnergy(); ok {
+			b.publishValue("today_import_wh", snap.ImportWh)
+			b.publishValue("today_export_wh", snap.ExportWh)
+			b.publishValue("today_pv_wh", snap.PVWh)
+			b.publishValue("today_bat_charged_wh", snap.BatChargedWh)
+			b.publishValue("today_bat_discharged_wh", snap.BatDischargedWh)
+			b.publishValue("today_load_wh", snap.LoadWh)
+		}
+	}
 
 	// ---- MPC plan + price + plan-stale ----
 	if b.plan != nil {
@@ -971,6 +1061,7 @@ func (b *Bridge) publishPlan() {
 
 	currentAction := "unavailable"
 	var curBatW, curGridW, curSoCPct float64
+	var curPVW, curLoadW float64
 	var curStart, curEnd string
 	var curPriceOre, curSpotOre, curCostOre, curConfidence float64
 	var curReason, curEMSMode string
@@ -1000,6 +1091,8 @@ func (b *Bridge) publishPlan() {
 			curBatW = a.BatteryW
 			curGridW = a.GridW
 			curSoCPct = a.SoCPct
+			curPVW = a.PVW
+			curLoadW = a.LoadW
 			curStart = start
 			curEnd = end
 			curPriceOre = a.PriceOre
@@ -1061,6 +1154,11 @@ func (b *Bridge) publishPlan() {
 	if d, err := json.Marshal(priceAttrs); err == nil {
 		b.publish(b.stateTopic("price_json"), d, false)
 	}
+
+	// Predicted PV and load from the current MPC slot — exposed as standalone
+	// sensors so HA dashboards can compare forecast vs. actual in real time.
+	b.publishValue("pv_w_predicted", curPVW)
+	b.publishValue("load_w_predicted", curLoadW)
 }
 
 // planActionLabel converts a signed battery power to a human-readable label.


### PR DESCRIPTION
## Summary

Rewrites `go/internal/ha/bridge.go` to publish substantially richer data to Home Assistant. All existing sensors and commands are preserved.

### Reliability
- **LWT (Last Will Testament)**: HA marks all entities unavailable on unclean disconnect; `online` is published before discovery on reconnect.
- **`IsConnectionOpen()` fix**: `teardown()` now uses paho's correct liveness check — prevents a 2-second hang during `ConnectRetry` loops.

### Per-driver health sensors
Each configured driver gets a `<name>_status` sensor + JSON attributes (`consecutive_errors`, `last_error`, `tick_count`, `last_seen`).

### `emit_metric` sensors (lazy discovery)
Any scalar from `host.emit_metric(name, value)` is automatically announced. Unit and device_class are inferred from suffix (`_w`→W, `_c`→°C, `_v`→V, `_a`→A, `_hz`→Hz, `_pct`→%, `_wh`→Wh).

### MPC plan sensor
`plan_json` publishes the current action slot (battery W, grid W, SoC %, price, cost, reason, EMS mode, PV W, load W). `plan_stale` binary_sensor flags when the plan is stale.

### Price sensor
`price_ore` — current spot price in öre/kWh from the MPC plan.

### EV charger and vehicle sensors (lazy discovery)
EV drivers → `ev_w` + `ev_json`. Vehicle drivers → `vehicle_soc_pct` + `vehicle_json`.

### Phase sensors
`phase_1/2/3_power` (W) and `phase_1/2/3_current` (A) from the site-meter driver's raw JSON. Published only when the driver reports phase data.

### Today's energy totals
Six daily Wh accumulators from the DB (`today_import`, `today_export`, `today_pv`, `today_bat_charged`, `today_bat_discharged`, `today_load`) with `state_class: total_increasing` for the HA energy dashboard.

### Peak import ceiling + predicted PV/load
`peak_import_ceiling` sensor + `pv_predicted` / `load_predicted` from the current MPC slot.

## Interface changes

`ha.Start()` gains two injected interfaces (`PlanSource`, `EnergySource`) — adapters live in `main.go` to avoid import cycles.

## Test plan
- [ ] `make test` — all packages green
- [ ] `TestStopAfterFailedConnectDoesNotDeadlock` completes in < 1 s
- [ ] Entities appear in HA under Devices → forty-two-watts
- [ ] Disconnect broker → entities show "unavailable"; reconnect → recover
- [ ] Phase/EV/vehicle/emit_metric sensors appear after first relevant driver poll
- [ ] `plan_stale` flips when MPC hasn't replanned
