### PR TITLE
docs: merge duplicate Pixii diagnostics subsections

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,14 +147,6 @@ Driver-specific fields are parsed by the Lua driver, not by the generic
 config schema. See the driver source and
 [`docs/driver-catalog.md`](driver-catalog.md) for expected keys.
 
-### Pixii Diagnostics
-
-When Troubleshooting mode is enabled from Settings, the Pixii driver emits
-extra SunSpec battery diagnostics: charge status, control mode, battery state,
-vendor state, event bits, and setpoint readback. `charge_status=testing` is
-the useful signal for suspected Pixii calibration/testing sessions that may
-ignore external setpoints.
-
 The same `pplim_release_w` value (when set > 0) also arms a self-
 healing watchdog in the Ferroamp driver. If the SSO reports the
 sticky-pplim signature — DC bus voltage above 200 V, zero PV current,


### PR DESCRIPTION
## What

After the v0.121.0 merge, `docs/configuration.md` had two adjacent Pixii subsections:

- a short pre-existing `### Pixii Diagnostics`
- a richer `### Pixii diagnostics in troubleshooting mode` (added by the V2X/troubleshooting branch)

The richer one fully subsumes the short one — charge status, control mode, battery state, vendor state, event bits and setpoint readback are all documented in its long-format metric list (`battery_charge_status_code`/`ChaSt`, `battery_control_mode_code`, `battery_state_code`, `battery_vendor_state_code`, `battery_event1_bits`, `pixii_setpoint_ems_w`, `pixii_last_command_*`, …).

## Changes

- Removed the duplicate `### Pixii Diagnostics` heading and its now-redundant paragraph. Nothing unique was lost — every signal it mentioned is covered by the richer section's metric list.
- Kept the richer `### Pixii diagnostics in troubleshooting mode` subsection (YAML example + metric list + status-transition notes) intact.
- The Ferroamp `pplim_release_w` self-healing-watchdog paragraphs that happened to live under the old heading were **not** Pixii content — they document the `pplim_release_w` field from the YAML example above. They now sit directly under `## Driver-Specific config`, which reads more coherently ("The same `pplim_release_w` value …" follows the example that introduces it).

Heading convention preserved: `##` for top-level config sections, `###` for subsections.

## Notes

Docs-only change — auto-exempt from the changeset gate.