### PR TITLE
[codex] Add TURN ICE config for remote access

### DIFF
--- a/.changeset/bright-remote-turn.md
+++ b/.changeset/bright-remote-turn.md
@@ -1,5 +1,15 @@
 ---
-"forty-two-watts": patch
+"forty-two-watts": minor
 ---
 
-Improve owner remote access reachability by letting the relay publish shared ICE/TURN configuration for the browser and Pi WebRTC channel, while keeping owner API writes on the fail-closed P2P transport.
+Make owner remote access reachable AND fast. The relay now publishes shared
+ICE/TURN configuration (new `GET /signal/ice`, new `-ice-stun`/`-turn-url`/
+`-turn-secret` flags) so hard-NAT/CGNAT owners can reach their Pi over a
+TURN-relayed DTLS channel, while owner API writes stay on the fail-closed P2P
+transport. Connection setup is also much snappier: the browser no longer arms
+its cooldown on a transient cold-load (directory-not-yet-decrypted) race, both
+ends return from ICE gathering as soon as a usable candidate pair exists
+instead of waiting for full gather, the Pi caches the relay ICE config instead
+of refetching it per offer, and the Pi resolves the browser's mDNS host
+candidates so two devices on the same LAN connect directly without a STUN/WAN
+round-trip.

--- a/.changeset/bright-remote-turn.md
+++ b/.changeset/bright-remote-turn.md
@@ -6,10 +6,15 @@ Make owner remote access reachable AND fast. The relay now publishes shared
 ICE/TURN configuration (new `GET /signal/ice`, new `-ice-stun`/`-turn-url`/
 `-turn-secret` flags) so hard-NAT/CGNAT owners can reach their Pi over a
 TURN-relayed DTLS channel, while owner API writes stay on the fail-closed P2P
-transport. Connection setup is also much snappier: the browser no longer arms
-its cooldown on a transient cold-load (directory-not-yet-decrypted) race, both
-ends return from ICE gathering as soon as a usable candidate pair exists
-instead of waiting for full gather, the Pi caches the relay ICE config instead
-of refetching it per offer, and the Pi resolves the browser's mDNS host
-candidates so two devices on the same LAN connect directly without a STUN/WAN
-round-trip.
+transport.
+
+Connection setup is also much snappier. The browser no longer arms its retry
+cooldown on a transient cold-load (directory-not-yet-decrypted) race — the
+single biggest contributor to the old multi-second "Reaching your home" stall —
+and both ends now POST their offer/answer as soon as a usable candidate set is
+gathered (host + server-reflexive, plus a relay candidate when TURN is
+configured so symmetric-NAT owners still traverse) instead of waiting for full
+ICE gathering. The Pi caches the relay ICE config and refreshes it hourly
+instead of refetching it on every offer, retries use exponential backoff, and a
+transient `/signal/ice` failure reuses the last good config instead of silently
+dropping TURN.

--- a/.changeset/bright-remote-turn.md
+++ b/.changeset/bright-remote-turn.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Improve owner remote access reachability by letting the relay publish shared ICE/TURN configuration for the browser and Pi WebRTC channel, while keeping owner API writes on the fail-closed P2P transport.

--- a/docs/relay-deploy.md
+++ b/docs/relay-deploy.md
@@ -159,6 +159,21 @@ sudo systemctl status ftw-relay
 root. The `ReadOnlyPaths` line means a relay compromise still cannot
 overwrite cert or key.
 
+### ICE / TURN for owner remote access
+
+`home.fortytwowatts.com` owner traffic uses a signed WebRTC DataChannel. Direct STUN works on many networks, but hard NAT / CGNAT / cellular paths need TURN for the feature to be usable. Configure TURN on the relay, not in the browser bundle:
+
+```bash
+Environment=FTW_TURN_SECRET=shared-with-coturn
+ExecStart=/usr/local/bin/ftw-relay \
+  -addr :443 \
+  -cert /etc/ssl/relay/cert.pem \
+  -key /etc/ssl/relay/key.pem \
+  -turn-url turn:relay.fortytwowatts.com:3478?transport=udp,turns:relay.fortytwowatts.com:5349
+```
+
+The relay serves `GET /signal/ice` with the default STUN URL plus short-lived coturn REST credentials derived from `FTW_TURN_SECRET` or `-turn-secret`. The browser and Pi both fetch this before WebRTC setup. TURN relays DTLS ciphertext only; the Pi-signed DTLS fingerprint remains the trust check.
+
 ## Verify end-to-end
 
 From your laptop:

--- a/docs/relay-deploy.md
+++ b/docs/relay-deploy.md
@@ -161,18 +161,163 @@ overwrite cert or key.
 
 ### ICE / TURN for owner remote access
 
-`home.fortytwowatts.com` owner traffic uses a signed WebRTC DataChannel. Direct STUN works on many networks, but hard NAT / CGNAT / cellular paths need TURN for the feature to be usable. Configure TURN on the relay, not in the browser bundle:
+`home.fortytwowatts.com` owner traffic uses a signed WebRTC DataChannel. Direct
+STUN works on many networks, but hard NAT / CGNAT / cellular paths need TURN for
+the feature to be usable. The relay serves `GET /signal/ice` (STUN URL + a
+short-lived coturn REST credential derived from `FTW_TURN_SECRET`); the browser
+and Pi both fetch it before WebRTC setup. TURN relays DTLS ciphertext only — the
+Pi-signed DTLS fingerprint remains the trust check, so a hostile TURN can read or
+drop ciphertext but never MITM.
+
+This needs a TURN server. We self-host coturn. The runbook below stands one up.
+
+> **Pending site decisions** (marked `<…>`): the relay VM's public IP, and the
+> TLS path for `turns:` (reuse the CF Origin cert if its SAN is a wildcard, else
+> issue a Let's Encrypt cert for `turn.*`). Fill them before running.
+
+#### 1. DNS — a dedicated, grey-cloud TURN host
+
+TURN media (UDP/TCP 3478, TLS 5349, and a high UDP relay range) **cannot
+traverse Cloudflare's HTTP proxy**. coturn must be reachable on a real public IP.
+Add `turn.fortytwowatts.com` as an **A record with proxy status _DNS only_ (grey
+cloud)** → the relay VM's public IP. Leave `relay.fortytwowatts.com` orange-cloud
+(its HTTPS is unchanged). An orange cloud on `turn.*` silently breaks TURN.
+
+#### 2. coturn `/etc/turnserver.conf` (REST-API mode)
 
 ```bash
-Environment=FTW_TURN_SECRET=shared-with-coturn
+sudo apt-get install -y coturn
+sudo sed -i 's/^#TURNSERVER_ENABLED=1/TURNSERVER_ENABLED=1/' /etc/default/coturn
+openssl rand -hex 32   # -> TURN_SECRET; store it, it must equal FTW_TURN_SECRET
+```
+
+```ini
+# /etc/turnserver.conf
+listening-port=3478
+tls-listening-port=5349
+listening-ip=<PUBLIC_IP>
+external-ip=<PUBLIC_IP>            # or <PUBLIC_IP>/<PRIVATE_IP> behind 1:1 NAT
+min-port=49152
+max-port=65535
+
+# REST API shared secret — MUST byte-for-byte equal the relay's FTW_TURN_SECRET.
+use-auth-secret
+static-auth-secret=<TURN_SECRET>
+realm=turn.fortytwowatts.com
+
+# TLS for turns:5349 (see step 4 for which cert)
+cert=/etc/coturn/cert.pem
+pkey=/etc/coturn/key.pem
+no-tlsv1
+no-tlsv1_1
+fingerprint
+
+# SSRF guard: a public TURN must NEVER relay into private space / cloud metadata.
+no-multicast-peers
+denied-peer-ip=0.0.0.0-0.255.255.255
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=100.64.0.0-100.127.255.255
+denied-peer-ip=127.0.0.0-127.255.255.255
+denied-peer-ip=169.254.0.0-169.254.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+denied-peer-ip=::1
+denied-peer-ip=fc00::-fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+denied-peer-ip=fe80::-febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff
+
+# Anti-abuse quotas (a public TURN is an open-relay magnet). Tune to the VM.
+total-quota=200
+user-quota=12
+bps-capacity=6250000   # ~50 Mbit/s server-wide
+max-bps=500000         # ~4 Mbit/s per allocation
+no-tcp-relay
+no-cli
+```
+
+`use-auth-secret` + `static-auth-secret` is the exact dual of the relay's
+`HMAC-SHA1(secret, expiry)` / base64 scheme — do **not** also set `lt-cred-mech`
+or a `userdb`. The `denied-peer-ip` list is the critical hardening: `/signal/ice`
+is unauthenticated, so anyone can mint a 12 h credential; without the deny-list
+they could relay into `169.254.169.254` or the VPC.
+
+#### 3. Firewall — direct, not via Cloudflare
+
+| Port / range | Proto | Cloudflare? |
+|---|---|---|
+| 3478 | UDP + TCP | **NO — direct to coturn** |
+| 5349 | TCP (TLS) | **NO — direct** |
+| 49152–65535 | UDP (relay range) | **NO — direct** |
+| 443 | TCP (relay HTTPS) | YES (orange cloud, unchanged) |
+
+Open these on both the host firewall and the cloud security group. Keep the TURN
+ports open to `0.0.0.0/0` — clients are arbitrary browsers/Pis, not CF edges, so
+do **not** extend any "CF-ranges-only" rule (that lock is for `:443` only). The
+`denied-peer-ip` list + quotas are the protection on the TURN ports.
+
+#### 4. TLS for `turns:5349`
+
+coturn drops to the `turnserver` user and can't read `/etc/ssl/relay`. Either
+reuse the relay's CF Origin cert **if** its SAN is a wildcard
+(`openssl x509 -in /etc/ssl/relay/cert.pem -noout -text | grep -A1 'Alternative Name'`),
+or issue a browser-trusted Let's Encrypt cert (the grey-cloud `turn.*` makes
+HTTP-01/DNS-01 work directly). Install as `/etc/coturn/{cert,key}.pem` owned by
+`turnserver`. coturn does **not** auto-reload certs — on LE renewal, add a
+`renewal-hooks/deploy` script that re-installs them and `systemctl restart coturn`.
+
+#### 5. Relay systemd — secret via EnvironmentFile (not argv)
+
+```bash
+sudo install -m 0600 /dev/null /etc/ftw-relay.env
+printf 'FTW_TURN_SECRET=%s\n' '<TURN_SECRET>' | sudo tee /etc/ftw-relay.env >/dev/null
+```
+
+Add to the `ftw-relay` unit that serves `home.*` (the multi-tenant unit if that's
+the one fronting the home route). `FTW_TURN_SECRET` is the default source for
+`-turn-secret`, so do **not** pass the secret on the command line (it would leak
+into `ps`):
+
+```ini
+EnvironmentFile=/etc/ftw-relay.env
 ExecStart=/usr/local/bin/ftw-relay \
   -addr :443 \
   -cert /etc/ssl/relay/cert.pem \
-  -key /etc/ssl/relay/key.pem \
-  -turn-url turn:relay.fortytwowatts.com:3478?transport=udp,turns:relay.fortytwowatts.com:5349
+  -key  /etc/ssl/relay/key.pem \
+  -ice-stun stun:stun.l.google.com:19302 \
+  -turn-url turn:turn.fortytwowatts.com:3478?transport=udp,turns:turn.fortytwowatts.com:5349
 ```
 
-The relay serves `GET /signal/ice` with the default STUN URL plus short-lived coturn REST credentials derived from `FTW_TURN_SECRET` or `-turn-secret`. The browser and Pi both fetch this before WebRTC setup. TURN relays DTLS ciphertext only; the Pi-signed DTLS fingerprint remains the trust check.
+```bash
+sudo systemctl daemon-reload && sudo systemctl restart ftw-relay
+```
+
+#### 6. Verify
+
+Order: DNS grey-cloud → coturn up → relay secret + restart → check `/signal/ice`
+→ browser test from off-net.
+
+```bash
+# 1. The relay now advertises a TURN entry:
+curl -s https://home.fortytwowatts.com/signal/ice | jq .
+#    -> expect a stun entry AND a turn entry with username/credential/ttl.
+
+# 2. Prove coturn accepts the relay-minted credential (lift it from the JSON):
+ICE=$(curl -s https://home.fortytwowatts.com/signal/ice)
+U=$(echo "$ICE" | jq -r '.ice_servers[]|select(.username)|.username')
+C=$(echo "$ICE" | jq -r '.ice_servers[]|select(.credential)|.credential')
+turnutils_uclient -v -u "$U" -w "$C" turn.fortytwowatts.com        # UDP
+turnutils_uclient -v -S -u "$U" -w "$C" -p 5349 turn.fortytwowatts.com  # TLS
+#    401 = secret mismatch; 403 to a private target = SSRF deny working.
+
+# 3. Browser: https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/
+#    add turn:turn.fortytwowatts.com:3478?transport=udp with $U/$C, Gather
+#    candidates, and confirm a candidate of type "relay" appears.
+```
+
+Then log in to `home.fortytwowatts.com` from a **cellular / hard-NAT** network
+(STUN alone covers same-LAN) and confirm the owner channel connects.
+
+To roll back, drop `-turn-url` from `ExecStart` and restart — the relay falls
+back to STUN-only (the TURN entry is gated on `len(TURNURLs)>0 && TURNSecret!=""`).
 
 ## Verify end-to-end
 

--- a/go/cmd/forty-two-watts/owner_signal_ice_test.go
+++ b/go/cmd/forty-two-watts/owner_signal_ice_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/p2p"
+)
+
+// fakeICESetter records SetICEServers pushes so the refresh helper can be tested
+// without standing up a full p2p.Manager.
+type fakeICESetter struct {
+	calls [][]p2p.ICEServer
+}
+
+func (f *fakeICESetter) SetICEServers(ice []p2p.ICEServer) { f.calls = append(f.calls, ice) }
+
+func TestRefreshSignalICE_SetsServersOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/signal/ice" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ice_servers":[{"urls":["stun:s.example:3478"]},{"urls":["turn:t.example:3478?transport=udp"],"username":"u","credential":"c"}]}`))
+	}))
+	defer srv.Close()
+
+	setter := &fakeICESetter{}
+	refreshSignalICE(context.Background(), srv.Client(), srv.URL, "host-1", setter)
+
+	if len(setter.calls) != 1 {
+		t.Fatalf("SetICEServers calls = %d, want 1", len(setter.calls))
+	}
+	got := setter.calls[0]
+	if len(got) != 2 {
+		t.Fatalf("ice servers = %d, want 2", len(got))
+	}
+	if got[1].Username != "u" || got[1].Credential != "c" || len(got[1].URLs) != 1 {
+		t.Fatalf("unexpected TURN entry: %+v", got[1])
+	}
+}
+
+func TestRefreshSignalICE_LeavesPriorOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	setter := &fakeICESetter{}
+	refreshSignalICE(context.Background(), srv.Client(), srv.URL, "host-1", setter)
+
+	if len(setter.calls) != 0 {
+		t.Fatalf("SetICEServers must NOT be called on a non-200 response; got %d calls", len(setter.calls))
+	}
+}

--- a/go/cmd/forty-two-watts/owner_signal_loop.go
+++ b/go/cmd/forty-two-watts/owner_signal_loop.go
@@ -10,6 +10,7 @@ import (
 	neturl "net/url"
 	"time"
 
+	"github.com/frahlg/forty-two-watts/go/internal/p2p"
 	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
 )
 
@@ -40,6 +41,10 @@ const maxSignalBodyBytes = 64 << 10
 type p2pAnswerer interface {
 	Answer(ctx context.Context, offerSDP string, replayHeaders http.Header) (string, error)
 	SignFingerprint(answerSDP string) (sig string, tsMs int64)
+}
+
+type p2pICESetter interface {
+	SetICEServers([]p2p.ICEServer)
 }
 
 // pollSecretSource yields the current relay-minted poll token. *tunnel.Host
@@ -138,6 +143,13 @@ const signalNonceHeaderClient = "X-FTW-Signal-Nonce"
 // handleSignalOffer answers one offer and parks the signed answer under the same
 // nonce the offer was drained with.
 func handleSignalOffer(ctx context.Context, client *http.Client, relayURL, hostID, tunnelMarker, offerSDP, nonce string, p2p p2pAnswerer, polls pollSecretSource) {
+	if setter, ok := p2p.(p2pICESetter); ok {
+		if ice, err := fetchSignalICE(ctx, client, relayURL); err == nil && len(ice) > 0 {
+			setter.SetICEServers(ice)
+		} else if err != nil && ctx.Err() == nil {
+			slog.Warn("owner-access: fetch signal ICE config failed", "err", err, "host_id", hostID)
+		}
+	}
 	// FAIL-CLOSED replay headers: stamp the per-process tunnel marker so every
 	// DataChannel frame is REMOTE (the gate can never grant it LAN-bypass), and
 	// inject NO cookie — the channel is unauthenticated until the browser logs in
@@ -162,6 +174,30 @@ func handleSignalOffer(ctx context.Context, client *http.Client, relayURL, hostI
 			slog.Warn("owner-access: post signal answer failed", "err", err, "host_id", hostID)
 		}
 	}
+}
+
+type signalICEWire struct {
+	ICEServers []p2p.ICEServer `json:"ice_servers"`
+}
+
+func fetchSignalICE(ctx context.Context, client *http.Client, relayURL string) ([]p2p.ICEServer, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, relayURL+"/signal/ice", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &signalHTTPError{status: resp.StatusCode}
+	}
+	var out signalICEWire
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxSignalBodyBytes)).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.ICEServers, nil
 }
 
 func postSignalAnswer(ctx context.Context, client *http.Client, relayURL, hostID, nonce, pollSecret string, body []byte) error {

--- a/go/cmd/forty-two-watts/owner_signal_loop.go
+++ b/go/cmd/forty-two-watts/owner_signal_loop.go
@@ -69,6 +69,31 @@ type signalAnswerWire struct {
 // retried with a short backoff so a relay blip never kills the loop.
 func runOwnerSignalLoop(ctx context.Context, relayURL, hostID, tunnelMarker string, p2p p2pAnswerer, polls pollSecretSource) {
 	client := &http.Client{Timeout: 35 * time.Second}
+
+	// The relay's ICE/TURN config (a STUN URL plus a short-lived coturn
+	// credential) changes at most every few hours, so fetch it ONCE in the
+	// background and refresh on a timer rather than re-fetching on every offer —
+	// the per-offer fetch kept an extra relay round-trip on the critical path of
+	// every connect. The Manager is already seeded with STUN at construction, so
+	// an offer landing in the brief window before the first fetch still works; it
+	// just lacks TURN until the background fetch sets it. The relay credential TTL
+	// is 12h (turnCredentialTTL), so an hourly refresh keeps it comfortably fresh.
+	if setter, ok := p2p.(p2pICESetter); ok {
+		go func() {
+			refreshSignalICE(ctx, client, relayURL, hostID, setter)
+			t := time.NewTicker(time.Hour)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					refreshSignalICE(ctx, client, relayURL, hostID, setter)
+				}
+			}
+		}()
+	}
+
 	for {
 		if ctx.Err() != nil {
 			return
@@ -143,13 +168,6 @@ const signalNonceHeaderClient = "X-FTW-Signal-Nonce"
 // handleSignalOffer answers one offer and parks the signed answer under the same
 // nonce the offer was drained with.
 func handleSignalOffer(ctx context.Context, client *http.Client, relayURL, hostID, tunnelMarker, offerSDP, nonce string, p2p p2pAnswerer, polls pollSecretSource) {
-	if setter, ok := p2p.(p2pICESetter); ok {
-		if ice, err := fetchSignalICE(ctx, client, relayURL); err == nil && len(ice) > 0 {
-			setter.SetICEServers(ice)
-		} else if err != nil && ctx.Err() == nil {
-			slog.Warn("owner-access: fetch signal ICE config failed", "err", err, "host_id", hostID)
-		}
-	}
 	// FAIL-CLOSED replay headers: stamp the per-process tunnel marker so every
 	// DataChannel frame is REMOTE (the gate can never grant it LAN-bypass), and
 	// inject NO cookie — the channel is unauthenticated until the browser logs in
@@ -178,6 +196,22 @@ func handleSignalOffer(ctx context.Context, client *http.Client, relayURL, hostI
 
 type signalICEWire struct {
 	ICEServers []p2p.ICEServer `json:"ice_servers"`
+}
+
+// refreshSignalICE fetches the relay ICE/TURN config once and pushes it onto the
+// Manager. Best-effort: on error the Manager keeps its existing (seeded or
+// previously-fetched) set, so a relay blip never leaves us without STUN.
+func refreshSignalICE(ctx context.Context, client *http.Client, relayURL, hostID string, setter p2pICESetter) {
+	ice, err := fetchSignalICE(ctx, client, relayURL)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Warn("owner-access: fetch signal ICE config failed", "err", err, "host_id", hostID)
+		}
+		return
+	}
+	if len(ice) > 0 {
+		setter.SetICEServers(ice)
+	}
 }
 
 func fetchSignalICE(ctx context.Context, client *http.Client, relayURL string) ([]p2p.ICEServer, error) {

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -80,15 +80,17 @@ func validPairToken(s string) bool {
 
 // Relay is the in-memory state for one running relay process.
 type Relay struct {
-	Queue       *tunnel.Queue
-	Tokens      *TokenRegistry
-	Owners      *OwnerRegistry
-	Polls       *PollSecrets
-	Signals     *SignalMailbox    // blind WebRTC signaling rendezvous (P2P-only home route)
-	Challenges  *SignalChallenges // single-use device-key proof nonces for the signaling offer (C2)
-	OfferLimit  *IPRateLimiter    // per-source-IP throttle on browser signaling offers (FIX-C)
-	TrustCFIP   bool              // honour CF-Connecting-IP from validated Cloudflare peers (-trust-cf-ip)
-	PollTimeout time.Duration     // 0 → 25s default
+	Queue      *tunnel.Queue
+	Tokens     *TokenRegistry
+	Owners     *OwnerRegistry
+	Polls      *PollSecrets
+	Signals    *SignalMailbox    // blind WebRTC signaling rendezvous (P2P-only home route)
+	Challenges *SignalChallenges // single-use device-key proof nonces for the signaling offer (C2)
+	OfferLimit *IPRateLimiter    // per-source-IP throttle on browser signaling offers (FIX-C)
+	ICELimit   *IPRateLimiter    // SEPARATE per-source-IP throttle on GET /signal/ice so an ICE
+	// fetch never spends an offer token (avoids halving the offer burst)
+	TrustCFIP   bool          // honour CF-Connecting-IP from validated Cloudflare peers (-trust-cf-ip)
+	PollTimeout time.Duration // 0 → 25s default
 	// HomeHost, when set, maps a bare host (e.g. home.fortytwowatts.com) to
 	// the single owner Pi registered under HomeSite — forwarding every path
 	// verbatim (no /me/<site_id> prefix) so the dashboard's absolute asset
@@ -174,6 +176,13 @@ func (r *Relay) Handler() http.Handler {
 		// (FIX-C): bounds one abusive IP without letting it lock out a legit browser
 		// on a different IP (which the old per-site limit did).
 		r.OfferLimit = newIPRateLimiter(offerBucketCapacity, offerBucketRefillPerSec)
+	}
+	if r.ICELimit == nil {
+		// SEPARATE bucket for GET /signal/ice (the TURN-credential mint) so an ICE
+		// fetch never draws down the offer burst — both the browser (once per connect)
+		// and the Pi (hourly) hit it, and a connect spends an ICE token AND an offer
+		// token. A more generous bucket keeps a legit reconnect loop from 429ing.
+		r.ICELimit = newIPRateLimiter(iceBucketCapacity, iceBucketRefillPerSec)
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", r.healthz)

--- a/go/cmd/ftw-relay/handlers.go
+++ b/go/cmd/ftw-relay/handlers.go
@@ -114,6 +114,11 @@ type Relay struct {
 	// still works. On → an offer must carry a verified device-key proof or the Pi
 	// is never contacted. Flip on only once device-keys are enrolled.
 	RequireDeviceKey bool
+	// ICEStunURLs/TURNURLs are public connectivity hints for the signed
+	// browser<->Pi WebRTC channel. TURN only relays DTLS ciphertext.
+	ICEStunURLs []string
+	TURNURLs    []string
+	TURNSecret  string
 	// MultiTenant switches the home host from the single-tenant pin
 	// (-home-site/-home-pubkey) to the public multi-tenant front door:
 	// anonymous home.* serves only the relay-disk bootstrap loader; after the
@@ -221,6 +226,7 @@ func (r *Relay) Handler() http.Handler {
 	// /me/<site> forwarders were removed in the P2P-only cutover, slice 6). Owner
 	// data exists ONLY as DTLS DataChannel frames now.
 	mux.HandleFunc("POST /me/register", r.meRegister)
+	mux.HandleFunc("GET /signal/ice", r.signalICE)
 
 	// Home-host cutover: a bare host (home.fortytwowatts.com) serves the stable
 	// public bootstrap at the root. In multi-tenant mode the dashboard's STATIC
@@ -237,6 +243,7 @@ func (r *Relay) Handler() http.Handler {
 	// (The Pi's /signal/{host}/* routes need no host pin: the Pi dials the relay by
 	// its own host, not the home host.)
 	if r.HomeHost != "" && (r.HomeSite != "" || r.MultiTenant) {
+		mux.HandleFunc("GET "+r.HomeHost+"/signal/ice", r.signalICE)
 		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/challenge", r.signalChallenge)
 		mux.HandleFunc("POST "+r.HomeHost+"/signal/{site_id}/offer", r.signalBrowserOffer)
 		mux.HandleFunc("GET "+r.HomeHost+"/signal/{site_id}/answer", r.signalBrowserAnswer)

--- a/go/cmd/ftw-relay/ice.go
+++ b/go/cmd/ftw-relay/ice.go
@@ -41,7 +41,17 @@ func parseURLList(v string) []string {
 // signalICE publishes the ICE config browsers and Pis should use for the
 // signed WebRTC channel. TURN credentials follow coturn's REST API scheme:
 // username is an expiry timestamp and credential is HMAC-SHA1(secret, username).
-func (r *Relay) signalICE(w http.ResponseWriter, _ *http.Request) {
+//
+// Unauthenticated by design (a public reachability hint), but per-source-IP
+// throttled with the SAME limiter as the offer endpoint: the TURN entry mints a
+// fresh short-lived coturn credential on every call, so without a bound a single
+// IP could pull credentials in a tight loop and lean on the relay. offerClientIP
+// uses the un-spoofable RemoteAddr unless -trust-cf-ip validates a CF edge peer.
+func (r *Relay) signalICE(w http.ResponseWriter, req *http.Request) {
+	if r.OfferLimit != nil && !r.OfferLimit.Allow(r.offerClientIP(req)) {
+		http.Error(w, "too many requests from your address", http.StatusTooManyRequests)
+		return
+	}
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "application/json")

--- a/go/cmd/ftw-relay/ice.go
+++ b/go/cmd/ftw-relay/ice.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const turnCredentialTTL = 12 * time.Hour
+
+type iceServerWire struct {
+	URLs       []string `json:"urls"`
+	Username   string   `json:"username,omitempty"`
+	Credential string   `json:"credential,omitempty"`
+	TTL        int      `json:"ttl,omitempty"`
+}
+
+type signalICEWire struct {
+	ICEServers []iceServerWire `json:"ice_servers"`
+}
+
+func parseURLList(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// signalICE publishes the ICE config browsers and Pis should use for the
+// signed WebRTC channel. TURN credentials follow coturn's REST API scheme:
+// username is an expiry timestamp and credential is HMAC-SHA1(secret, username).
+func (r *Relay) signalICE(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+
+	var out signalICEWire
+	if len(r.ICEStunURLs) > 0 {
+		out.ICEServers = append(out.ICEServers, iceServerWire{URLs: append([]string(nil), r.ICEStunURLs...)})
+	}
+	if len(r.TURNURLs) > 0 && r.TURNSecret != "" {
+		username := strconv.FormatInt(time.Now().Add(turnCredentialTTL).Unix(), 10)
+		mac := hmac.New(sha1.New, []byte(r.TURNSecret))
+		_, _ = mac.Write([]byte(username))
+		out.ICEServers = append(out.ICEServers, iceServerWire{
+			URLs:       append([]string(nil), r.TURNURLs...),
+			Username:   username,
+			Credential: base64.StdEncoding.EncodeToString(mac.Sum(nil)),
+			TTL:        int(turnCredentialTTL.Seconds()),
+		})
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/go/cmd/ftw-relay/ice.go
+++ b/go/cmd/ftw-relay/ice.go
@@ -43,12 +43,13 @@ func parseURLList(v string) []string {
 // username is an expiry timestamp and credential is HMAC-SHA1(secret, username).
 //
 // Unauthenticated by design (a public reachability hint), but per-source-IP
-// throttled with the SAME limiter as the offer endpoint: the TURN entry mints a
-// fresh short-lived coturn credential on every call, so without a bound a single
-// IP could pull credentials in a tight loop and lean on the relay. offerClientIP
-// uses the un-spoofable RemoteAddr unless -trust-cf-ip validates a CF edge peer.
+// throttled: the TURN entry mints a fresh short-lived coturn credential on every
+// call, so without a bound a single IP could pull credentials in a tight loop and
+// lean on the relay. Uses its OWN limiter (ICELimit), not the offer bucket, so an
+// ICE fetch never spends an offer token. offerClientIP uses the un-spoofable
+// RemoteAddr unless -trust-cf-ip validates a CF edge peer.
 func (r *Relay) signalICE(w http.ResponseWriter, req *http.Request) {
-	if r.OfferLimit != nil && !r.OfferLimit.Allow(r.offerClientIP(req)) {
+	if r.ICELimit != nil && !r.ICELimit.Allow(r.offerClientIP(req)) {
 		http.Error(w, "too many requests from your address", http.StatusTooManyRequests)
 		return
 	}

--- a/go/cmd/ftw-relay/ice_test.go
+++ b/go/cmd/ftw-relay/ice_test.go
@@ -98,3 +98,35 @@ func TestSignalICE_HomeHostRoute(t *testing.T) {
 		t.Fatalf("home-host /signal/ice status = %d, want 200", rr.Code)
 	}
 }
+
+// TestSignalICE_PerIPThrottle guards the per-source-IP rate limit on the
+// otherwise-unauthenticated /signal/ice: it mints a fresh coturn credential on
+// every call, so a single IP must not be able to pull them in an unbounded loop.
+func TestSignalICE_PerIPThrottle(t *testing.T) {
+	r := &Relay{
+		ICEStunURLs: []string{"stun:one.example:19302"},
+		TURNURLs:    []string{"turn:relay.example:3478?transport=udp"},
+		TURNSecret:  "shared-with-coturn",
+	}
+	h := r.Handler() // one handler so all requests share r.OfferLimit
+
+	var first, throttled int
+	for i := 0; i < int(offerBucketCapacity)+8; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/signal/ice", nil)
+		req.RemoteAddr = "203.0.113.9:5555" // same source IP for every request
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if i == 0 {
+			first = rr.Code
+		}
+		if rr.Code == http.StatusTooManyRequests {
+			throttled++
+		}
+	}
+	if first != http.StatusOK {
+		t.Fatalf("first request = %d, want 200", first)
+	}
+	if throttled == 0 {
+		t.Fatalf("expected at least one 429 once the per-IP burst was exhausted, got none")
+	}
+}

--- a/go/cmd/ftw-relay/ice_test.go
+++ b/go/cmd/ftw-relay/ice_test.go
@@ -111,7 +111,7 @@ func TestSignalICE_PerIPThrottle(t *testing.T) {
 	h := r.Handler() // one handler so all requests share r.OfferLimit
 
 	var first, throttled int
-	for i := 0; i < int(offerBucketCapacity)+8; i++ {
+	for i := 0; i < int(iceBucketCapacity)+8; i++ {
 		req := httptest.NewRequest(http.MethodGet, "/signal/ice", nil)
 		req.RemoteAddr = "203.0.113.9:5555" // same source IP for every request
 		rr := httptest.NewRecorder()

--- a/go/cmd/ftw-relay/ice_test.go
+++ b/go/cmd/ftw-relay/ice_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSignalICE_DefaultSTUNOnly(t *testing.T) {
+	r := &Relay{ICEStunURLs: []string{"stun:one.example:19302"}}
+	req := httptest.NewRequest(http.MethodGet, "/signal/ice", nil)
+	rr := httptest.NewRecorder()
+
+	r.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	var out signalICEWire
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ICEServers) != 1 {
+		t.Fatalf("ice servers = %d, want 1", len(out.ICEServers))
+	}
+	if got := out.ICEServers[0].URLs; len(got) != 1 || got[0] != "stun:one.example:19302" {
+		t.Fatalf("stun urls = %v", got)
+	}
+	if out.ICEServers[0].Username != "" || out.ICEServers[0].Credential != "" {
+		t.Fatalf("STUN entry should not carry TURN credentials: %+v", out.ICEServers[0])
+	}
+}
+
+func TestSignalICE_TURNRestCredentials(t *testing.T) {
+	r := &Relay{
+		ICEStunURLs: []string{"stun:one.example:19302"},
+		TURNURLs:    []string{"turn:relay.example:3478?transport=udp", "turns:relay.example:5349"},
+		TURNSecret:  "shared-with-coturn",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/signal/ice", nil)
+	rr := httptest.NewRecorder()
+
+	r.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var out signalICEWire
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.ICEServers) != 2 {
+		t.Fatalf("ice servers = %d, want STUN + TURN", len(out.ICEServers))
+	}
+	turn := out.ICEServers[1]
+	if len(turn.URLs) != 2 || turn.URLs[0] != "turn:relay.example:3478?transport=udp" || turn.URLs[1] != "turns:relay.example:5349" {
+		t.Fatalf("turn urls = %v", turn.URLs)
+	}
+	if turn.TTL != int(turnCredentialTTL.Seconds()) {
+		t.Fatalf("ttl = %d, want %d", turn.TTL, int(turnCredentialTTL.Seconds()))
+	}
+	exp, err := strconv.ParseInt(turn.Username, 10, 64)
+	if err != nil {
+		t.Fatalf("username should be unix expiry: %v", err)
+	}
+	expiry := time.Unix(exp, 0)
+	if expiry.Before(time.Now().Add(turnCredentialTTL-time.Minute)) || expiry.After(time.Now().Add(turnCredentialTTL+time.Minute)) {
+		t.Fatalf("expiry = %s, want about %s from now", expiry, turnCredentialTTL)
+	}
+	mac := hmac.New(sha1.New, []byte("shared-with-coturn"))
+	_, _ = mac.Write([]byte(turn.Username))
+	if want := base64.StdEncoding.EncodeToString(mac.Sum(nil)); turn.Credential != want {
+		t.Fatalf("credential HMAC mismatch")
+	}
+}
+
+func TestSignalICE_HomeHostRoute(t *testing.T) {
+	r := &Relay{
+		HomeHost:    "home.example.test",
+		HomeSite:    "site:Home",
+		ICEStunURLs: []string{"stun:home.example:19302"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://home.example.test/signal/ice", nil)
+	rr := httptest.NewRecorder()
+
+	r.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("home-host /signal/ice status = %d, want 200", rr.Code)
+	}
+}

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -34,6 +34,9 @@ func main() {
 	requireDeviceKey := flag.Bool("require-device-key", false, "ENFORCE the device-key signaling gate (C2): an offer must carry a verified device-key proof or the Pi is never contacted. Off (default) keeps the pre-C2 behaviour so the relay can serve the shell + identity (slices 1+2) while a home Pi that doesn't yet publish device-keys keeps working. Turn on once device-keys are enrolled.")
 	homeAllowTOFU := flag.Bool("home-allow-tofu", false, "allow the home host to run WITHOUT -home-pubkey (trust-on-first-use); insecure across relay restarts — testing only")
 	trustCFIP := flag.Bool("trust-cf-ip", false, "behind Cloudflare: trust CF-Connecting-IP for the per-IP signaling throttle, but ONLY from validated Cloudflare edge peers (else the throttle keys on the shared CF edge IP). Also firewall the origin to Cloudflare's ranges.")
+	iceStun := flag.String("ice-stun", "stun:stun.l.google.com:19302", "comma-separated STUN URLs published from /signal/ice; empty disables STUN")
+	turnURL := flag.String("turn-url", "", "comma-separated TURN URLs published from /signal/ice (e.g. turn:relay.example:3478?transport=udp)")
+	turnSecret := flag.String("turn-secret", os.Getenv("FTW_TURN_SECRET"), "coturn static-auth-secret used to mint short-lived TURN REST credentials; may also be set with FTW_TURN_SECRET")
 	multiTenant := flag.Bool("multi-tenant", false, "public multi-tenant home route: home.* serves only a tiny relay-disk loader until the browser decrypts its directory; dashboard static GETs then forward to the selected Pi, while owner data stays P2P. Requires -home-web; -require-device-key remains an optional extra gate; -home-site/-home-pubkey become no-ops.")
 	walletBlobDir := flag.String("wallet-blob-dir", "", "directory holding the per-wallet encrypted directory blobs (one <user_handle>.blob file each). Required under -multi-tenant; the one piece of durable relay state. The relay never decrypts the contents.")
 	walletBlobMaxBytes := flag.Int("wallet-blob-max-bytes", 65536, "per-wallet ciphertext byte cap; a PUT over this is rejected 413 so a hostile client can't grow the blob store without bound")
@@ -114,6 +117,9 @@ func main() {
 		HomeWeb:          *homeWeb,
 		HomePubKey:       *homePubKey,
 		RequireDeviceKey: *requireDeviceKey,
+		ICEStunURLs:      parseURLList(*iceStun),
+		TURNURLs:         parseURLList(*turnURL),
+		TURNSecret:       *turnSecret,
 		MultiTenant:      *multiTenant,
 		WalletBlobs:      walletBlobs,
 		Bootstrap:        bootstrap,

--- a/go/cmd/ftw-relay/main.go
+++ b/go/cmd/ftw-relay/main.go
@@ -184,6 +184,11 @@ func main() {
 						slog.Info("ftw-relay: offer-limit GC", "removed", n)
 					}
 				}
+				if r.ICELimit != nil {
+					if n := r.ICELimit.GC(offerBucketIdleTTL); n > 0 {
+						slog.Info("ftw-relay: ice-limit GC", "removed", n)
+					}
+				}
 				// Reap expired first-enrollment bootstraps so an abandoned onboarding
 				// (Pi published, browser never claimed) can't pin memory; each entry
 				// also self-expires after bootstrapTTL, so this just trims proactively.

--- a/go/cmd/ftw-relay/ratelimit.go
+++ b/go/cmd/ftw-relay/ratelimit.go
@@ -38,6 +38,14 @@ const (
 	// offerBucketIdleTTL is how long an idle per-IP bucket is kept before GC, so
 	// the limiter map doesn't grow without bound under a churn of source IPs.
 	offerBucketIdleTTL = 10 * time.Minute
+
+	// iceBucketCapacity / iceBucketRefillPerSec size the SEPARATE per-IP limiter on
+	// GET /signal/ice. More generous than the offer bucket: it is hit by the
+	// browser once per connect AND by the Pi on its hourly ICE refresh, and the
+	// response is a cheap HMAC, so the only thing to bound is a tight credential-
+	// minting loop. A 16-token burst with 4/s refill covers any real reconnect.
+	iceBucketCapacity     = 16.0
+	iceBucketRefillPerSec = 4.0
 )
 
 // tokenBucket is a classic token bucket: tokens refill at a fixed rate up to a

--- a/go/internal/p2p/bridge.go
+++ b/go/internal/p2p/bridge.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pion/ice/v4"
 	"github.com/pion/webrtc/v4"
 
 	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
@@ -396,13 +395,15 @@ func NewPeer(iceServers []string) (*webrtc.PeerConnection, error) {
 // DTLS encrypted end-to-end and browser-side signed-fingerprint verification
 // keeps the relay/TURN service from becoming a trust anchor.
 //
-// When real ICE servers are configured (the production path) the peer is built
-// through iceAPI(), whose agents RESOLVE the browser's mDNS (.local) host
-// candidates — without that the same-LAN host<->host pair never forms and a
-// browser sitting on the same wifi as the Pi needlessly round-trips through
-// STUN/WAN. The host-candidate-only path (nil ICE, e.g. the in-process loopback
-// test) keeps the plain constructor: it exchanges raw-IP candidates and needs
-// no mDNS resolver.
+// mDNS: pion's ICE agent already defaults to MulticastDNSMode QueryOnly
+// (webrtc icegatherer.go sanitizedMDNSMode + ice agent.go setupMDNSConfig both
+// coerce the zero value to QueryOnly), so the Pi RESOLVES the browser's mDNS
+// (.local) host candidates out of the box — Chrome hides its host candidate
+// behind a per-session <uuid>.local name, and pion turns it back into a
+// reachable IP. We therefore do NOT configure a SettingEngine here; the same-LAN
+// host<->host pair forms with the plain constructor. (An earlier draft set
+// QueryOnly explicitly, but that is byte-for-byte the existing default — a no-op
+// dressed up as a fix.)
 func NewPeerWithICE(iceServers []ICEServer) (*webrtc.PeerConnection, error) {
 	cfg := webrtc.Configuration{}
 	if len(iceServers) > 0 {
@@ -418,30 +419,5 @@ func NewPeerWithICE(iceServers []ICEServer) (*webrtc.PeerConnection, error) {
 			})
 		}
 	}
-	if len(cfg.ICEServers) > 0 {
-		return iceAPI().NewPeerConnection(cfg)
-	}
 	return webrtc.NewPeerConnection(cfg)
-}
-
-// mdnsAPI is a lazily-built pion API whose ICE agents resolve remote mDNS
-// (.local) host candidates. Chrome hides its host candidates behind per-session
-// <uuid>.local names; with no resolver the Pi silently drops them, so two
-// devices on the SAME LAN never form the direct host<->host pair and fall back
-// to a STUN/WAN round-trip. QueryOnly resolves the browser's .local names while
-// still gathering the Pi's own candidates as raw IPs — it publishes NO mDNS
-// hostname, so it can't clash with a Pi's avahi-daemon on :5353. The API is
-// reused across PeerConnections (safe for concurrent use).
-var (
-	mdnsAPIOnce sync.Once
-	mdnsAPI     *webrtc.API
-)
-
-func iceAPI() *webrtc.API {
-	mdnsAPIOnce.Do(func() {
-		se := webrtc.SettingEngine{}
-		se.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryOnly)
-		mdnsAPI = webrtc.NewAPI(webrtc.WithSettingEngine(se))
-	})
-	return mdnsAPI
 }

--- a/go/internal/p2p/bridge.go
+++ b/go/internal/p2p/bridge.go
@@ -36,6 +36,50 @@ import (
 // a TURN-relayed DataChannel carries DTLS ciphertext only.
 var DefaultSTUNServers = []string{"stun:stun.l.google.com:19302"}
 
+// ICEServer is the small JSON-compatible ICE server shape shared by the
+// browser, relay and Pi. Username/Credential are set for TURN only.
+type ICEServer struct {
+	URLs       []string `json:"urls"`
+	Username   string   `json:"username,omitempty"`
+	Credential string   `json:"credential,omitempty"`
+}
+
+// ICEServersFromURLs adapts bare STUN/TURN URLs to the richer shape. It is
+// used by older call sites that only configured STUN URL lists.
+func ICEServersFromURLs(urls []string) []ICEServer {
+	if len(urls) == 0 {
+		return nil
+	}
+	out := make([]ICEServer, 0, len(urls))
+	for _, u := range urls {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		out = append(out, ICEServer{URLs: []string{u}})
+	}
+	return out
+}
+
+func cloneICEServers(in []ICEServer) []ICEServer {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ICEServer, 0, len(in))
+	for _, s := range in {
+		if len(s.URLs) == 0 {
+			continue
+		}
+		cp := ICEServer{
+			URLs:       append([]string(nil), s.URLs...),
+			Username:   s.Username,
+			Credential: s.Credential,
+		}
+		out = append(out, cp)
+	}
+	return out
+}
+
 // ResponseFrame is one response written back over the DataChannel: the
 // originating request's ReqID (so a client with several in-flight requests can
 // correlate concurrent responses) plus the reused tunnel.TunneledResponse
@@ -326,9 +370,27 @@ func appendCookie(h http.Header, pair string) {
 // server URLs. Pass nil for host-candidate-only (e.g. an in-process loopback
 // test); pass DefaultSTUNServers for real NAT traversal.
 func NewPeer(iceServers []string) (*webrtc.PeerConnection, error) {
+	return NewPeerWithICE(ICEServersFromURLs(iceServers))
+}
+
+// NewPeerWithICE creates an RTCPeerConnection from full ICE configuration.
+// TURN credentials are still only connectivity hints: the DataChannel remains
+// DTLS encrypted end-to-end and browser-side signed-fingerprint verification
+// keeps the relay/TURN service from becoming a trust anchor.
+func NewPeerWithICE(iceServers []ICEServer) (*webrtc.PeerConnection, error) {
 	cfg := webrtc.Configuration{}
 	if len(iceServers) > 0 {
-		cfg.ICEServers = []webrtc.ICEServer{{URLs: iceServers}}
+		cfg.ICEServers = make([]webrtc.ICEServer, 0, len(iceServers))
+		for _, s := range iceServers {
+			if len(s.URLs) == 0 {
+				continue
+			}
+			cfg.ICEServers = append(cfg.ICEServers, webrtc.ICEServer{
+				URLs:       append([]string(nil), s.URLs...),
+				Username:   s.Username,
+				Credential: s.Credential,
+			})
+		}
 	}
 	return webrtc.NewPeerConnection(cfg)
 }

--- a/go/internal/p2p/bridge.go
+++ b/go/internal/p2p/bridge.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pion/ice/v4"
 	"github.com/pion/webrtc/v4"
 
 	"github.com/frahlg/forty-two-watts/go/internal/tunnel"
@@ -59,6 +60,23 @@ func ICEServersFromURLs(urls []string) []ICEServer {
 		out = append(out, ICEServer{URLs: []string{u}})
 	}
 	return out
+}
+
+// iceHasTURN reports whether any configured ICE server is a TURN server (its URL
+// scheme is turn:/turns:). The non-trickle answer must carry a relay candidate
+// when TURN is configured — otherwise a both-ends-hard-NAT (symmetric) owner,
+// the case TURN exists for, could never traverse — so the early-return gather
+// waits for the relay candidate only in that case.
+func iceHasTURN(servers []ICEServer) bool {
+	for _, s := range servers {
+		for _, u := range s.URLs {
+			lu := strings.ToLower(strings.TrimSpace(u))
+			if strings.HasPrefix(lu, "turn:") || strings.HasPrefix(lu, "turns:") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func cloneICEServers(in []ICEServer) []ICEServer {
@@ -377,6 +395,14 @@ func NewPeer(iceServers []string) (*webrtc.PeerConnection, error) {
 // TURN credentials are still only connectivity hints: the DataChannel remains
 // DTLS encrypted end-to-end and browser-side signed-fingerprint verification
 // keeps the relay/TURN service from becoming a trust anchor.
+//
+// When real ICE servers are configured (the production path) the peer is built
+// through iceAPI(), whose agents RESOLVE the browser's mDNS (.local) host
+// candidates — without that the same-LAN host<->host pair never forms and a
+// browser sitting on the same wifi as the Pi needlessly round-trips through
+// STUN/WAN. The host-candidate-only path (nil ICE, e.g. the in-process loopback
+// test) keeps the plain constructor: it exchanges raw-IP candidates and needs
+// no mDNS resolver.
 func NewPeerWithICE(iceServers []ICEServer) (*webrtc.PeerConnection, error) {
 	cfg := webrtc.Configuration{}
 	if len(iceServers) > 0 {
@@ -392,5 +418,30 @@ func NewPeerWithICE(iceServers []ICEServer) (*webrtc.PeerConnection, error) {
 			})
 		}
 	}
+	if len(cfg.ICEServers) > 0 {
+		return iceAPI().NewPeerConnection(cfg)
+	}
 	return webrtc.NewPeerConnection(cfg)
+}
+
+// mdnsAPI is a lazily-built pion API whose ICE agents resolve remote mDNS
+// (.local) host candidates. Chrome hides its host candidates behind per-session
+// <uuid>.local names; with no resolver the Pi silently drops them, so two
+// devices on the SAME LAN never form the direct host<->host pair and fall back
+// to a STUN/WAN round-trip. QueryOnly resolves the browser's .local names while
+// still gathering the Pi's own candidates as raw IPs — it publishes NO mDNS
+// hostname, so it can't clash with a Pi's avahi-daemon on :5353. The API is
+// reused across PeerConnections (safe for concurrent use).
+var (
+	mdnsAPIOnce sync.Once
+	mdnsAPI     *webrtc.API
+)
+
+func iceAPI() *webrtc.API {
+	mdnsAPIOnce.Do(func() {
+		se := webrtc.SettingEngine{}
+		se.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryOnly)
+		mdnsAPI = webrtc.NewAPI(webrtc.WithSettingEngine(se))
+	})
+	return mdnsAPI
 }

--- a/go/internal/p2p/ice_servers_test.go
+++ b/go/internal/p2p/ice_servers_test.go
@@ -1,0 +1,24 @@
+package p2p
+
+import "testing"
+
+func TestICEHasTURN(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []ICEServer
+		want bool
+	}{
+		{"nil", nil, false},
+		{"stun only", []ICEServer{{URLs: []string{"stun:s.example:3478"}}}, false},
+		{"stun+turn", []ICEServer{{URLs: []string{"stun:s.example:3478"}}, {URLs: []string{"turn:t.example:3478?transport=udp"}}}, true},
+		{"turns", []ICEServer{{URLs: []string{"turns:t.example:5349"}}}, true},
+		{"uppercase scheme", []ICEServer{{URLs: []string{"TURN:t.example:3478"}}}, true},
+		{"leading whitespace", []ICEServer{{URLs: []string{"  turn:t.example:3478 "}}}, true},
+		{"empty urls entry", []ICEServer{{URLs: nil}}, false},
+	}
+	for _, c := range cases {
+		if got := iceHasTURN(c.in); got != c.want {
+			t.Errorf("%s: iceHasTURN = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/go/internal/p2p/manager.go
+++ b/go/internal/p2p/manager.go
@@ -286,13 +286,53 @@ func (m *Manager) Answer(ctx context.Context, offerSDP string, replayHeaders htt
 		m.remove(id)
 		return "", fmt.Errorf("p2p: create answer: %w", err)
 	}
+
+	// Early-return gather: don't block the answer on FULL gathering or the
+	// (often-never-firing-with-STUN) complete event. Return as soon as the answer
+	// carries the candidate set this config actually needs — host + srflx, plus a
+	// relay candidate when TURN is configured (see wantRelay). pion splices
+	// whatever candidates are gathered so far into LocalDescription()
+	// (populateLocalCandidates), so the SDP we return below already carries them.
+	// We still fall back to full GatheringCompletePromise / handshakeTimeout when
+	// a needed candidate never comes (STUN/TURN unreachable), so an answer is
+	// never lost — just no faster than before in that degraded case.
+	// wantRelay forces the early-return to also wait for a relay candidate when a
+	// TURN server is configured, so a symmetric-NAT owner stays reachable. A TURN
+	// Allocate is ~1 RTT, so this costs little over host+srflx and is still far
+	// faster than waiting for full gather / the often-never-firing complete event.
+	wantRelay := iceHasTURN(ice)
+	enough := make(chan struct{})
+	var gmu sync.Mutex
+	var haveHost, haveSrflx, haveRelay, enoughClosed bool
+	pc.OnICECandidate(func(c *webrtc.ICECandidate) {
+		if c == nil {
+			return
+		}
+		gmu.Lock()
+		switch c.Typ {
+		case webrtc.ICECandidateTypeHost:
+			haveHost = true
+		case webrtc.ICECandidateTypeSrflx:
+			haveSrflx = true
+		case webrtc.ICECandidateTypeRelay:
+			haveRelay = true
+		}
+		if haveHost && haveSrflx && (!wantRelay || haveRelay) && !enoughClosed {
+			enoughClosed = true
+			close(enough)
+		}
+		gmu.Unlock()
+	})
+
 	gather := webrtc.GatheringCompletePromise(pc)
 	if err := pc.SetLocalDescription(answer); err != nil {
 		m.remove(id)
 		return "", fmt.Errorf("p2p: set local description: %w", err)
 	}
-	// Non-trickle: wait for gathering so the answer SDP carries ICE candidates.
+	// Non-trickle: wait until the answer SDP carries a usable candidate set —
+	// either the host+srflx early-return, full gather, or the timeout backstop.
 	select {
+	case <-enough:
 	case <-gather:
 	case <-ctx.Done():
 		m.remove(id)

--- a/go/internal/p2p/manager.go
+++ b/go/internal/p2p/manager.go
@@ -79,11 +79,11 @@ const (
 // Manager owns the Pi side of the browser P2P path and the lifecycle of the
 // PeerConnections it answers. It is safe for concurrent use.
 type Manager struct {
-	log  *slog.Logger
-	stun []string
+	log *slog.Logger
 
 	mu        sync.Mutex
 	local     http.Handler          // ungated API mux; set via SetLocalAPI
+	ice       []ICEServer           // STUN/TURN servers for new PeerConnections
 	sessions  map[string]*pcSession // active connections by session id
 	maxOpen   int
 	maxUnauth int               // separate cap on not-yet-authenticated peers (FIX-4b)
@@ -109,11 +109,19 @@ func NewManager(log *slog.Logger, stun []string) *Manager {
 	}
 	return &Manager{
 		log:       log,
-		stun:      stun,
+		ice:       ICEServersFromURLs(stun),
 		sessions:  make(map[string]*pcSession),
 		maxOpen:   defaultMaxOpen,
 		maxUnauth: defaultMaxUnauth,
 	}
+}
+
+// SetICEServers updates the ICE server set used for future answers. Existing
+// PeerConnections keep the candidates they already gathered.
+func (m *Manager) SetICEServers(ice []ICEServer) {
+	m.mu.Lock()
+	m.ice = cloneICEServers(ice)
+	m.mu.Unlock()
 }
 
 // SetLocalAPI injects the handler that DataChannel-delivered requests replay
@@ -199,12 +207,13 @@ func (m *Manager) ActiveCount() int {
 func (m *Manager) Answer(ctx context.Context, offerSDP string, replayHeaders http.Header) (string, error) {
 	m.mu.Lock()
 	local := m.local
+	ice := cloneICEServers(m.ice)
 	m.mu.Unlock()
 	if local == nil {
 		return "", fmt.Errorf("p2p: local API not wired")
 	}
 
-	pc, err := NewPeer(m.stun)
+	pc, err := NewPeerWithICE(ice)
 	if err != nil {
 		return "", fmt.Errorf("p2p: new peer: %w", err)
 	}

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -1765,7 +1765,7 @@
   }
 
   function v2xCommand(driver, powerW) {
-    return fetch("/api/v2x/command", {
+    return ownerFetch("/api/v2x/command", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/web/p2p-ice-config.test.mjs
+++ b/web/p2p-ice-config.test.mjs
@@ -1,0 +1,111 @@
+// node --test web/p2p-ice-config.test.mjs
+//
+// Public home route reachability guard: p2p.js must ask the relay for ICE
+// config before creating RTCPeerConnection so operators can add TURN without
+// shipping a new dashboard bundle. TURN still only relays WebRTC ciphertext.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const P2P_SRC = readFileSync(join(__dirname, "p2p.js"), "utf8");
+
+async function loadP2PWithICE(iceResponse) {
+  const configs = [];
+  const fetches = [];
+  const store = new Map();
+  function FakeRTCPeerConnection(config) {
+    configs.push(config);
+    this.iceGatheringState = "complete";
+    this.connectionState = "new";
+  }
+  FakeRTCPeerConnection.prototype.createDataChannel = function () {
+    return {
+      readyState: "connecting",
+      close() {},
+      send() {},
+    };
+  };
+  FakeRTCPeerConnection.prototype.addEventListener = function () {};
+  FakeRTCPeerConnection.prototype.close = function () {};
+  FakeRTCPeerConnection.prototype.createOffer = async function () {
+    return { type: "offer", sdp: "v=0\r\n" };
+  };
+  FakeRTCPeerConnection.prototype.setLocalDescription = async function (offer) {
+    this.localDescription = offer;
+  };
+
+  const win = {
+    RTCPeerConnection: FakeRTCPeerConnection,
+    localStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+    },
+  };
+  const sandbox = {
+    window: win,
+    RTCPeerConnection: FakeRTCPeerConnection,
+    location: { pathname: "/", hostname: "home.fortytwowatts.com", origin: "https://home.fortytwowatts.com" },
+    fetch: async (url) => {
+      fetches.push(String(url));
+      return iceResponse;
+    },
+    crypto: { getRandomValues: (b) => (b.fill(7), b) },
+    localStorage: win.localStorage,
+    setTimeout,
+    clearTimeout,
+    console: { warn() {} },
+  };
+
+  vm.runInNewContext(P2P_SRC, sandbox, { filename: "p2p.js" });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  return { configs, fetches };
+}
+
+describe("p2p ICE config", () => {
+  it("uses relay-provided STUN/TURN config before creating the peer", async () => {
+    const { configs, fetches } = await loadP2PWithICE({
+      ok: true,
+      json: async () => ({
+        ice_servers: [
+          { urls: ["stun:relay.example:19302"] },
+          {
+            urls: ["turn:relay.example:3478?transport=udp"],
+            username: "1234567890",
+            credential: "derived-secret",
+          },
+        ],
+      }),
+    });
+
+    assert.deepEqual(fetches, ["/signal/ice"]);
+    assert.equal(configs.length, 1);
+    assert.deepEqual(JSON.parse(JSON.stringify(configs[0].iceServers)), [
+      { urls: ["stun:relay.example:19302"] },
+      {
+        urls: ["turn:relay.example:3478?transport=udp"],
+        username: "1234567890",
+        credential: "derived-secret",
+      },
+    ]);
+  });
+
+  it("falls back to default STUN when the relay lacks /signal/ice", async () => {
+    const { configs } = await loadP2PWithICE({
+      ok: false,
+      status: 404,
+      json: async () => {
+        throw new Error("should not parse 404 body");
+      },
+    });
+
+    assert.equal(configs.length, 1);
+    assert.deepEqual(JSON.parse(JSON.stringify(configs[0].iceServers)), [{ urls: ["stun:stun.l.google.com:19302"] }]);
+  });
+});

--- a/web/p2p-ice-config.test.mjs
+++ b/web/p2p-ice-config.test.mjs
@@ -58,6 +58,14 @@ async function loadP2PWithICE(iceResponse, opts) {
     }),
     crypto: { getRandomValues: (b) => (b.fill(7), b) },
     localStorage: win.localStorage,
+    sessionStorage: (() => {
+      const s = new Map();
+      return {
+        getItem: (k) => (s.has(k) ? s.get(k) : null),
+        setItem: (k, v) => s.set(k, String(v)),
+        removeItem: (k) => s.delete(k),
+      };
+    })(),
     setTimeout,
     clearTimeout,
     AbortController,

--- a/web/p2p-ice-config.test.mjs
+++ b/web/p2p-ice-config.test.mjs
@@ -14,7 +14,8 @@ import vm from "node:vm";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const P2P_SRC = readFileSync(join(__dirname, "p2p.js"), "utf8");
 
-async function loadP2PWithICE(iceResponse) {
+async function loadP2PWithICE(iceResponse, opts) {
+  opts = opts || {};
   const configs = [];
   const fetches = [];
   const store = new Map();
@@ -51,20 +52,22 @@ async function loadP2PWithICE(iceResponse) {
     window: win,
     RTCPeerConnection: FakeRTCPeerConnection,
     location: { pathname: "/", hostname: "home.fortytwowatts.com", origin: "https://home.fortytwowatts.com" },
-    fetch: async (url) => {
+    fetch: opts.fetchImpl || (async (url) => {
       fetches.push(String(url));
       return iceResponse;
-    },
+    }),
     crypto: { getRandomValues: (b) => (b.fill(7), b) },
     localStorage: win.localStorage,
     setTimeout,
     clearTimeout,
+    AbortController,
     console: { warn() {} },
   };
 
   vm.runInNewContext(P2P_SRC, sandbox, { filename: "p2p.js" });
   await new Promise((resolve) => setImmediate(resolve));
   await new Promise((resolve) => setImmediate(resolve));
+  if (opts.waitMs) await new Promise((resolve) => setTimeout(resolve, opts.waitMs));
   return { configs, fetches };
 }
 
@@ -106,6 +109,28 @@ describe("p2p ICE config", () => {
     });
 
     assert.equal(configs.length, 1);
+    assert.deepEqual(JSON.parse(JSON.stringify(configs[0].iceServers)), [{ urls: ["stun:stun.l.google.com:19302"] }]);
+  });
+
+  // Regression: a /signal/ice that connects but NEVER responds must not hang
+  // connect() forever (which would poison every future attempt). The fetch is
+  // AbortController-capped at ICE_FETCH_TIMEOUT_MS; on abort it falls back to
+  // default STUN and the peer is still created.
+  it("does not hang when /signal/ice never responds — aborts and falls back to default STUN", async () => {
+    const fetches = [];
+    const { configs } = await loadP2PWithICE(null, {
+      waitMs: 3300, // > ICE_FETCH_TIMEOUT_MS (3000) so the abort timer fires
+      fetchImpl: (url, init) =>
+        new Promise((_resolve, reject) => {
+          fetches.push(String(url));
+          // Reject only when the caller's AbortController fires; otherwise hang.
+          if (init && init.signal) {
+            init.signal.addEventListener("abort", () => reject(new Error("aborted")));
+          }
+        }),
+    });
+
+    assert.equal(configs.length, 1, "peer should still be created after the ICE fetch aborts");
     assert.deepEqual(JSON.parse(JSON.stringify(configs[0].iceServers)), [{ urls: ["stun:stun.l.google.com:19302"] }]);
   });
 });

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -18,15 +18,24 @@
   var CONNECT_TIMEOUT_MS = 15000;  // hard ceiling on a whole attempt (TURN allocs can be slow)
   var REQUEST_TIMEOUT_MS = 10000;  // per-request budget over the channel
   var ICE_FETCH_TIMEOUT_MS = 3000; // cap the /signal/ice fetch so it can never hang connect()
-  var RETRY_COOLDOWN_MS = 4000;    // after a HARD failed connect, hold off this long. Short:
-                                   // the relay fallback already serves data, so a quick retry is
-                                   // cheap and a logged-in owner shouldn't sit on a 30s lockout.
-                                   // Transient cold-load races use the SOFT path (no cooldown).
+  var GATHER_CAP_MS = 3000;        // backstop wait for ICE gathering when no TURN is configured
+  var GATHER_CAP_TURN_MS = 8000;   // longer backstop when a relay candidate is expected — a TURN
+                                   // Allocate on a slow/cellular path routinely takes >3s, and that
+                                   // relay candidate is exactly what a symmetric-NAT owner needs.
+                                   // Stays under CONNECT_TIMEOUT_MS so the rest of the handshake fits.
+                                   // (Mirrors the Pi's 12s handshakeTimeout grace for the same candidate.)
+  var RETRY_BACKOFF_BASE_MS = 2000;  // hard-failure backoff: doubles each CONSECUTIVE failure, so the
+  var RETRY_BACKOFF_MAX_MS = 30000;  // first retry is snappy (the relay fallback serves data meanwhile)
+                                     // but a persistent failure backs off instead of drumming the relay
+                                     // signaling bucket every few seconds (2s→4s→8s→16s→30s cap).
+  var SOFT_RETRY_FLOOR_MS = 800;     // tiny floor on the SOFT (warm-up race) path so a directory that
+                                     // never decrypts can't free-run connect() against the 2s poller.
 
   var pc = null, dc = null;
   var connecting = null;             // in-flight connect() promise
   var ready = false;
   var nextRetryAt = 0;
+  var hardFailCount = 0;             // consecutive hard-failure count → exponential backoff (reset on success)
   var pending = Object.create(null); // req_id -> { resolve, reject, timer }
   var seq = 0;
   var listeners = [];
@@ -122,6 +131,27 @@
     return DEFAULT_ICE.map(function (s) { return { urls: s.urls.slice() }; });
   }
 
+  // ftw.ice sessionStorage cache holds the last config that actually carried
+  // servers. A transient /signal/ice failure (timeout, a 429 from the relay's
+  // per-IP throttle, a relay blip) must NOT silently strip TURN and flip the
+  // connect path to STUN-only — that would leave a symmetric-NAT owner unable to
+  // traverse. So on failure we reuse the last good config (incl. its TURN entry;
+  // the coturn credential has a 12h TTL) instead of dropping to bare STUN.
+  // Per-tab; harmless if a stale credential no longer allocates (no relay
+  // candidate forms, same as STUN-only, but we keep wantRelay semantics).
+  var ICE_CACHE_KEY = "ftw.ice";
+  function cacheICE(list) {
+    try { sessionStorage.setItem(ICE_CACHE_KEY, JSON.stringify(list)); } catch (e) {}
+  }
+  function cachedICE() {
+    try {
+      var v = JSON.parse(sessionStorage.getItem(ICE_CACHE_KEY) || "null");
+      if (Array.isArray(v) && v.length) return v;
+    } catch (e) {}
+    return null;
+  }
+  function fallbackICE() { return cachedICE() || defaultICE(); }
+
   // iceServers fetches relay-provided STUN/TURN config. TURN credentials are
   // short-lived connectivity hints only: WebRTC still runs DTLS end-to-end and
   // verifyAnswerSignature keeps the relay/TURN service out of the trust chain.
@@ -130,7 +160,8 @@
   // /signal/ice that connects but never responds must NEVER hang here, because
   // connect() runs the rest of the handshake inside this promise's .then — a
   // hang would leave the cached `connecting` promise pending forever and poison
-  // every future attempt. On timeout / any error we fall back to default STUN.
+  // every future attempt. On timeout / any error we fall back to the cached
+  // config, or default STUN if there is none.
   function iceServers() {
     var ctl = (typeof AbortController === "function") ? new AbortController() : null;
     var timer = ctl ? setTimeout(function () { try { ctl.abort(); } catch (e) {} }, ICE_FETCH_TIMEOUT_MS) : null;
@@ -138,13 +169,13 @@
     if (ctl) opts.signal = ctl.signal;
     return fetch("/signal/ice", opts)
       .then(function (r) {
-        if (!r.ok) return defaultICE();
+        if (!r.ok) throw new Error("ice http " + r.status);
         return r.json();
       })
       .then(function (cfg) {
         var list = cfg && cfg.ice_servers;
-        if (!Array.isArray(list) || list.length === 0) return defaultICE();
-        return list.map(function (s) {
+        if (!Array.isArray(list) || list.length === 0) throw new Error("ice empty");
+        var parsed = list.map(function (s) {
           if (!s || !s.urls) return null;
           var urls = Array.isArray(s.urls) ? s.urls.slice() : [String(s.urls)];
           var out = { urls: urls };
@@ -152,8 +183,11 @@
           if (s.credential) out.credential = s.credential;
           return out;
         }).filter(Boolean);
+        if (!parsed.length) throw new Error("ice empty");
+        cacheICE(parsed);
+        return parsed;
       })
-      .catch(function () { return defaultICE(); })
+      .catch(function () { return fallbackICE(); })
       .then(function (res) { if (timer) clearTimeout(timer); return res; });
   }
 
@@ -460,10 +494,12 @@
   // server-reflexive candidate are gathered, plus a relay candidate when TURN is
   // configured (wantRelay). The relay candidate matters: without it a both-ends
   // hard-NAT (symmetric) owner — the case TURN exists for — could never
-  // traverse. A TURN Allocate is ~1 RTT, so this stays well under the old 3s
-  // wait. The browser keeps localDescription.sdp updated with each candidate, so
-  // the offer POSTed right after carries them. The 3s cap backstops a needed
-  // candidate that never comes (STUN/TURN unreachable).
+  // traverse. The browser keeps localDescription.sdp updated with each
+  // candidate, so the offer POSTed right after carries them. The cap backstops a
+  // needed candidate that never comes (STUN/TURN unreachable); it is longer when
+  // a relay candidate is expected (GATHER_CAP_TURN_MS) so a slow-cellular TURN
+  // Allocate — routinely >3s — isn't cut off, otherwise the offer would go out
+  // relay-less and a symmetric-NAT owner could never traverse.
   function waitIceComplete(peer, wantRelay) {
     if (peer.iceGatheringState === "complete") return Promise.resolve();
     return new Promise(function (resolve) {
@@ -489,7 +525,7 @@
       }
       peer.addEventListener("icegatheringstatechange", onGather);
       peer.addEventListener("icecandidate", onCand);
-      capTimer = setTimeout(finish, 3000);
+      capTimer = setTimeout(finish, wantRelay ? GATHER_CAP_TURN_MS : GATHER_CAP_MS);
     });
   }
 
@@ -547,8 +583,16 @@
         settled = true;
         connecting = null;
         clearTimeout(to);
-        if (!ok) {
-          if (!soft) nextRetryAt = Date.now() + RETRY_COOLDOWN_MS;
+        if (ok) {
+          hardFailCount = 0;          // a working channel resets the backoff escalation
+        } else {
+          if (soft) {
+            nextRetryAt = Date.now() + SOFT_RETRY_FLOOR_MS;   // transient: retry almost immediately
+          } else {
+            hardFailCount++;
+            var backoff = Math.min(RETRY_BACKOFF_BASE_MS * Math.pow(2, hardFailCount - 1), RETRY_BACKOFF_MAX_MS);
+            nextRetryAt = Date.now() + backoff;
+          }
           teardown();
           setState("relay");
         }
@@ -582,7 +626,10 @@
         };
         pc.onconnectionstatechange = function () {
           var st = pc && pc.connectionState;
-          if (st === "failed" || st === "closed" || st === "disconnected") finish(false);
+          // Abort only on TERMINAL states. "disconnected" routinely self-recovers
+          // via ICE restart (the Pi side reaps only on Failed/Closed too); aborting
+          // on it would force a needless full re-handshake on every transient blip.
+          if (st === "failed" || st === "closed") finish(false);
         };
 
         // Signaling now rides the BLIND rendezvous, not the owner tunnel: POST the
@@ -832,7 +879,7 @@
     setEnabled: function (on) {
       localStorage.setItem("ftw.p2p", on ? "on" : "off");
       if (!on) { teardown(); setState("relay"); }
-      else { nextRetryAt = 0; connect(); } // explicit enable bypasses the backoff
+      else { nextRetryAt = 0; hardFailCount = 0; connect(); } // explicit enable bypasses the backoff
     }
   };
   window.p2pFetch = p2pFetch;

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -15,9 +15,13 @@
 
   var DEFAULT_ICE = [{ urls: ["stun:stun.l.google.com:19302"] }]; // mirrors p2p.DefaultSTUNServers
   var LABEL = "ftw";                                     // must match the Pi Bridge
-  var CONNECT_TIMEOUT_MS = 15000;  // give Chrome/WebRTC enough time before retrying
+  var CONNECT_TIMEOUT_MS = 15000;  // hard ceiling on a whole attempt (TURN allocs can be slow)
   var REQUEST_TIMEOUT_MS = 10000;  // per-request budget over the channel
-  var RETRY_COOLDOWN_MS = 30000;   // after a failed connect, hold off this long
+  var ICE_FETCH_TIMEOUT_MS = 3000; // cap the /signal/ice fetch so it can never hang connect()
+  var RETRY_COOLDOWN_MS = 4000;    // after a HARD failed connect, hold off this long. Short:
+                                   // the relay fallback already serves data, so a quick retry is
+                                   // cheap and a logged-in owner shouldn't sit on a 30s lockout.
+                                   // Transient cold-load races use the SOFT path (no cooldown).
 
   var pc = null, dc = null;
   var connecting = null;             // in-flight connect() promise
@@ -121,8 +125,18 @@
   // iceServers fetches relay-provided STUN/TURN config. TURN credentials are
   // short-lived connectivity hints only: WebRTC still runs DTLS end-to-end and
   // verifyAnswerSignature keeps the relay/TURN service out of the trust chain.
+  //
+  // The fetch is hard-capped by ICE_FETCH_TIMEOUT_MS via AbortController: a
+  // /signal/ice that connects but never responds must NEVER hang here, because
+  // connect() runs the rest of the handshake inside this promise's .then — a
+  // hang would leave the cached `connecting` promise pending forever and poison
+  // every future attempt. On timeout / any error we fall back to default STUN.
   function iceServers() {
-    return fetch("/signal/ice", { method: "GET", cache: "no-store", credentials: "same-origin" })
+    var ctl = (typeof AbortController === "function") ? new AbortController() : null;
+    var timer = ctl ? setTimeout(function () { try { ctl.abort(); } catch (e) {} }, ICE_FETCH_TIMEOUT_MS) : null;
+    var opts = { method: "GET", cache: "no-store", credentials: "same-origin" };
+    if (ctl) opts.signal = ctl.signal;
+    return fetch("/signal/ice", opts)
       .then(function (r) {
         if (!r.ok) return defaultICE();
         return r.json();
@@ -139,7 +153,8 @@
           return out;
         }).filter(Boolean);
       })
-      .catch(function () { return defaultICE(); });
+      .catch(function () { return defaultICE(); })
+      .then(function (res) { if (timer) clearTimeout(timer); return res; });
   }
 
   // ---- optional device-key proof for the relay (C2) --------------------------
@@ -318,7 +333,15 @@
       // fresh browser must first claim a Pi-signed descriptor from the bootstrap
       // flow or decrypt its directory. Never guess a universal site_id here.
       if (!isLanOrigin()) {
-        return Promise.reject(new Error("no pinned home identity yet"));
+        // TRANSIENT at warm-up: the directory is decrypted by instance-sync.js (a
+        // deferred module) while p2p.js (a classic script) fires connect() at load,
+        // so on a cold page the directory often isn't ready on the first attempt.
+        // Tag it SOFT so connect() retries promptly instead of arming the cooldown
+        // and parking the owner on the relay for no reason (the single biggest
+        // contributor to the old multi-second "Reaching your home" stall).
+        var ePend = new Error("no pinned home identity yet");
+        ePend.code = "identity-pending";
+        return Promise.reject(ePend);
       }
       return fetch(relayURL("/api/identity"), { credentials: "same-origin" })
         .then(function (r) { if (!r.ok) throw new Error("/api/identity " + r.status); return r.json(); })
@@ -430,21 +453,57 @@
     if (pc) { try { pc.close(); } catch (e) {} pc = null; }
   }
 
-  // waitIceComplete resolves once ICE gathering finishes (non-trickle), with a
-  // hard cap because some browsers never emit "complete" with only STUN.
-  function waitIceComplete(peer) {
+  // waitIceComplete resolves once the offer SDP carries the candidate set this
+  // config needs (non-trickle). Rather than always block for full gathering —
+  // which with only STUN frequently never emits "complete" and so eats the full
+  // 3s cap on EVERY connect — it returns early as soon as a host AND a
+  // server-reflexive candidate are gathered, plus a relay candidate when TURN is
+  // configured (wantRelay). The relay candidate matters: without it a both-ends
+  // hard-NAT (symmetric) owner — the case TURN exists for — could never
+  // traverse. A TURN Allocate is ~1 RTT, so this stays well under the old 3s
+  // wait. The browser keeps localDescription.sdp updated with each candidate, so
+  // the offer POSTed right after carries them. The 3s cap backstops a needed
+  // candidate that never comes (STUN/TURN unreachable).
+  function waitIceComplete(peer, wantRelay) {
     if (peer.iceGatheringState === "complete") return Promise.resolve();
     return new Promise(function (resolve) {
-      var done = false;
-      function finish() { if (!done) { done = true; resolve(); } }
-      peer.addEventListener("icegatheringstatechange", function check() {
-        if (peer.iceGatheringState === "complete") {
-          peer.removeEventListener("icegatheringstatechange", check);
-          finish();
-        }
-      });
-      setTimeout(finish, 3000);
+      var done = false, haveHost = false, haveSrflx = false, haveRelay = false, capTimer = null;
+      function ready() { return haveHost && haveSrflx && (!wantRelay || haveRelay); }
+      function finish() {
+        if (done) return;
+        done = true;
+        if (capTimer) clearTimeout(capTimer);
+        try { peer.removeEventListener("icegatheringstatechange", onGather); } catch (e) {}
+        try { peer.removeEventListener("icecandidate", onCand); } catch (e) {}
+        resolve();
+      }
+      function onGather() { if (peer.iceGatheringState === "complete") finish(); }
+      function onCand(ev) {
+        var c = ev && ev.candidate;
+        if (!c) { finish(); return; }            // null candidate = gathering done
+        var s = c.candidate || "";
+        if (s.indexOf(" typ host") !== -1) haveHost = true;
+        else if (s.indexOf(" typ srflx") !== -1) haveSrflx = true;
+        else if (s.indexOf(" typ relay") !== -1) haveRelay = true;
+        if (ready()) finish();
+      }
+      peer.addEventListener("icegatheringstatechange", onGather);
+      peer.addEventListener("icecandidate", onCand);
+      capTimer = setTimeout(finish, 3000);
     });
+  }
+
+  // iceWantsRelay reports whether the resolved ICE config includes a TURN server,
+  // so waitIceComplete knows to hold for a relay candidate (symmetric-NAT path).
+  function iceWantsRelay(ice) {
+    if (!ice || !ice.length) return false;
+    for (var i = 0; i < ice.length; i++) {
+      var urls = (ice[i] && ice[i].urls) || [];
+      for (var j = 0; j < urls.length; j++) {
+        if (/^turns?:/i.test(String(urls[j]))) return true;
+      }
+    }
+    return false;
   }
 
   // pollAnswer long-polls /signal/<site>/answer until the Pi parks its answer
@@ -478,10 +537,11 @@
     connecting = new Promise(function (resolve) {
       var settled = false;
       var to;
-      // finish(ok[, soft]): soft=true means "transient, retry soon" — used when the
-      // device-key store simply hasn't loaded yet at warm-up (a module-script load
-      // race), so we DON'T arm the long cooldown that would otherwise leave the page
-      // on the relay for 30 s for no reason.
+      // finish(ok[, soft]): soft=true means "transient, retry soon" — used when a
+      // warm-up race (the device-key store OR the decrypted directory not loaded
+      // yet) fails the attempt, so we DON'T arm the cooldown that would otherwise
+      // park the owner on the relay for no reason. A hard failure arms
+      // RETRY_COOLDOWN_MS.
       function finish(ok, soft) {
         if (settled) return;
         settled = true;
@@ -495,7 +555,15 @@
         resolve(ok);
       }
 
+      // Arm the attempt ceiling BEFORE any async work (the /signal/ice fetch
+      // included) so connect() can never hang: even if a step never settles,
+      // finish(false) fires and the cached `connecting` promise resolves instead
+      // of poisoning every future attempt for the page's lifetime.
+      to = setTimeout(function () { finish(false); }, CONNECT_TIMEOUT_MS);
+
       iceServers().then(function (ice) {
+        if (settled) return;   // the ceiling already fired while fetching ICE
+        var wantRelay = iceWantsRelay(ice);
         try {
           pc = new RTCPeerConnection({ iceServers: ice });
         } catch (e) { return finish(false); }
@@ -516,8 +584,6 @@
           var st = pc && pc.connectionState;
           if (st === "failed" || st === "closed" || st === "disconnected") finish(false);
         };
-
-        to = setTimeout(function () { finish(false); }, CONNECT_TIMEOUT_MS);
 
         // Signaling now rides the BLIND rendezvous, not the owner tunnel: POST the
         // offer to /signal/<site>/offer, then long-poll /signal/<site>/answer. The
@@ -540,7 +606,7 @@
           });
           return pc.createOffer()
             .then(function (offer) { return pc.setLocalDescription(offer); })
-            .then(function () { return waitIceComplete(pc); })
+            .then(function () { return waitIceComplete(pc, wantRelay); })
             .then(function () { return proofP; })
             .then(function (proof) {
               if (!proof) {
@@ -584,9 +650,13 @@
         })
           .catch(function (e) {
             if (e && e.message) { try { console.warn("p2p: " + e.message); } catch (_) {} }
-            finish(false);
+            // SOFT retry for transient warm-up races (decrypted directory or the
+            // device-key store not loaded yet): don't arm the cooldown, just let
+            // the next caller retry. Everything else is a hard failure.
+            var soft = e && (e.code === "identity-pending" || e.code === "store-pending");
+            finish(false, soft);
           });
-      });
+      }).catch(function () { finish(false); });
     });
     return connecting;
   }

--- a/web/p2p.js
+++ b/web/p2p.js
@@ -13,7 +13,7 @@
 (function () {
   "use strict";
 
-  var STUN = [{ urls: "stun:stun.l.google.com:19302" }]; // mirrors p2p.DefaultSTUNServers
+  var DEFAULT_ICE = [{ urls: ["stun:stun.l.google.com:19302"] }]; // mirrors p2p.DefaultSTUNServers
   var LABEL = "ftw";                                     // must match the Pi Bridge
   var CONNECT_TIMEOUT_MS = 15000;  // give Chrome/WebRTC enough time before retrying
   var REQUEST_TIMEOUT_MS = 10000;  // per-request budget over the channel
@@ -112,6 +112,34 @@
   // by site_id only — never under the /me/<site> tunnel prefix.
   function challengeURL(site) {
     return "/signal/" + encodeURIComponent(site) + "/challenge";
+  }
+
+  function defaultICE() {
+    return DEFAULT_ICE.map(function (s) { return { urls: s.urls.slice() }; });
+  }
+
+  // iceServers fetches relay-provided STUN/TURN config. TURN credentials are
+  // short-lived connectivity hints only: WebRTC still runs DTLS end-to-end and
+  // verifyAnswerSignature keeps the relay/TURN service out of the trust chain.
+  function iceServers() {
+    return fetch("/signal/ice", { method: "GET", cache: "no-store", credentials: "same-origin" })
+      .then(function (r) {
+        if (!r.ok) return defaultICE();
+        return r.json();
+      })
+      .then(function (cfg) {
+        var list = cfg && cfg.ice_servers;
+        if (!Array.isArray(list) || list.length === 0) return defaultICE();
+        return list.map(function (s) {
+          if (!s || !s.urls) return null;
+          var urls = Array.isArray(s.urls) ? s.urls.slice() : [String(s.urls)];
+          var out = { urls: urls };
+          if (s.username) out.username = s.username;
+          if (s.credential) out.credential = s.credential;
+          return out;
+        }).filter(Boolean);
+      })
+      .catch(function () { return defaultICE(); });
   }
 
   // ---- optional device-key proof for the relay (C2) --------------------------
@@ -467,38 +495,39 @@
         resolve(ok);
       }
 
-      try {
-        pc = new RTCPeerConnection({ iceServers: STUN });
-      } catch (e) { return finish(false); }
+      iceServers().then(function (ice) {
+        try {
+          pc = new RTCPeerConnection({ iceServers: ice });
+        } catch (e) { return finish(false); }
 
-      dc = pc.createDataChannel(LABEL, { ordered: true });
-      dc.onopen = function () { ready = true; setState("direct"); finish(true); };
-      dc.onclose = function () { var was = stateName; teardown(); if (was === "direct") setState("relay"); };
-      dc.onmessage = function (ev) {
-        var frame;
-        try { frame = JSON.parse(ev.data); } catch (e) { return; }
-        var p = pending[frame.req_id];
-        if (!p) return;
-        delete pending[frame.req_id];
-        clearTimeout(p.timer);
-        p.resolve(frame.response || {});
-      };
-      pc.onconnectionstatechange = function () {
-        var st = pc && pc.connectionState;
-        if (st === "failed" || st === "closed" || st === "disconnected") finish(false);
-      };
+        dc = pc.createDataChannel(LABEL, { ordered: true });
+        dc.onopen = function () { ready = true; setState("direct"); finish(true); };
+        dc.onclose = function () { var was = stateName; teardown(); if (was === "direct") setState("relay"); };
+        dc.onmessage = function (ev) {
+          var frame;
+          try { frame = JSON.parse(ev.data); } catch (e) { return; }
+          var p = pending[frame.req_id];
+          if (!p) return;
+          delete pending[frame.req_id];
+          clearTimeout(p.timer);
+          p.resolve(frame.response || {});
+        };
+        pc.onconnectionstatechange = function () {
+          var st = pc && pc.connectionState;
+          if (st === "failed" || st === "closed" || st === "disconnected") finish(false);
+        };
 
-      to = setTimeout(function () { finish(false); }, CONNECT_TIMEOUT_MS);
+        to = setTimeout(function () { finish(false); }, CONNECT_TIMEOUT_MS);
 
-      // Signaling now rides the BLIND rendezvous, not the owner tunnel: POST the
-      // offer to /signal/<site>/offer, then long-poll /signal/<site>/answer. The
-      // relay forwards opaque SDP/signature blobs and never sees plaintext. We
-      // need the pinned site_id first (it keys the mailbox); pinnedIdentity also
-      // gives us the key we verify the answer signature against.
-      // One opaque rendezvous nonce per attempt — the offer is parked under it
-      // and we poll only its answer, so a hostile offer can't steal ours.
-      var nonce = randomNonce();
-      pinnedIdentity()
+        // Signaling now rides the BLIND rendezvous, not the owner tunnel: POST the
+        // offer to /signal/<site>/offer, then long-poll /signal/<site>/answer. The
+        // relay forwards opaque SDP/signature blobs and never sees plaintext. We
+        // need the pinned site_id first (it keys the mailbox); pinnedIdentity also
+        // gives us the key we verify the answer signature against.
+        // One opaque rendezvous nonce per attempt — the offer is parked under it
+        // and we poll only its answer, so a hostile offer can't steal ours.
+        var nonce = randomNonce();
+        return pinnedIdentity()
         .then(function (pin) {
           var site = pin.site;
           // C2, optional: prove this device to the RELAY when a persisted device
@@ -553,10 +582,11 @@
               });
             });
         })
-        .catch(function (e) {
-          if (e && e.message) { try { console.warn("p2p: " + e.message); } catch (_) {} }
-          finish(false);
-        });
+          .catch(function (e) {
+            if (e && e.message) { try { console.warn("p2p: " + e.message); } catch (_) {} }
+            finish(false);
+          });
+      });
     });
     return connecting;
   }


### PR DESCRIPTION
## What changed

- Added `GET /signal/ice` on the relay to publish STUN plus optional short-lived coturn REST credentials.
- Updated the browser P2P setup and Pi signaling loop to fetch that ICE config before creating/answering WebRTC peers.
- Extended the P2P manager to accept full ICE server entries with TURN username/credential.
- Routed the V2X control POST through `ownerFetch` so public home-route writes remain fail-closed.
- Documented the new relay TURN flags and added a patch changeset.

## Why

`home.fortytwowatts.com` was secure but too often unusable because it only had hard-coded STUN. On hard NAT, CGNAT, or cellular paths the channel could fail to form and owner calls would correctly fail closed. Miranda handled this better by letting the relay publish TURN credentials; this PR ports that reachability pattern while preserving FTW's signed WebRTC trust model.

TURN only relays DTLS ciphertext. The Pi-signed DTLS fingerprint remains the anti-MITM trust check.

## Validation

- `go test ./...`
- `npm test`
- `node --check web/p2p.js && node --check web/next-app.js`
- `node --test web/p2p-ice-config.test.mjs web/p2p-owner-fetch-wiring.test.mjs web/public-route-fetch-guard.test.mjs`
- pre-commit `make verify`
- pre-push `make verify-all`