### PR TITLE
MyUplink: authorization-code OAuth + in-app consent + heat-pump dashboard

### DIFF
--- a/.changeset/myuplink-oauth-heating.md
+++ b/.changeset/myuplink-oauth-heating.md
@@ -1,0 +1,18 @@
+---
+"forty-two-watts": minor
+---
+
+MyUplink heat-pump driver now uses the authorization-code OAuth flow the
+MyUplink developer portal actually supports, fixing the `invalid_client`
+startup failure (the old `client_credentials` grant is not offered for portal
+apps). A new in-app consent flow (Settings → Devices → "Connect to MyUplink")
+handles the one-time browser sign-in, stores the refresh token as a masked
+secret, and keeps it fresh — the driver runs `grant_type=refresh_token` at
+runtime and persists Azure-B2C-rotated tokens via the new `host.persist_secret`
+capability so they survive restarts.
+
+A new **Heat pump** dashboard card surfaces the driver's telemetry (compressor
+power + hot-water / indoor / outdoor temperatures, with a 24h power sparkline).
+
+Note: the driver has no `mode` field — it is read-only telemetry for one
+physical pump.

--- a/.changeset/myuplink-oauth-heating.md
+++ b/.changeset/myuplink-oauth-heating.md
@@ -9,7 +9,11 @@ apps). A new in-app consent flow (Settings → Devices → "Connect to MyUplink"
 handles the one-time browser sign-in, stores the refresh token as a masked
 secret, and keeps it fresh — the driver runs `grant_type=refresh_token` at
 runtime and persists Azure-B2C-rotated tokens via the new `host.persist_secret`
-capability so they survive restarts.
+capability so they survive restarts. A manual fallback (paste the redirected
+URL) completes the consent on origins where the auto-callback can't reach the
+Pi (relay/home route, or an http LAN callback the portal rejects) — the Pi
+exchanges the code over its own outbound HTTPS, so no inbound callback is
+needed.
 
 A new **Heat pump** dashboard card surfaces the driver's telemetry (compressor
 power + hot-water / indoor / outdoor temperatures, with a 24h power sparkline).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,9 @@ global exposes:
 - `host.set_make(s)`, `host.set_sn(s)` — anchors device identity
 - `host.emit("battery"|"pv"|"meter", {…})` — structured telemetry
 - `host.emit_metric(name, value)` — arbitrary scalar diagnostics into TS DB
+- `host.persist_secret(key, value)` — durably store a rotated secret (e.g. an
+  OAuth refresh_token) in the unwatched state KV; layered back over
+  `config.<key>` at next init via the registry's `SecretOverride`
 - `host.mqtt_sub/pub/messages`, `host.modbus_read/write/write_multi`
 - `host.decode_u32_le/be`, `host.decode_i32_le/be`, `host.decode_i16`
 - `host.json_encode/decode`

--- a/docs/myuplink-oauth.md
+++ b/docs/myuplink-oauth.md
@@ -53,9 +53,25 @@ In **Settings → Devices**, on the MyUplink driver:
 ## Step 3 — connect
 
 Click **Connect to MyUplink**. A new tab opens MyUplink's sign-in; log in and
-grant access. You're redirected back to 42-watts, which exchanges the code for a
-refresh token, stores it, and restarts the driver. Return to Settings and
-**reload** — the badge flips to **✓ Connected**.
+grant access.
+
+**If you're redirected back to 42-watts** (typical for LAN-direct access): it
+exchanges the code, stores the refresh token, and restarts the driver. Return to
+Settings and **reload** — the badge flips to **✓ Connected**.
+
+**If you're _not_ redirected back** — you reach 42-watts over the relay / home
+route, or the portal rejected an `http` LAN callback — the browser still lands
+on a URL containing `?code=…&state=…` in the address bar. This is expected.
+Then:
+
+1. Copy the **full address** from your browser's address bar.
+2. Back in Settings → Devices, expand **"Not redirected back? Paste the URL
+   instead"**, paste it, and click **Complete connection**.
+
+42-watts exchanges the code over its own outbound HTTPS — no inbound callback
+needed — so this path works on any origin (relay, headless, http LAN). Reload to
+see the **✓ Connected** badge. Do this within ~15 minutes of clicking Connect
+(the consent state expires).
 
 Within a minute the **Heat pump** card appears on the dashboard with live
 compressor power and temperatures, plus a 24-hour power sparkline.

--- a/docs/myuplink-oauth.md
+++ b/docs/myuplink-oauth.md
@@ -1,0 +1,90 @@
+# MyUplink heat-pump setup (NIBE, Bosch, Atlantic, Daikin, …)
+
+The `myuplink` driver reads heat-pump telemetry — compressor power and
+hot-water / indoor / outdoor temperatures — from the MyUplink Cloud API. It is
+**read-only**: it observes the pump, it cannot control it.
+
+> There is **no `mode` field**. One physical pump = one driver. The driver does
+> not split into hot-water / heating instances. (Earlier troubleshooting advice
+> that mentioned `mode: hotwater | heating` was wrong — ignore it.)
+
+## Why there's a "Connect" step
+
+MyUplink's developer portal issues **authorization-code** apps: you register a
+*Callback URL*, get a *Client Identifier* and a *Client Secret*, and the user
+grants access through a browser sign-in. It does **not** support the
+`client_credentials` grant — an app of that kind fails at startup with:
+
+```
+MyUplink: token request failed: HTTP 400: {"error":"invalid_client", ...}
+```
+
+So 42-watts does a one-time browser consent for you and stores the resulting
+refresh token. After that the driver refreshes silently; you never paste a
+token by hand. (Background: issue #496.)
+
+## Step 1 — register an application
+
+1. Go to the MyUplink **developer web portal**: <https://dev.myuplink.com> →
+   **Applications** → create an application. (This is the *web* portal — not the
+   iOS/Android MyUplink app, which will not show a 42-watts client.)
+2. In 42-watts, open **Settings → Devices**, add the **MyUplink** driver from
+   the catalogue, and copy the **Callback URL** it shows you (it looks like
+   `http://<your-42w-address>/api/oauth/myuplink/callback`).
+3. Paste that exact string into the portal's **Callback Url** field. It must
+   match the address you use to reach 42-watts, character for character.
+4. Save the portal app and copy its **Client Identifier** and **Client
+   Secret**.
+
+> **Callback URL must be reachable by your browser after sign-in.** If you reach
+> 42-watts over plain `http://<lan-ip>:8080` and MyUplink rejects a non-HTTPS
+> callback, use an HTTPS address instead — e.g. your relay URL
+> (`https://…`) — and register *that* as the callback. Whatever address you
+> register is the one you must be on when you click Connect.
+
+## Step 2 — enter credentials in 42-watts
+
+In **Settings → Devices**, on the MyUplink driver:
+
+- **Client ID** → paste the *Client Identifier*.
+- **Secrets → Client Secret** → paste the *Client Secret*.
+- **Save** the settings (the Connect button reads the *saved* Client ID).
+
+## Step 3 — connect
+
+Click **Connect to MyUplink**. A new tab opens MyUplink's sign-in; log in and
+grant access. You're redirected back to 42-watts, which exchanges the code for a
+refresh token, stores it, and restarts the driver. Return to Settings and
+**reload** — the badge flips to **✓ Connected**.
+
+Within a minute the **Heat pump** card appears on the dashboard with live
+compressor power and temperatures, plus a 24-hour power sparkline.
+
+## How the token is kept fresh
+
+- The refresh token is stored as a masked `config_secret` (shown as "saved",
+  never echoed back to the browser).
+- At runtime the driver exchanges it for short-lived access tokens
+  (`grant_type=refresh_token`).
+- MyUplink (Azure B2C) rotates the refresh token on each refresh; the driver
+  persists the rotated value via `host.persist_secret` into the state database,
+  so it survives restarts without you reconnecting.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `invalid_client` at startup | Old `client_credentials` build, or wrong Client ID/Secret. Update 42-watts and re-enter the credentials. |
+| Connect button: "save the Client ID first" | Save the settings before clicking Connect — `/start` reads the *saved* Client ID. |
+| Redirected to a "connection failed — invalid state" page | The consent took longer than 10 minutes, or you started Connect from a different address than you finished on. Start again from the address you registered as the callback. |
+| Badge stays "Not connected" after consent | Reload the Settings page; the badge reflects the last config load. |
+| "awaiting OAuth connect" in the logs | Credentials saved but consent not completed — click Connect. |
+| Card never appears | The pump has not reported `hp_power_w` yet (first poll is ~1 min), or the parameter IDs don't match your model — override `param_power_id` etc. in config (see the driver header). |
+
+## Parameter IDs
+
+The defaults target common NIBE models (`10012` compressor power, `40013` BT6
+hot-water top, `40033` BT50 indoor, `40004` BT1 outdoor). If your model differs,
+list your device's points via `GET /v2/devices/{deviceId}/points` and override
+`param_power_id`, `param_hw_temp_id`, `param_indoor_temp_id`,
+`param_outdoor_temp_id` in the driver config.

--- a/docs/superpowers/plans/2026-06-20-myuplink-oauth-and-heating-ui.md
+++ b/docs/superpowers/plans/2026-06-20-myuplink-oauth-and-heating-ui.md
@@ -1,0 +1,364 @@
+# MyUplink OAuth + Heating View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix MyUplink heat-pump auth (issue #496) by replacing the unsupported `client_credentials` OAuth flow with the authorization-code + refresh-token flow the MyUplink developer portal actually supports, with a built-in in-app consent flow; and surface heat-pump telemetry in a dedicated dashboard view.
+
+**Architecture:** MyUplink uses Azure-B2C authorization-code. A one-time browser consent (Go bootstrap endpoint builds the authorize URL, a callback handler exchanges the code) yields a `refresh_token` persisted into the driver's config block as a masked secret. The Lua driver runs `grant_type=refresh_token` at runtime, holding rotation in memory and persisting any rotated token via a new generic `host.persist_secret` capability so it survives restarts. The heating view reuses the existing `/api/series` + per-driver live-metrics endpoints.
+
+**Tech Stack:** Go 1.26 (stdlib `net/http` method mux), gopher-lua 5.1 drivers, vanilla JS web UI (no framework), SQLite TS DB.
+
+## Global Constraints
+
+- No CGo; pure Go + embedded Lua. `go build` must stay a static single binary.
+- Driver owns protocol logic; Go owns capabilities only (CLAUDE.md).
+- New API handlers live in `api_<feature>.go`, never in `api.go`; only the one-line route registration goes in `routes()` (api/CLAUDE.md).
+- Config writes go through the injected `Deps.SaveConfig` / `config.SaveAtomic`, never `os.WriteFile`; take `CfgMu` before mutating `Deps.Cfg`.
+- Secrets are declared in the driver `DRIVER.config_secrets` block; masked on GET via `maskDriverConfigSecrets`, restored on POST via `restoreDriverConfigSecrets`. Never echo a secret into the DOM.
+- Site sign convention unaffected (read-only telemetry; no power-math).
+- UI follows `DESIGN.md`: theme tokens from `web/components/theme.css`, one amber accent, mono for labels/numerics, 1px hairlines, no Google Fonts, no hard-coded hex.
+- `slog` for Go logging; `host.log(level,msg)` in Lua.
+- Every user-visible change needs a changeset (`npx changeset`); new driver capability + new feature = **minor**.
+- All GitHub / Discord text in English (chat may be Swedish).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `go/internal/drivers/host.go` | Add `PersistSecret func(key, value string) error` field to `HostEnv`. |
+| `go/internal/drivers/lua.go` | Register `host.persist_secret(key, value)` Lua primitive → `env.PersistSecret`. |
+| `go/internal/drivers/registry.go` | Carry a `SecretPersister func(driverName, key, value string) error`; wire each driver's `HostEnv.PersistSecret` to a closure binding its name. |
+| `go/cmd/forty-two-watts/main.go` | Provide the `SecretPersister` impl: under `CfgMu`, set `cfg.Drivers[i].Config[key]`, `config.SaveAtomic`. |
+| `drivers/myuplink.lua` | Rewrite auth: `grant_type=refresh_token`; persist rotated token; `config_secrets={client_secret,refresh_token}`; clear "not connected" idle state. |
+| `go/internal/drivers/myuplink_test.go` | Update driver test to the refresh-token flow + a rotation-persist assertion. |
+| `go/internal/api/api_myuplink_oauth.go` | NEW: `/api/oauth/myuplink/start` + `/api/oauth/myuplink/callback` bootstrap. |
+| `go/internal/api/api_myuplink_oauth_test.go` | NEW: state lifecycle + code-exchange + config-write tests. |
+| `go/internal/api/api.go` | Register the two new routes in `routes()` only. |
+| `web/settings/tabs/devices.js` | MyUplink fieldset: callback-URL hint, Connect button, connection badge; fix stale `client_credentials` copy. |
+| `web/heating.js` | NEW: heating dashboard view — metric cards + history chart via `/api/series`. |
+| `web/index.html` | Add the heating `<section>` host + script include. |
+| `docs/myuplink-oauth.md` | NEW: operator setup walkthrough (portal app, callback URL, connect). |
+| `docs/writing-a-driver.md` | Document `host.persist_secret`. |
+| `drivers/myuplink.lua` header + `CLAUDE.md` driver notes | Reflect new auth. |
+| `.changeset/<name>.md` | minor bump entry. |
+
+---
+
+## Task 1: `host.persist_secret` capability (Go)
+
+**Files:**
+- Modify: `go/internal/drivers/host.go` (HostEnv struct)
+- Modify: `go/internal/drivers/lua.go` (register primitive)
+- Modify: `go/internal/drivers/registry.go` (wire per-driver closure)
+- Modify: `go/cmd/forty-two-watts/main.go` (provide persister impl)
+- Test: `go/internal/drivers/lua_persist_test.go` (new)
+
+**Interfaces:**
+- Produces: `HostEnv.PersistSecret func(key, value string) error` (nil → primitive returns `"capability not granted"`). Lua: `host.persist_secret(key, value) -> ok, err`.
+- Produces: `Registry` gains `SecretPersister func(driverName, key, value string) error`; set by `main.go` before `Add`.
+
+- [ ] **Step 1: Write the failing test** — `lua_persist_test.go`: a driver that calls `host.persist_secret("refresh_token", "RT2")` in `driver_poll`; inject a `PersistSecret` capturing the call; assert key/value received.
+
+```go
+func TestHostPersistSecret(t *testing.T) {
+    tel := telemetry.NewStore()
+    var gotKey, gotVal string
+    env := NewHostEnv("dummy", tel)
+    env.PersistSecret = func(k, v string) error { gotKey, gotVal = k, v; return nil }
+    src := `function driver_init(c) end
+            function driver_poll() local ok = host.persist_secret("refresh_token","RT2"); return 1000 end`
+    d := newLuaDriverFromString(t, src, env) // helper mirroring existing inline-source tests
+    if err := d.Init(context.Background(), map[string]any{}); err != nil { t.Fatal(err) }
+    if _, err := d.Poll(context.Background()); err != nil { t.Fatal(err) }
+    if gotKey != "refresh_token" || gotVal != "RT2" {
+        t.Fatalf("persist got (%q,%q)", gotKey, gotVal)
+    }
+}
+```
+
+(If no inline-source helper exists, add one or write a tiny temp `.lua` file via `t.TempDir()`.)
+
+- [ ] **Step 2: Run, expect FAIL** (`host.persist_secret` undefined). `cd go && go test ./internal/drivers/ -run TestHostPersistSecret`.
+
+- [ ] **Step 3: Add the field** in `host.go` HostEnv struct:
+
+```go
+// PersistSecret, when non-nil, lets a driver durably write a config
+// secret (e.g. a rotated OAuth refresh_token) back into its own config
+// block so it survives restarts. nil → host.persist_secret returns an
+// error. Wired by the Registry to a per-driver closure (see registry.go).
+PersistSecret func(key, value string) error
+```
+
+- [ ] **Step 4: Register the primitive** in `lua.go` `registerHost` (mirror the `set_sn` shape):
+
+```go
+host.RawSetString("persist_secret", L.NewFunction(func(L *lua.LState) int {
+    key := L.CheckString(1)
+    val := L.CheckString(2)
+    if env.PersistSecret == nil {
+        L.Push(lua.LBool(false))
+        L.Push(lua.LString("persist_secret: capability not granted"))
+        return 2
+    }
+    if err := env.PersistSecret(key, val); err != nil {
+        L.Push(lua.LBool(false))
+        L.Push(lua.LString(err.Error()))
+        return 2
+    }
+    L.Push(lua.LBool(true))
+    L.Push(lua.LNil)
+    return 2
+}))
+```
+
+- [ ] **Step 5: Run, expect PASS.**
+
+- [ ] **Step 6: Wire the Registry closure.** In `registry.go`, add `SecretPersister func(driverName, key, value string) error` to the Registry struct, and where each driver's `HostEnv` is built in `Add`, set:
+
+```go
+if reg.SecretPersister != nil {
+    name := <driver name in scope>
+    env.PersistSecret = func(key, value string) error {
+        return reg.SecretPersister(name, key, value)
+    }
+}
+```
+
+- [ ] **Step 7: Provide the impl** in `main.go` where the registry is constructed:
+
+```go
+reg.SecretPersister = func(driverName, key, value string) error {
+    cfgMu.Lock()
+    defer cfgMu.Unlock()
+    for i := range cfg.Drivers {
+        if cfg.Drivers[i].Name == driverName {
+            if cfg.Drivers[i].Config == nil {
+                cfg.Drivers[i].Config = map[string]any{}
+            }
+            cfg.Drivers[i].Config[key] = value
+            return config.SaveAtomic(cfgPath, cfg)
+        }
+    }
+    return fmt.Errorf("persist_secret: driver %q not in config", driverName)
+}
+```
+
+(Match the exact identifiers main.go uses for the config pointer / mutex / path — confirm before writing.)
+
+- [ ] **Step 8: `cd go && go build ./... && go test ./internal/drivers/`. Commit.**
+
+```bash
+git add go/internal/drivers/host.go go/internal/drivers/lua.go go/internal/drivers/registry.go go/cmd/forty-two-watts/main.go go/internal/drivers/lua_persist_test.go
+git commit -m "feat(drivers): add host.persist_secret capability for rotated OAuth tokens"
+```
+
+---
+
+## Task 2: Rewrite `drivers/myuplink.lua` to refresh-token auth
+
+**Files:**
+- Modify: `drivers/myuplink.lua`
+- Test: `go/internal/drivers/myuplink_test.go`
+
+**Interfaces:**
+- Consumes: `host.persist_secret` (Task 1), `host.http_post`, `host.json_decode`.
+- Config keys: `client_id`, `client_secret` (secret), `refresh_token` (secret), optional `device_id`, param overrides, `base_url` (tests).
+
+- [ ] **Step 1: Update the test** `TestMyUplinkEmitsTelemetry` so the fake server handles a refresh-token grant and returns a rotated refresh token; add `refresh_token` to config; assert telemetry still lands AND that `persist_secret` is called with the rotated token.
+
+```go
+// fake /oauth/token: assert grant_type=refresh_token, return rotated token
+case "/oauth/token":
+    body, _ := io.ReadAll(r.Body)
+    if !strings.Contains(string(body), "grant_type=refresh_token") {
+        t.Errorf("expected refresh_token grant, got %q", body)
+    }
+    _ = json.NewEncoder(w).Encode(map[string]any{
+        "access_token": "test-token", "expires_in": 3600, "refresh_token": "RT-rotated",
+    })
+```
+```go
+var persisted = map[string]string{}
+env := NewHostEnv("myuplink", tel).WithHTTP()
+env.PersistSecret = func(k, v string) error { persisted[k] = v; return nil }
+cfg := map[string]any{"client_id":"cid","client_secret":"csec","refresh_token":"RT-initial","device_id":"DEV1","base_url":srv.URL}
+// ...after Init...
+if persisted["refresh_token"] != "RT-rotated" {
+    t.Errorf("rotated refresh_token not persisted: %v", persisted)
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`go test ./internal/drivers/ -run TestMyUplink`).
+
+- [ ] **Step 3: Rewrite `fetch_token()`** in `drivers/myuplink.lua`:
+
+```lua
+local refresh_token = nil  -- module-level, alongside access_token
+
+local function fetch_token()
+    if not refresh_token then
+        host.log("error", "MyUplink: no refresh_token — complete the OAuth connect in Settings → Devices")
+        return false
+    end
+    local body = "grant_type=refresh_token"
+        .. "&client_id="     .. url_encode(client_id)
+        .. "&client_secret=" .. url_encode(client_secret)
+        .. "&refresh_token=" .. url_encode(refresh_token)
+    local resp, err = host.http_post(
+        BASE_URL .. "/oauth/token", body,
+        { ["Content-Type"] = "application/x-www-form-urlencoded" })
+    if err then
+        host.log("error", "MyUplink: token refresh failed: " .. tostring(err))
+        return false
+    end
+    local data = host.json_decode(resp)
+    if not data or not data.access_token then
+        host.log("error", "MyUplink: no access_token in refresh response")
+        return false
+    end
+    access_token = data.access_token
+    local expires_in = tonumber(data.expires_in) or 3600
+    token_expires_at = host.millis() + (expires_in * 1000) - 60000
+    -- Azure B2C rotates refresh tokens; persist the new one so it survives restart.
+    if data.refresh_token and data.refresh_token ~= refresh_token then
+        refresh_token = data.refresh_token
+        local ok, perr = host.persist_secret("refresh_token", refresh_token)
+        if not ok then host.log("warn", "MyUplink: could not persist rotated refresh_token: " .. tostring(perr)) end
+    end
+    return true
+end
+```
+
+- [ ] **Step 4: Read `refresh_token` from config** in `driver_init` (alongside client_id/secret), normalize `""`→nil. Update `config_secrets = { "client_secret", "refresh_token" }` in the DRIVER block. Update the top-of-file comment + DRIVER `description` to say authorization-code/refresh-token (no `client_credentials`, and explicitly NO `mode` field — that was never implemented). If `refresh_token` is nil after init, log the "complete OAuth connect" message and leave the driver idle (poll returns 60000 and does nothing).
+
+- [ ] **Step 5: Run, expect PASS.** Also run the full `go test ./internal/drivers/`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add drivers/myuplink.lua go/internal/drivers/myuplink_test.go
+git commit -m "fix(myuplink): use authorization-code/refresh-token OAuth (closes #496)"
+```
+
+---
+
+## Task 3: OAuth bootstrap endpoints (Go)
+
+**Files:**
+- Create: `go/internal/api/api_myuplink_oauth.go`
+- Create: `go/internal/api/api_myuplink_oauth_test.go`
+- Modify: `go/internal/api/api.go` (routes only)
+
+**Interfaces:**
+- `GET /api/oauth/myuplink/start?driver=<name>` → `{authorize_url, redirect_uri, callback}`. Reads `client_id` from `cfg.Drivers[name].Config`; generates random `state`; stores `{driver, redirect_uri, exp}` in an in-memory map (mutex-guarded, 10-min TTL); `redirect_uri` derived from request scheme+host as `<origin>/api/oauth/myuplink/callback`.
+- `GET /api/oauth/myuplink/callback?code=&state=` → validates state, POSTs to MyUplink `https://api.myuplink.com/oauth/token` with `grant_type=authorization_code,code,client_id,client_secret,redirect_uri`; on success writes `refresh_token` into the driver config via `Deps.SaveConfig` (mirroring `handlePostConfig`'s restore+save), restarts the driver, returns a small HTML success page. Base URL overridable via an unexported package var for tests.
+
+- [ ] **Step 1: Write failing test** `api_myuplink_oauth_test.go`: `/start` returns an authorize URL containing the configured client_id, `response_type=code`, `scope=READSYSTEM offline_access`, and the derived redirect_uri; `/callback` with a valid state exchanges against a stub token server and the resulting config has `refresh_token` set. Use the existing api test harness (in-memory `SaveConfig` fake — see `api_drivers_debug_test.go` for the pattern).
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** `api_myuplink_oauth.go` (`handleMyUplinkOAuthStart`, `handleMyUplinkOAuthCallback`, the in-memory `oauthStateStore`, `buildAuthorizeURL`, `exchangeCode`). Scope string: `"READSYSTEM offline_access"`. Validate `state` exists + not expired + matches driver; delete on use (single-use). On exchange failure, render an error page with the MyUplink error body (do not leak secrets).
+
+- [ ] **Step 4: Register routes** in `api.go` `routes()`:
+
+```go
+s.handle("GET /api/oauth/myuplink/start", s.handleMyUplinkOAuthStart)
+s.handle("GET /api/oauth/myuplink/callback", s.handleMyUplinkOAuthCallback)
+```
+
+- [ ] **Step 5: Run, expect PASS.** `cd go && go test ./internal/api/ -run OAuth`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add go/internal/api/api_myuplink_oauth.go go/internal/api/api_myuplink_oauth_test.go go/internal/api/api.go
+git commit -m "feat(api): MyUplink OAuth authorize/callback bootstrap"
+```
+
+---
+
+## Task 4: Settings UI — Connect flow
+
+**Files:**
+- Modify: `web/settings/tabs/devices.js`
+
+- [ ] **Step 1:** In the `isApiCredsDriver` fieldset, fix the stale `client_credentials` comment/copy → "OAuth2 authorization-code". Add, after the Client ID input: a read-only Callback URL line computed as `location.origin + '/api/oauth/myuplink/callback'` with a copy hint ("Register this exact URL as the Callback Url in the MyUplink developer portal"); a "Connect to MyUplink" button; and a connection badge driven by whether `refresh_token` is saved (use the existing masked-secret "saved/not saved" signal — MyUplink declares `refresh_token` in `config_secrets`, so the catalog/secret-status path already reports it; reuse the `creds-badge` styling).
+
+- [ ] **Step 2:** Wire the button: `GET /api/oauth/myuplink/start?driver=<name>` then `window.open(authorize_url, '_blank')`. After the popup, show "Finish the consent in the new tab, then reload this page." (No SSE; the callback persists server-side and the badge flips on next config load.) Save client_id + secret first if dirty (reuse the existing save path; prompt if unsaved).
+
+- [ ] **Step 3:** Manual check via `make dev` — render the MyUplink device card, confirm the callback URL, button, and badge appear and match DESIGN.md tokens (no hard-coded hex; use `creds-badge`, `btn-add` classes already present).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add web/settings/tabs/devices.js
+git commit -m "feat(ui): MyUplink OAuth connect flow in Settings → Devices"
+```
+
+---
+
+## Task 5: Heating dashboard view
+
+**Files:**
+- Create: `web/heating.js`
+- Modify: `web/index.html`
+
+**Interfaces:**
+- Consumes: `GET /api/drivers/{name}` (live metrics array; `m.name`/`m.value`) for current values; `GET /api/series?driver=<name>&metric=hp_power_w&range=24h&points=300` for the chart; `GET /api/drivers` to discover any driver whose live metrics include `hp_*` (so it works for any MyUplink-class driver, not a hard-coded name).
+
+- [ ] **Step 1:** Add a `<section class="heating-row" id="heating-section" hidden>` to `index.html` (after the energy/history rows) with a `<div id="heating-grid">` host, and include `<script src="heating.js" defer></script>`.
+
+- [ ] **Step 2:** Implement `web/heating.js` (IIFE, matching `twins.js` conventions): on load, `GET /api/drivers`; for each driver whose metrics include `hp_power_w`, unhide the section and render a card: compressor power (W), hot-water top (°C), indoor (°C), outdoor (°C) as labelled rows (mono numerics), plus a small inline SVG sparkline of `hp_power_w` over 24h from `/api/series`. Poll every 30s while visible. All colours via theme tokens (`var(--fg)`, `var(--accent-e)`, `var(--line)`); eyebrow label in mono uppercase per DESIGN.md. If no heat-pump driver is present, keep the section hidden.
+
+- [ ] **Step 3:** Manual check via `make dev` with a stubbed MyUplink (or seed `hp_*` via the dev backfill) — section appears only when hp_* metrics exist; values + sparkline render; light theme flips cleanly.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add web/heating.js web/index.html
+git commit -m "feat(ui): heat-pump telemetry dashboard view"
+```
+
+---
+
+## Task 6: Docs + changeset + driver notes
+
+**Files:**
+- Create: `docs/myuplink-oauth.md`
+- Modify: `docs/writing-a-driver.md` (document `host.persist_secret`)
+- Modify: `drivers/myuplink.lua` header + (if present) driver `CLAUDE.md` notes
+- Create: `.changeset/<name>.md`
+
+- [ ] **Step 1:** Write `docs/myuplink-oauth.md`: register an app at dev.myuplink.com → Applications; paste the exact Callback URL 42W shows; copy Client Identifier → Client ID and Client Secret → secret; click Connect to MyUplink; complete consent; verify the badge + the heating card. Note the HTTPS-callback caveat (if the portal rejects an http LAN origin, use the relay/https origin or `http://localhost`). Explicitly state there is **no `mode` field** (corrects the earlier misinformation) and that the driver is read-only telemetry.
+
+- [ ] **Step 2:** Add `host.persist_secret(key, value) -> ok, err` to the host-API section of `docs/writing-a-driver.md` and the lua.go top-of-file capability list.
+
+- [ ] **Step 3:** `npx changeset` → **minor**, summary: "MyUplink heat-pump driver: authorization-code OAuth with in-app consent, rotated-token persistence, and a heat-pump telemetry dashboard view."
+
+- [ ] **Step 4:** `cd go && make verify` (vet + test + build). Commit.
+
+```bash
+git add docs/ drivers/myuplink.lua .changeset/
+git commit -m "docs(myuplink): OAuth setup guide + host.persist_secret + changeset"
+```
+
+---
+
+## Task 7: Correct issue #496 + draft Discord reply
+
+**Files:** none (GitHub + a drafted message for Fredrik to post)
+
+- [ ] **Step 1:** Comment on issue #496 (English): root cause confirmed (portal = authorization-code, `client_credentials` unsupported → `invalid_client`); the fix (in-app consent + refresh-token); and the correction that the driver has **no `mode` field** — the earlier `hotwater`/`heating` guidance was wrong. Link the PR.
+- [ ] **Step 2:** Draft (do not auto-post) a short English Discord reply for the #troubleshooting thread: the real cause, that a fix is shipping, the corrected setup (Callback URL + Connect button, no `mode`), for Fredrik to send when the release is out.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: #496 root cause → Tasks 2–3; `mode` misinformation → Tasks 2 (driver comment), 6 (docs), 7 (issue/Discord); heating UI gap → Task 5; rotation/persistence → Task 1. ✔
+- Rotation across restart handled by Task 1 + Task 2 step 3 (`persist_secret` on rotation). ✔
+- HTTPS-callback risk is documented (Task 6 step 1), not silently assumed. ✔
+- Reuses `/api/series` + live-metrics rather than adding a redundant endpoint. ✔

--- a/docs/writing-a-driver.md
+++ b/docs/writing-a-driver.md
@@ -139,6 +139,11 @@ entry. The function signatures here match that file exactly.
 | `host.set_sn(serial)` | Serial number. Promotes device_id to canonical `make:serial`. |
 | `host.set_poll_interval(ms)` | Request a different poll cadence. Same effect as returning `ms` from `driver_poll`. |
 | `host.millis()` | Monotonic milliseconds since host startup (`host.go:83`). |
+| `host.persist_secret(key, value) → ok, err` | Durably store a rotated secret (e.g. an OAuth `refresh_token`) for THIS driver. Written to the unwatched state KV — **not** `config.yaml` — so persisting can't trigger a config-reload restart loop. The value is layered back over `config.<key>` at the next `driver_init` (`SecretOverride`), so it survives a restart while `config.yaml` keeps the bootstrap seed the UI shows as "saved". Returns `false, err` if the host didn't grant it. |
+
+Use `host.persist_secret` only for values the *provider* rotates out from
+under you (rotating refresh tokens). Operator-entered credentials belong in
+`config.<key>` (declared in `config_secrets`); don't write those back.
 
 Call `set_make` and `set_sn` as early as you reliably can — before them,
 the device shows up under its config name only.

--- a/drivers/myuplink.lua
+++ b/drivers/myuplink.lua
@@ -8,6 +8,19 @@
 -- It cannot actuate the pump, so it cannot cause harm. The OAuth scope is
 -- READSYSTEM only (least privilege).
 --
+-- AUTH (authorization-code + refresh-token):
+--   MyUplink's developer portal issues authorization-code apps (you register
+--   a Callback URL, Client Identifier and Client Secret) — it does NOT support
+--   the client_credentials grant, which is why a portal app returns
+--   `invalid_client` (issue #496). 42w handles the one-time browser consent in
+--   Settings → Devices ("Connect to MyUplink"); the resulting refresh_token is
+--   stored in config and this driver runs `grant_type=refresh_token` at
+--   runtime. Azure B2C rotates the refresh_token on each refresh, so we persist
+--   the rotated value via host.persist_secret to survive restarts.
+--
+--   There is NO `mode` field — this driver is read-only telemetry for one
+--   physical pump; it does not split into hot-water/heating instances.
+--
 -- Config example (config.yaml):
 --   drivers:
 --     - name: myuplink
@@ -15,6 +28,7 @@
 --       config:
 --         client_id: "..."
 --         client_secret: "..."     # masked via config_secrets
+--         refresh_token: "..."     # written by the OAuth connect flow; masked
 --         # device_id: "..."       # optional; auto-detected if omitted
 --       capabilities:
 --         http:
@@ -31,13 +45,13 @@ DRIVER = {
   version      = "1.0.0",
   protocols    = { "http" },
   capabilities = { "apicreds" },
-  description  = "Read-only heat-pump telemetry via MyUplink Cloud REST API v2: compressor power + hot-water/indoor/outdoor temperatures. Observe-only — no control.",
+  description  = "Read-only heat-pump telemetry via MyUplink Cloud REST API v2: compressor power + hot-water/indoor/outdoor temperatures. Observe-only — no control. OAuth: authorization-code + refresh-token (connect in Settings → Devices).",
   homepage     = "https://dev.myuplink.com",
   http_hosts   = { "api.myuplink.com" },
   authors      = { "hannesb90", "forty-two-watts contributors" },
   tested_models = { "NIBE F1145", "NIBE S1255", "NIBE F730" },
   verification_status = "experimental",
-  config_secrets = { "client_secret" },
+  config_secrets = { "client_secret", "refresh_token" },
 }
 
 PROTOCOL = "http"
@@ -46,6 +60,7 @@ local BASE_URL = "https://api.myuplink.com"
 
 local access_token     = nil
 local token_expires_at = 0
+local refresh_token    = nil   -- rotated on each refresh; persisted via host.persist_secret
 
 local client_id     = nil
 local client_secret = nil
@@ -68,25 +83,42 @@ end
 -- ---- Auth ----------------------------------------------------------------
 
 local function fetch_token()
-    local body = "grant_type=client_credentials"
+    if not refresh_token then
+        host.log("warn", "MyUplink: not connected — complete the OAuth connect in Settings → Devices (no refresh_token)")
+        return false
+    end
+    -- MyUplink (Azure B2C) only supports authorization-code apps; the
+    -- runtime grant is refresh_token. client_credentials returns
+    -- invalid_client (#496).
+    local body = "grant_type=refresh_token"
         .. "&client_id=" .. url_encode(client_id)
         .. "&client_secret=" .. url_encode(client_secret)
-        .. "&scope=READSYSTEM"
+        .. "&refresh_token=" .. url_encode(refresh_token)
     local resp, err = host.http_post(
         BASE_URL .. "/oauth/token", body,
         { ["Content-Type"] = "application/x-www-form-urlencoded" })
     if err then
-        host.log("error", "MyUplink: token request failed: " .. tostring(err))
+        host.log("error", "MyUplink: token refresh failed: " .. tostring(err))
         return false
     end
     local data = host.json_decode(resp)
     if not data or not data.access_token then
-        host.log("error", "MyUplink: no access_token in response")
+        host.log("error", "MyUplink: no access_token in refresh response")
         return false
     end
     access_token = data.access_token
     local expires_in = tonumber(data.expires_in) or 3600
     token_expires_at = host.millis() + (expires_in * 1000) - 60000
+    -- Azure B2C rotates the refresh_token; persist the new one so it
+    -- survives a restart. persist_secret writes to the unwatched state
+    -- KV, so this never triggers a config-reload loop.
+    if data.refresh_token and data.refresh_token ~= "" and data.refresh_token ~= refresh_token then
+        refresh_token = data.refresh_token
+        local ok, perr = host.persist_secret("refresh_token", refresh_token)
+        if not ok then
+            host.log("warn", "MyUplink: could not persist rotated refresh_token: " .. tostring(perr))
+        end
+    end
     return true
 end
 
@@ -153,9 +185,11 @@ function driver_init(config)
 
     client_id     = config and config.client_id
     client_secret = config and config.client_secret
+    refresh_token = config and config.refresh_token
     device_id     = config and config.device_id
     if client_id     == "" then client_id     = nil end
     if client_secret == "" then client_secret = nil end
+    if refresh_token == "" then refresh_token = nil end
     if device_id     == "" then device_id     = nil end
 
     if config then
@@ -172,8 +206,15 @@ function driver_init(config)
         host.log("error", "MyUplink: client_id and client_secret required")
         return
     end
+    if not refresh_token then
+        -- Not connected yet: the operator has saved the app credentials but
+        -- not completed the browser consent. Idle quietly (no error spam);
+        -- driver_poll stays a no-op until a refresh_token is configured.
+        host.log("info", "MyUplink: awaiting OAuth connect — click \"Connect to MyUplink\" in Settings → Devices")
+        return
+    end
     if not ensure_auth() then
-        host.log("error", "MyUplink: initial auth failed")
+        host.log("error", "MyUplink: initial auth failed (refresh_token rejected — reconnect in Settings → Devices)")
         return
     end
     if not device_id then
@@ -219,4 +260,7 @@ end
 function driver_cleanup()
     access_token     = nil
     token_expires_at = 0
+    -- refresh_token is re-read from config (with any KV override) on the
+    -- next driver_init; clear it so a hot-reload starts from a clean slate.
+    refresh_token    = nil
 end

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -305,6 +305,25 @@ func main() {
 	cfgMu := &sync.RWMutex{}
 	modelsMu := &sync.Mutex{}
 
+	// Durable secret write-back for drivers (rotated OAuth refresh tokens).
+	// Drivers call host.persist_secret(key, value); the registry routes it
+	// here with the driver's name. We write to the state KV store — NOT
+	// config.yaml — on purpose: config.yaml is watched by configreload, and
+	// rewriting it on every token rotation would restart the driver, which
+	// re-auths, rotates again, and loops. SecretOverride then layers these
+	// KV values back over config.yaml at driver_init, so the freshest token
+	// always reaches the driver while config.yaml keeps the bootstrap seed
+	// the UI renders as "saved".
+	driverSecretKey := func(driverName, key string) string {
+		return "driver_secret:" + driverName + ":" + key
+	}
+	reg.SecretPersister = func(driverName, key, value string) error {
+		return st.SaveConfig(driverSecretKey(driverName, key), value)
+	}
+	reg.SecretOverride = func(driverName, key string) (string, bool) {
+		return st.LoadConfig(driverSecretKey(driverName, key))
+	}
+
 	// Pre-declare services that the hot-reload Applier needs to touch.
 	// The Applier closure captures these by reference; they're assigned
 	// further down when their packages are wired, and the Applier only

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -299,6 +299,8 @@ func (s *Server) routes() {
 	s.handle("GET  /api/config", s.handleGetConfig)
 	s.handle("POST /api/config", s.handlePostConfig)
 	s.handle("POST /api/drivers/verify_tesla", s.handleVerifyTesla)
+	s.handle("GET /api/oauth/myuplink/start", s.handleMyUplinkOAuthStart)
+	s.handle("GET /api/oauth/myuplink/callback", s.handleMyUplinkOAuthCallback)
 	s.handle("GET  /api/mode", s.handleGetMode)
 	s.handle("POST /api/mode", s.handleSetMode)
 	s.handle("POST /api/target", s.handleSetTarget)

--- a/go/internal/api/api.go
+++ b/go/internal/api/api.go
@@ -301,6 +301,7 @@ func (s *Server) routes() {
 	s.handle("POST /api/drivers/verify_tesla", s.handleVerifyTesla)
 	s.handle("GET /api/oauth/myuplink/start", s.handleMyUplinkOAuthStart)
 	s.handle("GET /api/oauth/myuplink/callback", s.handleMyUplinkOAuthCallback)
+	s.handle("POST /api/oauth/myuplink/exchange", s.handleMyUplinkOAuthExchange)
 	s.handle("GET  /api/mode", s.handleGetMode)
 	s.handle("POST /api/mode", s.handleSetMode)
 	s.handle("POST /api/target", s.handleSetTarget)

--- a/go/internal/api/api_myuplink_oauth.go
+++ b/go/internal/api/api_myuplink_oauth.go
@@ -1,0 +1,316 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+)
+
+// MyUplink OAuth bootstrap.
+//
+// MyUplink (Azure B2C) only issues authorization-code apps via its developer
+// portal — the client_credentials grant the driver originally used returns
+// invalid_client (#496). This file owns the one-time browser consent so the
+// operator never has to hand-paste tokens:
+//
+//	GET /api/oauth/myuplink/start?driver=<name>
+//	  → mints a state, returns the MyUplink authorize URL + the exact
+//	    redirect/callback URL the operator must register in the portal.
+//	GET /api/oauth/myuplink/callback?code=&state=
+//	  → exchanges the code for a refresh_token, persists it into the driver
+//	    config (masked) + the state KV (so SecretOverride supersedes any
+//	    stale rotated value), restarts the driver, and renders a result page.
+//
+// The driver then runs grant_type=refresh_token at runtime (drivers/myuplink.lua)
+// and persists rotations via host.persist_secret.
+
+// myUplinkOAuthBase is the MyUplink OAuth + API host. Overridable in tests.
+var myUplinkOAuthBase = "https://api.myuplink.com"
+
+// myUplinkScope is the least-privilege scope set; offline_access is what
+// makes MyUplink return a refresh_token.
+const myUplinkScope = "READSYSTEM offline_access"
+
+// oauthPending is an in-flight authorization-code request, created by /start
+// and consumed (once) by /callback.
+type oauthPending struct {
+	driver      string
+	redirectURI string
+	expires     time.Time
+}
+
+var (
+	oauthMu       sync.Mutex
+	oauthPending_ = map[string]oauthPending{} //nolint:revive // package-local state store
+)
+
+// pruneOAuthStateLocked drops expired pending entries. Caller holds oauthMu.
+func pruneOAuthStateLocked(now time.Time) {
+	for k, p := range oauthPending_ {
+		if now.After(p.expires) {
+			delete(oauthPending_, k)
+		}
+	}
+}
+
+// requestOrigin reconstructs the externally-visible scheme://host the browser
+// used, honouring the relay's X-Forwarded-Proto. The redirect URI must match
+// byte-for-byte across authorize + token exchange + portal registration, so
+// it is derived once and stored with the pending state.
+func requestOrigin(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
+		// May be a comma-separated list; take the first token.
+		scheme = strings.TrimSpace(strings.Split(fp, ",")[0])
+	}
+	return scheme + "://" + r.Host
+}
+
+// driverConfigValue reads a string config value for a named driver under
+// CfgMu. Returns ("", false) if the driver or key is absent.
+func (s *Server) driverConfigValue(driver, key string) (string, bool) {
+	s.deps.CfgMu.RLock()
+	defer s.deps.CfgMu.RUnlock()
+	for i := range s.deps.Cfg.Drivers {
+		if s.deps.Cfg.Drivers[i].Name == driver {
+			if v, ok := s.deps.Cfg.Drivers[i].Config[key]; ok {
+				if sv, ok := v.(string); ok {
+					return sv, true
+				}
+			}
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// handleMyUplinkOAuthStart: GET /api/oauth/myuplink/start?driver=<name>
+func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request) {
+	driver := r.URL.Query().Get("driver")
+	if driver == "" {
+		writeJSON(w, 400, map[string]string{"error": "driver query param required"})
+		return
+	}
+	clientID, ok := s.driverConfigValue(driver, "client_id")
+	if !ok || clientID == "" {
+		writeJSON(w, 400, map[string]string{"error": "save the MyUplink Client ID for this driver first"})
+		return
+	}
+
+	redirectURI := requestOrigin(r) + "/api/oauth/myuplink/callback"
+
+	stateBytes := make([]byte, 16)
+	if _, err := rand.Read(stateBytes); err != nil {
+		writeJSON(w, 500, map[string]string{"error": "could not generate state"})
+		return
+	}
+	stateTok := hex.EncodeToString(stateBytes)
+
+	now := time.Now()
+	oauthMu.Lock()
+	pruneOAuthStateLocked(now)
+	oauthPending_[stateTok] = oauthPending{
+		driver:      driver,
+		redirectURI: redirectURI,
+		expires:     now.Add(10 * time.Minute),
+	}
+	oauthMu.Unlock()
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("scope", myUplinkScope)
+	q.Set("redirect_uri", redirectURI)
+	q.Set("state", stateTok)
+	authorizeURL := myUplinkOAuthBase + "/oauth/authorize?" + q.Encode()
+
+	writeJSON(w, 200, map[string]string{
+		"authorize_url": authorizeURL,
+		"redirect_uri":  redirectURI,
+		"callback":      redirectURI,
+	})
+}
+
+// handleMyUplinkOAuthCallback: GET /api/oauth/myuplink/callback?code=&state=
+func (s *Server) handleMyUplinkOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	code := q.Get("code")
+	stateTok := q.Get("state")
+
+	if e := q.Get("error"); e != "" {
+		// MyUplink redirected back with a consent error.
+		renderOAuthResult(w, false, "MyUplink returned an error: "+e+" "+q.Get("error_description"))
+		return
+	}
+
+	oauthMu.Lock()
+	pruneOAuthStateLocked(time.Now())
+	pending, found := oauthPending_[stateTok]
+	if found {
+		delete(oauthPending_, stateTok) // single-use
+	}
+	oauthMu.Unlock()
+
+	if !found {
+		renderOAuthResult(w, false, "Invalid or expired state — start the connect again from Settings → Devices.")
+		return
+	}
+	if code == "" {
+		renderOAuthResult(w, false, "No authorization code in the callback.")
+		return
+	}
+
+	clientID, _ := s.driverConfigValue(pending.driver, "client_id")
+	clientSecret, _ := s.driverConfigValue(pending.driver, "client_secret")
+	if clientID == "" || clientSecret == "" {
+		renderOAuthResult(w, false, "Missing Client ID / Secret for driver "+pending.driver+".")
+		return
+	}
+
+	refreshToken, err := s.exchangeMyUplinkCode(code, clientID, clientSecret, pending.redirectURI)
+	if err != nil {
+		renderOAuthResult(w, false, "Token exchange failed: "+err.Error())
+		return
+	}
+
+	if err := s.persistMyUplinkRefreshToken(r, pending.driver, refreshToken); err != nil {
+		renderOAuthResult(w, false, "Could not save the token: "+err.Error())
+		return
+	}
+
+	renderOAuthResult(w, true, "MyUplink connected for driver \""+pending.driver+"\". You can close this tab and return to 42-watts.")
+}
+
+// exchangeMyUplinkCode swaps an authorization code for a refresh_token.
+func (s *Server) exchangeMyUplinkCode(code, clientID, clientSecret, redirectURI string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", clientID)
+	form.Set("client_secret", clientSecret)
+	form.Set("redirect_uri", redirectURI)
+
+	req, err := http.NewRequest("POST", myUplinkOAuthBase+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, redactToken(string(body)))
+	}
+	var tok struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if tok.RefreshToken == "" {
+		return "", fmt.Errorf("no refresh_token in response (is offline_access granted?)")
+	}
+	return tok.RefreshToken, nil
+}
+
+// persistMyUplinkRefreshToken writes the refresh_token into the driver config
+// (so it's masked + visible as "saved" in the UI) AND into the state KV (so
+// SecretOverride supersedes any stale rotated value), then restarts the
+// driver so it picks up the token immediately.
+func (s *Server) persistMyUplinkRefreshToken(r *http.Request, driver, refreshToken string) error {
+	// 1. KV first — this is what SecretOverride reads at driver_init and what
+	//    the runtime rotation persists to. Writing it before the config save
+	//    guarantees the post-restart override matches the fresh token.
+	if s.deps.State != nil {
+		if err := s.deps.State.SaveConfig("driver_secret:"+driver+":refresh_token", refreshToken); err != nil {
+			return err
+		}
+	}
+
+	// 2. Driver config + atomic save.
+	var restartCfg *config.Driver
+	s.deps.CfgMu.Lock()
+	for i := range s.deps.Cfg.Drivers {
+		if s.deps.Cfg.Drivers[i].Name == driver {
+			if s.deps.Cfg.Drivers[i].Config == nil {
+				s.deps.Cfg.Drivers[i].Config = map[string]any{}
+			}
+			s.deps.Cfg.Drivers[i].Config["refresh_token"] = refreshToken
+			c := s.deps.Cfg.Drivers[i]
+			restartCfg = &c
+			break
+		}
+	}
+	var saveErr error
+	if s.deps.SaveConfig != nil {
+		saveErr = s.deps.SaveConfig(s.deps.ConfigPath, s.deps.Cfg)
+	}
+	s.deps.CfgMu.Unlock()
+	if saveErr != nil {
+		return saveErr
+	}
+	if restartCfg == nil {
+		return fmt.Errorf("driver %q not found in config", driver)
+	}
+
+	// 3. Restart so the driver re-auths now (best-effort; the config watcher
+	//    would also reload, but the explicit restart is deterministic).
+	if s.deps.Registry != nil {
+		if err := s.deps.Registry.Restart(r.Context(), *restartCfg); err != nil {
+			return fmt.Errorf("driver restart: %w", err)
+		}
+	}
+	return nil
+}
+
+// renderOAuthResult writes a minimal self-contained result page. The browser
+// lands here from the MyUplink redirect, so it cannot rely on the SPA chrome.
+func renderOAuthResult(w http.ResponseWriter, ok bool, msg string) {
+	status := http.StatusOK
+	title := "MyUplink connected"
+	accent := "#1f9d57"
+	if !ok {
+		status = http.StatusBadRequest
+		title = "MyUplink connection failed"
+		accent = "#c23b3b"
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, `<!doctype html><html><head><meta charset="utf-8">`+
+		`<meta name="viewport" content="width=device-width, initial-scale=1">`+
+		`<title>`+html.EscapeString(title)+`</title>`+
+		`<style>body{font-family:system-ui,-apple-system,sans-serif;background:#0f1115;color:#e8e8ea;`+
+		`display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}`+
+		`.card{max-width:30rem;padding:2rem;border:1px solid #2a2d34;border-radius:12px;text-align:center}`+
+		`h1{font-size:1.15rem;color:`+accent+`}p{line-height:1.5;color:#b8bcc4}</style></head>`+
+		`<body><div class="card"><h1>`+html.EscapeString(title)+`</h1><p>`+html.EscapeString(msg)+`</p></div></body></html>`)
+}
+
+// redactToken blanks anything that looks like a bearer/refresh token in an
+// error body so secrets never reach logs or the result page.
+func redactToken(s string) string {
+	for _, key := range []string{"refresh_token", "access_token", "id_token"} {
+		if i := strings.Index(s, key); i >= 0 {
+			return s[:i] + key + "=<redacted>"
+		}
+	}
+	return s
+}

--- a/go/internal/api/api_myuplink_oauth.go
+++ b/go/internal/api/api_myuplink_oauth.go
@@ -41,6 +41,28 @@ var myUplinkOAuthBase = "https://api.myuplink.com"
 // makes MyUplink return a refresh_token.
 const myUplinkScope = "READSYSTEM offline_access"
 
+// myUplinkCallbackPath is the 42w route MyUplink redirects back to. The
+// operator registers <origin>+this as the Callback Url in the portal.
+const myUplinkCallbackPath = "/api/oauth/myuplink/callback"
+
+// validMyUplinkCallback guards the browser-supplied redirect_uri so our
+// authorize state can't be turned into an open redirect: it must be an
+// absolute http(s) URL whose path is exactly the callback route, with no
+// query or fragment.
+func validMyUplinkCallback(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	if u.Host == "" {
+		return false
+	}
+	return u.Path == myUplinkCallbackPath && u.RawQuery == "" && u.Fragment == ""
+}
+
 // oauthPending is an in-flight authorization-code request, created by /start
 // and consumed (once) by /callback.
 type oauthPending struct {
@@ -110,7 +132,21 @@ func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	redirectURI := requestOrigin(r) + "/api/oauth/myuplink/callback"
+	// The redirect URI must match byte-for-byte across the portal
+	// registration, the authorize call, and the token exchange. Prefer an
+	// explicit redirect_uri from the browser (location.origin) — on a
+	// remote/relay origin the request Host the server sees is NOT the
+	// browser's origin, so deriving it server-side would be wrong. Fall
+	// back to the request origin for plain LAN access. Validate the passed
+	// value so our authorize state can't be used as an open redirect.
+	redirectURI := requestOrigin(r) + myUplinkCallbackPath
+	if ru := r.URL.Query().Get("redirect_uri"); ru != "" {
+		if !validMyUplinkCallback(ru) {
+			writeJSON(w, 400, map[string]string{"error": "invalid redirect_uri (must be <origin>" + myUplinkCallbackPath + ")"})
+			return
+		}
+		redirectURI = ru
+	}
 
 	stateBytes := make([]byte, 16)
 	if _, err := rand.Read(stateBytes); err != nil {

--- a/go/internal/api/api_myuplink_oauth.go
+++ b/go/internal/api/api_myuplink_oauth.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -68,7 +70,25 @@ func validMyUplinkCallback(raw string) bool {
 type oauthPending struct {
 	driver      string
 	redirectURI string
-	expires     time.Time
+	// codeVerifier is the PKCE (RFC 7636, S256) secret. We always send a
+	// code_challenge on /authorize and the verifier on token exchange:
+	// harmless if MyUplink ignores PKCE, required if it enforces it (Azure
+	// B2C can). Bound to the state so it never leaves the Pi.
+	codeVerifier string
+	expires      time.Time
+}
+
+// newPKCEPair returns a high-entropy code_verifier and its S256
+// code_challenge per RFC 7636 (base64url, no padding).
+func newPKCEPair() (verifier, challenge string, err error) {
+	b := make([]byte, 32)
+	if _, err = rand.Read(b); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(b) // 43 chars, allowed charset
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge, nil
 }
 
 var (
@@ -155,12 +175,19 @@ func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request
 	}
 	stateTok := hex.EncodeToString(stateBytes)
 
+	verifier, challenge, err := newPKCEPair()
+	if err != nil {
+		writeJSON(w, 500, map[string]string{"error": "could not generate PKCE challenge"})
+		return
+	}
+
 	now := time.Now()
 	oauthMu.Lock()
 	pruneOAuthStateLocked(now)
 	oauthPending_[stateTok] = oauthPending{
-		driver:      driver,
-		redirectURI: redirectURI,
+		driver:       driver,
+		redirectURI:  redirectURI,
+		codeVerifier: verifier,
 		// 15 min: enough headroom for the manual-paste path (sign in, copy
 		// the redirected URL, paste it back) when the auto-callback can't
 		// reach the Pi (relay origin / http LAN rejected by the portal).
@@ -174,6 +201,8 @@ func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request
 	q.Set("scope", myUplinkScope)
 	q.Set("redirect_uri", redirectURI)
 	q.Set("state", stateTok)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
 	authorizeURL := myUplinkOAuthBase + "/oauth/authorize?" + q.Encode()
 
 	writeJSON(w, 200, map[string]string{
@@ -268,7 +297,7 @@ func (s *Server) completeMyUplinkConsent(r *http.Request, stateTok, code string)
 		return "", fmt.Errorf("missing Client ID / Secret for driver %q", pending.driver)
 	}
 
-	refreshToken, err := s.exchangeMyUplinkCode(code, clientID, clientSecret, pending.redirectURI)
+	refreshToken, err := s.exchangeMyUplinkCode(code, clientID, clientSecret, pending.redirectURI, pending.codeVerifier)
 	if err != nil {
 		return "", fmt.Errorf("token exchange failed: %w", err)
 	}
@@ -279,13 +308,16 @@ func (s *Server) completeMyUplinkConsent(r *http.Request, stateTok, code string)
 }
 
 // exchangeMyUplinkCode swaps an authorization code for a refresh_token.
-func (s *Server) exchangeMyUplinkCode(code, clientID, clientSecret, redirectURI string) (string, error) {
+func (s *Server) exchangeMyUplinkCode(code, clientID, clientSecret, redirectURI, codeVerifier string) (string, error) {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
 	form.Set("client_id", clientID)
 	form.Set("client_secret", clientSecret)
 	form.Set("redirect_uri", redirectURI)
+	if codeVerifier != "" {
+		form.Set("code_verifier", codeVerifier) // PKCE (RFC 7636)
+	}
 
 	req, err := http.NewRequest("POST", myUplinkOAuthBase+"/oauth/token", strings.NewReader(form.Encode()))
 	if err != nil {

--- a/go/internal/api/api_myuplink_oauth.go
+++ b/go/internal/api/api_myuplink_oauth.go
@@ -161,7 +161,10 @@ func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request
 	oauthPending_[stateTok] = oauthPending{
 		driver:      driver,
 		redirectURI: redirectURI,
-		expires:     now.Add(10 * time.Minute),
+		// 15 min: enough headroom for the manual-paste path (sign in, copy
+		// the redirected URL, paste it back) when the auto-callback can't
+		// reach the Pi (relay origin / http LAN rejected by the portal).
+		expires: now.Add(15 * time.Minute),
 	}
 	oauthMu.Unlock()
 
@@ -181,17 +184,69 @@ func (s *Server) handleMyUplinkOAuthStart(w http.ResponseWriter, r *http.Request
 }
 
 // handleMyUplinkOAuthCallback: GET /api/oauth/myuplink/callback?code=&state=
+//
+// The happy path on a LAN-direct origin: MyUplink redirects the browser here,
+// we complete the consent and render a result page. When the callback can't
+// reach the Pi (relay origin refuses /api/*, or the portal rejected an http
+// LAN callback), the operator instead copies the redirected URL and pastes it
+// into the manual exchange endpoint below — same completion logic.
 func (s *Server) handleMyUplinkOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	code := q.Get("code")
-	stateTok := q.Get("state")
-
 	if e := q.Get("error"); e != "" {
-		// MyUplink redirected back with a consent error.
 		renderOAuthResult(w, false, "MyUplink returned an error: "+e+" "+q.Get("error_description"))
 		return
 	}
+	driver, err := s.completeMyUplinkConsent(r, q.Get("state"), q.Get("code"))
+	if err != nil {
+		renderOAuthResult(w, false, err.Error())
+		return
+	}
+	renderOAuthResult(w, true, "MyUplink connected for driver \""+driver+"\". You can close this tab and return to 42-watts.")
+}
 
+// handleMyUplinkOAuthExchange: POST /api/oauth/myuplink/exchange
+// Manual fallback for origins where the auto-callback can't reach the Pi.
+// Body: {"redirect_url": "<full URL from the address bar after sign-in>"}
+// or {"code": "...", "state": "..."}. Completes the same consent flow.
+func (s *Server) handleMyUplinkOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RedirectURL string `json:"redirect_url"`
+		Code        string `json:"code"`
+		State       string `json:"state"`
+	}
+	if err := readJSON(r, &req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	code, stateTok := req.Code, req.State
+	// Prefer parsing the full redirected URL — easiest for the operator (copy
+	// the whole address bar); it carries both code and state.
+	if req.RedirectURL != "" {
+		u, perr := url.Parse(strings.TrimSpace(req.RedirectURL))
+		if perr != nil {
+			writeJSON(w, 400, map[string]string{"error": "could not parse the pasted URL"})
+			return
+		}
+		if e := u.Query().Get("error"); e != "" {
+			writeJSON(w, 400, map[string]string{"error": "MyUplink returned an error: " + e})
+			return
+		}
+		code = u.Query().Get("code")
+		stateTok = u.Query().Get("state")
+	}
+	driver, err := s.completeMyUplinkConsent(r, stateTok, code)
+	if err != nil {
+		writeJSON(w, 400, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, 200, map[string]string{"status": "connected", "driver": driver})
+}
+
+// completeMyUplinkConsent validates+consumes the pending state, exchanges the
+// authorization code for a refresh_token, and persists it (config + KV) with a
+// driver restart. Shared by the auto-callback (GET) and the manual exchange
+// (POST). Returns the driver name on success. Errors are operator-facing.
+func (s *Server) completeMyUplinkConsent(r *http.Request, stateTok, code string) (string, error) {
 	oauthMu.Lock()
 	pruneOAuthStateLocked(time.Now())
 	pending, found := oauthPending_[stateTok]
@@ -201,33 +256,26 @@ func (s *Server) handleMyUplinkOAuthCallback(w http.ResponseWriter, r *http.Requ
 	oauthMu.Unlock()
 
 	if !found {
-		renderOAuthResult(w, false, "Invalid or expired state — start the connect again from Settings → Devices.")
-		return
+		return "", fmt.Errorf("invalid or expired state — start the connect again from Settings → Devices")
 	}
 	if code == "" {
-		renderOAuthResult(w, false, "No authorization code in the callback.")
-		return
+		return "", fmt.Errorf("no authorization code found")
 	}
 
 	clientID, _ := s.driverConfigValue(pending.driver, "client_id")
 	clientSecret, _ := s.driverConfigValue(pending.driver, "client_secret")
 	if clientID == "" || clientSecret == "" {
-		renderOAuthResult(w, false, "Missing Client ID / Secret for driver "+pending.driver+".")
-		return
+		return "", fmt.Errorf("missing Client ID / Secret for driver %q", pending.driver)
 	}
 
 	refreshToken, err := s.exchangeMyUplinkCode(code, clientID, clientSecret, pending.redirectURI)
 	if err != nil {
-		renderOAuthResult(w, false, "Token exchange failed: "+err.Error())
-		return
+		return "", fmt.Errorf("token exchange failed: %w", err)
 	}
-
 	if err := s.persistMyUplinkRefreshToken(r, pending.driver, refreshToken); err != nil {
-		renderOAuthResult(w, false, "Could not save the token: "+err.Error())
-		return
+		return "", fmt.Errorf("could not save the token: %w", err)
 	}
-
-	renderOAuthResult(w, true, "MyUplink connected for driver \""+pending.driver+"\". You can close this tab and return to 42-watts.")
+	return pending.driver, nil
 }
 
 // exchangeMyUplinkCode swaps an authorization code for a refresh_token.

--- a/go/internal/api/api_myuplink_oauth_test.go
+++ b/go/internal/api/api_myuplink_oauth_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -42,6 +44,25 @@ func buildMyUplinkOAuthServer(t *testing.T) (*Server, *config.Config, *state.Sto
 	return srv, cfg, st
 }
 
+func TestNewPKCEPair(t *testing.T) {
+	v, c, err := newPKCEPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v) < 43 || len(v) > 128 {
+		t.Errorf("verifier length %d outside RFC 7636 range 43..128", len(v))
+	}
+	// challenge MUST be base64url(SHA256(verifier)), no padding.
+	sum := sha256.Sum256([]byte(v))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if c != want {
+		t.Errorf("challenge = %q, want S256(verifier) = %q", c, want)
+	}
+	if v2, _, _ := newPKCEPair(); v2 == v {
+		t.Errorf("verifier not random: two calls returned %q", v)
+	}
+}
+
 func TestMyUplinkOAuthStartBuildsAuthorizeURL(t *testing.T) {
 	srv, _, _ := buildMyUplinkOAuthServer(t)
 
@@ -75,6 +96,12 @@ func TestMyUplinkOAuthStartBuildsAuthorizeURL(t *testing.T) {
 	}
 	if q.Get("state") == "" {
 		t.Errorf("missing state")
+	}
+	if q.Get("code_challenge") == "" {
+		t.Errorf("missing PKCE code_challenge")
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", q.Get("code_challenge_method"))
 	}
 	wantRedirect := "http://pi.local/api/oauth/myuplink/callback"
 	if resp.RedirectURI != wantRedirect {
@@ -136,6 +163,9 @@ func TestMyUplinkOAuthCallbackExchangesAndPersists(t *testing.T) {
 		gotGrant = vals.Get("grant_type")
 		gotRedirect = vals.Get("redirect_uri")
 		gotSecret = vals.Get("client_secret")
+		if vals.Get("code_verifier") == "" {
+			t.Errorf("missing PKCE code_verifier in token exchange")
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  "AT",
 			"refresh_token": "RT-from-consent",

--- a/go/internal/api/api_myuplink_oauth_test.go
+++ b/go/internal/api/api_myuplink_oauth_test.go
@@ -85,6 +85,47 @@ func TestMyUplinkOAuthStartBuildsAuthorizeURL(t *testing.T) {
 	}
 }
 
+func TestMyUplinkOAuthStartHonoursBrowserRedirectURI(t *testing.T) {
+	srv, _, _ := buildMyUplinkOAuthServer(t)
+
+	// Browser on a relay origin supplies its own callback URL.
+	browserCb := "https://homelab.relay.example/api/oauth/myuplink/callback"
+	req := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/start?driver=myuplink&redirect_uri="+url.QueryEscape(browserCb), nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		AuthorizeURL string `json:"authorize_url"`
+		RedirectURI  string `json:"redirect_uri"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.RedirectURI != browserCb {
+		t.Errorf("redirect_uri = %q, want browser-supplied %q", resp.RedirectURI, browserCb)
+	}
+	u, _ := url.Parse(resp.AuthorizeURL)
+	if u.Query().Get("redirect_uri") != browserCb {
+		t.Errorf("authorize redirect_uri = %q, want %q", u.Query().Get("redirect_uri"), browserCb)
+	}
+}
+
+func TestMyUplinkOAuthStartRejectsBadRedirectURI(t *testing.T) {
+	srv, _, _ := buildMyUplinkOAuthServer(t)
+	for _, bad := range []string{
+		"https://evil.example/steal",                           // wrong path
+		"javascript:alert(1)",                                  // wrong scheme
+		"https://evil.example/api/oauth/myuplink/callback?x=1", // has query
+	} {
+		req := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/start?driver=myuplink&redirect_uri="+url.QueryEscape(bad), nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != 400 {
+			t.Errorf("redirect_uri %q: status = %d, want 400", bad, rec.Code)
+		}
+	}
+}
+
 func TestMyUplinkOAuthCallbackExchangesAndPersists(t *testing.T) {
 	// Stub MyUplink token endpoint: assert authorization_code grant + the
 	// client_secret from config, return a refresh_token.

--- a/go/internal/api/api_myuplink_oauth_test.go
+++ b/go/internal/api/api_myuplink_oauth_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/config"
+	"github.com/frahlg/forty-two-watts/go/internal/state"
+)
+
+// buildMyUplinkOAuthServer wires a test Server with one MyUplink driver in
+// config plus an in-memory state store, and returns it alongside the live
+// *config.Config (so tests can read the persisted refresh_token back).
+func buildMyUplinkOAuthServer(t *testing.T) (*Server, *config.Config, *state.Store) {
+	t.Helper()
+	st, err := state.Open(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	cfg := &config.Config{Drivers: []config.Driver{{
+		Name: "myuplink",
+		Lua:  "drivers/myuplink.lua",
+		Config: map[string]any{
+			"client_id":     "the-client-id",
+			"client_secret": "the-client-secret",
+		},
+	}}}
+	srv := New(&Deps{
+		Cfg:        cfg,
+		CfgMu:      &sync.RWMutex{},
+		ConfigPath: filepath.Join(t.TempDir(), "config.yaml"),
+		State:      st,
+		SaveConfig: func(string, *config.Config) error { return nil }, // in-memory cfg is the source of truth here
+	})
+	return srv, cfg, st
+}
+
+func TestMyUplinkOAuthStartBuildsAuthorizeURL(t *testing.T) {
+	srv, _, _ := buildMyUplinkOAuthServer(t)
+
+	req := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/start?driver=myuplink", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("start status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		AuthorizeURL string `json:"authorize_url"`
+		RedirectURI  string `json:"redirect_uri"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	u, err := url.Parse(resp.AuthorizeURL)
+	if err != nil {
+		t.Fatalf("authorize_url not a URL: %v", err)
+	}
+	q := u.Query()
+	if q.Get("client_id") != "the-client-id" {
+		t.Errorf("client_id = %q", q.Get("client_id"))
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want code", q.Get("response_type"))
+	}
+	if q.Get("scope") != "READSYSTEM offline_access" {
+		t.Errorf("scope = %q", q.Get("scope"))
+	}
+	if q.Get("state") == "" {
+		t.Errorf("missing state")
+	}
+	wantRedirect := "http://pi.local/api/oauth/myuplink/callback"
+	if resp.RedirectURI != wantRedirect {
+		t.Errorf("redirect_uri = %q, want %q", resp.RedirectURI, wantRedirect)
+	}
+	if q.Get("redirect_uri") != wantRedirect {
+		t.Errorf("authorize redirect_uri = %q, want %q", q.Get("redirect_uri"), wantRedirect)
+	}
+}
+
+func TestMyUplinkOAuthCallbackExchangesAndPersists(t *testing.T) {
+	// Stub MyUplink token endpoint: assert authorization_code grant + the
+	// client_secret from config, return a refresh_token.
+	var gotGrant, gotRedirect, gotSecret string
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		gotGrant = vals.Get("grant_type")
+		gotRedirect = vals.Get("redirect_uri")
+		gotSecret = vals.Get("client_secret")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "AT",
+			"refresh_token": "RT-from-consent",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenSrv.Close()
+
+	old := myUplinkOAuthBase
+	myUplinkOAuthBase = tokenSrv.URL
+	defer func() { myUplinkOAuthBase = old }()
+
+	srv, cfg, st := buildMyUplinkOAuthServer(t)
+
+	// First /start to mint a valid state for this driver.
+	startReq := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/start?driver=myuplink", nil)
+	startRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(startRec, startReq)
+	var sresp struct {
+		AuthorizeURL string `json:"authorize_url"`
+	}
+	_ = json.Unmarshal(startRec.Body.Bytes(), &sresp)
+	u, _ := url.Parse(sresp.AuthorizeURL)
+	stateTok := u.Query().Get("state")
+	if stateTok == "" {
+		t.Fatal("no state minted")
+	}
+
+	// Now the callback the browser would hit after consent.
+	cbReq := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/callback?code=AUTH-CODE&state="+stateTok, nil)
+	cbRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(cbRec, cbReq)
+
+	if cbRec.Code != 200 {
+		t.Fatalf("callback status = %d, body=%s", cbRec.Code, cbRec.Body.String())
+	}
+	if gotGrant != "authorization_code" {
+		t.Errorf("grant_type = %q, want authorization_code", gotGrant)
+	}
+	if gotSecret != "the-client-secret" {
+		t.Errorf("client_secret = %q, want the-client-secret", gotSecret)
+	}
+	if gotRedirect != "http://pi.local/api/oauth/myuplink/callback" {
+		t.Errorf("redirect_uri = %q", gotRedirect)
+	}
+	// The refresh_token must land in the driver config...
+	if got := cfg.Drivers[0].Config["refresh_token"]; got != "RT-from-consent" {
+		t.Errorf("config refresh_token = %v, want RT-from-consent", got)
+	}
+	// ...and in the unwatched KV so SecretOverride supersedes any stale value.
+	if v, ok := st.LoadConfig("driver_secret:myuplink:refresh_token"); !ok || v != "RT-from-consent" {
+		t.Errorf("KV refresh_token = %q (ok=%v), want RT-from-consent", v, ok)
+	}
+}
+
+func TestMyUplinkOAuthCallbackRejectsBadState(t *testing.T) {
+	srv, _, _ := buildMyUplinkOAuthServer(t)
+	req := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/callback?code=X&state=not-a-real-state", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code == 200 {
+		t.Errorf("expected non-200 for unknown state, got 200")
+	}
+	if !strings.Contains(strings.ToLower(rec.Body.String()), "state") {
+		t.Errorf("error page should mention state, got: %s", rec.Body.String())
+	}
+}

--- a/go/internal/api/api_myuplink_oauth_test.go
+++ b/go/internal/api/api_myuplink_oauth_test.go
@@ -191,6 +191,67 @@ func TestMyUplinkOAuthCallbackExchangesAndPersists(t *testing.T) {
 	}
 }
 
+func TestMyUplinkOAuthManualExchange(t *testing.T) {
+	// Stub MyUplink token endpoint.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		vals, _ := url.ParseQuery(string(body))
+		if vals.Get("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q", vals.Get("grant_type"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "AT", "refresh_token": "RT-manual", "expires_in": 3600,
+		})
+	}))
+	defer tokenSrv.Close()
+	old := myUplinkOAuthBase
+	myUplinkOAuthBase = tokenSrv.URL
+	defer func() { myUplinkOAuthBase = old }()
+
+	srv, cfg, st := buildMyUplinkOAuthServer(t)
+
+	// /start mints state.
+	startReq := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/start?driver=myuplink", nil)
+	startRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(startRec, startReq)
+	var sresp struct {
+		AuthorizeURL string `json:"authorize_url"`
+	}
+	_ = json.Unmarshal(startRec.Body.Bytes(), &sresp)
+	u, _ := url.Parse(sresp.AuthorizeURL)
+	stateTok := u.Query().Get("state")
+
+	// Operator pastes the full redirected URL (auto-callback never reached us).
+	redirectURL := "http://pi.local/api/oauth/myuplink/callback?code=MANUAL-CODE&state=" + stateTok
+	body, _ := json.Marshal(map[string]string{"redirect_url": redirectURL})
+	exReq := httptest.NewRequest("POST", "http://pi.local/api/oauth/myuplink/exchange", strings.NewReader(string(body)))
+	exReq.Header.Set("Content-Type", "application/json")
+	exRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(exRec, exReq)
+
+	if exRec.Code != 200 {
+		t.Fatalf("exchange status = %d, body=%s", exRec.Code, exRec.Body.String())
+	}
+	if got := cfg.Drivers[0].Config["refresh_token"]; got != "RT-manual" {
+		t.Errorf("config refresh_token = %v, want RT-manual", got)
+	}
+	if v, ok := st.LoadConfig("driver_secret:myuplink:refresh_token"); !ok || v != "RT-manual" {
+		t.Errorf("KV refresh_token = %q (ok=%v), want RT-manual", v, ok)
+	}
+}
+
+func TestMyUplinkOAuthManualExchangeBadState(t *testing.T) {
+	srv, _, _ := buildMyUplinkOAuthServer(t)
+	body, _ := json.Marshal(map[string]string{"code": "X", "state": "nope"})
+	req := httptest.NewRequest("POST", "http://pi.local/api/oauth/myuplink/exchange", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != 400 {
+		t.Errorf("status = %d, want 400 for unknown state", rec.Code)
+	}
+}
+
 func TestMyUplinkOAuthCallbackRejectsBadState(t *testing.T) {
 	srv, _, _ := buildMyUplinkOAuthServer(t)
 	req := httptest.NewRequest("GET", "http://pi.local/api/oauth/myuplink/callback?code=X&state=not-a-real-state", nil)

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -112,6 +112,14 @@ type HostEnv struct {
 	SN       string
 	MAC      string // resolved by ARP after first connection (best-effort)
 	Endpoint string // e.g. "modbus://192.168.1.1:502" or "mqtt://broker:1883"
+
+	// PersistSecret, when non-nil, lets a driver durably write a config
+	// secret (e.g. a rotated OAuth refresh_token) back into its own
+	// config block so it survives a restart. nil → host.persist_secret
+	// returns ok=false + an error. Wired by the Registry to a per-driver
+	// closure (see registry.go SecretPersister). Keep the value small:
+	// it is round-tripped through config.yaml as a plain string.
+	PersistSecret func(key, value string) error
 }
 
 // NewHostEnv creates a fresh host environment for a driver.

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -329,6 +329,28 @@ func registerHost(L *lua.LState, env *HostEnv) {
 		return 0
 	}))
 
+	// host.persist_secret(key, value) -> ok, err
+	// Durably writes a config secret back into the driver's own config
+	// block (e.g. a rotated OAuth refresh_token) so it survives restarts.
+	// Returns ok=false + an error string when the capability isn't wired.
+	host.RawSetString("persist_secret", L.NewFunction(func(L *lua.LState) int {
+		key := L.CheckString(1)
+		val := L.CheckString(2)
+		if env.PersistSecret == nil {
+			L.Push(lua.LBool(false))
+			L.Push(lua.LString("persist_secret: capability not granted"))
+			return 2
+		}
+		if err := env.PersistSecret(key, val); err != nil {
+			L.Push(lua.LBool(false))
+			L.Push(lua.LString(err.Error()))
+			return 2
+		}
+		L.Push(lua.LBool(true))
+		L.Push(lua.LNil)
+		return 2
+	}))
+
 	mqttSubscribe := L.NewFunction(func(L *lua.LState) int {
 		topic := L.CheckString(1)
 		if env.MQTT == nil {

--- a/go/internal/drivers/lua_persist_test.go
+++ b/go/internal/drivers/lua_persist_test.go
@@ -1,0 +1,101 @@
+package drivers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// TestHostPersistSecret verifies a driver can durably write a config
+// secret (e.g. a rotated OAuth refresh_token) back through the
+// host.persist_secret capability, and that the (key, value) pair reaches
+// the injected HostEnv.PersistSecret hook unchanged.
+func TestHostPersistSecret(t *testing.T) {
+	tel := telemetry.NewStore()
+	var gotKey, gotVal string
+	var called int
+	env := NewHostEnv("dummy", tel)
+	env.PersistSecret = func(key, value string) error {
+		called++
+		gotKey, gotVal = key, value
+		return nil
+	}
+
+	src := `
+		function driver_init() end
+		function driver_poll()
+			local ok, err = host.persist_secret("refresh_token", "RT2")
+			if ok then host.emit_metric("persist_ok", 1) end
+			return 60000
+		end
+		function driver_command() end
+		function driver_default_mode() end
+		function driver_cleanup() end
+	`
+	path := filepath.Join(t.TempDir(), "drv.lua")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	if called != 1 {
+		t.Fatalf("PersistSecret called %d times, want 1", called)
+	}
+	if gotKey != "refresh_token" || gotVal != "RT2" {
+		t.Errorf("PersistSecret got (%q, %q), want (refresh_token, RT2)", gotKey, gotVal)
+	}
+	if v, _, ok := tel.LatestMetric("dummy", "persist_ok"); !ok || v != 1 {
+		t.Errorf("persist_ok = %v (ok=%v), want 1 — host.persist_secret should return ok=true", v, ok)
+	}
+}
+
+// TestHostPersistSecretNotGranted verifies that without a PersistSecret
+// hook the primitive returns ok=false + an error string rather than
+// panicking, so a driver can degrade gracefully.
+func TestHostPersistSecretNotGranted(t *testing.T) {
+	tel := telemetry.NewStore()
+	env := NewHostEnv("dummy", tel) // no PersistSecret wired
+
+	src := `
+		function driver_init() end
+		function driver_poll()
+			local ok, err = host.persist_secret("k", "v")
+			if not ok and err then host.emit_metric("got_err", 1) end
+			return 60000
+		end
+		function driver_command() end
+		function driver_default_mode() end
+		function driver_cleanup() end
+	`
+	path := filepath.Join(t.TempDir(), "drv.lua")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if v, _, ok := tel.LatestMetric("dummy", "got_err"); !ok || v != 1 {
+		t.Errorf("got_err = %v (ok=%v), want 1 — primitive should return an error when not granted", v, ok)
+	}
+}

--- a/go/internal/drivers/myuplink_test.go
+++ b/go/internal/drivers/myuplink_test.go
@@ -3,10 +3,12 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
@@ -26,13 +28,26 @@ func myuplinkDriverPath(t *testing.T) string {
 }
 
 // TestMyUplinkEmitsTelemetry loads the real driver against a fake MyUplink
-// server and asserts the compressor-power metric lands in the telemetry store.
+// server and asserts (1) it authenticates with the refresh_token grant the
+// MyUplink portal actually supports (NOT client_credentials, which produced
+// the invalid_client failure in #496), (2) the compressor-power + temperature
+// metrics land in the telemetry store, and (3) a rotated refresh_token is
+// persisted via host.persist_secret so it survives a restart.
 func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/oauth/token":
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "grant_type=refresh_token") {
+				t.Errorf("expected refresh_token grant, got body %q", string(body))
+			}
+			if !strings.Contains(string(body), "refresh_token=RT-initial") {
+				t.Errorf("expected the configured refresh_token in the request, got %q", string(body))
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"access_token": "test-token", "expires_in": 3600,
+				"access_token":  "test-token",
+				"expires_in":    3600,
+				"refresh_token": "RT-rotated", // Azure B2C rotates on refresh
 			})
 		default:
 			// /v2/devices/{id}/points
@@ -45,7 +60,9 @@ func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	defer srv.Close()
 
 	tel := telemetry.NewStore()
+	persisted := map[string]string{}
 	env := NewHostEnv("myuplink", tel).WithHTTP()
+	env.PersistSecret = func(k, v string) error { persisted[k] = v; return nil }
 
 	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
 	if err != nil {
@@ -56,6 +73,7 @@ func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	cfg := map[string]any{
 		"client_id":     "cid",
 		"client_secret": "csecret",
+		"refresh_token": "RT-initial",
 		"device_id":     "DEV1",
 		"base_url":      srv.URL,
 	}
@@ -71,5 +89,37 @@ func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	}
 	if v, _, ok := tel.LatestMetric("myuplink", "hp_hw_top_temp_c"); !ok || v != 52 {
 		t.Errorf("hp_hw_top_temp_c = %v (ok=%v), want 52", v, ok)
+	}
+	if persisted["refresh_token"] != "RT-rotated" {
+		t.Errorf("rotated refresh_token not persisted: got %q, want RT-rotated", persisted["refresh_token"])
+	}
+}
+
+// TestMyUplinkNoRefreshTokenIdles verifies the driver degrades gracefully
+// when it has not been connected yet (no refresh_token in config): init must
+// not error or crash, and a poll must not panic — it simply emits nothing.
+func TestMyUplinkNoRefreshTokenIdles(t *testing.T) {
+	tel := telemetry.NewStore()
+	env := NewHostEnv("myuplink", tel).WithHTTP()
+
+	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+
+	cfg := map[string]any{
+		"client_id":     "cid",
+		"client_secret": "csecret",
+		// no refresh_token — user hasn't completed the OAuth connect yet
+	}
+	if err := d.Init(context.Background(), cfg); err != nil {
+		t.Fatalf("init should not error when not yet connected: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll should not error when not yet connected: %v", err)
+	}
+	if _, _, ok := tel.LatestMetric("myuplink", "hp_power_w"); ok {
+		t.Errorf("expected no telemetry before OAuth connect")
 	}
 }

--- a/go/internal/drivers/registry.go
+++ b/go/internal/drivers/registry.go
@@ -29,6 +29,16 @@ type Registry struct {
 	// ARPLookup resolves a hostname/IP to a MAC for L2-stable identity.
 	// Optional — when nil, devices fall back to endpoint-hash IDs.
 	ARPLookup func(host string) (mac string, ok bool)
+	// SecretPersister, when set, durably stores a driver secret (keyed by
+	// driver name + key) in the unwatched state KV. Wired by main.go.
+	// Optional — when nil, host.persist_secret returns an error and the
+	// driver degrades (an OAuth driver re-uses its last in-memory token).
+	SecretPersister func(driverName, key, value string) error
+	// SecretOverride, when set, returns a durably-persisted secret for a
+	// driver (the counterpart to SecretPersister). Applied over the
+	// config.yaml value at driver_init so a rotated token survives a
+	// restart. Returns ("", false) when no override exists.
+	SecretOverride func(driverName, key string) (string, bool)
 
 	mu  sync.Mutex
 	rec map[string]*runningDriver
@@ -125,6 +135,17 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 
 	env := NewHostEnv(cfg.Name, r.tel)
 	env.BatteryCapacityWh = cfg.BatteryCapacityWh
+	// Wire durable secret write-back (rotated OAuth tokens). The closure
+	// reads r.SecretPersister lazily at call time so main.go may set it
+	// either before or after the initial Add loop; persists only ever
+	// happen at runtime poll, long after wiring completes.
+	driverName := cfg.Name
+	env.PersistSecret = func(key, value string) error {
+		if r.SecretPersister == nil {
+			return fmt.Errorf("persist_secret: not supported on this host")
+		}
+		return r.SecretPersister(driverName, key, value)
+	}
 	if mq := cfg.EffectiveMQTT(); mq != nil && r.MQTTFactory != nil {
 		cap, err := r.MQTTFactory(cfg.Name, mq)
 		if err != nil {
@@ -191,9 +212,28 @@ func (r *Registry) Add(ctx context.Context, cfg config.Driver) error {
 	troubleshootingMode := r.troubleshootingMode
 	r.mu.Unlock()
 
+	// Layer any durably-persisted secret overrides (e.g. a rotated OAuth
+	// refresh_token from the unwatched state KV) over the config.yaml
+	// values, for driver_init only. rd.cfg below keeps the ORIGINAL cfg so
+	// the config-watcher's sameDriverConfig comparison stays stable — a
+	// rotated token must never look like an operator edit (that would
+	// trigger a restart→re-auth→rotate loop).
+	initDriverCfg := cfg
+	if r.SecretOverride != nil && len(cfg.Config) > 0 {
+		merged := make(map[string]any, len(cfg.Config))
+		for k, v := range cfg.Config {
+			if ov, ok := r.SecretOverride(cfg.Name, k); ok {
+				merged[k] = ov
+			} else {
+				merged[k] = v
+			}
+		}
+		initDriverCfg.Config = merged
+	}
+
 	// Pass the driver's config map as JSON to driver_init, with reserved
 	// host-level keys injected only at runtime.
-	initCfg := driverInitConfigJSON(cfg, troubleshootingMode)
+	initCfg := driverInitConfigJSON(initDriverCfg, troubleshootingMode)
 	if err := drv.Init(ctx, initCfg); err != nil {
 		drv.Cleanup(ctx)
 		return fmt.Errorf("driver_init: %w", err)

--- a/web/heating.js
+++ b/web/heating.js
@@ -1,0 +1,188 @@
+// heating.js — heat-pump telemetry card on the main dashboard.
+//
+// Read-only view over the MyUplink driver's hp_* metrics (compressor power +
+// hot-water/indoor/outdoor temperatures). The section stays hidden until a
+// driver actually reports hp_power_w, so a site without a heat pump never
+// sees an empty card. Discovery runs once on load (one /api/drivers/{name}
+// fetch per driver); steady-state polling then only touches the heat-pump
+// drivers, so remote routes don't pay for every driver every 30 s.
+//
+// See docs/myuplink-oauth.md. No control here — telemetry only.
+
+(function () {
+  'use strict';
+
+  var REFRESH_MS = 30000;
+  var timer = null;
+  var heatPumpDrivers = null; // cached after discovery: array of driver names
+
+  // Route reads over the owner/P2P transport when present (remote home
+  // route), else plain fetch (LAN / tests). Mirrors twins.js.
+  function ownerFetch(path, opts) {
+    if (typeof window.ownerFetch === 'function') return window.ownerFetch(path, opts);
+    return fetch(path, opts);
+  }
+
+  // hp_* metric → display label + formatter. Order here is render order.
+  var METRICS = [
+    { key: 'hp_power_w', label: 'Compressor', fmt: fmtPower },
+    { key: 'hp_hw_top_temp_c', label: 'Hot water', fmt: fmtTemp },
+    { key: 'hp_indoor_temp_c', label: 'Indoor', fmt: fmtTemp },
+    { key: 'hp_outdoor_temp_c', label: 'Outdoor', fmt: fmtTemp },
+  ];
+
+  function fmtPower(v) {
+    if (v == null) return '—';
+    if (Math.abs(v) >= 1000) return (v / 1000).toFixed(2) + ' kW';
+    return Math.round(v) + ' W';
+  }
+  function fmtTemp(v) {
+    if (v == null) return '—';
+    return v.toFixed(1) + ' °C';
+  }
+
+  function injectStyles() {
+    if (document.getElementById('ftw-heating-styles')) return;
+    var css = [
+      '#heating-grid{display:flex;flex-direction:column;gap:18px}',
+      '.ftw-hp{display:flex;flex-direction:column;gap:12px}',
+      '.ftw-hp-name{font-family:var(--mono);font-size:0.72rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--fg-muted)}',
+      '.ftw-hp-tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:10px 18px}',
+      '.ftw-hp-tile{display:flex;flex-direction:column;gap:3px}',
+      '.ftw-hp-tile-label{font-family:var(--mono);font-size:0.68rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--fg-muted)}',
+      '.ftw-hp-tile-val{font-family:var(--mono);font-size:1.05rem;font-variant-numeric:tabular-nums;color:var(--fg)}',
+      '.ftw-hp-spark{display:flex;flex-direction:column;gap:4px}',
+      '.ftw-hp-spark-label{font-family:var(--mono);font-size:0.66rem;letter-spacing:0.12em;text-transform:uppercase;color:var(--fg-muted)}',
+      '.ftw-hp-spark svg{width:100%;height:48px;display:block}',
+      '.ftw-hp-empty{font-family:var(--mono);font-size:0.8rem;color:var(--fg-muted)}',
+    ].join('');
+    var el = document.createElement('style');
+    el.id = 'ftw-heating-styles';
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+
+  // Build a sparkline <svg> from [{ts, v}] points. Pure SVG so it themes via
+  // CSS vars (stroke = accent). Returns '' when there's nothing to draw.
+  function sparkline(points) {
+    if (!points || points.length < 2) return '';
+    var w = 240, h = 48, pad = 3;
+    var vals = points.map(function (p) { return p.v; });
+    var min = Math.min.apply(null, vals);
+    var max = Math.max.apply(null, vals);
+    var span = max - min || 1;
+    var n = points.length;
+    var coords = points.map(function (p, i) {
+      var x = pad + (i / (n - 1)) * (w - 2 * pad);
+      var y = h - pad - ((p.v - min) / span) * (h - 2 * pad);
+      return x.toFixed(1) + ',' + y.toFixed(1);
+    });
+    return '<svg viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" aria-hidden="true">' +
+      '<polyline fill="none" stroke="var(--accent-e)" stroke-width="1.5" ' +
+      'stroke-linejoin="round" stroke-linecap="round" points="' + coords.join(' ') + '"></polyline>' +
+      '</svg>';
+  }
+
+  function metricMap(metrics) {
+    var m = {};
+    (metrics || []).forEach(function (s) { if (s && s.name) m[s.name] = s.value; });
+    return m;
+  }
+
+  function isHeatPump(detail) {
+    var m = metricMap(detail && detail.metrics);
+    return Object.prototype.hasOwnProperty.call(m, 'hp_power_w');
+  }
+
+  function fetchJSON(path) {
+    return ownerFetch(path).then(function (r) { return r.json(); }).catch(function () { return null; });
+  }
+
+  // One-time discovery: list drivers, fetch each detail, keep the ones that
+  // report hp_power_w.
+  function discover() {
+    return fetchJSON('/api/drivers').then(function (health) {
+      if (!health || typeof health !== 'object') return [];
+      var names = Object.keys(health);
+      return Promise.all(names.map(function (n) {
+        return fetchJSON('/api/drivers/' + encodeURIComponent(n)).then(function (d) {
+          return d && isHeatPump(d) ? n : null;
+        });
+      })).then(function (found) {
+        return found.filter(Boolean);
+      });
+    });
+  }
+
+  function renderPump(name, detail, sparkPoints) {
+    var m = metricMap(detail && detail.metrics);
+    var tiles = METRICS.map(function (def) {
+      var has = Object.prototype.hasOwnProperty.call(m, def.key);
+      return '<div class="ftw-hp-tile">' +
+        '<span class="ftw-hp-tile-label">' + def.label + '</span>' +
+        '<span class="ftw-hp-tile-val">' + (has ? def.fmt(m[def.key]) : '—') + '</span>' +
+        '</div>';
+    }).join('');
+    var spark = sparkline(sparkPoints);
+    var sparkBlock = spark
+      ? '<div class="ftw-hp-spark"><span class="ftw-hp-spark-label">Compressor power · 24h</span>' + spark + '</div>'
+      : '';
+    return '<div class="ftw-hp">' +
+      '<span class="ftw-hp-name">' + escapeHtml(name) + '</span>' +
+      '<div class="ftw-hp-tiles">' + tiles + '</div>' +
+      sparkBlock +
+      '</div>';
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  function refresh() {
+    var section = document.getElementById('heating-section');
+    var grid = document.getElementById('heating-grid');
+    if (!section || !grid) return;
+
+    var ready = heatPumpDrivers
+      ? Promise.resolve(heatPumpDrivers)
+      : discover().then(function (names) { heatPumpDrivers = names; return names; });
+
+    ready.then(function (names) {
+      if (!names || names.length === 0) {
+        section.hidden = true;
+        return;
+      }
+      // Fetch detail + 24h power series for each heat pump in parallel.
+      return Promise.all(names.map(function (n) {
+        return Promise.all([
+          fetchJSON('/api/drivers/' + encodeURIComponent(n)),
+          fetchJSON('/api/series?driver=' + encodeURIComponent(n) + '&metric=hp_power_w&range=24h&points=200'),
+        ]).then(function (parts) {
+          return { name: n, detail: parts[0], series: (parts[1] && parts[1].points) || [] };
+        });
+      })).then(function (pumps) {
+        var live = pumps.filter(function (p) { return p.detail && isHeatPump(p.detail); });
+        if (live.length === 0) { section.hidden = true; return; }
+        injectStyles();
+        section.hidden = false;
+        grid.innerHTML = live.map(function (p) {
+          return renderPump(p.name, p.detail, p.series);
+        }).join('');
+      });
+    });
+  }
+
+  function start() {
+    if (timer) return;
+    refresh();
+    timer = setInterval(refresh, REFRESH_MS);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -363,6 +363,17 @@
       <ftw-savings-card default-range="week"></ftw-savings-card>
     </section>
 
+    <!-- Heat-pump telemetry (MyUplink). Hidden until a driver reports hp_*
+         metrics; heating.js unhides it and renders one card per heat pump
+         (compressor power + hot-water/indoor/outdoor temps + 24h power
+         sparkline). Read-only — see docs/myuplink-oauth.md. -->
+    <section class="heating-row" id="heating-section" hidden>
+      <div class="card">
+        <div class="card-label">Heat pump</div>
+        <div id="heating-grid"></div>
+      </div>
+    </section>
+
     <!-- Strategy now lives inside the Plan card header (below) — it's
          the operator-facing control that drives plan behaviour, so
          visually attaching it to the Plan removes the standalone
@@ -787,6 +798,7 @@
   <script src="/models.js?v=diag2"></script>
   <script src="/plan.js?v=diag2"></script>
   <script src="/twins.js?v=diag2"></script>
+  <script src="/heating.js?v=heat1"></script>
   <script src="/loadpoints.js?v=lp3"></script>
   <script src="/diagnose.js?v=diag2"></script>
   <script src="/update-badge.js?v=modal2" defer></script>

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -154,15 +154,33 @@
             '</fieldset>';
         }
         if (isApiCredsDriver) {
-          // OAuth2 client_credentials drivers (e.g. MyUplink).
-          // User registers an app at the provider's developer portal and
-          // pastes the Client ID here. The Client Secret is rendered by the
-          // config_secrets slot below (masked, never echoed into the DOM).
+          // OAuth2 authorization-code drivers (e.g. MyUplink). The operator
+          // registers an app at the provider's developer portal (Callback
+          // URL + Client Identifier + Client Secret), pastes the Client ID
+          // here and the secret in the Secrets section below (masked, never
+          // echoed into the DOM), then clicks Connect to complete the
+          // one-time browser consent. The resulting refresh_token is stored
+          // server-side as a config_secret and the badge flips to Connected.
           var acfg = d.config || {};
+          // refresh_token is a config_secret: when saved it round-trips as a
+          // masked placeholder (non-empty string), so a non-empty value here
+          // means "consent completed".
+          var connected = typeof acfg.refresh_token === 'string' && acfg.refresh_token !== '';
+          var connBadge = connected
+            ? '<span class="creds-badge creds-saved">✓ Connected</span>'
+            : '<span class="creds-badge creds-missing">⚠ Not connected</span>';
+          var callbackURL = location.origin + '/api/oauth/myuplink/callback';
           html += '<fieldset><legend>API credentials</legend>' +
-            '<p style="color:var(--text-dim);font-size:0.75rem;margin:0 0 8px">Register an application at the provider\'s developer portal to get a Client ID and Client Secret. Paste the secret in the Secrets section below.</p>' +
+            '<p style="color:var(--text-dim);font-size:0.75rem;margin:0 0 8px">Register an application at the provider\'s developer portal to get a Client ID and Client Secret. Paste the secret in the Secrets section below, then click Connect.</p>' +
             '<label>Client ID ' + help('Application identifier from the developer portal.') + '</label>' +
             '<input type="text" data-path="drivers.' + idx + '.config.client_id" value="' + escHtml(acfg.client_id || '') + '" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx">' +
+            '<label style="margin-top:8px">Callback URL ' + help('Register this exact URL as the Callback Url in the MyUplink developer portal. It must match the address you use to reach 42-watts.') + '</label>' +
+            '<input type="text" class="myuplink-callback-url" value="' + escHtml(callbackURL) + '" readonly onclick="this.select()" style="font-family:var(--mono);font-size:0.8rem">' +
+            '<div style="margin-top:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">' +
+            '<button class="btn-add myuplink-connect-btn" type="button" data-driver-idx="' + idx + '" data-driver-name="' + escHtml(d.name || '') + '">Connect to MyUplink</button>' +
+            connBadge +
+            '<span class="myuplink-connect-status" data-driver-idx="' + idx + '" style="font-size:0.82rem;color:var(--text-dim)"></span>' +
+            '</div>' +
             '</fieldset>';
         }
         // Slot for catalog-declared config_secrets (e.g. sonnen Auth-Token).
@@ -521,6 +539,41 @@
           }).finally(function () {
             vbtn.disabled = false;
           });
+        });
+      });
+
+      // MyUplink (and any OAuth authorization-code apicreds driver): open the
+      // provider consent in a new tab. /start reads the SAVED client_id, so
+      // the operator must save the row first; we pass the browser's own
+      // callback URL (location.origin) because on a relay origin the server
+      // can't derive it. The refresh_token lands server-side; the operator
+      // reloads to see the badge flip to Connected.
+      bodyEl.querySelectorAll(".myuplink-connect-btn").forEach(function (cbtn) {
+        cbtn.addEventListener("click", function () {
+          var dIdx = cbtn.dataset.driverIdx;
+          var name = cbtn.dataset.driverName || "";
+          var statusEl = bodyEl.querySelector('.myuplink-connect-status[data-driver-idx="' + dIdx + '"]');
+          function setStatus(msg, color) {
+            if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || "var(--text-dim)"; }
+          }
+          if (!name) { setStatus("Save the driver name first", "var(--red-e)"); return; }
+          setStatus("Opening MyUplink…");
+          cbtn.disabled = true;
+          var redirectURI = location.origin + "/api/oauth/myuplink/callback";
+          var qs = "?driver=" + encodeURIComponent(name) +
+            "&redirect_uri=" + encodeURIComponent(redirectURI);
+          ownerFetch("/api/oauth/myuplink/start" + qs)
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, body: j }; }); })
+            .then(function (res) {
+              if (!res.ok || !res.body || !res.body.authorize_url) {
+                setStatus("✗ " + ((res.body && res.body.error) || "could not start consent — save Client ID + Secret first"), "var(--red-e)");
+                return;
+              }
+              window.open(res.body.authorize_url, "_blank");
+              setStatus("Complete the consent in the new tab, then reload this page.", "var(--green-e)");
+            })
+            .catch(function (e) { setStatus("✗ " + e.message, "var(--red-e)"); })
+            .finally(function () { cbtn.disabled = false; });
         });
       });
 

--- a/web/settings/tabs/devices.js
+++ b/web/settings/tabs/devices.js
@@ -181,6 +181,17 @@
             connBadge +
             '<span class="myuplink-connect-status" data-driver-idx="' + idx + '" style="font-size:0.82rem;color:var(--text-dim)"></span>' +
             '</div>' +
+            // Manual fallback: when the automatic redirect can't reach this
+            // device (remote/relay access, or the portal rejected an http LAN
+            // callback), the operator copies the redirected URL from the
+            // address bar and pastes it here. The Pi exchanges the code over
+            // its own outbound HTTPS, so no inbound callback is needed.
+            '<details style="margin-top:10px">' +
+            '<summary style="cursor:pointer;font-size:0.8rem;color:var(--text-dim)">Not redirected back? Paste the URL instead</summary>' +
+            '<p style="color:var(--text-dim);font-size:0.72rem;margin:6px 0">After signing in at MyUplink, copy the full address from your browser\'s address bar and paste it here. Use this for remote/relay access or if the page didn\'t return to 42-watts.</p>' +
+            '<input type="text" class="myuplink-manual-url" data-driver-idx="' + idx + '" placeholder=".../api/oauth/myuplink/callback?code=...&amp;state=..." style="font-family:var(--mono);font-size:0.78rem">' +
+            '<button class="btn-add myuplink-manual-btn" type="button" data-driver-idx="' + idx + '" style="margin-top:6px">Complete connection</button>' +
+            '</details>' +
             '</fieldset>';
         }
         // Slot for catalog-declared config_secrets (e.g. sonnen Auth-Token).
@@ -570,10 +581,43 @@
                 return;
               }
               window.open(res.body.authorize_url, "_blank");
-              setStatus("Complete the consent in the new tab, then reload this page.", "var(--green-e)");
+              setStatus("Complete the consent in the new tab. If it returns here, reload; if not, paste the URL below.", "var(--green-e)");
             })
             .catch(function (e) { setStatus("✗ " + e.message, "var(--red-e)"); })
             .finally(function () { cbtn.disabled = false; });
+        });
+      });
+
+      // Manual fallback: exchange a pasted redirect URL (carries code + state)
+      // server-side. Works on any origin since the Pi exchanges the code over
+      // outbound HTTPS — no inbound callback required.
+      bodyEl.querySelectorAll(".myuplink-manual-btn").forEach(function (mbtn) {
+        mbtn.addEventListener("click", function () {
+          var dIdx = mbtn.dataset.driverIdx;
+          var input = bodyEl.querySelector('.myuplink-manual-url[data-driver-idx="' + dIdx + '"]');
+          var statusEl = bodyEl.querySelector('.myuplink-connect-status[data-driver-idx="' + dIdx + '"]');
+          function setStatus(msg, color) {
+            if (statusEl) { statusEl.textContent = msg; statusEl.style.color = color || "var(--text-dim)"; }
+          }
+          var url = input ? input.value.trim() : "";
+          if (!url) { setStatus("Paste the redirect URL first", "var(--red-e)"); return; }
+          setStatus("Completing…");
+          mbtn.disabled = true;
+          ownerFetch("/api/oauth/myuplink/exchange", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ redirect_url: url }),
+          })
+            .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, body: j }; }); })
+            .then(function (res) {
+              if (res.ok && res.body && res.body.status === "connected") {
+                setStatus("✓ Connected — reload to refresh the badge.", "var(--green-e)");
+              } else {
+                setStatus("✗ " + ((res.body && res.body.error) || "exchange failed"), "var(--red-e)");
+              }
+            })
+            .catch(function (e) { setStatus("✗ " + e.message, "var(--red-e)"); })
+            .finally(function () { mbtn.disabled = false; });
         });
       });
 


### PR DESCRIPTION
## Why

A Discord tester (and soon Fredrik) hit `invalid_client` when setting up the MyUplink/NIBE heat-pump driver (#496). Root cause: the driver used the `client_credentials` OAuth grant, but the MyUplink developer portal only issues **authorization-code** apps (Callback URL + Client Identifier + Client Secret, Azure B2C). `client_credentials` is simply not offered, so a normal portal app fails at the token request before any polling starts.

Separately, the heat-pump telemetry the driver already emits (`hp_*`) had **no UI** — it only showed as raw live metrics in the per-driver Diagnose modal. And the earlier troubleshooting guidance about a `mode: hotwater | heating` config was wrong: the driver has no `mode` field.

## What

**Auth (closes #496) — authorization-code + refresh-token, with in-app consent:**
- `drivers/myuplink.lua` now runs `grant_type=refresh_token` at runtime and persists Azure-B2C-rotated tokens. With no token yet it idles quietly ("awaiting OAuth connect") instead of erroring.
- New Go bootstrap: `GET /api/oauth/myuplink/start` (mints state, returns the authorize URL + the exact callback URL to register) and `GET /api/oauth/myuplink/callback` (exchanges the code, stores the refresh token, restarts the driver, renders a result page).
- New generic `host.persist_secret(key, value)` capability: drivers durably store a rotated secret in the **unwatched state KV** (not `config.yaml`, which would trigger a config-reload restart loop). `SecretOverride` layers it back over config at `driver_init`, so the freshest token survives a restart while `config.yaml` keeps the bootstrap seed the UI shows as "saved".
- Settings → Devices gains a Callback-URL hint, a **Connect to MyUplink** button, and a Connected/Not-connected badge. The browser passes its own `location.origin` callback (validated server-side) so the flow works over a relay origin too.

**Heating UI:**
- New **Heat pump** dashboard card: compressor power + hot-water/indoor/outdoor temperatures + a 24h power sparkline (reuses `/api/series`). Hidden until a driver reports `hp_power_w`.

**Docs:** `docs/myuplink-oauth.md` setup walkthrough (incl. the HTTPS-callback caveat and an explicit "there is no `mode` field" correction); `host.persist_secret` documented.

## Testing

- Unit tests: `host.persist_secret` (granted + not-granted), driver refresh-token flow + rotation persistence + not-connected idle, OAuth `start`/`callback` (state lifecycle, code exchange, config+KV persistence, redirect_uri validation/rejection). `make verify` green.
- Manual end-to-end against a running instance with a stub heat pump: `/api/drivers/{name}` live metrics, `/api/series` sparkline data, `/api/oauth/myuplink/start` authorize URL + 400 on a bad redirect_uri, and the rendered Heat pump dashboard card (screenshot-verified, on-theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Onboarding reachability (added)

The automatic OAuth callback can't reach the Pi on every origin: the relay/home route refuses `/api/*` (owner data stays P2P), and the MyUplink portal may reject a non-HTTPS LAN callback. So consent also has a **manual fallback**: `POST /api/oauth/myuplink/exchange` — the operator pastes the redirected URL (carrying `code` + `state`) and the Pi exchanges the code over its own **outbound** HTTPS. No inbound callback is needed, so onboarding works on relay, headless, and http-LAN origins. Both paths share `completeMyUplinkConsent`; consent-state TTL is 15 min.

Verified live: `/api/oauth/myuplink/exchange` reaches the real token endpoint with a valid minted state (returns `invalid_client` only because the test creds are fake — the happy path is unit-tested against a stub).
