### PR TITLE
fix(myuplink): read 'systems' + 'parameterUnit' API keys (connects but finds nothing)

### DIFF
--- a/.changeset/myuplink-systems-key.md
+++ b/.changeset/myuplink-systems-key.md
@@ -1,0 +1,9 @@
+---
+"forty-two-watts": patch
+---
+
+Fix MyUplink "connects but finds nothing": the driver read the wrong JSON
+keys from the MyUplink API. Device auto-detection used `systems.objects`
+but the real `/v2/systems/me` response keys the array as `systems`, so no
+device was ever found. Also read the points unit from `parameterUnit`
+(the real field name) instead of `unit`, so kW→W conversion works.

--- a/drivers/myuplink.lua
+++ b/drivers/myuplink.lua
@@ -147,7 +147,9 @@ local function detect_device_id()
         host.log("error", "MyUplink: /v2/systems/me failed: " .. err)
         return nil
     end
-    for _, system in ipairs(systems.objects or {}) do
+    -- MyUplink /v2/systems/me returns {"systems":[{"devices":[{"id":...}]}]}.
+    -- The top-level key is "systems" (not "objects").
+    for _, system in ipairs(systems.systems or {}) do
         local devices = system.devices or {}
         if #devices > 0 then
             local did = devices[1].id
@@ -238,7 +240,9 @@ function driver_poll()
 
     if pts[PARAM_POWER] then
         local raw = tonumber(pts[PARAM_POWER].value) or 0
-        local power_w = (pts[PARAM_POWER].unit == "kW") and raw * 1000 or raw
+        -- MyUplink points report the unit in "parameterUnit" (not "unit").
+        local unit = pts[PARAM_POWER].parameterUnit or pts[PARAM_POWER].unit
+        local power_w = (unit == "kW") and raw * 1000 or raw
         host.emit_metric("hp_power_w", power_w)
     end
     if pts[PARAM_HW_TEMP]      then host.emit_metric("hp_hw_top_temp_c",  decode_temp(pts[PARAM_HW_TEMP])      or 0) end

--- a/go/internal/drivers/myuplink_test.go
+++ b/go/internal/drivers/myuplink_test.go
@@ -95,6 +95,67 @@ func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	}
 }
 
+// TestMyUplinkAutoDetectsDevice exercises the device auto-detection path
+// (no device_id in config) against the REAL MyUplink response shape:
+// GET /v2/systems/me returns {"systems":[{"devices":[{"id":...}]}]} — the
+// top-level key is "systems", not "objects" (the bug behind "connects but
+// finds nothing"). Points use "parameterUnit", not "unit".
+func TestMyUplinkAutoDetectsDevice(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/oauth/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "AT", "expires_in": 3600, "refresh_token": "RT",
+			})
+		case r.URL.Path == "/v2/systems/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"page": 1, "itemsPerPage": 10, "numItems": 1,
+				"systems": []map[string]any{
+					{"systemId": "sys-1", "name": "Home", "devices": []map[string]any{
+						{"id": "DEV-AUTO"},
+					}},
+				},
+			})
+		default: // /v2/devices/DEV-AUTO/points
+			if !strings.Contains(r.URL.Path, "DEV-AUTO") {
+				t.Errorf("points fetched for wrong device: %s", r.URL.Path)
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"parameterId": "10012", "value": "2", "parameterUnit": "kW"}, // 2 kW → 2000 W
+			})
+		}
+	}))
+	defer srv.Close()
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("myuplink", tel).WithHTTP()
+	env.PersistSecret = func(k, v string) error { return nil }
+
+	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+
+	cfg := map[string]any{
+		"client_id":     "cid",
+		"client_secret": "csec",
+		"refresh_token": "RT",
+		// no device_id → must auto-detect via /v2/systems/me
+		"base_url": srv.URL,
+	}
+	if err := d.Init(context.Background(), cfg); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	// 2 kW must be converted to 2000 W via parameterUnit.
+	if v, _, ok := tel.LatestMetric("myuplink", "hp_power_w"); !ok || v != 2000 {
+		t.Errorf("hp_power_w = %v (ok=%v), want 2000 (2 kW via parameterUnit)", v, ok)
+	}
+}
+
 // TestMyUplinkNoRefreshTokenIdles verifies the driver degrades gracefully
 // when it has not been connected yet (no refresh_token in config): init must
 // not error or crash, and a poll must not panic — it simply emits nothing.


### PR DESCRIPTION
## Why

Field testing v0.123.0: MyUplink OAuth now **connects** (refresh token obtained, badge flips to Connected), but the driver **finds no device** and emits no telemetry — the Heat pump card never appears.

## Root cause

Two JSON field-name mismatches against the real MyUplink API v2:

1. **Device auto-detection** iterated `systems.objects`, but `GET /v2/systems/me` keys the array as **`systems`** (`{"systems":[{"devices":[{"id":...}]}]}`). So `detect_device_id()` always logged "no devices found" and the driver idled.
2. **Points unit** was read from `pt.unit`, but the real field is **`parameterUnit`** — so the kW→W conversion never triggered.

Confirmed against the MyUplink API v2 response shape and reference clients (Home Assistant `myuplink`, MarshFlattsFarm).

## Fix

- `systems.objects` → `systems.systems` in `detect_device_id`.
- Read the point unit from `parameterUnit` (fall back to `unit`).

## Test

New `TestMyUplinkAutoDetectsDevice` exercises the no-`device_id` path against the real `/v2/systems/me` shape (`systems[].devices[].id`) and asserts a `2 kW` point is emitted as `2000 W` via `parameterUnit`. It reproduced the bug (failed with "no devices found") before the fix. Existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)