### PR TITLE
fix(drivers): emit_metric records health success (metric-only drivers no longer show offline)

### DIFF
--- a/.changeset/metric-only-driver-health.md
+++ b/.changeset/metric-only-driver-health.md
@@ -1,0 +1,11 @@
+---
+"forty-two-watts": patch
+---
+
+Fix read-only telemetry drivers showing "offline" with "last success:
+never" despite live data. A driver that only calls `host.emit_metric`
+(e.g. the MyUplink heat-pump driver) never recorded a health success, so
+the watchdog flipped it offline even while it polled and emitted metrics
+fine. `emit_metric` now records a health success like the structured
+`host.emit` does. The dispatch stale-meter guard is unaffected — it keys
+on per-reading (DerMeter) freshness, not driver-level last-success.

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -285,6 +285,12 @@ func (h *HostEnv) emitMetric(name string, value float64) error {
 		return nil
 	}
 	h.Telemetry.EmitMetric(h.DriverName, name, value)
+	// A metric emission is fresh telemetry just like a structured emit, so
+	// it counts as a health success. Without this, a read-only driver that
+	// only uses emit_metric (e.g. the MyUplink heat-pump telemetry driver)
+	// never bumps LastSuccess and the watchdog flips it offline despite
+	// live data flowing.
+	h.Telemetry.RecordDriverSuccess(h.DriverName)
 	return nil
 }
 

--- a/go/internal/drivers/lua_metric_health_test.go
+++ b/go/internal/drivers/lua_metric_health_test.go
@@ -1,0 +1,58 @@
+package drivers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frahlg/forty-two-watts/go/internal/telemetry"
+)
+
+// TestEmitMetricRecordsHealthSuccess guards a read-only telemetry driver
+// (MyUplink heat pump) that ONLY calls host.emit_metric — never the
+// structured host.emit. Such a driver still polls successfully and emits
+// fresh data, so it must register as healthy/online. Before the fix,
+// emit_metric buffered the sample but never bumped LastSuccess, so the
+// watchdog flipped the driver offline despite live telemetry.
+func TestEmitMetricRecordsHealthSuccess(t *testing.T) {
+	tel := telemetry.NewStore()
+	env := NewHostEnv("metric-only", tel)
+
+	src := `
+		function driver_init() end
+		function driver_poll()
+			host.emit_metric("hp_outdoor_temp_c", 7.3)
+			return 60000
+		end
+		function driver_command() end
+		function driver_default_mode() end
+		function driver_cleanup() end
+	`
+	path := filepath.Join(t.TempDir(), "drv.lua")
+	if err := os.WriteFile(path, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := NewLuaDriver(path, env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	if err := d.Init(context.Background(), nil); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	h := tel.DriverHealth("metric-only")
+	if h == nil {
+		t.Fatal("no health record")
+	}
+	if h.LastSuccess == nil {
+		t.Error("LastSuccess is nil — a metric-only driver must record health success on emit_metric")
+	}
+	if !h.IsOnline() {
+		t.Errorf("driver should be online after emitting a metric, got status %v", h.Status)
+	}
+}


### PR DESCRIPTION
## Why

Field testing the MyUplink heat-pump driver: it polls fine and emits live temperatures, but the driver shows **offline / "last success: never"** in the UI, and the watchdog keeps flipping it offline.

## Root cause

`HostEnv.emitMetric` (host.go) buffers the sample but never calls `RecordDriverSuccess`. Only the structured `host.emit("meter"|"pv"|"battery")` path bumps `DriverHealth.LastSuccess` (host.go:260,272). The MyUplink driver is read-only telemetry that **only** uses `host.emit_metric`, so `LastSuccess` stayed nil and `WatchdogScan` (which keys on `LastSuccess`) flipped it offline despite live data.

## Fix

`emitMetric` now records a health success after buffering the sample — a metric emission is fresh telemetry just like a structured emit.

**Safety:** the dispatch stale-meter guard keys on **per-reading** freshness (`tel.IsStale(meterDriver, DerMeter, …)`, stamped only by `host.emit("meter")`), not driver-level `LastSuccess`. So a power driver that emits a diagnostic metric on a poll without fresh meter data still can't mask a stale meter — the guard is unaffected.

## Test

`TestEmitMetricRecordsHealthSuccess`: a driver that only `emit_metric`s must have a non-nil `LastSuccess` and be `IsOnline()` after a poll. Failed before the fix ("no health record"). Full drivers suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)