### PR TITLE
fix: detect MyUplink devices from systems response

### DIFF
--- a/.changeset/gentle-myuplink-towels.md
+++ b/.changeset/gentle-myuplink-towels.md
@@ -1,0 +1,5 @@
+---
+"forty-two-watts": patch
+---
+
+Fix MyUplink device auto-detection for `/v2/systems/me` responses that return devices under `systems` instead of `objects`.

--- a/drivers/myuplink.lua
+++ b/drivers/myuplink.lua
@@ -115,15 +115,23 @@ local function detect_device_id()
         host.log("error", "MyUplink: /v2/systems/me failed: " .. err)
         return nil
     end
-    for _, system in ipairs(systems.objects or {}) do
+    local system_list = systems.systems or systems.objects or {}
+    local system_count = 0
+    local device_count = 0
+    for _, system in ipairs(system_list) do
+        system_count = system_count + 1
         local devices = system.devices or {}
-        if #devices > 0 then
-            local did = devices[1].id
-            host.log("info", "MyUplink: auto-detected device " .. tostring(did))
-            return did
+        for _, dev in ipairs(devices) do
+            device_count = device_count + 1
+            local did = dev.id or dev.deviceId or dev.idDevice
+            if did then
+                host.log("info", "MyUplink: auto-detected device " .. tostring(did))
+                return tostring(did)
+            end
         end
     end
-    host.log("error", "MyUplink: no devices found")
+    host.log("error", "MyUplink: no usable device id found in " .. tostring(system_count)
+        .. " system(s), " .. tostring(device_count) .. " device entrie(s)")
     return nil
 end
 

--- a/go/internal/drivers/myuplink_test.go
+++ b/go/internal/drivers/myuplink_test.go
@@ -27,6 +27,54 @@ func myuplinkDriverPath(t *testing.T) string {
 
 // TestMyUplinkEmitsTelemetry loads the real driver against a fake MyUplink
 // server and asserts the compressor-power metric lands in the telemetry store.
+func TestMyUplinkAutoDetectsDeviceIDFromSystemsResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "test-token", "expires_in": 3600,
+			})
+		case "/v2/systems/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"page": 1, "itemsPerPage": 25, "numItems": 1,
+				"systems": []map[string]any{{
+					"name": "Värmepanna",
+					"devices": []map[string]any{{
+						"id": "DEV1",
+						"product": map[string]any{"name": "CTC EcoZenith i255"},
+					}},
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("myuplink", tel).WithHTTP()
+
+	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+
+	cfg := map[string]any{
+		"client_id":     "cid",
+		"client_secret": "csecret",
+		"base_url":      srv.URL,
+	}
+	if err := d.Init(context.Background(), cfg); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	_, sn := env.Identity()
+	if sn != "DEV1" {
+		t.Fatalf("serial = %q, want DEV1", sn)
+	}
+}
+
 func TestMyUplinkEmitsTelemetry(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Summary
- read MyUplink auto-detect responses from `systems` as returned by `/v2/systems/me`
- keep `objects` as a fallback for older/mock response shapes
- add a regression test using the reported CTC EcoZenith-style response envelope
- add a patch changeset

## Test Plan
- `cd go && go test ./internal/drivers -count=1`
