### PR TITLE
feat: MyUplink rich telemetry — all points + grouped drill-in

### DIFF
--- a/.changeset/myuplink-rich-telemetry.md
+++ b/.changeset/myuplink-rich-telemetry.md
@@ -1,0 +1,12 @@
+---
+"forty-two-watts": minor
+---
+
+Rich heat-pump telemetry. The MyUplink driver now captures **every** device
+point (not just four), emitting each as a metric with its unit. A new
+click-through **detail view** on the Heat pump dashboard card groups all
+signals by unit class (temperatures / power / frequency / percent / electrical
+/ counters & degree-minutes / state), each with its current value and a 24h
+sparkline. `host.emit_metric` gains an optional `unit` argument (carried into
+the live snapshot for UI grouping); metric emission now also registers a driver
+health success, so a read-only telemetry driver no longer shows as offline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,8 @@ global exposes:
 - `host.log(level, msg)`, `host.millis()`, `host.set_poll_interval(ms)`
 - `host.set_make(s)`, `host.set_sn(s)` — anchors device identity
 - `host.emit("battery"|"pv"|"meter", {…})` — structured telemetry
-- `host.emit_metric(name, value)` — arbitrary scalar diagnostics into TS DB
+- `host.emit_metric(name, value [, unit])` — arbitrary scalar diagnostics into
+  TS DB; optional display unit feeds UI grouping/labels + counts as a health tick
 - `host.persist_secret(key, value)` — durably store a rotated secret (e.g. an
   OAuth refresh_token) in the unwatched state KV; layered back over
   `config.<key>` at next init via the registry's `SecretOverride`

--- a/docs/superpowers/specs/2026-06-20-myuplink-rich-telemetry-design.md
+++ b/docs/superpowers/specs/2026-06-20-myuplink-rich-telemetry-design.md
@@ -1,0 +1,127 @@
+# MyUplink rich telemetry + grouped drill-in — design
+
+**Date:** 2026-06-20
+**Status:** approved (Fredrik, 2026-06-20)
+**Workstream:** heating / thermal systems — observability layer (precedes Step 2)
+**Builds on:** `2026-06-15-myuplink-telemetry-design.md` (read-only Step 1, shipped)
+
+## Motivation
+
+The MyUplink driver currently reads four fixed parameters (compressor power +
+three temperatures). The MyUplink API exposes **dozens to ~100 points** per
+heat pump (supply/return, brine, degree-minutes, compressor frequency,
+electrical, hot-water charge, setpoints, operating mode, …). We want all of it
+flowing and observable — both as a first-class operator view and as the data
+that will ground the later thermal-store model.
+
+A heat pump is **not** a battery/PV/meter. It must not be shoehorned into the
+DER model. Its rich signals live as long-format TS metrics; the DER reading
+slots (battery SoC / PV) must not render for it.
+
+## Decisions (brainstorm, 2026-06-20)
+
+1. **Purpose:** observability now **and** groundwork for the thermal model.
+2. **Capture:** all points, auto-grouped (not a curated subset).
+3. **UI:** at-a-glance summary card + click-through detail view, grouped by unit.
+4. **Thermal model is a separate follow-up spec** — it needs days of this real
+   telemetry before it can be fitted. This spec ships the data + the view.
+
+## Scope of THIS spec
+
+Rich telemetry capture + a grouped drill-in view + small cleanups. The
+thermal-store model + compressor control (Step 2–4) are explicitly **out**.
+
+## Design
+
+### 1. Host — `emit_metric` gains an optional unit
+
+`host.emit_metric(name, value [, unit])`. The unit threads through
+`telemetry.Store.EmitMetric(driver, name, value, unit)` into the existing
+`ts_metrics.unit` column and into the live `MetricSnapshot` (add a `Unit`
+field). Backward compatible: existing 2-arg calls pass `unit=""`.
+
+- `MetricSnapshot` gains `Unit string `json:"unit,omitempty"``.
+- `Store.EmitMetric` signature gains `unit string`; all existing Go callers
+  pass `""` (none today besides the Lua bridge).
+- The Lua bridge (`host.emit_metric`) reads an optional 3rd string arg.
+
+### 2. Driver — fetch all points
+
+`driver_poll` switches from `GET /points?parameters=<ids>` to
+`GET /v2/devices/{id}/points` (no filter) → the full array. For each point
+whose `value` parses as a number:
+
+- Metric name: `hp_` + **sanitize(parameterName)** — lowercase, every run of
+  non-`[a-z0-9]` → `_`, trimmed, collapsed. On a sanitize collision, append
+  `_` + `parameterId`.
+- Unit: `parameterUnit`.
+- Emit `host.emit_metric(name, value, unit)`.
+
+The four canonical headline metrics (`hp_power_w`, `hp_hw_top_temp_c`,
+`hp_indoor_temp_c`, `hp_outdoor_temp_c`) are still emitted from their fixed
+parameter IDs (so the dashboard card + its history stay stable). Those four
+parameter IDs are **skipped** in the generic all-points loop to avoid duplicate
+metrics.
+
+Enum/state points: emit the numeric `value` (the enum index) with its unit;
+human enum-label decoding is a later nice-to-have (noted, not built).
+
+Cardinality note: ~50–100 metrics at 1/min. The TS DB + hourly parquet rolloff
+already handle this; no schema change beyond the unit column (which exists).
+
+### 3. API — surface the unit
+
+`GET /api/drivers/{name}` already returns `metrics`; each entry now includes
+`unit` (from the `MetricSnapshot.Unit` added in §1). `GET /api/series` and
+`GET /api/series/catalog` are reused as-is for the sparklines. No new endpoint.
+
+### 4. UI — summary card + grouped drill-in
+
+- The dashboard **Heat pump** card (existing `web/heating.js`) is unchanged in
+  content (4 headline values + 24 h power sparkline) but becomes **clickable**
+  → opens a heat-pump **detail modal**.
+- The detail modal fetches `GET /api/drivers/{name}` (metrics + units) and
+  groups rows by **unit class**:
+  - Temperatures (`°C`)
+  - Power (`W`, `kW`)
+  - Frequency (`Hz`)
+  - Percent (`%`)
+  - Counters / degree-minutes (`h`, `GM`/`DM`, counts)
+  - State / other (no unit / enum)
+- Each row: de-sanitized label, current value + unit, a 24 h mini-sparkline
+  from `GET /api/series?driver=<name>&metric=<name>&range=24h`.
+- Styling reuses the diagnostics-modal tokens/patterns (mono numerics, hairline
+  rows, theme `var(--*)` colours, amber sparkline). Follows `DESIGN.md`.
+- Implementation lives in `web/heating.js` (+ a small style block), self-
+  contained like the existing card.
+
+### 5. Cleanup — no DER zero-slots for non-DER drivers
+
+Audit the web UI for any place that renders a battery-SoC / PV slot per driver
+and shows `0` for a driver that emits no such DER reading (the MyUplink driver
+emits none — `readings` is null, capabilities are `apicreds` only). Render
+those slots only when the driver actually has the corresponding DER reading.
+(Exact location to be pinned during implementation — confirm with Fredrik
+where he observed it.)
+
+## Out of scope (next spec)
+
+Thermal-store model (stored-energy proxy from tank temp + degree-minutes), COP
+estimation (electrical-in vs heat-out), and the compressor control primitive
+(block / shed / shift) for MPC as a deferrable thermal load. These get their
+own spec, fed by the telemetry this spec produces.
+
+## Testing
+
+- Host: `emit_metric(name, value, unit)` stores the unit; `MetricSnapshot`
+  carries it; 2-arg calls still work.
+- Driver: a fake `/points` payload with mixed units → all numeric points land
+  as `hp_*` metrics with units; the four canonical names still emit; the four
+  canonical parameter IDs are not double-emitted.
+- UI: covered by manual verification against a running instance with live
+  heat-pump metrics (grouping, sparklines, click-through). A node-level unit
+  test of the pure grouping/sanitize helpers if they are factored out.
+
+## Changeset
+
+Minor (new capability surface: per-metric units + rich heat-pump view).

--- a/docs/writing-a-driver.md
+++ b/docs/writing-a-driver.md
@@ -210,14 +210,18 @@ For anything that doesn't fit the pv/battery/meter shape — temperatures,
 DC voltages, MPPT currents, grid frequency — use:
 
 ```lua
-host.emit_metric("inverter_temp_c", 42.3)
-host.emit_metric("battery_dc_v",    48.7)
-host.emit_metric("grid_hz",         50.01)
+host.emit_metric("inverter_temp_c", 42.3, "°C")
+host.emit_metric("battery_dc_v",    48.7, "V")
+host.emit_metric("grid_hz",         50.01)         -- unit optional
 ```
 
-Naming convention: snake_case with a unit suffix. These land in the
-long-format TSDB where the UI charts them on demand. There's no
-allow-list — pick a stable name and keep using it.
+Naming convention: snake_case with a unit suffix. The optional 3rd
+argument is a display unit (`"°C"`, `"Hz"`, `"kW"`, …) carried into the
+live snapshot so the UI can group + label the metric (e.g. the heat-pump
+detail drill-in groups by unit class). These land in the long-format
+TSDB where the UI charts them on demand. There's no allow-list — pick a
+stable name and keep using it. Emitting a metric also counts as a driver
+health success (a metric-only driver stays online).
 
 ### 3.3 MQTT (granted only if the driver has `mqtt:` in its config)
 

--- a/drivers/myuplink.lua
+++ b/drivers/myuplink.lua
@@ -161,15 +161,17 @@ local function detect_device_id()
     return nil
 end
 
-local function fetch_points(param_ids)
-    local qs = table.concat(param_ids, ",")
-    local data, err = api_get("/v2/devices/" .. device_id .. "/points?parameters=" .. qs)
-    if err then return nil, err end
-    local pts = {}
+-- Fetch ALL points for the device (no ?parameters filter). Returns the raw
+-- array (for emitting everything) plus an id→point index (for the canonical
+-- headline lookups). MyUplink keys each point by parameterId.
+local function fetch_all_points()
+    local data, err = api_get("/v2/devices/" .. device_id .. "/points")
+    if err then return nil, nil, err end
+    local by_id = {}
     for _, pt in ipairs(data) do
-        if pt.parameterId then pts[tostring(pt.parameterId)] = pt end
+        if pt.parameterId then by_id[tostring(pt.parameterId)] = pt end
     end
-    return pts, nil
+    return data, by_id, nil
 end
 
 local function decode_temp(pt)
@@ -178,6 +180,26 @@ local function decode_temp(pt)
     if not raw then return nil end
     if math.abs(raw) > 100 then return raw / 10 end  -- NIBE °C×10 encoding
     return raw
+end
+
+-- Apply the NIBE °C×10 convention ONLY to temperature-unit points, so
+-- non-temperature points (Hz, GM, %, counts) are emitted raw. (The sub-10 °C
+-- ambiguity is a known, separately-tracked decode issue.)
+local function scale_value(raw, unit)
+    if unit == "°C" and math.abs(raw) > 100 then return raw / 10 end
+    return raw
+end
+
+-- Turn a MyUplink parameterName into a stable snake_case metric name,
+-- prefixed hp_. Non-ASCII and punctuation collapse to single underscores;
+-- empty names fall back to the parameterId.
+local function sanitize_metric_name(name, pid)
+    local s = string.lower(name or "")
+    s = string.gsub(s, "[^a-z0-9]+", "_")
+    s = string.gsub(s, "^_+", "")
+    s = string.gsub(s, "_+$", "")
+    if s == "" then s = "p" .. tostring(pid) end
+    return "hp_" .. s
 end
 
 -- ---- Lifecycle -----------------------------------------------------------
@@ -232,22 +254,46 @@ function driver_poll()
     if not device_id or not client_id then return 30000 end
     if not ensure_auth() then return 30000 end
 
-    local pts, err = fetch_points({ PARAM_POWER, PARAM_HW_TEMP, PARAM_INDOOR_TEMP, PARAM_OUTDOOR_TEMP })
+    local data, by_id, err = fetch_all_points()
     if err then
         host.log("warn", "MyUplink: poll failed: " .. err)
         return 30000
     end
 
-    if pts[PARAM_POWER] then
-        local raw = tonumber(pts[PARAM_POWER].value) or 0
+    -- Canonical headline metrics: stable names the dashboard card + history
+    -- depend on, mapped from fixed parameter IDs.
+    if by_id[PARAM_POWER] then
+        local raw = tonumber(by_id[PARAM_POWER].value) or 0
         -- MyUplink points report the unit in "parameterUnit" (not "unit").
-        local unit = pts[PARAM_POWER].parameterUnit or pts[PARAM_POWER].unit
+        local unit = by_id[PARAM_POWER].parameterUnit or by_id[PARAM_POWER].unit
         local power_w = (unit == "kW") and raw * 1000 or raw
-        host.emit_metric("hp_power_w", power_w)
+        host.emit_metric("hp_power_w", power_w, "W")
     end
-    if pts[PARAM_HW_TEMP]      then host.emit_metric("hp_hw_top_temp_c",  decode_temp(pts[PARAM_HW_TEMP])      or 0) end
-    if pts[PARAM_INDOOR_TEMP]  then host.emit_metric("hp_indoor_temp_c",  decode_temp(pts[PARAM_INDOOR_TEMP])  or 0) end
-    if pts[PARAM_OUTDOOR_TEMP] then host.emit_metric("hp_outdoor_temp_c", decode_temp(pts[PARAM_OUTDOOR_TEMP]) or 0) end
+    if by_id[PARAM_HW_TEMP]      then host.emit_metric("hp_hw_top_temp_c",  decode_temp(by_id[PARAM_HW_TEMP])      or 0, "°C") end
+    if by_id[PARAM_INDOOR_TEMP]  then host.emit_metric("hp_indoor_temp_c",  decode_temp(by_id[PARAM_INDOOR_TEMP])  or 0, "°C") end
+    if by_id[PARAM_OUTDOOR_TEMP] then host.emit_metric("hp_outdoor_temp_c", decode_temp(by_id[PARAM_OUTDOOR_TEMP]) or 0, "°C") end
+
+    -- Everything else → hp_<sanitized name> with its unit, so the UI can
+    -- auto-group (temperatures / power / frequency / state / …). Skip the
+    -- four canonical parameter IDs so they aren't emitted twice.
+    local canonical = {
+        [tostring(PARAM_POWER)] = true, [tostring(PARAM_HW_TEMP)] = true,
+        [tostring(PARAM_INDOOR_TEMP)] = true, [tostring(PARAM_OUTDOOR_TEMP)] = true,
+    }
+    local seen = {}
+    for _, pt in ipairs(data) do
+        local pid = tostring(pt.parameterId or "")
+        if pt.parameterId and not canonical[pid] then
+            local raw = tonumber(pt.value)
+            if raw ~= nil then
+                local unit = pt.parameterUnit or pt.unit or ""
+                local name = sanitize_metric_name(pt.parameterName, pid)
+                if seen[name] then name = name .. "_" .. pid end
+                seen[name] = true
+                host.emit_metric(name, scale_value(raw, unit), unit)
+            end
+        end
+    end
 
     return 60000
 end

--- a/go/internal/drivers/host.go
+++ b/go/internal/drivers/host.go
@@ -276,15 +276,16 @@ func (h *HostEnv) emitTelemetry(rawJSON []byte) error {
 
 // emitMetric buffers a scalar diagnostic metric for the long-format TS DB.
 // Driver authors call this for anything beyond the standard pv/battery/meter
-// shape — temperatures, voltages, frequencies, MPPT currents, etc.
-func (h *HostEnv) emitMetric(name string, value float64) error {
+// shape — temperatures, voltages, frequencies, MPPT currents, etc. unit is an
+// optional display unit (e.g. "°C", "Hz") used by the UI to group + label.
+func (h *HostEnv) emitMetric(name string, value float64, unit string) error {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return fmt.Errorf("emit_metric: %s is non-finite: %v", name, value)
 	}
 	if h.Telemetry == nil {
 		return nil
 	}
-	h.Telemetry.EmitMetric(h.DriverName, name, value)
+	h.Telemetry.EmitMetric(h.DriverName, name, value, unit)
 	// A metric emission is fresh telemetry just like a structured emit, so
 	// it counts as a health success. Without this, a read-only driver that
 	// only uses emit_metric (e.g. the MyUplink heat-pump telemetry driver)

--- a/go/internal/drivers/lua.go
+++ b/go/internal/drivers/lua.go
@@ -267,16 +267,18 @@ func registerHost(L *lua.LState, env *HostEnv) {
 		return 0
 	}))
 
-	// host.emit_metric("battery_temp_c", 23.5) — record an arbitrary
+	// host.emit_metric("battery_temp_c", 23.5 [, "°C"]) — record an arbitrary
 	// scalar diagnostic into the long-format TS DB. Use for anything that
 	// doesn't fit the structured pv/battery/meter shape: temperatures, DC
 	// voltages, MPPT currents, grid frequency, inverter heat-sink, etc.
 	// The metric name is the column name in the time-series — pick a stable
-	// snake_case identifier with the unit as a suffix.
+	// snake_case identifier with the unit as a suffix. The optional 3rd arg
+	// is a display unit (e.g. "°C", "Hz", "kW") the UI uses to group + label.
 	host.RawSetString("emit_metric", L.NewFunction(func(L *lua.LState) int {
 		name := L.CheckString(1)
 		val := float64(L.CheckNumber(2))
-		if err := env.emitMetric(name, val); err != nil {
+		unit := L.OptString(3, "")
+		if err := env.emitMetric(name, val, unit); err != nil {
 			L.Push(lua.LString(err.Error()))
 			return 1
 		}

--- a/go/internal/drivers/myuplink_test.go
+++ b/go/internal/drivers/myuplink_test.go
@@ -156,6 +156,94 @@ func TestMyUplinkAutoDetectsDevice(t *testing.T) {
 	}
 }
 
+// TestMyUplinkEmitsAllPointsWithUnits verifies the driver fetches the full
+// points list and emits every numeric point as hp_<sanitized name> with its
+// unit, while still emitting the four canonical headline metrics from their
+// fixed parameter IDs (and not double-emitting those four as generic).
+func TestMyUplinkEmitsAllPointsWithUnits(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "AT", "expires_in": 3600, "refresh_token": "RT",
+			})
+			return
+		}
+		// /v2/devices/DEV1/points — full list (driver must NOT send ?parameters)
+		if q := r.URL.RawQuery; q != "" {
+			t.Errorf("expected unfiltered points fetch, got query %q", q)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"parameterId": "10012", "parameterName": "Compressor power", "value": "1500", "parameterUnit": "W"}, // canonical
+			{"parameterId": "40004", "parameterName": "Outdoor temp (BT1)", "value": "226", "parameterUnit": "°C"}, // canonical
+			{"parameterId": "40008", "parameterName": "Supply line (BT2)", "value": "455", "parameterUnit": "°C"},  // generic temp, ×10
+			{"parameterId": "43136", "parameterName": "Compressor frequency", "value": "42", "parameterUnit": "Hz"}, // generic
+			{"parameterId": "43005", "parameterName": "Degree minutes", "value": "-600", "parameterUnit": "GM"},     // generic, negative
+		})
+	}))
+	defer srv.Close()
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("myuplink", tel).WithHTTP()
+	env.PersistSecret = func(k, v string) error { return nil }
+
+	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	cfg := map[string]any{
+		"client_id": "cid", "client_secret": "csec", "refresh_token": "RT",
+		"device_id": "DEV1", "base_url": srv.URL,
+	}
+	if err := d.Init(context.Background(), cfg); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, err := d.Poll(context.Background()); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	byName := map[string]telemetry.MetricSnapshot{}
+	for _, m := range tel.LatestMetricsByDriver("myuplink") {
+		byName[m.Name] = m
+	}
+	// Canonical headline metrics still present.
+	if m, ok := byName["hp_power_w"]; !ok || m.Value != 1500 {
+		t.Errorf("hp_power_w = %+v, want value 1500", m)
+	}
+	if m, ok := byName["hp_outdoor_temp_c"]; !ok || m.Value != 22.6 {
+		t.Errorf("hp_outdoor_temp_c = %+v, want 22.6", m)
+	}
+	// Generic points emitted with sanitized names + units.
+	supply, ok := byName["hp_supply_line_bt2"]
+	if !ok {
+		t.Fatalf("missing generic metric hp_supply_line_bt2; got %v", keysOf(byName))
+	}
+	if supply.Unit != "°C" || supply.Value != 45.5 {
+		t.Errorf("supply = %+v, want 45.5 °C (×10 decode for °C unit)", supply)
+	}
+	if hz, ok := byName["hp_compressor_frequency"]; !ok || hz.Unit != "Hz" || hz.Value != 42 {
+		t.Errorf("compressor frequency = %+v, want 42 Hz (no scaling)", hz)
+	}
+	if dm, ok := byName["hp_degree_minutes"]; !ok || dm.Value != -600 {
+		t.Errorf("degree minutes = %+v, want -600 (no scaling for non-°C)", dm)
+	}
+	// Canonical IDs must NOT be double-emitted under generic names.
+	if _, ok := byName["hp_compressor_power"]; ok {
+		t.Errorf("canonical PARAM_POWER (10012) was double-emitted as hp_compressor_power")
+	}
+	if _, ok := byName["hp_outdoor_temp_bt1"]; ok {
+		t.Errorf("canonical PARAM_OUTDOOR (40004) was double-emitted as a generic name")
+	}
+}
+
+func keysOf(m map[string]telemetry.MetricSnapshot) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestMyUplinkNoRefreshTokenIdles verifies the driver degrades gracefully
 // when it has not been connected yet (no refresh_token in config): init must
 // not error or crash, and a poll must not panic — it simply emits nothing.

--- a/go/internal/ocpp/handlers.go
+++ b/go/internal/ocpp/handlers.go
@@ -167,7 +167,7 @@ func (h *Handler) OnStatusNotification(id string, req *core.StatusNotificationRe
 	h.mu.Unlock()
 
 	if req.Status == core.ChargePointStatusFaulted {
-		h.tel.EmitMetric(id, "ev_fault", 1)
+		h.tel.EmitMetric(id, "ev_fault", 1, "")
 		slog.Warn("OCPP charger faulted", "charger", id, "errorCode", req.ErrorCode, "info", req.Info)
 	}
 	slog.Info("OCPP status",
@@ -251,7 +251,7 @@ func (h *Handler) OnStopTransaction(id string, req *core.StopTransactionRequest)
 		"charger", id, "txid", req.TransactionId,
 		"session_wh", sessionWh, "reason", req.Reason)
 	h.pushReading(id, s)
-	h.tel.EmitMetric(id, "ev_session_wh", sessionWh)
+	h.tel.EmitMetric(id, "ev_session_wh", sessionWh, "Wh")
 	h.tel.RecordDriverSuccess(id)
 	return core.NewStopTransactionConfirmation(), nil
 }

--- a/go/internal/telemetry/store.go
+++ b/go/internal/telemetry/store.go
@@ -218,6 +218,7 @@ type Store struct {
 
 type metricSnap struct {
 	Value     float64
+	Unit      string
 	UpdatedAt time.Time
 }
 
@@ -327,7 +328,11 @@ func (s *Store) Update(driver string, t DerType, rawW float64, soc *float64, dat
 // Use for diagnostic data drivers want to record beyond the standard
 // pv/battery/meter shape (temperatures, voltages, frequencies, etc.).
 // Drained by the control loop via FlushSamples.
-func (s *Store) EmitMetric(driver, name string, value float64) {
+// EmitMetric records a scalar metric. unit is an optional display unit
+// (e.g. "°C", "Hz", "kW") carried into the live snapshot so the UI can group
+// and label metrics; pass "" when unknown. Existing callers updated to the
+// 4-arg form.
+func (s *Store) EmitMetric(driver, name string, value float64, unit string) {
 	if !finite(value) {
 		return
 	}
@@ -338,7 +343,7 @@ func (s *Store) EmitMetric(driver, name string, value float64) {
 	})
 	s.pendingMu.Unlock()
 	s.latestMu.Lock()
-	s.latestMetric[driver+":"+name] = metricSnap{Value: value, UpdatedAt: now}
+	s.latestMetric[driver+":"+name] = metricSnap{Value: value, UpdatedAt: now, Unit: unit}
 	s.latestMu.Unlock()
 }
 
@@ -346,6 +351,7 @@ func (s *Store) EmitMetric(driver, name string, value float64) {
 type MetricSnapshot struct {
 	Name      string    `json:"name"`
 	Value     float64   `json:"value"`
+	Unit      string    `json:"unit,omitempty"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
@@ -365,6 +371,7 @@ func (s *Store) LatestMetricsByDriver(driver string) []MetricSnapshot {
 		out = append(out, MetricSnapshot{
 			Name:      k[len(prefix):],
 			Value:     v.Value,
+			Unit:      v.Unit,
 			UpdatedAt: v.UpdatedAt,
 		})
 	}

--- a/go/internal/telemetry/telemetry_test.go
+++ b/go/internal/telemetry/telemetry_test.go
@@ -186,15 +186,38 @@ func TestStoreRejectsInvalidReadings(t *testing.T) {
 
 func TestEmitMetricRejectsNonFinite(t *testing.T) {
 	s := NewStore()
-	s.EmitMetric("driver", "bad", math.Inf(1))
+	s.EmitMetric("driver", "bad", math.Inf(1), "")
 	if samples := s.FlushSamples(); len(samples) != 0 {
 		t.Fatalf("non-finite metric should be dropped, got %+v", samples)
 	}
 
-	s.EmitMetric("driver", "ok", 42)
+	s.EmitMetric("driver", "ok", 42, "")
 	samples := s.FlushSamples()
 	if len(samples) != 1 || samples[0].Metric != "ok" || samples[0].Value != 42 {
 		t.Fatalf("valid metric not buffered as expected: %+v", samples)
+	}
+}
+
+// TestEmitMetricCarriesUnit verifies the optional unit threads into the live
+// snapshot so the UI can group + label metrics (heat-pump drill-in).
+func TestEmitMetricCarriesUnit(t *testing.T) {
+	s := NewStore()
+	s.EmitMetric("hp", "hp_outdoor_temp_c", 7.3, "°C")
+	s.EmitMetric("hp", "hp_compressor_hz", 42, "Hz")
+	s.EmitMetric("hp", "hp_no_unit", 1, "")
+
+	got := map[string]string{}
+	for _, m := range s.LatestMetricsByDriver("hp") {
+		got[m.Name] = m.Unit
+	}
+	if got["hp_outdoor_temp_c"] != "°C" {
+		t.Errorf("outdoor temp unit = %q, want °C", got["hp_outdoor_temp_c"])
+	}
+	if got["hp_compressor_hz"] != "Hz" {
+		t.Errorf("compressor unit = %q, want Hz", got["hp_compressor_hz"])
+	}
+	if got["hp_no_unit"] != "" {
+		t.Errorf("no-unit metric unit = %q, want empty", got["hp_no_unit"])
 	}
 }
 

--- a/web/heating.js
+++ b/web/heating.js
@@ -46,6 +46,10 @@
     var css = [
       '#heating-grid{display:flex;flex-direction:column;gap:18px}',
       '.ftw-hp{display:flex;flex-direction:column;gap:12px}',
+      '.ftw-hp-clickable{cursor:pointer;border-radius:8px;margin:-6px;padding:6px;transition:background 0.12s}',
+      '.ftw-hp-clickable:hover,.ftw-hp-clickable:focus{background:var(--bg-hover,rgba(127,127,127,0.06));outline:none}',
+      '.ftw-hp-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px}',
+      '.ftw-hp-more{font-family:var(--mono);font-size:0.66rem;letter-spacing:0.1em;text-transform:uppercase;color:var(--accent-e)}',
       '.ftw-hp-name{font-family:var(--mono);font-size:0.72rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--fg-muted)}',
       '.ftw-hp-tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:10px 18px}',
       '.ftw-hp-tile{display:flex;flex-direction:column;gap:3px}',
@@ -127,8 +131,10 @@
     var sparkBlock = spark
       ? '<div class="ftw-hp-spark"><span class="ftw-hp-spark-label">Compressor power · 24h</span>' + spark + '</div>'
       : '';
-    return '<div class="ftw-hp">' +
-      '<span class="ftw-hp-name">' + escapeHtml(name) + '</span>' +
+    // The whole card is a button into the detail view (all signals grouped).
+    return '<div class="ftw-hp ftw-hp-clickable" data-hp-driver="' + escapeHtml(name) + '" role="button" tabindex="0" title="View all heat-pump signals">' +
+      '<div class="ftw-hp-head"><span class="ftw-hp-name">' + escapeHtml(name) + '</span>' +
+      '<span class="ftw-hp-more">All signals →</span></div>' +
       '<div class="ftw-hp-tiles">' + tiles + '</div>' +
       sparkBlock +
       '</div>';
@@ -174,8 +180,137 @@
     });
   }
 
+  // ---- Detail drill-in: all points grouped by unit ----
+
+  // Ordered unit groups. First matching predicate wins; anything unmatched
+  // falls into "State / other".
+  var UNIT_GROUPS = [
+    { title: 'Temperatures', match: function (u) { return u === '°C' || u === '°F' || u === 'K'; } },
+    { title: 'Power & energy', match: function (u) { return u === 'W' || u === 'kW' || u === 'Wh' || u === 'kWh'; } },
+    { title: 'Frequency', match: function (u) { return u === 'Hz'; } },
+    { title: 'Percent', match: function (u) { return u === '%'; } },
+    { title: 'Flow & pressure', match: function (u) { return u === 'l/m' || u === 'l/min' || u === 'bar' || u === 'kPa'; } },
+    { title: 'Electrical', match: function (u) { return u === 'A' || u === 'V'; } },
+    { title: 'Counters & degree-minutes', match: function (u) { return u === 'GM' || u === 'DM' || u === 'h' || u === 'min' || u === 's' || /count/i.test(u); } },
+  ];
+
+  function groupForUnit(unit) {
+    for (var i = 0; i < UNIT_GROUPS.length; i++) {
+      if (UNIT_GROUPS[i].match(unit || '')) return UNIT_GROUPS[i].title;
+    }
+    return 'State / other';
+  }
+
+  // hp_supply_line_bt2 → "Supply line bt2"
+  function prettyLabel(name) {
+    var s = String(name).replace(/^hp_/, '').replace(/_/g, ' ').trim();
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  function fmtValue(v, unit) {
+    if (v == null) return '—';
+    var n = Math.abs(v) >= 100 ? Math.round(v) : Math.round(v * 100) / 100;
+    return n + (unit ? ' ' + unit : '');
+  }
+
+  function injectDetailStyles() {
+    if (document.getElementById('ftw-heating-detail-styles')) return;
+    var css = [
+      '.ftw-hpd-backdrop{position:fixed;inset:0;background:rgba(0,0,0,0.55);display:flex;align-items:flex-start;justify-content:center;z-index:1000;overflow:auto;padding:5vh 16px}',
+      '.ftw-hpd{background:var(--ink-raised);border:1px solid var(--line);border-radius:10px;max-width:760px;width:100%;padding:20px 22px}',
+      '.ftw-hpd-top{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-bottom:14px}',
+      '.ftw-hpd-title{font-family:var(--mono);font-size:0.74rem;letter-spacing:0.18em;text-transform:uppercase;color:var(--fg-muted)}',
+      '.ftw-hpd-close{background:none;border:1px solid var(--line);color:var(--fg);border-radius:6px;cursor:pointer;font-size:1rem;line-height:1;padding:4px 9px}',
+      '.ftw-hpd-group{margin:16px 0 4px;font-family:var(--mono);font-size:0.68rem;letter-spacing:0.14em;text-transform:uppercase;color:var(--accent-e)}',
+      '.ftw-hpd-row{display:grid;grid-template-columns:1fr auto 120px;gap:10px 14px;align-items:center;padding:5px 0;border-bottom:1px solid var(--line-soft,var(--line))}',
+      '.ftw-hpd-label{color:var(--fg-muted);font-size:0.85rem}',
+      '.ftw-hpd-val{font-family:var(--mono);font-variant-numeric:tabular-nums;color:var(--fg);text-align:right}',
+      '.ftw-hpd-spark svg{width:120px;height:24px;display:block}',
+      '.ftw-hpd-empty{color:var(--fg-muted);font-family:var(--mono);font-size:0.82rem}',
+    ].join('');
+    var el = document.createElement('style');
+    el.id = 'ftw-heating-detail-styles';
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+
+  function closeDetail() {
+    var b = document.getElementById('ftw-hpd-backdrop');
+    if (b) b.remove();
+    document.removeEventListener('keydown', onDetailKey);
+  }
+  function onDetailKey(e) { if (e.key === 'Escape') closeDetail(); }
+
+  function openDetail(name) {
+    injectDetailStyles();
+    closeDetail();
+    var backdrop = document.createElement('div');
+    backdrop.className = 'ftw-hpd-backdrop';
+    backdrop.id = 'ftw-hpd-backdrop';
+    backdrop.innerHTML = '<div class="ftw-hpd">' +
+      '<div class="ftw-hpd-top"><span class="ftw-hpd-title">Heat pump · ' + escapeHtml(name) + '</span>' +
+      '<button class="ftw-hpd-close" type="button" aria-label="Close">✕</button></div>' +
+      '<div id="ftw-hpd-body"><div class="ftw-hpd-empty">Loading signals…</div></div></div>';
+    backdrop.addEventListener('click', function (e) { if (e.target === backdrop) closeDetail(); });
+    backdrop.querySelector('.ftw-hpd-close').addEventListener('click', closeDetail);
+    document.body.appendChild(backdrop);
+    document.addEventListener('keydown', onDetailKey);
+
+    fetchJSON('/api/drivers/' + encodeURIComponent(name)).then(function (d) {
+      var body = document.getElementById('ftw-hpd-body');
+      if (!body) return;
+      var metrics = (d && d.metrics) || [];
+      if (!metrics.length) { body.innerHTML = '<div class="ftw-hpd-empty">No signals reported yet.</div>'; return; }
+      // Bucket metrics into ordered groups.
+      var buckets = {};
+      metrics.forEach(function (m) {
+        var g = groupForUnit(m.unit);
+        (buckets[g] = buckets[g] || []).push(m);
+      });
+      var order = UNIT_GROUPS.map(function (g) { return g.title; }).concat(['State / other']);
+      var html = '';
+      order.forEach(function (g) {
+        var rows = buckets[g];
+        if (!rows || !rows.length) return;
+        rows.sort(function (a, b) { return a.name < b.name ? -1 : 1; });
+        html += '<div class="ftw-hpd-group">' + escapeHtml(g) + '</div>';
+        rows.forEach(function (m) {
+          html += '<div class="ftw-hpd-row">' +
+            '<span class="ftw-hpd-label">' + escapeHtml(prettyLabel(m.name)) + '</span>' +
+            '<span class="ftw-hpd-val">' + escapeHtml(fmtValue(m.value, m.unit)) + '</span>' +
+            '<span class="ftw-hpd-spark" data-spark-metric="' + escapeHtml(m.name) + '"></span>' +
+            '</div>';
+        });
+      });
+      body.innerHTML = html;
+      // Lazily fill sparklines (one /api/series per metric) — values already
+      // shown, so a slow series fetch never blocks the table.
+      metrics.forEach(function (m) {
+        fetchJSON('/api/series?driver=' + encodeURIComponent(name) + '&metric=' + encodeURIComponent(m.name) + '&range=24h&points=120')
+          .then(function (s) {
+            var slot = body.querySelector('.ftw-hpd-spark[data-spark-metric="' + (window.CSS && CSS.escape ? CSS.escape(m.name) : m.name) + '"]');
+            if (slot) slot.innerHTML = sparkline((s && s.points) || []);
+          });
+      });
+    });
+  }
+
+  function onGridClick(e) {
+    var card = e.target.closest && e.target.closest('.ftw-hp-clickable');
+    if (card && card.dataset.hpDriver) openDetail(card.dataset.hpDriver);
+  }
+
   function start() {
     if (timer) return;
+    var grid = document.getElementById('heating-grid');
+    if (grid) {
+      grid.addEventListener('click', onGridClick);
+      grid.addEventListener('keydown', function (e) {
+        if ((e.key === 'Enter' || e.key === ' ') && e.target.classList && e.target.classList.contains('ftw-hp-clickable')) {
+          e.preventDefault(); onGridClick(e);
+        }
+      });
+    }
     refresh();
     timer = setInterval(refresh, REFRESH_MS);
   }


### PR DESCRIPTION
## Why

A heat pump is not a battery/PV/meter, and the driver only captured 4 of the ~dozens of points MyUplink exposes. Heating Step-2 groundwork (and operator observability) wants all of it, surfaced cleanly. Spec: `docs/superpowers/specs/2026-06-20-myuplink-rich-telemetry-design.md`.

## What

- **`host.emit_metric(name, value [, unit])`** — optional display unit threads into the live `MetricSnapshot` so the UI can group + label. Backward compatible.
- **Driver captures all points** — `driver_poll` fetches the full `/points` list and emits every numeric point as `hp_<sanitized parameterName>` with its unit. The four canonical headline metrics still emit from fixed IDs (and are skipped in the generic loop — no duplicates). °C points keep the ×10 decode; other units stay raw.
- **Detail drill-in** — the dashboard Heat pump card is now clickable → a modal grouping all signals by unit class (temperatures / power / frequency / percent / electrical / counters & degree-minutes / state), each row with current value + a 24h sparkline (`/api/series`).

## Verification

- Unit tests: `emit_metric` carries unit into the snapshot; driver emits all points with units + scaling, keeps the 4 canonical, no double-emit. `make verify` green.
- Live: booted a stub emitting 10 mixed-unit signals → `/api/drivers/{name}` returns units; the detail modal rendered all 7 unit groups with correct values, units, and sparklines (screenshot-verified, on-theme).

## Follow-up (not in this PR)

- The phantom battery-SoC / PV "0" Fredrik observed for the heat pump: the driver emits **no** DER readings (confirmed `readings: null`), so it's a generic UI slot somewhere — needs Fredrik to point at the exact view to target the removal.
- Thermal-store model (Step 2 proper) is its own next spec, fed by this telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)