### PR TITLE
fix(ui): no phantom PV/battery/SoC on telemetry-only driver cards

### DIFF
--- a/.changeset/driver-card-telemetry-only.md
+++ b/.changeset/driver-card-telemetry-only.md
@@ -1,0 +1,11 @@
+---
+"forty-two-watts": patch
+---
+
+Driver cards no longer show phantom battery-SoC / PV / meter "0" rows for
+telemetry-only drivers. A driver that emits only scalar metrics (e.g. the
+MyUplink heat pump) has no meter/pv/battery DER reading, but the driver
+card fell through to the meter/pv/battery layout and rendered 0 W / 0 %
+with an empty SoC bar. Such drivers now render a compact "telemetry only"
+body (status + ticks + errors); open Diagnose / the Heat pump card for
+their signals.

--- a/web/app.js
+++ b/web/app.js
@@ -1287,7 +1287,7 @@
           '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + '</span>' +
           '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + '</span>' +
           '</div>';
-      } else {
+      } else if (d.meter_w != null || d.pv_w != null || d.bat_w != null || d.bat_soc != null) {
         var meterW = d.meter_w != null ? d.meter_w : 0;
         var pvWVal = d.pv_w != null ? d.pv_w : 0;
         var batWVal = d.bat_w != null ? d.bat_w : 0;
@@ -1318,6 +1318,15 @@
           '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
           "</div>" +
           '<div class="driver-soc-bar"><div class="driver-soc-fill" style="width:' + Math.round(batSocVal * 100) + '%"></div></div>';
+      } else {
+        // Metrics-only driver (e.g. MyUplink heat-pump telemetry): no
+        // meter/pv/battery DER reading — don't render phantom 0 PV/SoC rows.
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">Type</span><span class="stat-value stat-dim">telemetry only</span>' +
+          '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + "</span>" +
+          '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
+          "</div>";
       }
 
       // For disabled drivers the body is minimal — just show the label.

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2042,7 +2042,7 @@
           '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + '</span>' +
           '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + '</span>' +
           '</div>';
-      } else {
+      } else if (d.meter_w != null || d.pv_w != null || d.bat_w != null || d.bat_soc != null) {
         var meterW = d.meter_w != null ? d.meter_w : 0;
         var pvWVal = d.pv_w != null ? d.pv_w : 0;
         var batWVal = d.bat_w != null ? d.bat_w : 0;
@@ -2073,6 +2073,17 @@
           '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
           "</div>" +
           '<div class="driver-soc-bar"><div class="driver-soc-fill" style="width:' + Math.round(batSocVal * 100) + '%"></div></div>';
+      } else {
+        // Metrics-only driver (e.g. MyUplink heat-pump telemetry): emits
+        // scalar metrics via emit_metric, no meter/pv/battery DER reading.
+        // Don't render phantom 0 W / 0 % PV+battery+SoC rows — show liveness
+        // and point at the per-driver metrics view (Diagnose) instead.
+        body =
+          '<div class="driver-stats">' +
+          '  <span class="stat-label">Type</span><span class="stat-value stat-dim">telemetry only</span>' +
+          '  <span class="stat-label">Ticks</span><span class="stat-value">' + ticks + "</span>" +
+          '  <span class="stat-label">Errors</span><span class="stat-value">' + errors + "</span>" +
+          "</div>";
       }
 
       // For disabled drivers the body is minimal — just show the label.


### PR DESCRIPTION
## Why

Fredrik: "we show battery SoC and PV for the nibe driver … they show zero but the data model isn't compatible" — observed in the **driver view, at the bottom**. The MyUplink heat pump emits only scalar metrics (no meter/pv/battery DER reading), but the driver card fell through `renderDrivers` to the meter/pv/battery layout and rendered `0 W` PV / `0 W` battery / `0%` SoC + an empty SoC bar.

## What

Add a **metrics-only branch** to `renderDrivers` in both `next-app.js` (main UI) and `app.js` (legacy): if a driver has none of `meter_w` / `pv_w` / `bat_w` / `bat_soc`, render a compact `telemetry only` body (status + ticks + errors), no phantom DER rows, no SoC bar. Drivers with any DER reading are unchanged; vehicle / EV / V2X branches are unchanged.

## Verification

Booted a metrics-only heat-pump stub (only `hp_*` metrics) alongside a meter stub. Confirmed via the rendered DOM: the heat-pump card shows `Type: telemetry only · Ticks · Errors` with no SoC bar; the meter driver still shows its DER layout. `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)