### PR TITLE
feat(ui): manual SoC correction in the EV Charger modal

### DIFF
--- a/.changeset/ev-modal-soc-edit.md
+++ b/.changeset/ev-modal-soc-edit.md
@@ -1,0 +1,10 @@
+---
+"forty-two-watts": patch
+---
+
+Set the car's SoC from the EV Charger modal. Clicking the EV planet now
+shows a "State of charge" section: while the car is plugged in it offers
+an inline % field + Set (re-anchors the inferred SoC via
+POST /api/loadpoints/{id}/soc and replans); unplugged it shows the current
+value with a hint. Previously this lived only in the advanced loadpoints
+panel — now it's where the SoC is naturally looked for.

--- a/web/next-app.js
+++ b/web/next-app.js
@@ -2859,6 +2859,101 @@
       });
     });
 
+    // ---- State of charge (manual correction) ----
+    // The SoC is inferred from delivered energy when there's no vehicle BMS
+    // reading, so it can drift. Let the operator correct it via the existing
+    // POST /api/loadpoints/{id}/soc (re-anchors + replans). Only meaningful
+    // during an active session, so gate the editor on plugged_in.
+    var socBox = document.createElement("div");
+    socBox.style.marginTop = "0.75rem";
+    socBox.style.paddingTop = "0.6rem";
+    socBox.style.borderTop = "1px solid var(--line)";
+
+    var socEyebrow = document.createElement("div");
+    socEyebrow.textContent = "State of charge";
+    socEyebrow.style.fontFamily = "var(--mono)";
+    socEyebrow.style.fontSize = "0.7rem";
+    socEyebrow.style.letterSpacing = "0.18em";
+    socEyebrow.style.textTransform = "uppercase";
+    socEyebrow.style.color = "var(--text-dim)";
+    socEyebrow.style.marginBottom = "0.45rem";
+    socBox.appendChild(socEyebrow);
+
+    var curSoc = (lp && lp.current_soc_pct != null) ? lp.current_soc_pct : null;
+    var socSource = (lp && lp.soc_source) ? lp.soc_source : "";
+
+    if (lp && lp.plugged_in) {
+      var socRow = document.createElement("div");
+      socRow.style.display = "flex";
+      socRow.style.alignItems = "center";
+      socRow.style.gap = "0.5rem";
+
+      var socInput = document.createElement("input");
+      socInput.type = "number";
+      socInput.min = "0"; socInput.max = "100"; socInput.step = "0.1";
+      socInput.value = (curSoc != null) ? curSoc.toFixed(1) : "";
+      socInput.style.width = "5.5em";
+      socInput.style.fontFamily = "var(--mono)";
+
+      var pctLabel = document.createElement("span");
+      pctLabel.textContent = "%";
+      pctLabel.style.color = "var(--text-dim)";
+
+      var socSetBtn = document.createElement("button");
+      socSetBtn.type = "button";
+      socSetBtn.textContent = "Set SoC";
+      socSetBtn.style.padding = "0.35rem 0.7rem";
+      socSetBtn.style.border = "1px solid var(--line)";
+      socSetBtn.style.borderRadius = "4px";
+      socSetBtn.style.cursor = "pointer";
+      socSetBtn.style.background = "transparent";
+      socSetBtn.style.color = "var(--fg)";
+
+      socRow.appendChild(socInput);
+      socRow.appendChild(pctLabel);
+      socRow.appendChild(socSetBtn);
+      socBox.appendChild(socRow);
+
+      var socStatus = document.createElement("small");
+      socStatus.style.display = "block";
+      socStatus.style.color = "var(--text-dim)";
+      socStatus.style.marginTop = "0.35rem";
+      socStatus.style.minHeight = "1em";
+      socStatus.textContent = "Current: " + (curSoc != null ? curSoc.toFixed(1) + "%" : "—") +
+        (socSource ? " (" + socSource + ")" : "") + ". Correct it if the car's real SoC differs.";
+      socBox.appendChild(socStatus);
+
+      socSetBtn.addEventListener("click", function () {
+        var v = parseFloat(socInput.value);
+        if (!isFinite(v) || v < 0 || v > 100) { socStatus.textContent = "Enter 0–100%."; return; }
+        socSetBtn.disabled = true;
+        socStatus.textContent = "Saving…";
+        ownerFetch("/api/loadpoints/" + encodeURIComponent(lp.id) + "/soc", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ soc_pct: v }),
+        }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, body: j }; }); })
+          .then(function (res) {
+            socSetBtn.disabled = false;
+            if (res.ok && res.body && res.body.ok) {
+              socStatus.textContent = "Saved — SoC set to " + v.toFixed(1) + "%. Replanning.";
+              manualNeedsRebuild = true;
+            } else {
+              socStatus.textContent = (res.body && res.body.error) || "Set failed.";
+            }
+          }).catch(function (e) { socSetBtn.disabled = false; socStatus.textContent = "Set failed: " + e.message; });
+      });
+    } else {
+      var socMuted = document.createElement("small");
+      socMuted.style.display = "block";
+      socMuted.style.color = "var(--text-dim)";
+      socMuted.textContent = "Current: " + (curSoc != null ? curSoc.toFixed(1) + "%" : "—") +
+        (socSource ? " (" + socSource + ")" : "") + " · plug in to set manually.";
+      socBox.appendChild(socMuted);
+    }
+
+    box.appendChild(socBox);
+
     return box;
   }
 


### PR DESCRIPTION
## Why

"När jag trycker på EV så får jag ingen möjlighet till att ändra SoC." The manual-SoC edit I added earlier landed in the **advanced loadpoints panel**, but the natural place to look is the **EV Charger modal** that opens from the EV planet — and it showed neither the current SoC nor a way to set it.

## What

Added a **State of charge** section to the EV Charger modal (inside `buildManualControl`, which is mounted once per loadpoint so the 10 s poll doesn't clobber the input):

- **Plugged in:** an inline `%` number field + **Set SoC** → `POST /api/loadpoints/{id}/soc` (re-anchors the inferred SoC + triggers an MPC replan), with inline status.
- **Unplugged:** shows the current value + source with a "plug in to set" hint (the endpoint re-anchors during an active session, so it's gated on `plugged_in`).

Complements the advanced-panel inline ✎ from the previous PR.

## Verification

Booted a stub EV charger + loadpoint, opened the EV modal via its planet, and confirmed via DOM + screenshot that the **State of charge** section renders in the right place (between Manual Charge and PV Mode), on-theme. The sim's loadpoint didn't flip `plugged_in` (control-loop sim artifact) so the screenshot shows the unplugged variant; the plugged variant is the symmetric branch using the same confirmed loadpoint fields + the already-tested `/soc` endpoint. Best confirmed on a live plugged-in loadpoint. `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)