### PR TITLE
fix(myuplink): self-heal after transient post-consent auth failure (no manual restart)

### DIFF
--- a/.changeset/myuplink-self-heal.md
+++ b/.changeset/myuplink-self-heal.md
@@ -1,0 +1,10 @@
+---
+"forty-two-watts": patch
+---
+
+MyUplink driver self-heals instead of needing a manual restart. NIBE/MyUplink
+is touchy right after consent (token propagation / rate-limit), so the first
+auth or device-detect can fail — previously the driver then idled forever on a
+nil device_id and only came online after the operator hit Restart. driver_poll
+now retries setup (auth + device detection) with a 30 s backoff, so it recovers
+on its own within a poll or two.

--- a/drivers/myuplink.lua
+++ b/drivers/myuplink.lua
@@ -62,6 +62,13 @@ local access_token     = nil
 local token_expires_at = 0
 local refresh_token    = nil   -- rotated on each refresh; persisted via host.persist_secret
 
+-- Self-heal: NIBE/MyUplink is touchy right after consent (token propagation /
+-- rate-limit), so the first auth or device-detect can fail. Rather than idle
+-- forever on a nil device_id (which needed a manual driver restart), poll
+-- retries setup with this backoff between attempts.
+local SETUP_RETRY_MS   = 30000
+local last_setup_ms    = nil   -- nil = never attempted (first try is immediate)
+
 local client_id     = nil
 local client_secret = nil
 local device_id     = nil
@@ -202,6 +209,30 @@ local function sanitize_metric_name(name, pid)
     return "hp_" .. s
 end
 
+-- Bring the driver to "ready" (valid token + device_id). Safe to call
+-- repeatedly; rate-limited by SETUP_RETRY_MS so a touchy NIBE API isn't
+-- hammered. Returns true once device_id is established. This is what makes
+-- the driver self-heal after a transient post-consent auth/detect failure —
+-- no manual restart needed.
+local function try_setup()
+    if not client_id or not client_secret or not refresh_token then return false end
+    if device_id then return true end
+    local now = host.millis()
+    if last_setup_ms ~= nil and (now - last_setup_ms) < SETUP_RETRY_MS then
+        return false
+    end
+    last_setup_ms = now
+    if not ensure_auth() then
+        host.log("warn", "MyUplink: auth not ready yet — will retry")
+        return false
+    end
+    device_id = detect_device_id()
+    if not device_id then return false end
+    host.set_sn(device_id)
+    host.log("info", "MyUplink: ready (read-only) device=" .. device_id)
+    return true
+end
+
 -- ---- Lifecycle -----------------------------------------------------------
 
 function driver_init(config)
@@ -224,6 +255,8 @@ function driver_init(config)
         PARAM_OUTDOOR_TEMP = ov("param_outdoor_temp_id", PARAM_OUTDOOR_TEMP)
         -- base_url override exists for tests; production uses api.myuplink.com.
         if config.base_url and config.base_url ~= "" then BASE_URL = config.base_url end
+        -- setup_retry_ms override exists for tests (0 = retry immediately).
+        if config.setup_retry_ms ~= nil then SETUP_RETRY_MS = tonumber(config.setup_retry_ms) or SETUP_RETRY_MS end
     end
 
     if not client_id or not client_secret then
@@ -237,21 +270,21 @@ function driver_init(config)
         host.log("info", "MyUplink: awaiting OAuth connect — click \"Connect to MyUplink\" in Settings → Devices")
         return
     end
-    if not ensure_auth() then
-        host.log("error", "MyUplink: initial auth failed (refresh_token rejected — reconnect in Settings → Devices)")
-        return
+    -- Best-effort initial setup. If NIBE is touchy right after consent and
+    -- this fails, we DON'T give up — driver_poll retries with backoff, so no
+    -- manual restart is needed.
+    if not try_setup() then
+        host.log("warn", "MyUplink: initial setup did not complete — will retry automatically")
     end
-    if not device_id then
-        device_id = detect_device_id()
-        if not device_id then return end
-    end
-
-    host.set_sn(device_id)
-    host.log("info", "MyUplink: ready (read-only) device=" .. device_id)
 end
 
 function driver_poll()
-    if not device_id or not client_id then return 30000 end
+    if not client_id or not client_secret or not refresh_token then return 30000 end
+    -- Not yet set up (first auth/detect failed, or just connected) → retry
+    -- with backoff. Self-heals the "only works after a manual restart" case.
+    if not device_id then
+        if not try_setup() then return 30000 end
+    end
     if not ensure_auth() then return 30000 end
 
     local data, by_id, err = fetch_all_points()
@@ -313,4 +346,5 @@ function driver_cleanup()
     -- refresh_token is re-read from config (with any KV override) on the
     -- next driver_init; clear it so a hot-reload starts from a clean slate.
     refresh_token    = nil
+    last_setup_ms    = nil
 end

--- a/go/internal/drivers/myuplink_test.go
+++ b/go/internal/drivers/myuplink_test.go
@@ -173,9 +173,9 @@ func TestMyUplinkEmitsAllPointsWithUnits(t *testing.T) {
 			t.Errorf("expected unfiltered points fetch, got query %q", q)
 		}
 		_ = json.NewEncoder(w).Encode([]map[string]any{
-			{"parameterId": "10012", "parameterName": "Compressor power", "value": "1500", "parameterUnit": "W"}, // canonical
-			{"parameterId": "40004", "parameterName": "Outdoor temp (BT1)", "value": "226", "parameterUnit": "°C"}, // canonical
-			{"parameterId": "40008", "parameterName": "Supply line (BT2)", "value": "455", "parameterUnit": "°C"},  // generic temp, ×10
+			{"parameterId": "10012", "parameterName": "Compressor power", "value": "1500", "parameterUnit": "W"},    // canonical
+			{"parameterId": "40004", "parameterName": "Outdoor temp (BT1)", "value": "226", "parameterUnit": "°C"},  // canonical
+			{"parameterId": "40008", "parameterName": "Supply line (BT2)", "value": "455", "parameterUnit": "°C"},   // generic temp, ×10
 			{"parameterId": "43136", "parameterName": "Compressor frequency", "value": "42", "parameterUnit": "Hz"}, // generic
 			{"parameterId": "43005", "parameterName": "Degree minutes", "value": "-600", "parameterUnit": "GM"},     // generic, negative
 		})
@@ -242,6 +242,70 @@ func keysOf(m map[string]telemetry.MetricSnapshot) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestMyUplinkSelfHealsAfterTransientAuthFailure reproduces the "only works
+// after a manual restart" bug: NIBE/MyUplink is touchy right after consent,
+// so the first token request can fail. The driver must retry setup in
+// driver_poll (with backoff) instead of idling forever on a nil device_id.
+func TestMyUplinkSelfHealsAfterTransientAuthFailure(t *testing.T) {
+	var tokenCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			tokenCalls++
+			if tokenCalls == 1 {
+				// First attempt fails (transient, as NIBE does post-consent).
+				w.WriteHeader(400)
+				_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "AT", "expires_in": 3600, "refresh_token": "RT",
+			})
+		case "/v2/systems/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"systems": []map[string]any{{"devices": []map[string]any{{"id": "DEV1"}}}},
+			})
+		default: // points
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"parameterId": "10012", "value": "900", "parameterUnit": "W"},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	tel := telemetry.NewStore()
+	env := NewHostEnv("myuplink", tel).WithHTTP()
+	env.PersistSecret = func(k, v string) error { return nil }
+
+	d, err := NewLuaDriver(myuplinkDriverPath(t), env)
+	if err != nil {
+		t.Fatalf("load driver: %v", err)
+	}
+	defer d.Cleanup()
+	cfg := map[string]any{
+		"client_id": "cid", "client_secret": "csec", "refresh_token": "RT",
+		"base_url":       srv.URL,
+		"setup_retry_ms": 0, // no backoff delay in the test
+	}
+	// Init's first auth fails — driver must NOT permanently give up.
+	if err := d.Init(context.Background(), cfg); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, _, ok := tel.LatestMetric("myuplink", "hp_power_w"); ok {
+		t.Fatal("should not have telemetry yet (first auth failed)")
+	}
+	// A subsequent poll must retry setup (auth now succeeds) and recover —
+	// no manual restart needed. May take two polls (retry, then emit).
+	for i := 0; i < 3; i++ {
+		if _, err := d.Poll(context.Background()); err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+	}
+	if v, _, ok := tel.LatestMetric("myuplink", "hp_power_w"); !ok || v != 900 {
+		t.Errorf("hp_power_w = %v (ok=%v), want 900 — driver should self-heal after the transient auth failure", v, ok)
+	}
 }
 
 // TestMyUplinkNoRefreshTokenIdles verifies the driver degrades gracefully


### PR DESCRIPTION
## Why

Field feedback (Fredrik + HannesB): after connecting MyUplink, the driver stayed **offline until a manual Restart**. NIBE/MyUplink is touchy right after consent (token propagation / rate-limit), so the first token request or `/v2/systems/me` lookup can fail. The driver then never recovered: `driver_poll` early-returns on a nil `device_id`, so it idled forever until `driver_init` was re-run by a manual Restart.

## What

Extracted `try_setup()` (auth + device detection, rate-limited by `SETUP_RETRY_MS`, default 30 s). `driver_init` now does a best-effort setup but **doesn't give up** on failure; `driver_poll` calls `try_setup()` whenever `device_id` is nil, so the driver recovers on its own within a poll or two — no manual restart. `setup_retry_ms` is overridable (tests use 0).

## Test

`TestMyUplinkSelfHealsAfterTransientAuthFailure`: a stub that fails the first `/oauth/token` then succeeds. Init's first auth fails (no telemetry), and a subsequent poll retries setup and recovers (`hp_power_w` lands) — proving self-heal without a restart. Failed before the fix. `make verify` green.

## Note (separate, no code change)

The "refresh token" field testers asked about is **already removed** as a user-facing input as of v0.124.0 — it's machine-managed by the Connect flow and filtered from the Secrets section for OAuth drivers. Testers seeing it are on an older build; updating removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)