### PR TITLE
fix(loadpoint): anchor inferred SoC to live vehicle BMS reading

### DIFF
--- a/.changeset/loadpoint-anchor-soc-to-vehicle-bms.md
+++ b/.changeset/loadpoint-anchor-soc-to-vehicle-bms.md
@@ -1,0 +1,16 @@
+---
+"forty-two-watts": patch
+---
+
+Loadpoint SoC now anchors to the live vehicle BMS reading when a vehicle
+driver (e.g. Tesla via TeslaBLEProxy) is online and matched to the
+loadpoint. Previously the EV card showed the delivered-Wh *inferred*
+estimate labelled "(vehicle)", which drifts from the car's real SoC
+(chargers like Easee can't read the pack) — so an actively charging
+Tesla reading 31% could show e.g. 36% on the card. The control loop now
+re-anchors `current_soc_pct` to the paired vehicle's BMS SoC each tick
+(only when the reading is online, fresh, and not driver-flagged stale),
+so the dashboard, the planner's `InitialSoCPct`, and the MPC all agree on
+BMS ground truth. When the vehicle goes BLE-silent the estimate continues
+from the last known BMS value instead of snapping back to the plug-in
+guess.

--- a/go/cmd/forty-two-watts/main.go
+++ b/go/cmd/forty-two-watts/main.go
@@ -1991,6 +1991,30 @@ func main() {
 			lpMgr.RollSchedules(time.Now().UTC())
 			lpController.Tick(ctx, time.Now())
 
+			// Anchor each plugged-in loadpoint's inferred SoC to the live
+			// vehicle BMS reading when one is paired. Chargers like Easee
+			// can't read the car, so the manager otherwise drifts on a
+			// plug-in-anchor + delivered-Wh estimate; when a vehicle driver
+			// (TeslaBLEProxy etc.) is online and matched, its SoC is ground
+			// truth. Runs after Tick's Observe so the per-tick re-anchor
+			// wins over that tick's inference. Same picker the MPC spec and
+			// api.go's loadpoint decoration use, so all three agree on which
+			// vehicle is "the one"; we additionally require !Stale so a
+			// driver serving last-known cache (car asleep) can't pin the
+			// dashboard to a stale value — inference takes over until fresh
+			// BMS data returns.
+			for _, st := range lpMgr.States() {
+				if !st.PluggedIn {
+					continue
+				}
+				delivering := st.CurrentPowerW > loadpoint.DeliveringW
+				pick := telemetry.PickBestVehicleForLoadpoint(tel, delivering, time.Now())
+				if pick.Driver == "" || pick.Stale {
+					continue
+				}
+				lpMgr.AnchorVehicleSoC(st.ID, pick.SoCPct)
+			}
+
 			// ---- Safety: site meter stale → idle everything this cycle ----
 			// Otherwise stale grid readings cause one battery to charge another.
 			// Only meaningful when a site meter is actually configured;

--- a/go/internal/loadpoint/loadpoint.go
+++ b/go/internal/loadpoint/loadpoint.go
@@ -612,6 +612,49 @@ func (m *Manager) SetCurrentSoC(id string, socPct float64) bool {
 	if !lp.pluggedIn {
 		return false
 	}
+	reanchorSoCLocked(lp, socPct)
+	return true
+}
+
+// AnchorVehicleSoC re-anchors the inferred SoC to a trusted vehicle BMS
+// reading. It is the automatic counterpart to the operator's manual
+// SetCurrentSoC: the control loop calls it every tick with the SoC from
+// the vehicle driver paired to this loadpoint (e.g. Tesla via
+// TeslaBLEProxy), so the dashboard's current_soc and the planner's
+// InitialSoCPct both reflect BMS ground truth instead of the
+// delivered-Wh estimate, which is blind to the real pack (Easee and
+// other chargers can't read the car).
+//
+// Caller is responsible for the trust gate — only call with a reading
+// that is online, fresh, and matched to this loadpoint
+// (telemetry.PickBestVehicleForLoadpoint enforces this). Re-anchoring
+// every tick keeps current_soc locked to the latest BMS value; between
+// refreshes the inference advances from the last anchor on delivered Wh,
+// and if the vehicle goes BLE-silent (caller stops anchoring) the
+// estimate continues from the last known BMS truth rather than snapping
+// back to the plug-in guess.
+//
+// Returns false for unknown IDs or when the loadpoint is unplugged.
+func (m *Manager) AnchorVehicleSoC(id string, socPct float64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lp, ok := m.byID[id]
+	if !ok {
+		return false
+	}
+	if !lp.pluggedIn {
+		return false
+	}
+	reanchorSoCLocked(lp, socPct)
+	return true
+}
+
+// reanchorSoCLocked re-bases the session anchor so the CURRENT estimate
+// equals socPct, then recomputes current_soc from it. Caller must hold
+// m.mu and have verified the loadpoint is plugged in. Shared by the
+// manual (SetCurrentSoC) and automatic (AnchorVehicleSoC) correction
+// paths so they stay arithmetically identical.
+func reanchorSoCLocked(lp *loadpointRuntime, socPct float64) {
 	if socPct < 0 {
 		socPct = 0
 	}
@@ -634,7 +677,6 @@ func (m *Manager) SetCurrentSoC(id string, socPct float64) bool {
 	lp.sessionPluginSoCPct = anchor
 	lp.currentSoCPct = estimateSoCPct(anchor, lp.deliveredWhSession, lp.VehicleCapacityWh)
 	lp.updatedAtMs = time.Now().UnixMilli()
-	return true
 }
 
 func (lp *loadpointRuntime) snapshot() State {

--- a/go/internal/loadpoint/loadpoint_anchor_vehicle_test.go
+++ b/go/internal/loadpoint/loadpoint_anchor_vehicle_test.go
@@ -1,0 +1,75 @@
+package loadpoint
+
+import "testing"
+
+// TestAnchorVehicleSoC — when a trusted vehicle BMS reading (e.g. Tesla
+// via TeslaBLEProxy) is paired to a loadpoint, the control loop anchors
+// the inferred SoC to it. After AnchorVehicleSoC the current_soc equals
+// the BMS value, and any further delivered Wh advance from that anchor
+// (so the estimate keeps tracking between BMS refreshes). This is the
+// automatic counterpart to the operator's manual SetCurrentSoC.
+func TestAnchorVehicleSoC(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000, PluginSoCPct: 25}})
+	// Plug in, deliver 9 kWh → naive estimate = 25 + 9000/60000*100 = 40 %.
+	m.Observe("a", true, 7400, 9000, true)
+	if st, _ := m.State("a"); st.CurrentSoCPct < 39 || st.CurrentSoCPct > 41 {
+		t.Fatalf("pre-anchor SoC: got %.2f want ~40", st.CurrentSoCPct)
+	}
+	// The bound vehicle's BMS reports the real SoC is 31 %.
+	if !m.AnchorVehicleSoC("a", 31) {
+		t.Fatal("AnchorVehicleSoC returned false on plugged-in loadpoint")
+	}
+	st, _ := m.State("a")
+	if st.CurrentSoCPct < 30.5 || st.CurrentSoCPct > 31.5 {
+		t.Errorf("post-anchor SoC: got %.2f want ~31", st.CurrentSoCPct)
+	}
+	// Deliver another 3 kWh → should be ~36 % (31 + 3000/60000*100).
+	m.Observe("a", true, 7400, 12000, true)
+	st, _ = m.State("a")
+	if st.CurrentSoCPct < 35 || st.CurrentSoCPct > 37 {
+		t.Errorf("after more delivery SoC: got %.2f want ~36", st.CurrentSoCPct)
+	}
+}
+
+// TestAnchorVehicleSoCEveryTickStaysLocked — the control loop calls
+// AnchorVehicleSoC every tick with the latest BMS reading. Even though
+// Observe re-runs the inference each tick, the per-tick re-anchor keeps
+// current_soc locked to the latest BMS value rather than drifting on the
+// delivered-Wh estimate.
+func TestAnchorVehicleSoCEveryTickStaysLocked(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000, PluginSoCPct: 25}})
+	m.Observe("a", true, 7400, 9000, true)
+	// Tick 1: BMS says 31.
+	m.AnchorVehicleSoC("a", 31)
+	if st, _ := m.State("a"); st.CurrentSoCPct < 30.5 || st.CurrentSoCPct > 31.5 {
+		t.Fatalf("tick1 SoC: got %.2f want ~31", st.CurrentSoCPct)
+	}
+	// Tick 2: more energy delivered AND BMS refreshes to 32. Observe runs
+	// the inference first (as the controller does), then we re-anchor.
+	m.Observe("a", true, 7400, 10000, true)
+	m.AnchorVehicleSoC("a", 32)
+	st, _ := m.State("a")
+	if st.CurrentSoCPct < 31.5 || st.CurrentSoCPct > 32.5 {
+		t.Errorf("tick2 SoC: got %.2f want ~32 (locked to latest BMS)", st.CurrentSoCPct)
+	}
+}
+
+// TestAnchorVehicleSoCRejectsUnpluggedAndUnknown — a BMS reading is only
+// meaningful during an active session, and an unknown id is a no-op.
+func TestAnchorVehicleSoCRejectsUnpluggedAndUnknown(t *testing.T) {
+	m := NewManager()
+	m.Load([]Config{{ID: "a", VehicleCapacityWh: 60000}})
+	if m.AnchorVehicleSoC("a", 40) {
+		t.Error("should reject AnchorVehicleSoC on never-plugged loadpoint")
+	}
+	if m.AnchorVehicleSoC("ghost", 40) {
+		t.Error("should reject AnchorVehicleSoC on unknown id")
+	}
+	m.Observe("a", true, 0, 0, true)
+	m.Observe("a", false, 0, 0, true)
+	if m.AnchorVehicleSoC("a", 40) {
+		t.Error("should reject AnchorVehicleSoC after unplug")
+	}
+}


### PR DESCRIPTION
## Problem

The EV card (added in #514 / #510) renders the loadpoint's **inferred** `current_soc_pct` (a plug-in-anchor + delivered-Wh estimate) with a `(soc_source)` label. Chargers like Easee can't read the car's pack, so the inference drifts. When a live vehicle BLE reading is paired, `soc_source` becomes `"vehicle"` — so the card showed e.g. **"36% (vehicle)"**, the drifted inference mislabeled as vehicle truth, while the car's real `vehicle_soc_pct` (e.g. 31%) sat unused. Observed live on a 2-Tesla site: an actively charging car reading 31% displayed ~36%.

This is **not** a regression in the Tesla/BLE pipeline — the driver, host ingestion, and picker are unchanged. The driver + proxy work correctly; the bug is that the SoC *display* surface shows the inferred value even when BMS ground truth is available.

## Fix

The control loop now re-anchors each plugged-in loadpoint's `current_soc_pct` to the paired vehicle's **BMS SoC** every tick — only when the reading is online, fresh, and not driver-flagged stale (same `telemetry.PickBestVehicleForLoadpoint` the MPC spec and api.go decoration use). The dashboard, the planner's `InitialSoCPct`, and the MPC now all agree on BMS ground truth. When the vehicle goes BLE-silent the estimate falls back to inference, continuing from the last known BMS value rather than snapping back to the plug-in guess.

- New `Manager.AnchorVehicleSoC` (shares the re-anchor math with the manual `SetCurrentSoC` via `reanchorSoCLocked`).
- Wired in `main.go` after `lpController.Tick`.

## Tests

- `TestAnchorVehicleSoC`, `TestAnchorVehicleSoCEveryTickStaysLocked`, `TestAnchorVehicleSoCRejectsUnpluggedAndUnknown` (TDD — red before, green after).
- `go test ./...` all green; `go vet` clean.

## Deploy / verification

Built arm64 + deployed as a dev binary to a production Pi for testing (binary-only compose override). App healthy. Positive path could not be live-verified at deploy time because both Teslas were asleep (`"vehicle is sleeping"` from the proxy) — the loadpoint correctly falls back to inference, and the anchor engages automatically on the next charge. Math is covered by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)