### PR TITLE
fix(loadpoint): auto-release manual hold when vehicle stops requesting (car full)

### DIFF
--- a/.changeset/manual-hold-auto-release-on-full.md
+++ b/.changeset/manual-hold-auto-release-on-full.md
@@ -1,0 +1,13 @@
+---
+"forty-two-watts": patch
+---
+
+A manual EV charge hold ("Start" / amp slider) now auto-releases when the
+vehicle stops requesting current — e.g. it reaches its own charge limit
+and is full. Previously the hold pinned the wallbox at a fixed amperage
+and the loadpoint kept showing "charging" at 0 W until the operator
+pressed Stop. The controller now drops the hold after the vehicle has
+been not-requesting for SessionCompletionTimeout (90 s, debounced against
+brief ramp/handshake dips), falling back to automatic dispatch. Only
+applies to chargers that report "vehicle no longer requesting current"
+(e.g. Easee); chargers that can't distinguish that are unaffected.

--- a/go/internal/loadpoint/controller.go
+++ b/go/internal/loadpoint/controller.go
@@ -83,6 +83,14 @@ type Controller struct {
 	// compute-from-plan path.
 	holdMu sync.Mutex
 	holds  map[string]ManualHold
+	// manualIdleSince[id] is when a loadpoint with an active manual hold
+	// first observed the vehicle "not requesting current" this idle spell.
+	// Once it has stayed not-requesting for SessionCompletionTimeout the
+	// controller auto-releases the hold (the car is full / declined), so
+	// the operator doesn't have to press Stop. Reset whenever the car
+	// requests again or the hold goes away. Guarded by manualIdleMu.
+	manualIdleMu    sync.Mutex
+	manualIdleSince map[string]time.Time
 	// manualHoldSaver, if non-nil, persists operator (Persistent) manual
 	// holds so they survive a reboot / firmware update and the EV keeps
 	// charging across the restart. Called on Set (persistent) and Clear.
@@ -1067,6 +1075,35 @@ func (c *Controller) ClearManualHold(id string) {
 	if saver != nil && existed {
 		saver(id, ManualHold{}, true)
 	}
+	// The auto-release idle timer is meaningless without a hold.
+	c.resetManualIdle(id)
+}
+
+// manualHoldIdleFor returns how long the loadpoint has continuously seen
+// the vehicle "not requesting current" while a manual hold is active,
+// starting the timer on the first such tick. Used to debounce the
+// auto-release of a hold once the car is full / declines.
+func (c *Controller) manualHoldIdleFor(id string, now time.Time) time.Duration {
+	c.manualIdleMu.Lock()
+	defer c.manualIdleMu.Unlock()
+	if c.manualIdleSince == nil {
+		c.manualIdleSince = map[string]time.Time{}
+	}
+	since, ok := c.manualIdleSince[id]
+	if !ok {
+		c.manualIdleSince[id] = now
+		return 0
+	}
+	return now.Sub(since)
+}
+
+// resetManualIdle clears the auto-release idle timer for a loadpoint —
+// called when the vehicle resumes requesting current or the hold is
+// removed, so the next idle spell is timed from a clean start.
+func (c *Controller) resetManualIdle(id string) {
+	c.manualIdleMu.Lock()
+	delete(c.manualIdleSince, id)
+	c.manualIdleMu.Unlock()
 }
 
 // SetManualHoldSaver wires the persistence callback for operator manual
@@ -1193,6 +1230,28 @@ func (c *Controller) tickOne(ctx context.Context, now time.Time, lpCfg Config) {
 	// by the wake HTTP roundtrip.
 	if sample.PowerW >= DeliveringW && !wasDelivering {
 		go c.wakeVehicleAuto(context.Background(), lpCfg.ID, "delivering_edge")
+	}
+
+	// Auto-release an operator manual hold once the vehicle has stopped
+	// requesting current (it hit its own charge limit / is full). Without
+	// this a "Start" hold pins the wallbox at a fixed amperage and the
+	// loadpoint shows "charging" at 0 W until the operator presses Stop.
+	// Debounced by SessionCompletionTimeout so a brief ramp/handshake dip
+	// — or a car that hasn't woken yet — doesn't drop the hold early. Only
+	// trips for drivers that distinguish "explicitly not requesting" from
+	// "throttled to 0" (RequestActive); others leave it true and never
+	// auto-release. Done before the dispatch branch below so the freed
+	// tick falls straight through to automatic (surplus/plan) dispatch.
+	if _, held := c.GetManualHold(lpCfg.ID, now); held {
+		if !sample.RequestActive {
+			if c.manualHoldIdleFor(lpCfg.ID, now) >= SessionCompletionTimeout {
+				slog.Info("loadpoint manual hold auto-released — vehicle stopped requesting current (full/declined)",
+					"lp", lpCfg.ID, "idle", SessionCompletionTimeout)
+				c.ClearManualHold(lpCfg.ID)
+			}
+		} else {
+			c.resetManualIdle(lpCfg.ID)
+		}
 	}
 
 	cmd := map[string]any{"action": "ev_set_current"}

--- a/go/internal/loadpoint/controller_manual_auto_release_test.go
+++ b/go/internal/loadpoint/controller_manual_auto_release_test.go
@@ -1,0 +1,102 @@
+package loadpoint
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// When an operator pins a manual hold ("Start" / amp slider) and the
+// vehicle then stops requesting current (it hit its own charge limit /
+// is full), the hold should auto-release so the loadpoint drops back to
+// automatic instead of pinning the wallbox at a fixed amperage forever —
+// the operator shouldn't have to press Stop. Debounced by
+// SessionCompletionTimeout so a brief ramp/handshake dip doesn't drop it.
+
+func TestManualHoldAutoReleasesWhenVehicleFull(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	cfg := overrideLoadpoint()
+	dir := &Directive{
+		SlotStart:         base.Add(-1 * time.Second),
+		SlotEnd:           base.Add(24 * time.Hour),
+		LoadpointEnergyWh: map[string]float64{cfg.ID: 6000},
+	}
+	sender := &fakeSender{}
+	// Car connected but NOT requesting current (full / declined).
+	samples := map[string]EVSample{cfg.DriverName: {Connected: true, PowerW: 0, RequestActive: false}}
+	c := newTestController(t, []Config{cfg}, dir, samples, sender)
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	c.SetSiteSurplusForEV(func() (float64, bool) { return 0, true })
+
+	c.SetManualHold(cfg.ID, ManualHold{PowerW: 6900, PhaseMode: "3p", Persistent: true})
+
+	// First tick: the car is already not requesting, but the debounce
+	// timer only just started — the hold must NOT release yet.
+	c.Tick(context.Background(), base)
+	if _, active := c.GetManualHold(cfg.ID, base); !active {
+		t.Fatalf("hold released on the first not-requesting tick; want debounced")
+	}
+
+	// After the debounce window of sustained not-requesting, the hold
+	// auto-releases — no operator Stop needed.
+	later := base.Add(SessionCompletionTimeout + time.Second)
+	c.Tick(context.Background(), later)
+	if _, active := c.GetManualHold(cfg.ID, later); active {
+		t.Errorf("manual hold not auto-released after %s of vehicle not requesting current", SessionCompletionTimeout)
+	}
+}
+
+func TestManualHoldHeldWhileVehicleRequesting(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	cfg := overrideLoadpoint()
+	dir := &Directive{
+		SlotStart:         base.Add(-1 * time.Second),
+		SlotEnd:           base.Add(24 * time.Hour),
+		LoadpointEnergyWh: map[string]float64{cfg.ID: 6000},
+	}
+	sender := &fakeSender{}
+	// Car actively drawing + requesting current.
+	samples := map[string]EVSample{cfg.DriverName: {Connected: true, PowerW: 6900, RequestActive: true}}
+	c := newTestController(t, []Config{cfg}, dir, samples, sender)
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	c.SetSiteSurplusForEV(func() (float64, bool) { return 0, true })
+
+	c.SetManualHold(cfg.ID, ManualHold{PowerW: 6900, PhaseMode: "3p", Persistent: true})
+
+	c.Tick(context.Background(), base)
+	later := base.Add(SessionCompletionTimeout + time.Second)
+	c.Tick(context.Background(), later)
+	if _, active := c.GetManualHold(cfg.ID, later); !active {
+		t.Errorf("manual hold auto-released while the vehicle was actively requesting current")
+	}
+}
+
+func TestManualHoldIdleTimerResetsOnResumedRequest(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	cfg := overrideLoadpoint()
+	dir := &Directive{
+		SlotStart:         base.Add(-1 * time.Second),
+		SlotEnd:           base.Add(24 * time.Hour),
+		LoadpointEnergyWh: map[string]float64{cfg.ID: 6000},
+	}
+	sender := &fakeSender{}
+	samples := map[string]EVSample{cfg.DriverName: {Connected: true, PowerW: 0, RequestActive: false}}
+	c := newTestController(t, []Config{cfg}, dir, samples, sender)
+	c.SetSiteFuse(SiteFuse{MaxAmps: 16, Voltage: 230, PhaseCnt: 3})
+	c.SetSiteSurplusForEV(func() (float64, bool) { return 0, true })
+
+	c.SetManualHold(cfg.ID, ManualHold{PowerW: 6900, PhaseMode: "3p", Persistent: true})
+
+	// Not requesting for a while (but under the window)…
+	c.Tick(context.Background(), base)
+	c.Tick(context.Background(), base.Add(60*time.Second))
+	// …then the car resumes requesting — this must reset the idle timer.
+	samples[cfg.DriverName] = EVSample{Connected: true, PowerW: 6900, RequestActive: true}
+	c.Tick(context.Background(), base.Add(70*time.Second))
+	// Car drops out again; only ~30 s of fresh idle by now < window.
+	samples[cfg.DriverName] = EVSample{Connected: true, PowerW: 0, RequestActive: false}
+	c.Tick(context.Background(), base.Add(100*time.Second))
+	if _, active := c.GetManualHold(cfg.ID, base.Add(100*time.Second)); !active {
+		t.Errorf("hold released too early — the idle timer should have reset when the car resumed requesting")
+	}
+}


### PR DESCRIPTION
## Problem

A manual EV charge hold (the "Start" / amp-slider override) pins the wallbox at a fixed amperage until the operator presses **Stop**. So when the car fills up and stops requesting current, the hold stays pinned and the loadpoint keeps reporting "charging" at 0 W — the operator has to manually press Stop.

## Fix

The controller now auto-releases an active manual hold once the vehicle has been **not requesting current** for `SessionCompletionTimeout` (90 s), then falls back to automatic (surplus/plan) dispatch on the same tick.

- Debounced by the 90 s window so a brief ramp/handshake dip — or a car that hasn't woken yet — doesn't drop the hold early. The idle timer resets the moment the car resumes requesting.
- Reuses the existing `RequestActive` signal (the same one the session-completion latch uses). Only trips for chargers that distinguish "explicitly not requesting" from "throttled to 0" (e.g. Easee); chargers that leave `RequestActive` true are unaffected.
- Idle timer is cleared on hold removal (Stop / unplug) so the next session starts clean.

## Tests (TDD)

- `TestManualHoldAutoReleasesWhenVehicleFull` — not-requesting past the window → hold cleared.
- `TestManualHoldHeldWhileVehicleRequesting` — actively requesting → hold kept.
- `TestManualHoldIdleTimerResetsOnResumedRequest` — a mid-window resume resets the debounce.

`go test ./...` green, race-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)