### PR TITLE
fix(deploy): nftables table name can't start with a digit, breaking RPi port-80 redirect

### DIFF
--- a/.changeset/nft-redirect-table-leading-digit.md
+++ b/.changeset/nft-redirect-table-leading-digit.md
@@ -1,0 +1,14 @@
+---
+"forty-two-watts": patch
+---
+
+Fix the RPi image's port 80 → 8080 redirect, which never worked.
+
+The nftables rules file named its table `42w_redirect`. nftables identifiers
+must match `[a-zA-Z_][a-zA-Z0-9_]*`, so the leading digit was tokenized as a
+number and the entire file failed to parse. `42w-port-redirect.service` exited
+1 on every boot and no redirect was ever installed, leaving the dashboard
+reachable only at `http://42w.local:8080/` rather than the bare
+`http://42w.local/` the README advertises.
+
+Renamed the table to `ftw_redirect`. The rule logic was otherwise correct.

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
@@ -8,14 +8,19 @@
 # discovery, LAN MQTT brokers, and mDNS-based drivers like Sourceful
 # Zap. The Go app binds 8080 directly on the host's network namespace.
 #
-# Own table (`42w_redirect`) to stay isolated from any other nftables
+# Own table (`ftw_redirect`) to stay isolated from any other nftables
 # config a future image stage might add. `flush table` at the top
 # makes the load idempotent: re-running `nft -f` doesn't stack
 # duplicate rules.
-table ip 42w_redirect
-flush table ip 42w_redirect
+#
+# NB: the table name must NOT start with a digit — nftables identifiers
+# follow `[a-zA-Z_][a-zA-Z0-9_]*`, so a leading `4` (e.g. `42w_redirect`)
+# is tokenized as a number and the whole file fails to parse, silently
+# disabling the redirect. Hence `ftw_redirect`, not `42w_redirect`.
+table ip ftw_redirect
+flush table ip ftw_redirect
 
-table ip 42w_redirect {
+table ip ftw_redirect {
     chain prerouting {
         type nat hook prerouting priority dstnat; policy accept;
         tcp dport 80 redirect to :8080

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
@@ -11,7 +11,7 @@ Before=network.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/nft -f /etc/42w-port-redirect.nft
-# Idempotent — the rules file flushes the 42w_redirect table at the
+# Idempotent — the rules file flushes the ftw_redirect table at the
 # top before re-installing, so a manual `systemctl restart` doesn't
 # stack duplicates.
 ExecReload=/usr/sbin/nft -f /etc/42w-port-redirect.nft


### PR DESCRIPTION
## Problem

The RPi image's port 80 → 8080 redirect has **never worked**. The nftables rules file (`deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft`) names its table `42w_redirect`.

nftables identifiers must match `[a-zA-Z_][a-zA-Z0-9_]*` — a leading digit is tokenized as a number, so the parser rejects the file at the first line:

```
/etc/42w-port-redirect.nft:15:10-11: Error: syntax error, unexpected number, expecting string
table ip 42w_redirect
         ^^
```

`42w-port-redirect.service` therefore exits `1/FAILURE` on every boot, no redirect is installed, and the dashboard is reachable only at `http://42w.local:8080/` — not the bare `http://42w.local/` the README advertises. This has been broken since #200 introduced the redirect.

## Fix

Rename the table to `ftw_redirect` (rule logic unchanged) and add a comment documenting the leading-digit constraint so it doesn't regress. Also fixed a stale table-name reference in the `.service` comment.

## Verification

Reproduced on a running Pi flashed from the current image:
- `systemctl status 42w-port-redirect.service` → `failed (status=1/FAILURE)`, journal shows the syntax error above.
- The fixed file passes `sudo nft -c -f -` (check-only) with **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)