### PR TITLE
feat(rpi-image): Trixie + cloud-init image and Raspberry Pi Imager repository JSON

### DIFF
--- a/.changeset/trixie-imager-repository.md
+++ b/.changeset/trixie-imager-repository.md
@@ -1,0 +1,9 @@
+---
+"forty-two-watts": minor
+---
+
+Migrate the Raspberry Pi SD-card image to Raspberry Pi OS Trixie with cloud-init, and publish a Raspberry Pi Imager repository JSON so Imager 2.0's customisation panel (hostname, SSH user/password, WiFi) works again.
+
+Point Raspberry Pi Imager at `https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json` (App Options → Content Repository → Use custom file) to flash "Forty-Two Watts" with full per-flash customisation. The repository JSON is rebuilt and uploaded on every release with the new image's URL, sizes, and verified checksum.
+
+The on-image deploy directory moved from `/home/ftw/forty-two-watts` to `/opt/forty-two-watts` so a user-chosen account name can't orphan it. The `curl | install.sh` and manual docker-compose install paths are unaffected.

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -328,17 +328,17 @@ jobs:
           sudo docker system prune -af
           df -h /
 
-      - name: Register binfmt_misc handlers for arm / arm64
+      - name: Install qemu for arm64 cross-build
         # See rpi-image-build.yml for the full rationale. Short version:
-        # install qemu-user-static with --no-install-recommends (pi-gen's
-        # arm64 branch wants /usr/bin/qemu-aarch64-static, and
-        # the flag keeps the wrapper-registering qemu-user-binfmt out),
-        # then let tonistiigi/binfmt install F-flagged handlers that
-        # survive pi-gen's chroot mount-namespace switch.
+        # pi-gen's arm64 (trixie) branch needs the dynamic /usr/bin/qemu-aarch64
+        # (`which qemu-aarch64`) and registers its own F-flagged handler +
+        # dpkg-reconfigure qemu-user-binfmt in the privileged container, so
+        # we just install qemu-user-binfmt (not the old qemu-user-static +
+        # tonistiigi/binfmt combo that the bookworm-arm64 branch wanted).
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends qemu-user-static
-          sudo docker run --privileged --rm tonistiigi/binfmt --install arm,arm64
+          sudo apt-get install -y -qq qemu-user-binfmt
+          which qemu-aarch64   # the exact preflight build-docker.sh runs
 
       - name: Checkout tag
         uses: actions/checkout@v5

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Register binfmt_misc handlers for arm / arm64
         # See rpi-image-build.yml for the full rationale. Short version:
         # install qemu-user-static with --no-install-recommends (pi-gen's
-        # bookworm-arm64 branch wants /usr/bin/qemu-aarch64-static, and
+        # arm64 branch wants /usr/bin/qemu-aarch64-static, and
         # the flag keeps the wrapper-registering qemu-user-binfmt out),
         # then let tonistiigi/binfmt install F-flagged handlers that
         # survive pi-gen's chroot mount-namespace switch.
@@ -346,12 +346,12 @@ jobs:
           ref: ${{ needs.meta.outputs.tag }}
 
       - name: Build image
-        # Pin to pi-gen's bookworm-arm64 branch. Upstream master has
-        # advanced to Debian trixie; we keep the image on bookworm
-        # so the curl|bash installer and the SD image deploy to the
-        # same base OS. Bump this when we choose to jump to trixie.
-        env:
-          PI_GEN_REF: bookworm-arm64
+        # The pinned pi-gen ref (the arm64 / trixie branch commit) lives
+        # in deploy/pi-gen/build.sh as the single source of truth, so
+        # local builds and CI stay in lock-step. The image is Raspberry
+        # Pi OS Lite (64-bit, trixie) with cloud-init — the curl|bash
+        # installer is independent and runs on the user's own OS, so the
+        # two are intentionally no longer tied to the same Debian base.
         run: deploy/pi-gen/build.sh
 
       - name: Locate + rename artifact
@@ -380,6 +380,56 @@ jobs:
         # --clobber mirrors the binaries job — lets a manual re-run
         # replace a prior upload without aborting the job.
         run: gh release upload "${TAG}" "${ASSET}" --clobber
+
+      - name: Build + upload Imager repository JSON
+        # Raspberry Pi Imager 2.0 only offers the OS-customisation panel
+        # (hostname / SSH user / WiFi) for images described by a
+        # repository JSON declaring an `init_format`. Render the template
+        # at deploy/imager/os_list.json with THIS release's image URL,
+        # sizes, and (schema-required, Imager-verified) extract_sha256,
+        # then publish it as a release asset. Users point Imager at the
+        # stable, version-independent URL:
+        #   https://github.com/<owner>/<repo>/releases/latest/download/os_list.json
+        # which always redirects to the newest release's copy.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG:   ${{ needs.meta.outputs.tag }}
+          ASSET: ${{ steps.artifact.outputs.asset }}
+        run: |
+          set -euo pipefail
+          IMG_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/42w-rpi4-arm64-${TAG}.img.xz"
+          DL_SIZE="$(stat -c%s "${ASSET}")"
+          # xz --robot --list emits a `totals` row whose 5th field is the
+          # uncompressed (extracted) size in bytes.
+          EXTRACT_SIZE="$(xz --robot --list "${ASSET}" | awk '/^totals/{print $5}')"
+          # extract_sha256 is REQUIRED by the V4 schema and verified by
+          # Imager after writing. Stream-decompress so the ~2.4 GB image
+          # never has to land on disk.
+          EXTRACT_SHA="$(xz -dc "${ASSET}" | sha256sum | cut -d' ' -f1)"
+          RELEASE_DATE="$(date -u +%Y-%m-%d)"
+
+          jq \
+            --arg url   "${IMG_URL}" \
+            --argjson ds "${DL_SIZE}" \
+            --argjson es "${EXTRACT_SIZE}" \
+            --arg sha   "${EXTRACT_SHA}" \
+            --arg date  "${RELEASE_DATE}" \
+            '.os_list[0].url                  = $url
+            | .os_list[0].image_download_size = $ds
+            | .os_list[0].extract_size        = $es
+            | .os_list[0].extract_sha256      = $sha
+            | .os_list[0].release_date        = $date' \
+            deploy/imager/os_list.json > os_list.json
+
+          # Fail loudly if templating left any placeholder behind, and
+          # assert the checksum is a real 64-hex-char digest.
+          if grep -q '__IMAGE_URL__\|__EXTRACT_SHA256__' os_list.json; then
+            echo "os_list.json still contains placeholders after templating" >&2
+            exit 1
+          fi
+          jq -e '.os_list[0].extract_sha256 | test("^[0-9a-f]{64}$")' os_list.json >/dev/null
+
+          gh release upload "${TAG}" os_list.json --clobber
 
   discord:
     name: announce release on Discord

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -330,15 +330,21 @@ jobs:
 
       - name: Install qemu for arm64 cross-build
         # See rpi-image-build.yml for the full rationale. Short version:
-        # pi-gen's arm64 (trixie) branch needs the dynamic /usr/bin/qemu-aarch64
-        # (`which qemu-aarch64`) and registers its own F-flagged handler +
-        # dpkg-reconfigure qemu-user-binfmt in the privileged container, so
-        # we just install qemu-user-binfmt (not the old qemu-user-static +
-        # tonistiigi/binfmt combo that the bookworm-arm64 branch wanted).
+        # pi-gen's arm64 (trixie) branch needs a STATIC qemu-aarch64 as the
+        # binfmt interpreter (a dynamic one can't find its libs in the
+        # chroot → arch-test "arm64: not supported"). Install qemu-user-static,
+        # symlink it to the unsuffixed name the preflight checks, and use
+        # tonistiigi/binfmt for chroot-surviving F-flagged handlers.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq qemu-user-binfmt
-          which qemu-aarch64   # the exact preflight build-docker.sh runs
+          sudo apt-get install -y -qq --no-install-recommends qemu-user-static
+          sudo ln -sf /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
+          sudo docker run --privileged --rm tonistiigi/binfmt --install arm64
+          which qemu-aarch64
+          echo "--- binfmt_misc qemu-aarch64 handlers ---"
+          for f in /proc/sys/fs/binfmt_misc/qemu-aarch64*; do
+            echo "== ${f} =="; cat "${f}" 2>/dev/null || true
+          done
 
       - name: Checkout tag
         uses: actions/checkout@v5

--- a/.github/workflows/rpi-image-build.yml
+++ b/.github/workflows/rpi-image-build.yml
@@ -53,10 +53,10 @@ jobs:
           df -h /
 
       - name: Register binfmt_misc handlers for arm / arm64
-        # pi-gen's bookworm-arm64 branch checks for
+        # pi-gen's arm64 branch checks for
         # /usr/bin/qemu-aarch64-static (STATIC, with -static suffix,
         # from the qemu-user-static package) — NOT /usr/bin/qemu-arm
-        # like master does. Observed on run 24878263028: "qemu-
+        # like the armhf master does. Observed on run 24878263028: "qemu-
         # aarch64-static not found (please install qemu-user-static)".
         #
         # --no-install-recommends prevents qemu-user-binfmt from
@@ -81,10 +81,10 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.sha }}
 
       - name: Build image
-        env:
-          # Pin to pi-gen's bookworm-arm64 branch. master is on trixie
-          # now; keep us on bookworm until we deliberately jump.
-          PI_GEN_REF: bookworm-arm64
+        # The pinned pi-gen ref (arm64 / trixie branch commit) lives in
+        # deploy/pi-gen/build.sh as the single source of truth — no
+        # per-workflow override, so PR builds and release builds use the
+        # same base.
         run: deploy/pi-gen/build.sh
 
       - name: Locate artifact

--- a/.github/workflows/rpi-image-build.yml
+++ b/.github/workflows/rpi-image-build.yml
@@ -52,26 +52,23 @@ jobs:
           sudo docker system prune -af
           df -h /
 
-      - name: Register binfmt_misc handlers for arm / arm64
-        # pi-gen's arm64 branch checks for
-        # /usr/bin/qemu-aarch64-static (STATIC, with -static suffix,
-        # from the qemu-user-static package) — NOT /usr/bin/qemu-arm
-        # like the armhf master does. Observed on run 24878263028: "qemu-
-        # aarch64-static not found (please install qemu-user-static)".
-        #
-        # --no-install-recommends prevents qemu-user-binfmt from
-        # being pulled as a recommend. Its postinst registers wrapper
-        # handlers at /usr/libexec/qemu-binfmt/*-binfmt-P that don't
-        # exist inside pi-gen's chroot (arch-test then fails with
-        # "armhf: not supported"). Diagnosed on run 24875338536.
-        #
-        # tonistiigi/binfmt registers F-flagged handlers that resolve
-        # the interpreter at registration time and keep the fd valid
-        # across pi-gen's mount-namespace switch.
+      - name: Install qemu for arm64 cross-build
+        # pi-gen's arm64 (trixie) branch build-docker.sh requires the
+        # DYNAMIC `qemu-aarch64` binary on PATH (`which qemu-aarch64`)
+        # and then registers its OWN F-flagged binfmt handler
+        # (`qemu-aarch64-rpi`) plus `dpkg-reconfigure qemu-user-binfmt`
+        # inside the privileged container — see build-docker.sh on the
+        # arm64 branch. That's a different contract than the old
+        # bookworm-arm64 branch (which wanted qemu-aarch64-STATIC +
+        # tonistiigi/binfmt, and where qemu-user-binfmt's wrapper
+        # handlers broke arch-test in the chroot). For the arm64 branch
+        # we give it exactly what it asks for: qemu-user-binfmt, which
+        # provides /usr/bin/qemu-aarch64; pi-gen finishes the F-flag
+        # registration so it survives the chroot mount-namespace switch.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq --no-install-recommends qemu-user-static
-          sudo docker run --privileged --rm tonistiigi/binfmt --install arm,arm64
+          sudo apt-get install -y -qq qemu-user-binfmt
+          which qemu-aarch64   # the exact preflight build-docker.sh runs
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/rpi-image-build.yml
+++ b/.github/workflows/rpi-image-build.yml
@@ -53,22 +53,27 @@ jobs:
           df -h /
 
       - name: Install qemu for arm64 cross-build
-        # pi-gen's arm64 (trixie) branch build-docker.sh requires the
-        # DYNAMIC `qemu-aarch64` binary on PATH (`which qemu-aarch64`)
-        # and then registers its OWN F-flagged binfmt handler
-        # (`qemu-aarch64-rpi`) plus `dpkg-reconfigure qemu-user-binfmt`
-        # inside the privileged container — see build-docker.sh on the
-        # arm64 branch. That's a different contract than the old
-        # bookworm-arm64 branch (which wanted qemu-aarch64-STATIC +
-        # tonistiigi/binfmt, and where qemu-user-binfmt's wrapper
-        # handlers broke arch-test in the chroot). For the arm64 branch
-        # we give it exactly what it asks for: qemu-user-binfmt, which
-        # provides /usr/bin/qemu-aarch64; pi-gen finishes the F-flag
-        # registration so it survives the chroot mount-namespace switch.
+        # pi-gen's arm64 (trixie) branch build-docker.sh has a preflight
+        # `which qemu-aarch64` and registers an F-flagged binfmt handler
+        # pointing at that binary. The interpreter MUST be STATICALLY
+        # linked: a dynamic qemu (qemu-user / qemu-user-binfmt) can't
+        # resolve its shared libs inside pi-gen's chroot, so arch-test
+        # fails with "arm64: not supported" (run 27952017470). So install
+        # qemu-user-static (--no-install-recommends keeps the wrapper-
+        # registering qemu-user-binfmt out) and expose the static binary
+        # under the unsuffixed name the preflight expects, plus
+        # tonistiigi/binfmt for F-flagged handlers that survive the chroot
+        # mount-namespace switch — the combo that built the bookworm image.
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq qemu-user-binfmt
-          which qemu-aarch64   # the exact preflight build-docker.sh runs
+          sudo apt-get install -y -qq --no-install-recommends qemu-user-static
+          sudo ln -sf /usr/bin/qemu-aarch64-static /usr/bin/qemu-aarch64
+          sudo docker run --privileged --rm tonistiigi/binfmt --install arm64
+          which qemu-aarch64
+          echo "--- binfmt_misc qemu-aarch64 handlers ---"
+          for f in /proc/sys/fs/binfmt_misc/qemu-aarch64*; do
+            echo "== ${f} =="; cat "${f}" 2>/dev/null || true
+          done
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ data/
 /go/ftw-updater
 /go/sim-ferroamp
 /go/sim-sungrow
+# Windows build outputs of the same commands (`go build` adds .exe on Windows).
+/go/*.exe
 
 # Local config for simulators
 config.local.yaml

--- a/README.md
+++ b/README.md
@@ -51,17 +51,20 @@ Adding a new device starts with
 
 ### Option A: Raspberry Pi SD-card image
 
-A pre-built `42w-rpi4-arm64-vX.Y.Z.img.xz` ships with releases. To set the
-hostname, SSH user, and Wi-Fi from Raspberry Pi Imager, point it at the 42W
-repository (**App Options → Content Repository → Use custom file**):
+Recommended: point **Raspberry Pi Imager** at the 42W image repository
+(**App Options → Content Repository → Use custom file**):
 
 ```
 https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json
 ```
 
-Then pick **Forty-Two Watts**, customise, and write. Boot the Pi and open
-`http://42w.local/`. If Wi-Fi is not pre-configured, the image exposes a
-`42w-setup` captive portal for onboarding.
+Then pick **Forty-Two Watts**, set your hostname / SSH user / Wi-Fi in the
+customisation panel, and write — Imager downloads the image for you. Boot the
+Pi and open `http://42w.local/`.
+
+You can instead download the `42w-rpi4-arm64-vX.Y.Z.img.xz` release asset and
+flash it directly, but that skips the customisation panel (default
+credentials, Wi-Fi via the `42w-setup` captive portal) — not recommended.
 
 Full walkthrough: [`docs/rpi-image.md`](docs/rpi-image.md).
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@ Adding a new device starts with
 
 ### Option A: Raspberry Pi SD-card image
 
-A pre-built `42w-rpi4-arm64-vX.Y.Z.img.xz` ships with releases. Flash it
-with Raspberry Pi Imager or balenaEtcher, boot the Pi, and open
+A pre-built `42w-rpi4-arm64-vX.Y.Z.img.xz` ships with releases. To set the
+hostname, SSH user, and Wi-Fi from Raspberry Pi Imager, point it at the 42W
+repository (**App Options → Content Repository → Use custom file**):
+
+```
+https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json
+```
+
+Then pick **Forty-Two Watts**, customise, and write. Boot the Pi and open
 `http://42w.local/`. If Wi-Fi is not pre-configured, the image exposes a
 `42w-setup` captive portal for onboarding.
 

--- a/deploy/imager/README.md
+++ b/deploy/imager/README.md
@@ -31,3 +31,15 @@ writing) and uploads the rendered `os_list.json` as a release asset.
 cloud-init (Imager writes `user-data` / `network-config` / `meta-data` to the boot
 partition). If the image base ever changes, update `init_format` accordingly
 (`systemd` for the legacy `firstrun.sh` path on bookworm).
+
+## Why there is no `devices` filter
+
+The OS entry deliberately omits the `devices` array (e.g. `["pi4-64bit",
+"pi5-64bit"]`). When Imager loads a **custom** repository via `--repo`, it uses
+that repository for the OS list but does **not** get the hardware/device list
+that the stock repository ships — so the "CHOOSE DEVICE" picker is empty. A
+device-filtered entry then never appears, because no matching device can be
+selected. Omitting `devices` makes "Forty-Two Watts" show regardless of the
+selected device. The image only supports Pi 4/5 (64-bit), which the `name` and
+`description` already state. **Do not re-add `devices`** — it silently hides the
+entry in the custom-repo flow.

--- a/deploy/imager/README.md
+++ b/deploy/imager/README.md
@@ -1,0 +1,33 @@
+# Raspberry Pi Imager — custom OS repository
+
+`os_list.json` is a **Raspberry Pi Imager repository JSON** (V4 schema). It
+describes the forty-two-watts SD-card image so that **Raspberry Pi Imager 2.0+**
+shows the OS-customisation panel (hostname, SSH user/password, WiFi) for our
+image — Imager only offers that panel for images it has metadata for, which a
+bare `.img.xz` loaded via "Use custom" does not have.
+
+## How users consume it
+
+In Raspberry Pi Imager: **App Options → Content Repository → EDIT → Use custom
+file**, paste the URL below, then **APPLY & RESTART** (or `rpi-imager --repo <url>`):
+
+```
+https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json
+```
+
+`releases/latest/download/...` always redirects to the newest release's asset,
+so the URL never changes between versions.
+
+## This file is a template
+
+The committed copy is a **template**: `url`, `extract_size`, `extract_sha256`,
+`image_download_size`, and `release_date` carry placeholder/zero values. The
+`rpi-image` job in `.github/workflows/release-assets.yml` renders these with the
+real values for each release (the `.img.xz` URL, its compressed + decompressed
+sizes, and the SHA-256 of the decompressed image — which Imager verifies after
+writing) and uploads the rendered `os_list.json` as a release asset.
+
+`init_format` is `cloudinit-rpi` because the image is Raspberry Pi OS Trixie with
+cloud-init (Imager writes `user-data` / `network-config` / `meta-data` to the boot
+partition). If the image base ever changes, update `init_format` accordingly
+(`systemd` for the legacy `firstrun.sh` path on bookworm).

--- a/deploy/imager/os_list.json
+++ b/deploy/imager/os_list.json
@@ -10,8 +10,7 @@
       "image_download_size": 0,
       "release_date": "1970-01-01",
       "init_format": "cloudinit-rpi",
-      "website": "https://github.com/frahlg/forty-two-watts",
-      "devices": ["pi4-64bit", "pi5-64bit"]
+      "website": "https://github.com/frahlg/forty-two-watts"
     }
   ]
 }

--- a/deploy/imager/os_list.json
+++ b/deploy/imager/os_list.json
@@ -1,0 +1,17 @@
+{
+  "os_list": [
+    {
+      "name": "Forty-Two Watts",
+      "description": "Home Energy Management System — Raspberry Pi 4/5 (64-bit)",
+      "icon": "https://raw.githubusercontent.com/frahlg/forty-two-watts/master/web/favicon.svg",
+      "url": "__IMAGE_URL__",
+      "extract_size": 0,
+      "extract_sha256": "__EXTRACT_SHA256__",
+      "image_download_size": 0,
+      "release_date": "1970-01-01",
+      "init_format": "cloudinit-rpi",
+      "website": "https://github.com/frahlg/forty-two-watts",
+      "devices": ["pi4-64bit", "pi5-64bit"]
+    }
+  ]
+}

--- a/deploy/pi-gen/build.sh
+++ b/deploy/pi-gen/build.sh
@@ -47,14 +47,26 @@ install -m 0644 "${FTW_COMPOSE}"                                "${FILES_DIR}/do
 install -m 0644 "${REPO_ROOT}/mosquitto/config/mosquitto.conf"  "${FILES_DIR}/mosquitto.conf"
 
 if [ ! -d "${PI_GEN_DIR}" ]; then
-    # Clone then checkout the pinned ref. `git clone --branch` only
-    # accepts branch/tag names, not arbitrary commit SHAs, and we pin
-    # PI_GEN_REF to a SHA for reproducibility — so clone the default
-    # branch and check the ref out explicitly (works for SHA, branch,
-    # or tag). pi-gen is a small scripts repo, so a full clone is cheap.
+    # `git clone --branch` only accepts branch/tag names, not arbitrary
+    # commit SHAs, and we pin PI_GEN_REF to a SHA for reproducibility — so
+    # clone the default branch; the explicit checkout below pins the ref
+    # (works for SHA, branch, or tag). pi-gen is a small scripts repo, so a
+    # full clone is cheap.
     git clone https://github.com/RPi-Distro/pi-gen.git "${PI_GEN_DIR}"
-    git -C "${PI_GEN_DIR}" checkout --quiet "${PI_GEN_REF}"
 fi
+
+# Pin to PI_GEN_REF on EVERY run, not just a fresh clone. An existing
+# deploy/pi-gen/pi-gen would otherwise stay on whatever ref it was first
+# cloned at and silently ignore a bumped PI_GEN_REF — a reproducibility hole
+# that bites local rebuilds across a re-pin (CI is unaffected: it always
+# starts from a clean checkout). Try a local checkout first; fetch only if
+# the pinned ref isn't in the local clone yet. `-f` resets pi-gen's own
+# tracked files but leaves our untracked stage-42w/config/SKIP additions
+# (re-copied below) intact.
+git -C "${PI_GEN_DIR}" checkout -f --quiet "${PI_GEN_REF}" 2>/dev/null || {
+    git -C "${PI_GEN_DIR}" fetch --quiet origin
+    git -C "${PI_GEN_DIR}" checkout -f --quiet "${PI_GEN_REF}"
+}
 
 # Copy (not symlink) our stage + config into the pi-gen checkout.
 # build-docker.sh builds an image with `COPY . /pi-gen/` where . is

--- a/deploy/pi-gen/build.sh
+++ b/deploy/pi-gen/build.sh
@@ -24,12 +24,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 PI_GEN_DIR="${SCRIPT_DIR}/pi-gen"
-# pi-gen's `master` has moved on to Debian trixie. Pin to the
-# bookworm-arm64 branch to keep the image line on Debian 12
-# (Raspberry Pi OS Lite 64-bit bookworm) — matches what the
-# curl|bash installer and docs target. Bump deliberately when we
-# choose to jump to trixie.
-PI_GEN_REF="${PI_GEN_REF:-bookworm-arm64}"
+# 64-bit Raspberry Pi OS images build from pi-gen's `arm64` branch
+# (per pi-gen's README: "64 bit images should be built from the arm64
+# branch"); `master` defaults to armhf. The arm64 branch tracks trixie
+# now (RELEASE=trixie, ENABLE_CLOUD_INIT=1, stage2/04-cloud-init present).
+#
+# Pin to a specific commit rather than the moving branch tip: early
+# trixie images shipped cloud-init re-run bugs, so reproducibility +
+# a deliberate bump matter here. This is the arm64 branch HEAD captured
+# 2026-06-22; re-pin after validating a build on real hardware.
+PI_GEN_REF="${PI_GEN_REF:-ca8aeed0ae300c2a89f55ce9617d5f96a27e99e5}"
 
 # Sync repo-owned files into the stage's files/ directory. We copy
 # rather than symlink because pi-gen's stage runner treats files/ as
@@ -43,8 +47,13 @@ install -m 0644 "${FTW_COMPOSE}"                                "${FILES_DIR}/do
 install -m 0644 "${REPO_ROOT}/mosquitto/config/mosquitto.conf"  "${FILES_DIR}/mosquitto.conf"
 
 if [ ! -d "${PI_GEN_DIR}" ]; then
-    git clone --depth 1 --branch "${PI_GEN_REF}" \
-        https://github.com/RPi-Distro/pi-gen.git "${PI_GEN_DIR}"
+    # Clone then checkout the pinned ref. `git clone --branch` only
+    # accepts branch/tag names, not arbitrary commit SHAs, and we pin
+    # PI_GEN_REF to a SHA for reproducibility — so clone the default
+    # branch and check the ref out explicitly (works for SHA, branch,
+    # or tag). pi-gen is a small scripts repo, so a full clone is cheap.
+    git clone https://github.com/RPi-Distro/pi-gen.git "${PI_GEN_DIR}"
+    git -C "${PI_GEN_DIR}" checkout --quiet "${PI_GEN_REF}"
 fi
 
 # Copy (not symlink) our stage + config into the pi-gen checkout.
@@ -57,13 +66,17 @@ rm -rf "${PI_GEN_DIR}/stage-42w"
 cp -R "${SCRIPT_DIR}/stage-42w" "${PI_GEN_DIR}/stage-42w"
 cp    "${SCRIPT_DIR}/config"    "${PI_GEN_DIR}/config"
 
-# Skip stage2 (Lite "comfort" CLI tooling) and stage3-5 (desktop +
-# NOOBS) entirely — the only stages we run are stage0 + stage1 +
-# stage-42w. Stage-42w explicitly installs the few stage2 packages
-# we actually need (avahi-daemon, network-manager). pi-gen honours
-# SKIP files dropped into each stage's directory; SKIP prevents the
-# stage from running, SKIP_IMAGES prevents an .img export.
-for stage in stage2 stage3 stage4 stage5; do
+# pi-gen honours SKIP files per stage: SKIP prevents the stage from
+# running, SKIP_IMAGES prevents that stage from exporting an .img.
+#
+# stage2 RUNS now (on trixie it installs cloud-init + netplan and sets
+# the systemd.run= first-boot/resize cmdline that replaced the old
+# init=…firstboot path) — but we suppress its OWN image export so we
+# don't waste a full export on the plain Lite image; stage-42w (last in
+# STAGE_LIST, carries EXPORT_IMAGE) produces the only image.
+touch "${PI_GEN_DIR}/stage2/SKIP_IMAGES" 2>/dev/null || true
+# stage3-5 (desktop + NOOBS) are skipped entirely.
+for stage in stage3 stage4 stage5; do
     touch "${PI_GEN_DIR}/${stage}/SKIP" \
           "${PI_GEN_DIR}/${stage}/SKIP_IMAGES" 2>/dev/null || true
 done

--- a/deploy/pi-gen/config
+++ b/deploy/pi-gen/config
@@ -2,7 +2,15 @@
 # Sourced by pi-gen's build scripts — plain shell variables, no logic.
 
 IMG_NAME="42w-rpi4-arm64"
-RELEASE="bookworm"
+RELEASE="trixie"
+
+# Install + configure cloud-init and netplan (pi-gen stage2/04-cloud-init).
+# This is what lets Raspberry Pi Imager 2.0 apply hostname / SSH user /
+# WiFi customisation on first boot (init_format "cloudinit-rpi" in the
+# Imager repository JSON — see deploy/imager/os_list.json). Default on the
+# pi-gen arm64 (trixie) branch is already 1; set it explicitly so a
+# pi-gen branch bump can't silently turn it off.
+ENABLE_CLOUD_INIT=1
 
 # mDNS: the avahi-daemon shipped with Raspberry Pi OS picks up
 # /etc/hostname as its primary .local name. Setting this to `42w`
@@ -15,14 +23,16 @@ KEYBOARD_KEYMAP="us"
 KEYBOARD_LAYOUT="English (US)"
 TIMEZONE_DEFAULT="UTC"
 
-# Skip stage2 (Pi OS Lite "comfort" packages: vim, less, raspi-config,
-# build-essential, python3-pip, network-manager-gnome, etc.) — none of
-# its additions are needed for "boot → docker compose up". Stage-42w
-# explicitly pulls the bits we DO need (avahi-daemon for mDNS,
-# network-manager for wifi-connect) so we don't lose mDNS or WiFi
-# onboarding by dropping stage2. Stage3-5 (desktop + NOOBS) are
-# skipped separately via SKIP files in build.sh.
-STAGE_LIST="stage0 stage1 stage-42w"
+# Trixie note: stage2 is now INCLUDED. On bookworm we skipped stage2 and
+# hand-installed the few packages we needed, but trixie moved the
+# first-boot machinery (cloud-init + netplan + the systemd.run= resize
+# path that replaced the old init=…firstboot mechanism) into stage2
+# (stage2/04-cloud-init and friends). Replicating that actively-changing
+# wiring by hand is fragile and boot-loop-prone, so we ride pi-gen's
+# maintained stage2. Stage3-5 (desktop + NOOBS) stay skipped via SKIP
+# files in build.sh; stage2's own image export is suppressed there too
+# (SKIP_IMAGES) so stage-42w produces the only image.
+STAGE_LIST="stage0 stage1 stage2 stage-42w"
 
 # First-login creds. Users who flash with Raspberry Pi Imager will
 # override these via Imager's advanced-options panel (which writes to

--- a/deploy/pi-gen/stage-42w/00-install-packages/00-packages
+++ b/deploy/pi-gen/stage-42w/00-install-packages/00-packages
@@ -4,4 +4,3 @@ curl
 jq
 network-manager
 raspberrypi-sys-mods
-userconf-pi

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
@@ -93,6 +93,17 @@ install -m 0440 files/010_ftw-nopasswd      "${ROOTFS_DIR}/etc/sudoers.d/010_ftw
 # /opt/forty-two-watts stays root-owned (operators edit via passwordless
 # sudo); data/ keeps its 100:101 ownership for the in-container user,
 # already set numerically by `install -d -o 100 -g 101` above.
+# Mask the Raspberry Pi OS first-run user wizard. On a headless,
+# cloud-init-provisioned image it is both redundant and fatal: the `ftw`
+# account (or the Imager-customised account) already exists, yet
+# userconfig.service still runs `userconf-service`, which blocks on a
+# `whiptail "Please enter new username:"` dialog on tty8. It is
+# Type=oneshot WantedBy=multi-user.target, so that never-completing dialog
+# wedges multi-user.target — and with it ftw-firstboot.service (ordered
+# After=cloud-final.service, itself queued behind the wizard) — so the
+# stack is never pulled and the dashboard never comes up. Masking it lets
+# a no-customisation flash boot through to multi-user.target.
 on_chroot << 'EOF'
 systemctl enable ftw-firstboot.service
+systemctl mask userconfig.service
 EOF

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/00-run.sh
@@ -18,7 +18,12 @@ set -e
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
-echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+# Derive the Debian codename from the target rootfs (trixie on the
+# current image) rather than hardcoding it — keeps this correct across
+# a pi-gen base bump. This runs INSIDE the chroot (the heredoc is
+# single-quoted, so $(…) is evaluated here, not on the build host),
+# so /etc/os-release is the image's.
+echo "deb [arch=arm64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
     > /etc/apt/sources.list.d/docker.list
 apt-get -qq update
 DEBIAN_FRONTEND=noninteractive apt-get -y -qq install --no-install-recommends \
@@ -38,62 +43,56 @@ rm -f /etc/apt/sources.list.d/docker.list
 sed -i 's/^127\.0\.1\.1.*/127.0.1.1\t42w/' /etc/hosts
 EOF
 
-# init=firstboot on first boot — without stage2, nobody else injects
-# this into cmdline.txt. The firstboot script ships with
-# raspberrypi-sys-mods and handles partition resize, ssh enable, and
-# userconf-pi processing on the very first boot, then removes itself
-# from cmdline.txt and reboots. Mirrors what pi-gen's
-# stage2/01-sys-tweaks/01-run.sh does on a stock Lite build.
-# Idempotent — re-running the build won't double-inject.
-CMDLINE="${ROOTFS_DIR}/boot/firmware/cmdline.txt"
-if [ -f "${CMDLINE}" ] && ! grep -q "raspberrypi-sys-mods/firstboot" "${CMDLINE}"; then
-    sed -i 's| rootwait| init=/usr/lib/raspberrypi-sys-mods/firstboot rootwait|' "${CMDLINE}"
-fi
+# NO manual cmdline.txt first-boot injection on trixie.
+#
+# On bookworm we hand-injected `init=/usr/lib/raspberrypi-sys-mods/firstboot`
+# (because we skipped stage2). Trixie REPLACED that mechanism: the
+# `init=` first-boot path is gone, resize now runs via initramfs +
+# rpi-resize.service, and the customisation hook is `systemd.run=`.
+# Removing/forcing `init=` on trixie causes a boot loop. We now include
+# stage2 (see STAGE_LIST in config), so pi-gen sets the correct trixie
+# first-boot/resize cmdline + cloud-init datasource itself — we must not
+# fight it.
 
 # Deploy directory: docker-compose.yml lives here and
 # `docker compose up -d` runs from it on first boot.
 #
-# Path: /home/ftw/ — the user `ftw` is created at BUILD TIME by
-# stage1 (FIRST_USER_NAME=ftw in deploy/pi-gen/config), so its
-# home directory exists and is owned by ftw:ftw before stage-42w
-# runs. There's no `pi → ftw` rename in our flow — the rename
-# wizard pi-gen sets up is for END USERS who customize the
-# username via Imager's userconf.txt (handled by userconf-pi at
-# first boot, see below).
+# Path: /opt/forty-two-watts — a FIXED system path, deliberately NOT
+# under a user home. On trixie + cloud-init, Raspberry Pi Imager lets
+# the user set their own account name; cloud-init may create/rename the
+# uid-1000 user, which would orphan a deploy dir under /home/ftw/. A
+# fixed /opt path is immune to whatever the user names their account.
 #
-# Earlier builds (commit 6aa5a9d, "trim image") wrote to
-# /home/pi/ on a now-disproved theory that a rename would move
-# files. On real hardware, /home/pi/ ended up as a stale
-# root-owned directory and ftw-firstboot died with
-# "cd: /home/ftw/forty-two-watts: No such file or directory".
+# Self-update stays correct across this move: the ftw-updater sidecar
+# derives its compose path from ${PWD} at `docker compose up -d` time
+# (see docker-compose.yml) and firstboot.sh cd's here, so the updater
+# records /opt/forty-two-watts automatically. COMPOSE_PROJECT_NAME
+# stays the literal `forty-two-watts`.
 #
-# data/ is chowned 100:101 because the in-container ftw user
-# (alpine `adduser -S`) needs to own it before SQLite can create
-# state.db. Same UID/GID mapping as scripts/install.sh.
-install -d -m 0755                    "${ROOTFS_DIR}/home/ftw/forty-two-watts"
-install -d -m 0755 -o 100 -g 101      "${ROOTFS_DIR}/home/ftw/forty-two-watts/data"
-install -d -m 0755                    "${ROOTFS_DIR}/home/ftw/forty-two-watts/mosquitto"
-install -d -m 0755                    "${ROOTFS_DIR}/home/ftw/forty-two-watts/mosquitto/config"
+# data/ is owned 100:101 because the in-container ftw user (alpine
+# `adduser -S`) needs to own it before SQLite can create state.db.
+# Same UID/GID mapping as scripts/install.sh.
+install -d -m 0755                    "${ROOTFS_DIR}/opt/forty-two-watts"
+install -d -m 0755 -o 100 -g 101      "${ROOTFS_DIR}/opt/forty-two-watts/data"
+install -d -m 0755                    "${ROOTFS_DIR}/opt/forty-two-watts/mosquitto"
+install -d -m 0755                    "${ROOTFS_DIR}/opt/forty-two-watts/mosquitto/config"
 
-install -m 0644 files/docker-compose.yml    "${ROOTFS_DIR}/home/ftw/forty-two-watts/docker-compose.yml"
-install -m 0644 files/mosquitto.conf        "${ROOTFS_DIR}/home/ftw/forty-two-watts/mosquitto/config/mosquitto.conf"
+install -m 0644 files/docker-compose.yml    "${ROOTFS_DIR}/opt/forty-two-watts/docker-compose.yml"
+install -m 0644 files/mosquitto.conf        "${ROOTFS_DIR}/opt/forty-two-watts/mosquitto/config/mosquitto.conf"
 
 install -m 0755 files/firstboot.sh          "${ROOTFS_DIR}/usr/local/sbin/ftw-firstboot"
 install -m 0644 files/firstboot.service     "${ROOTFS_DIR}/etc/systemd/system/ftw-firstboot.service"
 
-# Sudoers fragment for ftw — without stage2, no `010_pi-nopasswd`
-# file gets installed, so the ftw user has no admin rights at all.
-# Mirror the pi-OS-Lite default of passwordless sudo for the
-# admin user; operators expect to be able to SSH in and diagnose
-# without remembering a password they probably overrode in Imager.
+# Sudoers fragment for ftw. Stage2 installs an `010_<user>-nopasswd` for
+# the build-time FIRST_USER (ftw); we drop this belt-and-suspenders copy
+# so the default ftw recovery account keeps passwordless sudo even if a
+# pi-gen internal changes. A user who renames the account via Imager gets
+# their NOPASSWD sudo from cloud-init's `users:` directive instead.
 install -m 0440 files/010_ftw-nopasswd      "${ROOTFS_DIR}/etc/sudoers.d/010_ftw-nopasswd"
 
-# Chown everything to ftw so `ls -la` and edit-without-sudo work
-# when an operator SSHes in. data/ keeps its 100:101 ownership for
-# the in-container user. Run inside chroot so /etc/passwd resolves
-# `ftw` correctly.
+# /opt/forty-two-watts stays root-owned (operators edit via passwordless
+# sudo); data/ keeps its 100:101 ownership for the in-container user,
+# already set numerically by `install -d -o 100 -g 101` above.
 on_chroot << 'EOF'
-chown -R ftw:ftw /home/ftw/forty-two-watts
-chown 100:101 /home/ftw/forty-two-watts/data
 systemctl enable ftw-firstboot.service
 EOF

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.service
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.service
@@ -2,7 +2,12 @@
 Description=forty-two-watts first-boot provisioner
 Documentation=https://github.com/frahlg/forty-two-watts/blob/master/docs/rpi-image.md
 Wants=network-online.target docker.service
-After=network-online.target docker.service
+# Order after cloud-init's final stage so the user account, hostname,
+# and network (the WiFi/Ethernet config cloud-init applies from the
+# Imager-written user-data/network-config) are fully in place before we
+# pull images. Ordering only — cloud-final.service is already part of
+# the normal trixie boot; we don't pull it in ourselves.
+After=network-online.target docker.service cloud-final.service
 ConditionPathExists=!/var/lib/ftw/firstboot.done
 
 [Service]

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.service
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.service
@@ -2,12 +2,17 @@
 Description=forty-two-watts first-boot provisioner
 Documentation=https://github.com/frahlg/forty-two-watts/blob/master/docs/rpi-image.md
 Wants=network-online.target docker.service
-# Order after cloud-init's final stage so the user account, hostname,
-# and network (the WiFi/Ethernet config cloud-init applies from the
-# Imager-written user-data/network-config) are fully in place before we
-# pull images. Ordering only — cloud-final.service is already part of
-# the normal trixie boot; we don't pull it in ourselves.
-After=network-online.target docker.service cloud-final.service
+# Order after the network and Docker only. We deliberately do NOT order
+# After=cloud-final.service: ftw-firstboot is WantedBy=multi-user.target,
+# and cloud-final.service is ordered around multi-user.target too (cloud-init
+# runs late), so that extra edge formed an ordering cycle
+# (multi-user.target -> ftw-firstboot -> cloud-final -> multi-user.target).
+# systemd broke it by DELETING ftw-firstboot's start job, so on a clean boot
+# the stack was never pulled and the dashboard never came up. The pull/up
+# only needs the network and Docker; firstboot runs as root (no cloud-init
+# account dependency) and firstboot.sh's retry loop covers a network that is
+# still settling after cloud-init's final stage.
+After=network-online.target docker.service
 ConditionPathExists=!/var/lib/ftw/firstboot.done
 
 [Service]

--- a/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.sh
+++ b/deploy/pi-gen/stage-42w/01-ftw-setup/files/firstboot.sh
@@ -19,7 +19,7 @@ mkdir -p "$(dirname "${SENTINEL}")"
 exec > >(tee -a "${LOG}") 2>&1
 echo "[$(date -Is)] ftw-firstboot starting"
 
-cd /home/ftw/forty-two-watts
+cd /opt/forty-two-watts
 
 # Retry loop: GHCR and general LAN DHCP can be flaky for the first
 # couple of minutes after boot. Back off linearly rather than

--- a/deploy/pi-gen/stage-42w/02-wifi-onboarding/01-run.sh
+++ b/deploy/pi-gen/stage-42w/02-wifi-onboarding/01-run.sh
@@ -26,12 +26,14 @@ install -m 0644 files/42w-wifi-onboarding.service    "${ROOTFS_DIR}/etc/systemd/
 on_chroot << 'EOF'
 systemctl enable 42w-wifi-onboarding.service
 
-# Bookworm's default dhcpcd setup fights NetworkManager over the wlan
-# interface. Raspberry Pi OS Lite has shipped with NM as the default
-# network stack since 2023, but dhcpcd is still installed and running
-# on a stock stage2 image. Disable it so NM owns wlan0 uncontested —
-# otherwise wifi-connect's AP-mode toggling races the dhcpcd wlan0
-# supplicant and both sides lose.
+# Make sure NetworkManager owns wlan0 uncontested so wifi-connect's
+# AP-mode toggling doesn't race another supplicant. On trixie, netplan
+# (NetworkManager renderer) is the source of truth and dhcpcd is
+# normally absent — these commands are then a guarded no-op (|| true).
+# We keep them as belt-and-suspenders in case a base bump reintroduces
+# a stray dhcpcd on wlan0. cloud-init-applied WiFi (from the Imager
+# network-config) lands as an NM connection via netplan, which the
+# onboarding script already detects so the captive portal is skipped.
 systemctl disable dhcpcd.service 2>/dev/null || true
 systemctl mask    dhcpcd.service 2>/dev/null || true
 EOF

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.nft
@@ -8,14 +8,19 @@
 # discovery, LAN MQTT brokers, and mDNS-based drivers like Sourceful
 # Zap. The Go app binds 8080 directly on the host's network namespace.
 #
-# Own table (`42w_redirect`) to stay isolated from any other nftables
+# Own table (`ftw_redirect`) to stay isolated from any other nftables
 # config a future image stage might add. `flush table` at the top
 # makes the load idempotent: re-running `nft -f` doesn't stack
 # duplicate rules.
-table ip 42w_redirect
-flush table ip 42w_redirect
+#
+# NB: the table name must NOT start with a digit — nftables identifiers
+# follow `[a-zA-Z_][a-zA-Z0-9_]*`, so a leading `4` (e.g. `42w_redirect`)
+# is tokenized as a number and the whole file fails to parse, silently
+# disabling the redirect. Hence `ftw_redirect`, not `42w_redirect`.
+table ip ftw_redirect
+flush table ip ftw_redirect
 
-table ip 42w_redirect {
+table ip ftw_redirect {
     chain prerouting {
         type nat hook prerouting priority dstnat; policy accept;
         tcp dport 80 redirect to :8080

--- a/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
+++ b/deploy/pi-gen/stage-42w/03-port-redirect/files/42w-port-redirect.service
@@ -11,7 +11,7 @@ Before=network.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/nft -f /etc/42w-port-redirect.nft
-# Idempotent — the rules file flushes the 42w_redirect table at the
+# Idempotent — the rules file flushes the ftw_redirect table at the
 # top before re-installing, so a manual `systemctl restart` doesn't
 # stack duplicates.
 ExecReload=/usr/sbin/nft -f /etc/42w-port-redirect.nft

--- a/docs/rpi-image.md
+++ b/docs/rpi-image.md
@@ -25,7 +25,7 @@ If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
 
 | Component | Version |
 |---|---|
-| Base OS | **Raspberry Pi OS Lite** (64-bit, Debian Bookworm) |
+| Base OS | **Raspberry Pi OS Lite** (64-bit, Debian Trixie) |
 | Kernel | Stock Pi kernel (whatever the matching Pi OS Lite ships) |
 | Init | systemd |
 | Container engine | Docker CE + compose plugin (from Docker's official apt repo) |
@@ -37,9 +37,12 @@ If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
 Image size: ~410 MB compressed, ~2.4 GB written to SD card. Any 8 GB
 or larger card works; 16 GB+ recommended for headroom.
 
-The base is **stock Raspberry Pi OS Lite** with stage2 trimmed off
-and a single custom stage layered on top. SSH is enabled by default
-so you have a recovery path if the dashboard ever gets stuck.
+The base is **stock Raspberry Pi OS Lite** (Debian Trixie) with a
+single custom stage layered on top. First-boot customisation
+(hostname, SSH user, WiFi) is handled by **cloud-init** — the same
+mechanism stock Raspberry Pi OS Trixie uses — when you set it in
+Raspberry Pi Imager. SSH is enabled by default so you have a recovery
+path if the dashboard ever gets stuck.
 
 ---
 
@@ -77,15 +80,31 @@ Both supported flashers handle `.img.xz` natively — they decompress
 on the fly while writing to the card. **You do not need to extract
 the file before flashing.**
 
-### Path A — Raspberry Pi Imager (recommended)
+### Path A — Raspberry Pi Imager with the 42W repository (recommended)
 
-1. Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
-2. **CHOOSE OS** → scroll to bottom → **Use custom** → select your
-   downloaded `42w-rpi4-arm64-*.img.xz`.
-3. **CHOOSE STORAGE** → pick the SD card.
-4. **WRITE**. Imager handles xz decompression + verification.
+Raspberry Pi Imager 2.0 only shows the customisation panel (hostname,
+SSH user/password, WiFi) for images it has metadata for. Point it at
+the 42W repository so it does:
+
+1. Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (2.0 or newer).
+2. **App Options → Content Repository → EDIT → Use custom file** → paste:
+   ```
+   https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json
+   ```
+   → **APPLY & RESTART**. (CLI equivalent: `rpi-imager --repo <url>`.)
+3. **CHOOSE OS** → **Forty-Two Watts** now appears in the list.
+4. **CHOOSE STORAGE** → pick the SD card.
+5. **NEXT** → when asked to apply OS customisation, set your **hostname**
+   (keep `42w` so the dashboard stays at `http://42w.local/`), **SSH
+   user/password**, and **WiFi** (SSID + password — the Pi joins your
+   network at first boot, no captive portal needed). Then **WRITE**.
 
 When it finishes, eject the card cleanly.
+
+> **No repository?** You can still **CHOOSE OS → Use custom** and pick a
+> downloaded `42w-rpi4-arm64-*.img.xz` directly — but Imager then offers
+> **no** customisation panel, so the Pi boots with default credentials
+> and WiFi is configured via the captive portal (below).
 
 ### Path B — balenaEtcher
 
@@ -110,15 +129,19 @@ WiFi is configured at first boot via the **captive portal** flow
 ## First boot
 
 Insert the SD card, plug in Ethernet (or rely on the captive
-portal), connect power. Two things happen automatically:
+portal), connect power. Three things happen automatically:
 
-1. **Partition resize.** The image is ~2.4 GB; the resize step grows
-   the rootfs to fill your SD card on the very first boot. The Pi
-   reboots once to pick up the resized partition. Adds ~30 s.
-2. **First-boot service** (`ftw-firstboot.service`). Pulls the
-   container images from GHCR (`forty-two-watts`, `mosquitto`,
-   `ftw-updater`), brings up the stack with `docker compose up -d`.
-   Takes ~60–90 s on a decent connection.
+1. **Partition resize.** The image is ~2.4 GB; Trixie grows the rootfs
+   to fill your SD card on first boot (initramfs + `rpi-resize.service`).
+   Adds ~30 s.
+2. **cloud-init customisation.** If you set a hostname / SSH user / WiFi
+   in Raspberry Pi Imager, cloud-init applies them now (from the
+   `user-data` / `network-config` it wrote to the boot partition).
+3. **First-boot service** (`ftw-firstboot.service`). Runs after
+   cloud-init finishes, pulls the container images from GHCR
+   (`forty-two-watts`, `mosquitto`, `ftw-updater`) and brings up the
+   stack with `docker compose up -d` from `/opt/forty-two-watts`. Takes
+   ~60–90 s on a decent connection.
 
 After that, the dashboard is up and stays up across reboots.
 
@@ -175,14 +198,15 @@ IP directly — `http://192.168.x.y/` (or `:8080`).
 
 | What | Default | How to change |
 |---|---|---|
-| SSH user | `ftw` | Imager advanced options |
-| SSH password | `fortytwowatts` | Imager advanced options, or `passwd` after first SSH |
-| Hostname | `42w` (mDNS: `42w.local`) | Imager advanced options |
+| SSH user | `ftw` | Imager customisation (via the 42W repository, Path A) |
+| SSH password | `fortytwowatts` | Imager customisation, or `passwd` after first SSH |
+| Hostname | `42w` (mDNS: `42w.local`) | Imager customisation |
 | Dashboard | no auth on the LAN | (planned for a future release) |
 
 The defaults exist so you have a recovery path if something goes
-wrong — they're not meant for production. Override them in Imager
-when you flash for real use.
+wrong — they're not meant for production. Override them in Imager's
+customisation panel (which appears when you load the image via the 42W
+repository — see Path A) when you flash for real use.
 
 ---
 
@@ -202,7 +226,7 @@ Diagnose:
 systemctl status ftw-firstboot           # first-boot provisioner
 journalctl -u ftw-firstboot -b           # its log (this boot)
 tail -f /var/log/ftw-firstboot.log       # durable log
-docker compose -f /home/ftw/forty-two-watts/docker-compose.yml ps
+docker compose -f /opt/forty-two-watts/docker-compose.yml ps
 ```
 
 If `ftw-firstboot` failed (bad network, GHCR outage), it's
@@ -234,7 +258,7 @@ Next boot, the captive portal comes up again.
 
 ```bash
 ssh ftw@42w.local
-cd /home/ftw/forty-two-watts
+cd /opt/forty-two-watts
 sudo docker compose down -v       # drops PV model, battery model,
                                   # price + load history, EV state
 sudo rm -rf data mosquitto/data
@@ -254,7 +278,7 @@ Two ways:
 
   ```bash
   ssh ftw@42w.local
-  cd /home/ftw/forty-two-watts
+  cd /opt/forty-two-watts
   sudo docker compose pull && sudo docker compose up -d
   ```
 

--- a/docs/rpi-image.md
+++ b/docs/rpi-image.md
@@ -1,23 +1,37 @@
 # Raspberry Pi SD-card image
 
-A pre-built `.img.xz` ships with every release. Flash it to an SD
-card, drop the card into a Raspberry Pi 4, plug in power + Ethernet
-(or follow the WiFi-onboarding flow below), and the dashboard is at
-`http://42w.local/` within ~90 s of first boot. No terminal, no
-manual install.
+The recommended way to install on a Raspberry Pi 4/5 is to point
+**Raspberry Pi Imager** at the 42W image repository (a small
+`os_list.json` file), pick **Forty-Two Watts**, and set your
+**hostname, SSH user/password, and WiFi** right in Imager's
+customisation panel before you write the card. Imager downloads the
+image for you — you never fetch the `.img.xz` by hand. Drop the card
+into a Pi, plug in power, and the dashboard is at `http://42w.local/`
+within ~90 s of first boot. No terminal, no manual install.
 
-This is the recommended path for new users.
+You *can* also download the `.img.xz` and flash it directly, but that
+skips the customisation panel — the Pi then boots with default
+credentials and WiFi has to be set up through the captive portal. It's
+the fallback, not the recommended path.
 
 ---
 
-## TL;DR
+## TL;DR (recommended)
 
-1. Download `42w-rpi4-arm64-vX.Y.Z.img.xz` from [Releases](https://github.com/frahlg/forty-two-watts/releases/latest).
-2. Flash to an SD card with [Raspberry Pi Imager](https://www.raspberrypi.com/software/) (recommended) or [balenaEtcher](https://etcher.balena.io/). Both handle `.img.xz` natively — no need to decompress first.
-3. Insert SD card → power on the Pi → wait ~90 s.
-4. Open `http://42w.local/` in any browser on the same network. (`:8080` also works — the image runs an nftables redirect from 80 to 8080 so the bare hostname is enough.)
+1. Install [Raspberry Pi Imager](https://www.raspberrypi.com/software/) 2.0 or newer.
+2. **App Options → Content Repository → EDIT → Use custom file** → paste the 42W repository URL, then **APPLY & RESTART**:
+   ```
+   https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json
+   ```
+3. **CHOOSE OS → Forty-Two Watts**, **CHOOSE STORAGE → your SD card**, then set **hostname / SSH user+password / WiFi** in the customisation panel and **WRITE**.
+4. Insert SD card → power on the Pi → wait ~90 s.
+5. Open `http://42w.local/` in any browser on the same network. (`:8080` also works — the image runs an nftables redirect from 80 to 8080 so the bare hostname is enough.)
 
-If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
+That's it — Imager pulls the image itself, so you never download a file
+by hand, and because WiFi is configured up front you need neither
+Ethernet nor the captive portal. Prefer to flash a raw image instead?
+See [the direct-download fallback](#download-the-image-directly-fallback)
+(no customisation panel).
 
 ---
 
@@ -34,8 +48,9 @@ If you don't have Ethernet, see [WiFi onboarding](#connect-to-your-network).
 | Port redirect | nftables maps 80 -> 8080 so `http://42w.local/` works without `:8080` |
 | Stack | `forty-two-watts`, `mosquitto`, `ftw-updater` (pulled from GHCR on first boot) |
 
-Image size: ~410 MB compressed, ~2.4 GB written to SD card. Any 8 GB
-or larger card works; 16 GB+ recommended for headroom.
+Image size: ~640 MB compressed, ~2.4 GB written to SD card (it then
+grows to fill the card on first boot). Any 8 GB or larger card works;
+16 GB+ recommended for headroom.
 
 The base is **stock Raspberry Pi OS Lite** (Debian Trixie) with a
 single custom stage layered on top. First-boot customisation
@@ -46,9 +61,16 @@ path if the dashboard ever gets stuck.
 
 ---
 
-## Download
+## Download the image directly (fallback)
 
-### Stable releases (recommended)
+> **Not the recommended path.** Downloading and flashing the raw
+> `.img.xz` skips Imager's customisation panel, so the Pi boots with
+> the default SSH credentials and you configure WiFi through the
+> captive portal. To set hostname / SSH / WiFi before first boot, use
+> the [repository flow](#tldr-recommended) instead — it downloads the
+> image for you.
+
+### Stable releases
 
 Each tagged release publishes the image as a release asset:
 

--- a/docs/rpi-image.md
+++ b/docs/rpi-image.md
@@ -48,7 +48,7 @@ See [the direct-download fallback](#download-the-image-directly-fallback)
 | Port redirect | nftables maps 80 -> 8080 so `http://42w.local/` works without `:8080` |
 | Stack | `forty-two-watts`, `mosquitto`, `ftw-updater` (pulled from GHCR on first boot) |
 
-Image size: ~640 MB compressed, ~2.4 GB written to SD card (it then
+Image size: ~630 MB compressed, ~3.1 GB written to SD card (it then
 grows to fill the card on first boot). Any 8 GB or larger card works;
 16 GB+ recommended for headroom.
 
@@ -153,7 +153,7 @@ WiFi is configured at first boot via the **captive portal** flow
 Insert the SD card, plug in Ethernet (or rely on the captive
 portal), connect power. Three things happen automatically:
 
-1. **Partition resize.** The image is ~2.4 GB; Trixie grows the rootfs
+1. **Partition resize.** The image is ~3.1 GB; Trixie grows the rootfs
    to fill your SD card on first boot (initramfs + `rpi-resize.service`).
    Adds ~30 s.
 2. **cloud-init customisation.** If you set a hostname / SSH user / WiFi


### PR DESCRIPTION
Closes #488.

## What & why

Raspberry Pi Imager 2.0 only shows its OS-customisation panel (hostname, SSH
user/password, WiFi) for images it has metadata for, supplied via a **repository
JSON** declaring an `init_format`. A bare `.img.xz` ("Use custom") has none, so
the panel stays hidden. This PR publishes that repository JSON **and** migrates
the image to the base OS Imager's customisation now expects:

- **Image → Raspberry Pi OS Trixie + cloud-init** (`init_format: cloudinit-rpi`;
  first-boot customisation via cloud-init / netplan / NetworkManager).
- **`deploy/imager/os_list.json`** — V4-schema repository template, rendered per
  release with the real image URL, sizes, and Imager-verified `extract_sha256`,
  uploaded as a release asset. Point Imager at:
  `https://github.com/frahlg/forty-two-watts/releases/latest/download/os_list.json`

## Changes

- **pi-gen → Trixie**: `RELEASE=trixie`, `ENABLE_CLOUD_INIT=1`, stage2 included
  (with `SKIP_IMAGES`) so cloud-init / netplan / the Trixie first-boot+resize
  cmdline are inherited rather than hand-replicated; pi-gen ref pinned.
- **stage-42w Trixie fixes**: dropped the Bookworm `init=…firstboot` cmdline
  (boot-loops on Trixie); Docker apt codename from `$VERSION_CODENAME`; `dhcpcd`
  disable made a guarded no-op on netplan+NM.
- **Headless-boot fixes (from real-hardware testing):** mask `userconfig.service`
  (the first-run wizard wedges a headless boot); rename the nft redirect table to
  `ftw_redirect` (a leading-digit name is invalid nft — mirrors #526); order
  `ftw-firstboot.service` after `network-online.target docker.service` only
  (dropping `cloud-final.service`, which formed an ordering cycle that made
  systemd delete its start job).
- **Deploy dir → `/opt/forty-two-watts`** so a cloud-init account name can't
  orphan the compose dir; `curl | install.sh` and manual paths unaffected.
- **CI arm64 cross-build**: static `qemu-aarch64` + `tonistiigi/binfmt` so the
  binfmt handler survives the pi-gen chroot.
- **Docs**: repository flow is now the recommended path, raw `.img.xz` demoted to
  fallback. Changeset: `minor`.

## Testing

- ✅ CI image build green on the pinned Trixie pi-gen ref (arm64); the rebuild at
  the PR head — all three boot fixes baked — passes.
- ✅ `release-assets` pipeline exercised on a fork test release (binaries, GHCR
  images, image, rendered `os_list.json` with valid `extract_sha256`);
  `releases/latest/download/os_list.json` resolves.
- ✅ Imager loads the repo and shows **Forty-Two Watts** with the customisation
  panel (`rpi-imager --repo <url>`).
- ✅ **Real-hardware boot validated** (RPi 4, Trixie, no-customisation flash).
  Testing found and fixed three boot blockers, all now confirmed on a clean boot:
  `userconfig.service` no longer wedges the boot, the `ftw_redirect` rule loads,
  and `ftw-firstboot` auto-starts (no ordering cycle). End state: `cloud-init:
  done`, all three containers up, dashboard serves `/setup`, and the
  port-80 → 8080 redirect works for LAN clients.

## Notes

- **Device filter omitted**: a custom `--repo` replaces Imager's manifest (incl.
  its device list), so a `devices`-filtered entry would never show; the entry
  omits `devices` and states Pi 4/5 (64-bit) in name/description. Can add device
  defs to the manifest if the device-selection step is wanted.
- Imager bug raspberrypi/rpi-imager#1609 ("Unable to download OS list", local
  manifests on Windows) is avoided by using a remote `--repo` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
